### PR TITLE
[gnoi] Add integration tests for sonic.gnoi.oras.v1.Oras Pull RPC

### DIFF
--- a/tests/common/ptf_gnoi.py
+++ b/tests/common/ptf_gnoi.py
@@ -434,3 +434,78 @@ class PtfGnoi:
         response = self.grpc_client.call_unary("gnoi.system.System", "RebootStatus", metadata=metadata)
         logger.debug(f"Reboot status: {response}")
         return response
+
+    def oras_pull(
+        self,
+        registry: str,
+        repository: str,
+        local_path: str,
+        tag: str = None,
+        digest: str = None,
+        username: str = None,
+        password: str = None,
+        metadata=None,
+    ) -> list:
+        """
+        Pull an OCI/ORAS artifact from a registry to a local path on the DUT.
+
+        This is a server-streaming RPC: the server sends PullStarted, then
+        zero or more PullProgress messages, and finally a PullResult.
+
+        Args:
+            registry: Registry hostname (e.g. "myregistry.azurecr.io")
+            repository: Repository path (e.g. "sonic-os-images")
+            local_path: Destination path on the DUT (e.g. "/tmp/image.bin")
+            tag: Image tag (e.g. "v1.0"). Mutually exclusive with digest.
+            digest: Image digest (e.g. "sha256:abc..."). Mutually exclusive with tag.
+            username: Basic auth username (omit for anonymous)
+            password: Basic auth password
+
+        Returns:
+            List of streaming response dicts, each containing one of:
+            - {"started": {"manifestDigest": "...", "totalBytes": "..."}}
+            - {"progress": {"bytesTransferred": "...", "totalBytes": "..."}}
+            - {"result": {"manifestDigest": "...", "layerDigest": "...", ...}}
+
+        Raises:
+            ValueError: If neither tag nor digest is provided
+            GrpcConnectionError: If connection fails
+            GrpcCallError: If the gRPC call fails
+            GrpcTimeoutError: If the call times out
+        """
+        if not tag and not digest:
+            raise ValueError("Either tag or digest must be provided")
+
+        # Build the PullRequest message
+        request = {
+            "registry": registry,
+            "repository": repository,
+            "local_path": local_path,
+        }
+
+        # Set the reference (tag or digest)
+        if tag:
+            request["tag"] = tag
+        else:
+            request["digest"] = digest
+
+        # Set auth if credentials provided
+        if username and password:
+            request["auth"] = {
+                "basic": {
+                    "username": username,
+                    "password": password,
+                }
+            }
+
+        logger.info(
+            f"ORAS Pull: registry={registry} repo={repository} "
+            f"ref={tag or digest} -> {local_path}"
+        )
+
+        responses = self.grpc_client.call_server_streaming(
+            "sonic.gnoi.oras.v1.Oras", "Pull", request, metadata=metadata
+        )
+
+        logger.info(f"ORAS Pull completed: received {len(responses)} stream messages")
+        return responses

--- a/tests/common/ptf_grpc.py
+++ b/tests/common/ptf_grpc.py
@@ -503,7 +503,9 @@ class PtfGrpc:
             GrpcTimeoutError: If call times out
         """
         service_method = f"{service}/{method}"
-        cmd = self._build_grpcurl_cmd(service_method=service_method)
+        # "-d @" tells grpcurl to take the request body from stdin; without
+        # it the piped-in request is ignored and an empty message is sent
+        cmd = self._build_grpcurl_cmd(extra_args=["-d", "@"], service_method=service_method, metadata=metadata)
 
         # Prepare request data
         request_data = "{}"  # Default empty JSON
@@ -515,32 +517,33 @@ class PtfGrpc:
 
         result = self._execute_grpcurl(cmd, request_data)
 
-        # Parse streaming responses (handle both single-line and multi-line JSON)
+        # Parse streaming responses. grpcurl -format json pretty-prints each
+        # stream message as its own multi-line JSON object, back to back, so
+        # neither json.loads on the whole output nor line-by-line parsing
+        # works. Decode objects incrementally instead.
         responses = []
         stdout_content = result['stdout'].strip()
-
-        # First try to parse entire output as a single JSON object (for unary calls)
-        try:
-            single_response = json.loads(stdout_content)
-            responses.append(single_response)
-            logger.debug(f"Parsed single JSON response from {service_method}: {single_response}")
-        except json.JSONDecodeError:
-            # If that fails, try parsing line by line for streaming responses
-            stdout_lines = stdout_content.split('\n')
-
-            for line in stdout_lines:
-                line = line.strip()
-                if not line:
-                    continue
-
-                try:
-                    response = json.loads(line)
-                    responses.append(response)
-                    logger.debug(f"Streaming response from {service_method}: {response}")
-                except json.JSONDecodeError as e:
-                    # Log the error but continue parsing other lines
-                    logger.debug(f"Failed to parse streaming response line '{line}': {e}")
-                    continue
+        decoder = json.JSONDecoder()
+        idx = 0  # cursor: position in stdout_content we have parsed up to
+        while idx < len(stdout_content):
+            try:
+                # Read ONE complete {...} object starting at idx; 'end' is
+                # the position right after it (raw_decode tolerates trailing
+                # text, unlike json.loads)
+                response, end = decoder.raw_decode(stdout_content, idx)
+            except json.JSONDecodeError as e:
+                # Remaining text is not JSON (e.g. a trailing error line) --
+                # keep what we parsed so far
+                logger.debug(
+                    f"Stopped parsing stream output from {service_method} at offset {idx}: {e}")
+                break
+            responses.append(response)
+            logger.debug(f"Streaming response from {service_method}: {response}")
+            # Move the cursor past this object and any whitespace/newlines
+            # separating it from the next one
+            idx = end
+            while idx < len(stdout_content) and stdout_content[idx] in ' \t\r\n':
+                idx += 1
 
         if not responses:
             raise GrpcCallError(f"No valid responses received from streaming call {service_method}")

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -21,6 +21,48 @@ VRF_SCENARIOS = [
 ]
 
 
+def pytest_addoption(parser):
+    """
+     * CLI options for the gNOI ORAS Pull tests (tests/gnmi/test_gnoi_oras.py).
+     *
+     * By default the ORAS tests are fully self-contained: they spin up a
+     * throwaway local registry on the PTF host (see the oras_registry
+     * fixture in test_gnoi_oras.py), so no external registry or
+     * credentials are required.
+     *
+     * These options only matter if you want to point the tests at a real,
+     * external registry instead. None of them have a hardcoded default --
+     * if --oras_test_registry is left unset, the tests stay in local mode.
+    """
+    parser.addoption(
+        "--oras_test_registry",
+        action="store",
+        default=None,
+        help="External ORAS registry host (e.g. myregistry.azurecr.io). "
+             "Setting this switches the ORAS tests from local (self-hosted) "
+             "mode to external mode.",
+    )
+    parser.addoption(
+        "--oras_test_repository",
+        action="store",
+        default=None,
+        help="External ORAS repository/image name (external mode only).",
+    )
+    parser.addoption(
+        "--oras_test_tag",
+        action="store",
+        default=None,
+        help="External ORAS tag to pull (external mode only).",
+    )
+    parser.addoption(
+        "--oras_test_username",
+        action="store",
+        default=None,
+        help="External ORAS registry username (external mode only). "
+             "Password is resolved from Ansible creds ('oras_registry_password').",
+    )
+
+
 @pytest.fixture(scope="module", params=VRF_SCENARIOS, ids=lambda scenario: f"vrf_{scenario['name']}")
 def vrf_config(request):
     return request.param

--- a/tests/gnmi/oras/registry_server.py
+++ b/tests/gnmi/oras/registry_server.py
@@ -1,0 +1,136 @@
+"""
+Minimal pull-only OCI registry for the gNOI ORAS tests.
+
+Runs on the PTF host (which has no Docker daemon, so a real registry:2
+container is not an option there). Serves pre-generated artifact files
+from a data directory over HTTPS with Basic auth -- just the read-side
+subset of the OCI distribution API that the DUT's oras-go client needs:
+
+    GET/HEAD /v2/                          -> 200 (API version probe)
+    GET/HEAD /v2/<repo>/manifests/<tag>    -> manifest JSON
+    GET/HEAD /v2/<repo>/blobs/<digest>     -> blob bytes
+
+Every request must carry the expected Basic auth header; anything else
+gets 401 with a "Basic realm" challenge. Unknown tags/digests get 404.
+
+Expected data directory layout (created by the test fixture):
+    server.crt, server.key   TLS certificate for this host's IP
+    manifests/<tag>          manifest JSON files
+    blobs/<sha256:...>       blob files named by their digest
+"""
+
+import argparse
+import base64
+import hashlib
+import os
+import re
+import ssl
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+MANIFEST_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json"
+
+# Tags are plain identifiers (e.g. "latest", "v1.2.3"); digests look like
+# "sha256:<hex>". Reject anything outside this allowlist before it is ever
+# used to build a filesystem path, rather than relying solely on
+# basename()/realpath() containment checks after the fact.
+SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.:-]*$")
+
+
+class OrasRegistryHandler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        self._handle(send_body=True)
+
+    def do_HEAD(self):
+        self._handle(send_body=False)
+
+    def _handle(self, send_body):
+        # Reject anything without the exact expected Basic auth header
+        if self.headers.get("Authorization") != self.server.auth_header:
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="Registry"')
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        # Route by path; the repository name segment is intentionally ignored
+        path = self.path.split("?", 1)[0]
+        if path in ("/v2", "/v2/"):
+            body, content_type = b"{}", "application/json"
+        elif "/manifests/" in path:
+            body = self._read_file("manifests", path.rsplit("/manifests/", 1)[1])
+            content_type = MANIFEST_MEDIA_TYPE
+        elif "/blobs/" in path:
+            body = self._read_file("blobs", path.rsplit("/blobs/", 1)[1])
+            content_type = "application/octet-stream"
+        else:
+            body = None
+
+        if body is None:
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        # Clients use this header to verify what they got is what they asked for
+        self.send_header(
+            "Docker-Content-Digest",
+            "sha256:" + hashlib.sha256(body).hexdigest())
+        self.end_headers()
+        if send_body:
+            self.wfile.write(body)
+
+    def _read_file(self, subdir, name):
+        # Reject anything that isn't a plain tag/digest identifier before it
+        # ever touches a filesystem path -- no "/", "..", or other
+        # traversal-relevant characters are permitted.
+        if not SAFE_NAME_RE.match(name):
+            return None
+        base_dir = os.path.realpath(os.path.join(self.server.data_dir, subdir))
+        # Resolve the request against the set of files actually present in
+        # base_dir (a fixed, trusted location) rather than trusting the
+        # client-supplied name to build a path directly. Only a name that is
+        # an exact match for an existing entry is ever opened.
+        try:
+            existing_names = set(os.listdir(base_dir))
+        except OSError:
+            return None
+        if name not in existing_names:
+            return None
+        fpath = os.path.join(base_dir, name)
+        if not os.path.isfile(fpath):
+            return None
+        with open(fpath, "rb") as f:
+            return f.read()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--dir", required=True, help="data directory")
+    parser.add_argument("--username", required=True)
+    parser.add_argument("--password", required=True)
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer(("", args.port), OrasRegistryHandler)
+    server.data_dir = args.dir
+    # Precompute the one header value that counts as authenticated
+    creds = "{}:{}".format(args.username, args.password).encode()
+    server.auth_header = "Basic " + base64.b64encode(creds).decode()
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    # Disallow the deprecated TLSv1 / TLSv1.1 protocol versions
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+    context.load_cert_chain(
+        os.path.join(args.dir, "server.crt"),
+        os.path.join(args.dir, "server.key"))
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/gnmi/oras/registry_server.py
+++ b/tests/gnmi/oras/registry_server.py
@@ -1,0 +1,112 @@
+"""
+Minimal pull-only OCI registry for the gNOI ORAS tests.
+
+Runs on the PTF host (which has no Docker daemon, so a real registry:2
+container is not an option there). Serves pre-generated artifact files
+from a data directory over HTTPS with Basic auth -- just the read-side
+subset of the OCI distribution API that the DUT's oras-go client needs:
+
+    GET/HEAD /v2/                          -> 200 (API version probe)
+    GET/HEAD /v2/<repo>/manifests/<tag>    -> manifest JSON
+    GET/HEAD /v2/<repo>/blobs/<digest>     -> blob bytes
+
+Every request must carry the expected Basic auth header; anything else
+gets 401 with a "Basic realm" challenge. Unknown tags/digests get 404.
+
+Expected data directory layout (created by the test fixture):
+    server.crt, server.key   TLS certificate for this host's IP
+    manifests/<tag>          manifest JSON files
+    blobs/<sha256:...>       blob files named by their digest
+"""
+
+import argparse
+import base64
+import hashlib
+import os
+import ssl
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+MANIFEST_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json"
+
+
+class OrasRegistryHandler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        self._handle(send_body=True)
+
+    def do_HEAD(self):
+        self._handle(send_body=False)
+
+    def _handle(self, send_body):
+        # Reject anything without the exact expected Basic auth header
+        if self.headers.get("Authorization") != self.server.auth_header:
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="Registry"')
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        # Route by path; the repository name segment is intentionally ignored
+        path = self.path.split("?", 1)[0]
+        if path in ("/v2", "/v2/"):
+            body, content_type = b"{}", "application/json"
+        elif "/manifests/" in path:
+            body = self._read_file("manifests", path.rsplit("/manifests/", 1)[1])
+            content_type = MANIFEST_MEDIA_TYPE
+        elif "/blobs/" in path:
+            body = self._read_file("blobs", path.rsplit("/blobs/", 1)[1])
+            content_type = "application/octet-stream"
+        else:
+            body = None
+
+        if body is None:
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        # Clients use this header to verify what they got is what they asked for
+        self.send_header(
+            "Docker-Content-Digest",
+            "sha256:" + hashlib.sha256(body).hexdigest())
+        self.end_headers()
+        if send_body:
+            self.wfile.write(body)
+
+    def _read_file(self, subdir, name):
+        # basename() blocks path traversal via crafted tag/digest names
+        fpath = os.path.join(self.server.data_dir, subdir, os.path.basename(name))
+        if not os.path.isfile(fpath):
+            return None
+        with open(fpath, "rb") as f:
+            return f.read()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--dir", required=True, help="data directory")
+    parser.add_argument("--username", required=True)
+    parser.add_argument("--password", required=True)
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer(("", args.port), OrasRegistryHandler)
+    server.data_dir = args.dir
+    # Precompute the one header value that counts as authenticated
+    creds = "{}:{}".format(args.username, args.password).encode()
+    server.auth_header = "Basic " + base64.b64encode(creds).decode()
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(
+        os.path.join(args.dir, "server.crt"),
+        os.path.join(args.dir, "server.key"))
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/gnmi/oras/registry_server.py
+++ b/tests/gnmi/oras/registry_server.py
@@ -77,18 +77,21 @@ class OrasRegistryHandler(BaseHTTPRequestHandler):
             self.wfile.write(body)
 
     def _read_file(self, subdir, name):
-        # Strip any directory components from the crafted tag/digest name, then
-        # resolve the final path and confirm it is still contained within the
-        # intended sub-directory. This defends against path traversal even if
-        # basename() leaves anything unexpected behind (e.g. symlinks).
-        base_dir = os.path.realpath(os.path.join(self.server.data_dir, subdir))
-        fpath = os.path.realpath(os.path.join(base_dir, os.path.basename(name)))
-        if os.path.commonpath([base_dir, fpath]) != base_dir:
-            return None
-        if not os.path.isfile(fpath):
-            return None
-        with open(fpath, "rb") as f:
-            return f.read()
+        return self.server.files.get(subdir, {}).get(name)
+
+
+def _load_registry_files(data_dir):
+    files = {}
+    for subdir in ("manifests", "blobs"):
+        files[subdir] = {}
+        directory = os.path.join(data_dir, subdir)
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                with open(entry.path, "rb") as f:
+                    files[subdir][entry.name] = f.read()
+    return files
 
 
 def main():
@@ -100,7 +103,9 @@ def main():
     args = parser.parse_args()
 
     server = ThreadingHTTPServer(("", args.port), OrasRegistryHandler)
-    server.data_dir = args.dir
+    # Load the fixed test artifact before accepting requests. Request path
+    # components are then dictionary keys, never filesystem path expressions.
+    server.files = _load_registry_files(args.dir)
     # Precompute the one header value that counts as authenticated
     creds = "{}:{}".format(args.username, args.password).encode()
     server.auth_header = "Basic " + base64.b64encode(creds).decode()

--- a/tests/gnmi/oras/registry_server.py
+++ b/tests/gnmi/oras/registry_server.py
@@ -77,8 +77,14 @@ class OrasRegistryHandler(BaseHTTPRequestHandler):
             self.wfile.write(body)
 
     def _read_file(self, subdir, name):
-        # basename() blocks path traversal via crafted tag/digest names
-        fpath = os.path.join(self.server.data_dir, subdir, os.path.basename(name))
+        # Strip any directory components from the crafted tag/digest name, then
+        # resolve the final path and confirm it is still contained within the
+        # intended sub-directory. This defends against path traversal even if
+        # basename() leaves anything unexpected behind (e.g. symlinks).
+        base_dir = os.path.realpath(os.path.join(self.server.data_dir, subdir))
+        fpath = os.path.realpath(os.path.join(base_dir, os.path.basename(name)))
+        if os.path.commonpath([base_dir, fpath]) != base_dir:
+            return None
         if not os.path.isfile(fpath):
             return None
         with open(fpath, "rb") as f:
@@ -100,6 +106,8 @@ def main():
     server.auth_header = "Basic " + base64.b64encode(creds).decode()
 
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    # Disallow the deprecated TLSv1 / TLSv1.1 protocol versions
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
     context.load_cert_chain(
         os.path.join(args.dir, "server.crt"),
         os.path.join(args.dir, "server.key"))

--- a/tests/gnmi/test_gnoi_oras.py
+++ b/tests/gnmi/test_gnoi_oras.py
@@ -1,0 +1,531 @@
+"""
+ * test_gnoi_oras.py -- Integration tests for gNOI ORAS Pull service.
+ *
+ * This module tests the sonic.gnoi.oras.v1.Oras service which allows
+ * an orchestrator to instruct a SONiC switch to pull an OCI/ORAS
+ * artifact (e.g. a SONiC OS image) from a container registry into
+ * local storage on the device.
+ *
+ * The Pull RPC is a server-streaming call that returns:
+ *   PullStarted  -> manifest resolved, total size known
+ *   PullProgress -> periodic byte-count updates (~1/sec)
+ *   PullResult   -> final digest, bytes written, elapsed time
+ *
+ * Registry: by default the tests are fully self-contained -- the
+ * oras_registry fixture starts a minimal pull-only OCI registry
+ * (gnmi/oras/registry_server.py, TLS + basic auth) on the PTF host,
+ * pre-loads it with a single-layer OCI artifact, and installs the
+ * CA into the DUT gnmi container trust store so the gNOI server can
+ * verify the registry certificate. The DUT reaches the registry at
+ * the PTF management IP (works on both virtual and physical
+ * testbeds; no internet/DNS/default route required).
+ *
+ * To test against an external registry instead (tests/gnmi/conftest.py):
+ *   --oras_test_registry     e.g. "myregistry.azurecr.io" (enables external mode)
+ *   --oras_test_repository   repository/image name
+ *   --oras_test_tag          tag to pull
+ *   --oras_test_username     registry username
+ * The password is never hardcoded or passed on the CLI -- it is resolved
+ * from the Ansible-managed (vaulted) secrets for the testbed via
+ * creds_on_dut() ('oras_registry_password'). External-mode tests skip if
+ * it isn't configured.
+ *
+ * Prerequisites:
+ *   - DUT must be running a sonic-gnmi build that includes the Oras
+ *     service (PR #692 or later).
+"""
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import tempfile
+
+import pytest
+import requests
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.dut_utils import creds_on_dut
+from tests.common.cert_utils import TlsCertificateGenerator
+from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
+from tests.common.utilities import wait_until
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("any"),
+]
+
+# ---------------------------------------------------------------------------
+# Test configuration
+# ---------------------------------------------------------------------------
+
+# Where to store the pulled artifact on the DUT
+ORAS_LOCAL_PATH = "/tmp/oras_test_image.bin"
+
+# Local registry (hermetic mode) settings -- served from the PTF host
+LOCAL_REGISTRY_PORT = 15000
+PTF_REGISTRY_DIR = "/root/oras_registry"          # data dir on the PTF host
+PTF_REGISTRY_SCRIPT = "/root/oras_registry_server.py"
+LOCAL_REPOSITORY = "sonic-oras-test"
+LOCAL_TAG = "sonic-oras-test-artifact"
+LOCAL_USERNAME = "orastest"
+# Local-only credential for the throwaway per-run registry; not a secret.
+LOCAL_PASSWORD = "orastest-Secret-1"
+LOCAL_PAYLOAD_SIZE = 1024 * 1024  # 1 MiB single-layer artifact
+
+
+# ---------------------------------------------------------------------------
+# Local registry helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_artifact_files(workdir, payload, tag):
+    """
+     * Write the files for a single-layer OCI artifact (config blob + one
+     * layer + manifest) in the layout registry_server.py serves from:
+     *   blobs/<digest>   and   manifests/<tag>
+     * Returns the layer digest.
+    """
+    blobs_dir = os.path.join(workdir, "blobs")
+    manifests_dir = os.path.join(workdir, "manifests")
+    os.makedirs(blobs_dir)
+    os.makedirs(manifests_dir)
+
+    # Content-addressable IDs: blobs are stored/fetched by their sha256
+    layer_digest = "sha256:" + hashlib.sha256(payload).hexdigest()
+    config_blob = b"{}"  # minimal empty-JSON config (OCI manifests require one)
+    config_digest = "sha256:" + hashlib.sha256(config_blob).hexdigest()
+    for data, digest in ((payload, layer_digest), (config_blob, config_digest)):
+        with open(os.path.join(blobs_dir, digest), "wb") as f:
+            f.write(data)
+
+    # The manifest ties config + layer together and is looked up by tag
+    manifest = {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": config_digest,
+            "size": len(config_blob),
+        },
+        "layers": [
+            {
+                "mediaType": "application/octet-stream",
+                "digest": layer_digest,
+                "size": len(payload),
+                "annotations": {"org.opencontainers.image.title": tag},
+            }
+        ],
+    }
+    manifest_bytes = json.dumps(manifest).encode()
+    manifest_digest = "sha256:" + hashlib.sha256(manifest_bytes).hexdigest()
+    # oras clients resolve the tag first, then fetch the manifest again by
+    # its digest -- so serve the same bytes under both names
+    for name in (tag, manifest_digest):
+        with open(os.path.join(manifests_dir, name), "wb") as f:
+            f.write(manifest_bytes)
+    return layer_digest
+
+
+def _find_gnmi_container(duthost):
+    """Return the name of the gNMI/telemetry container on the DUT."""
+    # NF-based awk instead of --format '{{.Names}}': double braces would be
+    # eaten by Ansible's Jinja2 templating of module args.
+    names = duthost.shell("docker ps | awk 'NR>1 {print $NF}'")["stdout_lines"]
+    container = next((c for c in ("gnmi", "telemetry") if c in names), None)
+    if container is None:
+        pytest.skip("No gnmi/telemetry container running on DUT")
+    return container
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def oras_registry(request, duthosts, rand_one_dut_hostname, ptfhost):
+    """
+     * Provide registry connection info for the ORAS pull tests.
+     *
+     * External mode (--oras_test_registry passed on the CLI): registry/
+     * repository/tag/username come from CLI options (tests/gnmi/conftest.py),
+     * password from the Ansible-managed (vaulted) secrets for the testbed
+     * via creds_on_dut() ('oras_registry_password'). No setup is performed.
+     *
+     * Local mode (default -- no CLI options needed): run a minimal
+     * pull-only OCI registry (gnmi/oras/registry_server.py, TLS + basic
+     * auth) on the PTF host, pre-loaded with a 1 MiB single-layer
+     * artifact, and trust the CA inside the DUT gnmi container. The DUT
+     * reaches it at the PTF management IP, which works on virtual and
+     * physical testbeds alike. Torn down completely at module end.
+     *
+     * Yields a dict:
+     *   registry, repository, tag, username, password,
+     *   expected_layer_digest (local mode only), expected_size (local only)
+    """
+    external_registry = (request.config.getoption("--oras_test_registry", default=None) or "").strip()
+    if external_registry:
+        duthost = duthosts[rand_one_dut_hostname]
+        creds = creds_on_dut(duthost)
+        repository = (request.config.getoption("--oras_test_repository", default=None) or "").strip()
+        tag = (request.config.getoption("--oras_test_tag", default=None) or "").strip()
+        username = (request.config.getoption("--oras_test_username", default=None) or "").strip()
+        password = (creds.get("oras_registry_password") or "").strip()
+        logger.info("Using external registry %s", external_registry)
+        yield {
+            "registry": external_registry,
+            "repository": repository,
+            "tag": tag,
+            "username": username,
+            "password": password,
+            "external": True,
+        }
+        return
+
+    duthost = duthosts[rand_one_dut_hostname]
+    ptf_ip = ptfhost.mgmt_ip
+    if not ptf_ip:
+        pytest.skip("PTF host has no IPv4 management address -- cannot host local registry")
+    registry = "{}:{}".format(ptf_ip, LOCAL_REGISTRY_PORT)
+    base_url = "https://{}".format(registry)
+    gnmi_container = _find_gnmi_container(duthost)
+
+    workdir = tempfile.mkdtemp(prefix="oras_registry_")
+    ca_bundle = "/etc/ssl/certs/ca-certificates.crt"
+    try:
+        # -- TLS certs: CA + server cert with the PTF IP in the SAN --------
+        cert_gen = TlsCertificateGenerator(server_ip=ptf_ip)
+        cert_gen.write_all(workdir)
+        ca_file = os.path.join(workdir, "ca.crt")
+
+        # -- Build the test artifact locally --------------------------------
+        # Random 1 MiB payload => unique digest per run, no stale-cache hits
+        payload = os.urandom(LOCAL_PAYLOAD_SIZE)
+        layer_digest = _write_artifact_files(workdir, payload, LOCAL_TAG)
+
+        # -- Deploy artifact + certs + server script to the PTF host --------
+        logger.info("Starting local ORAS registry at %s on PTF %s", registry, ptfhost.hostname)
+        ptfhost.shell("pkill -9 -f {}".format(PTF_REGISTRY_SCRIPT),
+                      module_ignore_errors=True)
+        ptfhost.shell("rm -rf {dir} && mkdir -p {dir}".format(dir=PTF_REGISTRY_DIR))
+        # Copying a directory (no trailing slash) copies it recursively
+        for name in ("blobs", "manifests", "server.crt", "server.key"):
+            ptfhost.copy(src=os.path.join(workdir, name),
+                         dest="{}/".format(PTF_REGISTRY_DIR))
+        ptfhost.copy(src="gnmi/oras/registry_server.py", dest=PTF_REGISTRY_SCRIPT)
+
+        # -- Start the registry server (same interpreter the gNMI CRL -------
+        #    server on the PTF already relies on)
+        ptfhost.shell(
+            "nohup /root/env-python3/bin/python {script} "
+            "--port {port} --dir {dir} --username {user} --password {pw} "
+            "> {dir}/server.log 2>&1 &".format(
+                script=PTF_REGISTRY_SCRIPT, port=LOCAL_REGISTRY_PORT,
+                dir=PTF_REGISTRY_DIR, user=LOCAL_USERNAME, pw=LOCAL_PASSWORD)
+        )
+
+        def _registry_up():
+            try:
+                # 200 = serving, 401 = serving but wants auth -- both mean "up"
+                code = requests.get("{}/v2/".format(base_url),
+                                    verify=ca_file, timeout=5).status_code
+                return code in (200, 401)
+            except Exception:
+                return False
+
+        pytest_assert(wait_until(60, 2, 0, _registry_up),
+                      "Local registry did not become ready at {}".format(base_url))
+        logger.info("Serving test artifact %s/%s:%s layer=%s size=%d",
+                    registry, LOCAL_REPOSITORY, LOCAL_TAG,
+                    layer_digest, len(payload))
+
+        # -- Trust the CA inside the DUT gnmi container ----------------------
+        #    The gNOI Oras client verifies the registry cert against the
+        #    container's system trust store; append our CA (backing up the
+        #    original bundle for teardown). Survives gnmi process restarts.
+        duthost.copy(src=ca_file, dest="/tmp/oras_test_ca.crt")
+        duthost.shell(
+            "docker exec {c} sh -c 'cp {b} {b}.oras_bak'".format(
+                c=gnmi_container, b=ca_bundle))
+        # Stream via stdin: docker cp can't reach tmpfs-backed paths like /tmp
+        duthost.shell(
+            "docker exec -i {c} sh -c 'cat >> {b}' < /tmp/oras_test_ca.crt".format(
+                c=gnmi_container, b=ca_bundle))
+
+        yield {
+            "registry": registry,
+            "repository": LOCAL_REPOSITORY,
+            "tag": LOCAL_TAG,
+            "username": LOCAL_USERNAME,
+            "password": LOCAL_PASSWORD,
+            "expected_layer_digest": layer_digest,
+            "expected_size": len(payload),
+            "external": False,
+        }
+    finally:
+        # -- Teardown: restore trust store, stop and remove registry ---------
+        duthost.shell(
+            "docker exec {c} sh -c 'mv {b}.oras_bak {b}'".format(
+                c=gnmi_container, b=ca_bundle),
+            module_ignore_errors=True)
+        duthost.shell("rm -f /tmp/oras_test_ca.crt", module_ignore_errors=True)
+        ptfhost.shell("pkill -9 -f {}".format(PTF_REGISTRY_SCRIPT),
+                      module_ignore_errors=True)
+        ptfhost.shell("rm -rf {} {}".format(PTF_REGISTRY_DIR, PTF_REGISTRY_SCRIPT),
+                      module_ignore_errors=True)
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def skip_if_external_and_no_password(cfg):
+    """
+     * In external-registry mode the tests need a real credential; skip
+     * if it wasn't provided. Local mode always has working credentials.
+    """
+    if cfg.get("external") and not cfg["password"]:
+        pytest.skip(
+            "External ORAS registry configured but 'oras_registry_password' "
+            "is not set in the Ansible secrets for this testbed -- skipping."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_gnoi_oras_pull_basic_auth(duthosts, rand_one_dut_hostname, oras_registry, gnmi_tls):  # noqa: F811
+    """
+     * test_gnoi_oras_pull_basic_auth
+     *
+     * Verify the Oras.Pull RPC can download an artifact from a registry
+     * using basic (username/password) authentication.
+     *
+     * Steps:
+     *   1. Call Oras.Pull with registry, repo, tag, and credentials.
+     *   2. Assert we receive a PullStarted message with total_bytes > 0.
+     *   3. Assert the final PullResult contains a valid layer digest.
+     *   4. Verify the file actually exists on the DUT at local_path.
+     *   5. Clean up the downloaded file.
+    """
+    cfg = oras_registry
+    skip_if_external_and_no_password(cfg)
+
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # -- Step 1: Call the Pull RPC ----------------------------------------
+    logger.info(
+        f"Pulling {cfg['registry']}/{cfg['repository']}:{cfg['tag']} "
+        f"-> {ORAS_LOCAL_PATH}"
+    )
+
+    # Blocks until the server-side stream finishes; returns the list of
+    # streamed messages (started / progress / result) as parsed dicts
+    responses = gnmi_tls.gnoi.oras_pull(
+        registry=cfg["registry"],
+        repository=cfg["repository"],
+        local_path=ORAS_LOCAL_PATH,
+        tag=cfg["tag"],
+        username=cfg["username"],
+        password=cfg["password"],
+    )
+
+    # -- Step 2: Validate PullStarted -------------------------------------
+    #    First message in the stream should be PullStarted.
+    pytest_assert(
+        len(responses) >= 2,
+        f"Expected at least 2 stream messages (started + result), got {len(responses)}"
+    )
+
+    first = responses[0]
+    pytest_assert(
+        "started" in first,
+        f"First stream message should be 'started', got: {first}"
+    )
+
+    total_bytes = int(first["started"].get("totalBytes", 0))
+    pytest_assert(
+        total_bytes > 0,
+        f"PullStarted.total_bytes should be > 0, got {total_bytes}"
+    )
+    logger.info(f"PullStarted: manifest resolved, total_bytes={total_bytes}")
+
+    # -- Step 3: Validate PullResult --------------------------------------
+    #    Last message in the stream should be PullResult.
+    last = responses[-1]
+    pytest_assert(
+        "result" in last,
+        f"Last stream message should be 'result', got: {last}"
+    )
+
+    result = last["result"]
+    layer_digest = result.get("layerDigest", "")
+    pytest_assert(
+        layer_digest.startswith("sha256:"),
+        f"Expected layer_digest to start with 'sha256:', got: {layer_digest}"
+    )
+
+    # In local mode we know exactly what was pushed -- verify end to end.
+    if cfg.get("expected_layer_digest"):
+        pytest_assert(
+            layer_digest == cfg["expected_layer_digest"],
+            f"layer_digest {layer_digest} != pushed digest {cfg['expected_layer_digest']}"
+        )
+        pytest_assert(
+            total_bytes == cfg["expected_size"],
+            f"total_bytes {total_bytes} != pushed size {cfg['expected_size']}"
+        )
+
+    bytes_written = int(result.get("bytesWritten", 0))
+    pytest_assert(
+        bytes_written == total_bytes,
+        f"bytes_written ({bytes_written}) should match total_bytes ({total_bytes})"
+    )
+    logger.info(f"PullResult: layer_digest={layer_digest}, bytes_written={bytes_written}")
+
+    # -- Step 4: Verify file exists on DUT --------------------------------
+    stat_cmd = f"stat --format='%s' {ORAS_LOCAL_PATH}"
+    stat_result = duthost.shell(stat_cmd, module_ignore_errors=True)
+    pytest_assert(
+        stat_result["rc"] == 0,
+        f"File {ORAS_LOCAL_PATH} not found on DUT after pull"
+    )
+
+    file_size = int(stat_result["stdout"].strip())
+    pytest_assert(
+        file_size == bytes_written,
+        f"File size on disk ({file_size}) != bytes_written ({bytes_written})"
+    )
+    logger.info(f"File verified on DUT: {ORAS_LOCAL_PATH} ({file_size} bytes)")
+
+    # -- Step 5: Cleanup --------------------------------------------------
+    duthost.shell(f"rm -f {ORAS_LOCAL_PATH}", module_ignore_errors=True)
+    logger.info("Cleanup complete")
+
+
+def test_gnoi_oras_pull_invalid_path(oras_registry, gnmi_tls):  # noqa: F811
+    """
+     * test_gnoi_oras_pull_invalid_path
+     *
+     * Verify that the Oras.Pull RPC rejects a local_path that is
+     * outside the allowed directories (/tmp, /var/tmp, /host).
+     *
+     * The server should return a FailedPrecondition (or InvalidArgument)
+     * gRPC error without downloading anything.
+    """
+    cfg = oras_registry
+    skip_if_external_and_no_password(cfg)
+
+    with pytest.raises(Exception) as exc_info:
+        gnmi_tls.gnoi.oras_pull(
+            registry=cfg["registry"],
+            repository=cfg["repository"],
+            local_path="/etc/passwd",  # Not allowed!
+            tag=cfg["tag"],
+            username=cfg["username"],
+            password=cfg["password"],
+        )
+
+    # The error should mention permission/precondition/allowlist
+    error_msg = str(exc_info.value).lower()
+    pytest_assert(
+        any(term in error_msg for term in ["precondition", "permission", "allowlist", "invalid"]),
+        f"Expected path rejection error, got: {exc_info.value}"
+    )
+    logger.info(f"Path correctly rejected: {exc_info.value}")
+
+
+def test_gnoi_oras_pull_bad_credentials(oras_registry, gnmi_tls):  # noqa: F811
+    """
+     * test_gnoi_oras_pull_bad_credentials
+     *
+     * Verify that the Oras.Pull RPC returns Unauthenticated when
+     * given wrong credentials.
+    """
+    cfg = oras_registry
+
+    with pytest.raises(Exception) as exc_info:
+        gnmi_tls.gnoi.oras_pull(
+            registry=cfg["registry"],
+            repository=cfg["repository"],
+            local_path=ORAS_LOCAL_PATH,
+            tag=cfg["tag"],
+            username="wrong_user",
+            password="wrong_password",
+        )
+
+    error_msg = str(exc_info.value).lower()
+    pytest_assert(
+        any(term in error_msg for term in ["unauthenticated", "unauthorized", "401"]),
+        f"Expected auth error, got: {exc_info.value}"
+    )
+    logger.info(f"Bad credentials correctly rejected: {exc_info.value}")
+
+
+def test_gnoi_oras_pull_nonexistent_tag(oras_registry, gnmi_tls):  # noqa: F811
+    """
+     * test_gnoi_oras_pull_nonexistent_tag
+     *
+     * Verify that the Oras.Pull RPC returns an appropriate error
+     * when the requested tag does not exist in the registry.
+    """
+    cfg = oras_registry
+    skip_if_external_and_no_password(cfg)
+
+    with pytest.raises(Exception) as exc_info:
+        gnmi_tls.gnoi.oras_pull(
+            registry=cfg["registry"],
+            repository=cfg["repository"],
+            local_path=ORAS_LOCAL_PATH,
+            tag="this-tag-does-not-exist-12345",
+            username=cfg["username"],
+            password=cfg["password"],
+        )
+
+    error_msg = str(exc_info.value).lower()
+    pytest_assert(
+        any(term in error_msg for term in ["not found", "notfound", "404", "unavailable", "unknown"]),
+        f"Expected not-found error, got: {exc_info.value}"
+    )
+    logger.info(f"Nonexistent tag correctly rejected: {exc_info.value}")
+
+
+def test_gnoi_oras_pull_anonymous_denied(oras_registry, gnmi_tls):  # noqa: F811
+    """
+     * test_gnoi_oras_pull_anonymous_denied
+     *
+     * Verify that pulling from a private registry without credentials
+     * returns an authentication error.
+     *
+     * The local registry fixture always requires auth; in external mode
+     * this assumes the configured registry does too.
+    """
+    cfg = oras_registry
+
+    with pytest.raises(Exception) as exc_info:
+        gnmi_tls.gnoi.oras_pull(
+            registry=cfg["registry"],
+            repository=cfg["repository"],
+            local_path=ORAS_LOCAL_PATH,
+            tag=cfg["tag"],
+            # No credentials -- anonymous
+        )
+
+    # Registries answering with a Bearer challenge (e.g. ACR) yield a 401
+    # ("unauthenticated"/"unauthorized"); registries with a Basic realm make
+    # oras-go fail client-side with "basic credential not found". Both mean
+    # anonymous access was denied.
+    error_msg = str(exc_info.value).lower()
+    pytest_assert(
+        any(term in error_msg for term in
+            ["unauthenticated", "unauthorized", "401", "credential not found"]),
+        f"Expected auth error for anonymous pull, got: {exc_info.value}"
+    )
+    logger.info(f"Anonymous pull correctly denied: {exc_info.value}")

--- a/tests/gnmi/test_gnoi_oras.py
+++ b/tests/gnmi/test_gnoi_oras.py
@@ -1,0 +1,278 @@
+"""
+ * test_gnoi_oras.py -- Integration tests for gNOI ORAS Pull service.
+ *
+ * This module tests the sonic.gnoi.oras.v1.Oras service which allows
+ * an orchestrator to instruct a SONiC switch to pull an OCI/ORAS
+ * artifact (e.g. a SONiC OS image) from a container registry into
+ * local storage on the device.
+ *
+ * The Pull RPC is a server-streaming call that returns:
+ *   PullStarted  -> manifest resolved, total size known
+ *   PullProgress -> periodic byte-count updates (~1/sec)
+ *   PullResult   -> final digest, bytes written, elapsed time
+ *
+ * Prerequisites:
+ *   - DUT must be running a sonic-gnmi build that includes the Oras
+ *     service (PR #692 or later).
+ *   - The registry (ksdatatest.azurecr.io) must be reachable from
+ *     the DUT or via an HTTP proxy configured on the gnmi container.
+ *   - Credentials are passed via environment variables:
+ *       ORAS_TEST_USERNAME  (default: ksdatatest)
+ *       ORAS_TEST_PASSWORD  (required)
+"""
+
+import os
+import logging
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("any"),
+]
+
+# ---------------------------------------------------------------------------
+# Test configuration -- override via environment variables if needed
+# ---------------------------------------------------------------------------
+
+ORAS_REGISTRY = os.environ.get("ORAS_TEST_REGISTRY", "ksdatatest.azurecr.io")
+ORAS_REPOSITORY = os.environ.get("ORAS_TEST_REPOSITORY", "sonic-os-images")
+ORAS_TAG = os.environ.get(
+    "ORAS_TEST_TAG", "sonic-broadcom-slim-20230531.46.bin"
+)
+ORAS_USERNAME = os.environ.get("ORAS_TEST_USERNAME", "ksdatatest")
+ORAS_PASSWORD = os.environ.get("ORAS_TEST_PASSWORD", "")
+
+# Where to store the pulled artifact on the DUT
+ORAS_LOCAL_PATH = "/tmp/oras_test_image.bin"
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def skip_if_no_password():
+    """
+     * Skip the test if ORAS_TEST_PASSWORD is not set.
+     * We don't want tests to fail just because creds weren't configured.
+    """
+    if not ORAS_PASSWORD:
+        pytest.skip(
+            "ORAS_TEST_PASSWORD not set -- skipping ORAS pull test. "
+            "Export the env var and re-run."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_gnoi_oras_pull_basic_auth(duthosts, rand_one_dut_hostname, gnmi_tls):  # noqa: F811
+    """
+     * test_gnoi_oras_pull_basic_auth
+     *
+     * Verify the Oras.Pull RPC can download an artifact from ACR
+     * using basic (username/password) authentication.
+     *
+     * Steps:
+     *   1. Call Oras.Pull with registry, repo, tag, and credentials.
+     *   2. Assert we receive a PullStarted message with total_bytes > 0.
+     *   3. Assert the final PullResult contains a valid layer digest.
+     *   4. Verify the file actually exists on the DUT at local_path.
+     *   5. Clean up the downloaded file.
+    """
+    skip_if_no_password()
+
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # -- Step 1: Call the Pull RPC ----------------------------------------
+    logger.info(
+        f"Pulling {ORAS_REGISTRY}/{ORAS_REPOSITORY}:{ORAS_TAG} "
+        f"-> {ORAS_LOCAL_PATH}"
+    )
+
+    responses = gnmi_tls.gnoi.oras_pull(
+        registry=ORAS_REGISTRY,
+        repository=ORAS_REPOSITORY,
+        local_path=ORAS_LOCAL_PATH,
+        tag=ORAS_TAG,
+        username=ORAS_USERNAME,
+        password=ORAS_PASSWORD,
+    )
+
+    # -- Step 2: Validate PullStarted -------------------------------------
+    #    First message in the stream should be PullStarted.
+    pytest_assert(
+        len(responses) >= 2,
+        f"Expected at least 2 stream messages (started + result), got {len(responses)}"
+    )
+
+    first = responses[0]
+    pytest_assert(
+        "started" in first,
+        f"First stream message should be 'started', got: {first}"
+    )
+
+    total_bytes = int(first["started"].get("totalBytes", 0))
+    pytest_assert(
+        total_bytes > 0,
+        f"PullStarted.total_bytes should be > 0, got {total_bytes}"
+    )
+    logger.info(f"PullStarted: manifest resolved, total_bytes={total_bytes}")
+
+    # -- Step 3: Validate PullResult --------------------------------------
+    #    Last message in the stream should be PullResult.
+    last = responses[-1]
+    pytest_assert(
+        "result" in last,
+        f"Last stream message should be 'result', got: {last}"
+    )
+
+    result = last["result"]
+    layer_digest = result.get("layerDigest", "")
+    pytest_assert(
+        layer_digest.startswith("sha256:"),
+        f"Expected layer_digest to start with 'sha256:', got: {layer_digest}"
+    )
+
+    bytes_written = int(result.get("bytesWritten", 0))
+    pytest_assert(
+        bytes_written == total_bytes,
+        f"bytes_written ({bytes_written}) should match total_bytes ({total_bytes})"
+    )
+    logger.info(f"PullResult: layer_digest={layer_digest}, bytes_written={bytes_written}")
+
+    # -- Step 4: Verify file exists on DUT --------------------------------
+    stat_cmd = f"stat --format='%s' {ORAS_LOCAL_PATH}"
+    stat_result = duthost.shell(stat_cmd, module_ignore_errors=True)
+    pytest_assert(
+        stat_result["rc"] == 0,
+        f"File {ORAS_LOCAL_PATH} not found on DUT after pull"
+    )
+
+    file_size = int(stat_result["stdout"].strip())
+    pytest_assert(
+        file_size == bytes_written,
+        f"File size on disk ({file_size}) != bytes_written ({bytes_written})"
+    )
+    logger.info(f"File verified on DUT: {ORAS_LOCAL_PATH} ({file_size} bytes)")
+
+    # -- Step 5: Cleanup --------------------------------------------------
+    duthost.shell(f"rm -f {ORAS_LOCAL_PATH}", module_ignore_errors=True)
+    logger.info("Cleanup complete")
+
+
+def test_gnoi_oras_pull_invalid_path(gnmi_tls):  # noqa: F811
+    """
+     * test_gnoi_oras_pull_invalid_path
+     *
+     * Verify that the Oras.Pull RPC rejects a local_path that is
+     * outside the allowed directories (/tmp, /var/tmp, /host).
+     *
+     * The server should return a FailedPrecondition (or InvalidArgument)
+     * gRPC error without downloading anything.
+    """
+    skip_if_no_password()
+
+    with pytest.raises(Exception) as exc_info:
+        gnmi_tls.gnoi.oras_pull(
+            registry=ORAS_REGISTRY,
+            repository=ORAS_REPOSITORY,
+            local_path="/etc/passwd",  # Not allowed!
+            tag=ORAS_TAG,
+            username=ORAS_USERNAME,
+            password=ORAS_PASSWORD,
+        )
+
+    # The error should mention permission/precondition/allowlist
+    error_msg = str(exc_info.value).lower()
+    pytest_assert(
+        any(term in error_msg for term in ["precondition", "permission", "allowlist", "invalid"]),
+        f"Expected path rejection error, got: {exc_info.value}"
+    )
+    logger.info(f"Path correctly rejected: {exc_info.value}")
+
+
+def test_gnoi_oras_pull_bad_credentials(gnmi_tls):  # noqa: F811
+    """
+     * test_gnoi_oras_pull_bad_credentials
+     *
+     * Verify that the Oras.Pull RPC returns Unauthenticated when
+     * given wrong credentials.
+    """
+    with pytest.raises(Exception) as exc_info:
+        gnmi_tls.gnoi.oras_pull(
+            registry=ORAS_REGISTRY,
+            repository=ORAS_REPOSITORY,
+            local_path=ORAS_LOCAL_PATH,
+            tag=ORAS_TAG,
+            username="wrong_user",
+            password="wrong_password",
+        )
+
+    error_msg = str(exc_info.value).lower()
+    pytest_assert(
+        any(term in error_msg for term in ["unauthenticated", "unauthorized", "401"]),
+        f"Expected auth error, got: {exc_info.value}"
+    )
+    logger.info(f"Bad credentials correctly rejected: {exc_info.value}")
+
+
+def test_gnoi_oras_pull_nonexistent_tag(gnmi_tls):  # noqa: F811
+    """
+     * test_gnoi_oras_pull_nonexistent_tag
+     *
+     * Verify that the Oras.Pull RPC returns an appropriate error
+     * when the requested tag does not exist in the registry.
+    """
+    skip_if_no_password()
+
+    with pytest.raises(Exception) as exc_info:
+        gnmi_tls.gnoi.oras_pull(
+            registry=ORAS_REGISTRY,
+            repository=ORAS_REPOSITORY,
+            local_path=ORAS_LOCAL_PATH,
+            tag="this-tag-does-not-exist-12345",
+            username=ORAS_USERNAME,
+            password=ORAS_PASSWORD,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    pytest_assert(
+        any(term in error_msg for term in ["not found", "404", "unavailable", "unknown"]),
+        f"Expected not-found error, got: {exc_info.value}"
+    )
+    logger.info(f"Nonexistent tag correctly rejected: {exc_info.value}")
+
+
+def test_gnoi_oras_pull_anonymous_denied(gnmi_tls):  # noqa: F811
+    """
+     * test_gnoi_oras_pull_anonymous_denied
+     *
+     * Verify that pulling from a private registry without credentials
+     * returns an authentication error.
+     *
+     * Note: This test assumes ksdatatest.azurecr.io requires auth.
+     * If the registry allows anonymous pulls, this test should be
+     * updated or skipped.
+    """
+    with pytest.raises(Exception) as exc_info:
+        gnmi_tls.gnoi.oras_pull(
+            registry=ORAS_REGISTRY,
+            repository=ORAS_REPOSITORY,
+            local_path=ORAS_LOCAL_PATH,
+            tag=ORAS_TAG,
+            # No credentials -- anonymous
+        )
+
+    error_msg = str(exc_info.value).lower()
+    pytest_assert(
+        any(term in error_msg for term in ["unauthenticated", "unauthorized", "401"]),
+        f"Expected auth error for anonymous pull, got: {exc_info.value}"
+    )
+    logger.info(f"Anonymous pull correctly denied: {exc_info.value}")

--- a/tests/gnmi/test_gnoi_oras.py
+++ b/tests/gnmi/test_gnoi_oras.py
@@ -92,8 +92,9 @@ def test_gnoi_oras_pull_basic_auth(duthosts, rand_one_dut_hostname, gnmi_tls):  
 
     # -- Step 1: Call the Pull RPC ----------------------------------------
     logger.info(
-        f"Pulling {ORAS_REGISTRY}/{ORAS_REPOSITORY}:{ORAS_TAG} "
-        f"-> {ORAS_LOCAL_PATH}"
+        "Pulling {}/{}:{} -> {}".format(
+            ORAS_REGISTRY, ORAS_REPOSITORY, ORAS_TAG, ORAS_LOCAL_PATH
+        )
     )
 
     responses = gnmi_tls.gnoi.oras_pull(
@@ -137,7 +138,7 @@ def test_gnoi_oras_pull_basic_auth(duthosts, rand_one_dut_hostname, gnmi_tls):  
     layer_digest = result.get("layerDigest", "")
     pytest_assert(
         layer_digest.startswith("sha256:"),
-        f"Expected layer_digest to start with 'sha256:', got: {layer_digest}"
+        "Expected layer_digest to start with 'sha256:', got: {}".format(layer_digest)
     )
 
     bytes_written = int(result.get("bytesWritten", 0))

--- a/tests/gnmi/test_gnoi_oras.py
+++ b/tests/gnmi/test_gnoi_oras.py
@@ -11,22 +11,45 @@
  *   PullProgress -> periodic byte-count updates (~1/sec)
  *   PullResult   -> final digest, bytes written, elapsed time
  *
+ * Registry: by default the tests are fully self-contained -- the
+ * oras_registry fixture starts a minimal pull-only OCI registry
+ * (gnmi/oras/registry_server.py, TLS + basic auth) on the PTF host,
+ * pre-loads it with a single-layer OCI artifact, and installs the
+ * CA into the DUT gnmi container trust store so the gNOI server can
+ * verify the registry certificate. The DUT reaches the registry at
+ * the PTF management IP (works on both virtual and physical
+ * testbeds; no internet/DNS/default route required).
+ *
+ * To test against an external registry instead (tests/gnmi/conftest.py):
+ *   --oras_test_registry     e.g. "myregistry.azurecr.io" (enables external mode)
+ *   --oras_test_repository   repository/image name
+ *   --oras_test_tag          tag to pull
+ *   --oras_test_username     registry username
+ * The password is never hardcoded or passed on the CLI -- it is resolved
+ * from the Ansible-managed (vaulted) secrets for the testbed via
+ * creds_on_dut() ('oras_registry_password'). External-mode tests skip if
+ * it isn't configured.
+ *
  * Prerequisites:
  *   - DUT must be running a sonic-gnmi build that includes the Oras
  *     service (PR #692 or later).
- *   - The registry (ksdatatest.azurecr.io) must be reachable from
- *     the DUT or via an HTTP proxy configured on the gnmi container.
- *   - Credentials are passed via environment variables:
- *       ORAS_TEST_USERNAME  (default: ksdatatest)
- *       ORAS_TEST_PASSWORD  (required)
 """
 
-import os
+import hashlib
+import json
 import logging
+import os
+import shutil
+import tempfile
+
 import pytest
+import requests
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.dut_utils import creds_on_dut
+from tests.common.cert_utils import TlsCertificateGenerator
 from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -35,19 +58,225 @@ pytestmark = [
 ]
 
 # ---------------------------------------------------------------------------
-# Test configuration -- override via environment variables if needed
+# Test configuration
 # ---------------------------------------------------------------------------
-
-ORAS_REGISTRY = os.environ.get("ORAS_TEST_REGISTRY", "ksdatatest.azurecr.io")
-ORAS_REPOSITORY = os.environ.get("ORAS_TEST_REPOSITORY", "sonic-os-images")
-ORAS_TAG = os.environ.get(
-    "ORAS_TEST_TAG", "sonic-broadcom-slim-20230531.46.bin"
-)
-ORAS_USERNAME = os.environ.get("ORAS_TEST_USERNAME", "ksdatatest")
-ORAS_PASSWORD = os.environ.get("ORAS_TEST_PASSWORD", "")
 
 # Where to store the pulled artifact on the DUT
 ORAS_LOCAL_PATH = "/tmp/oras_test_image.bin"
+
+# Local registry (hermetic mode) settings -- served from the PTF host
+LOCAL_REGISTRY_PORT = 15000
+PTF_REGISTRY_DIR = "/root/oras_registry"          # data dir on the PTF host
+PTF_REGISTRY_SCRIPT = "/root/oras_registry_server.py"
+LOCAL_REPOSITORY = "sonic-oras-test"
+LOCAL_TAG = "sonic-oras-test-artifact"
+LOCAL_USERNAME = "orastest"
+# Local-only credential for the throwaway per-run registry; not a secret.
+LOCAL_PASSWORD = "orastest-Secret-1"
+LOCAL_PAYLOAD_SIZE = 1024 * 1024  # 1 MiB single-layer artifact
+
+
+# ---------------------------------------------------------------------------
+# Local registry helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_artifact_files(workdir, payload, tag):
+    """
+     * Write the files for a single-layer OCI artifact (config blob + one
+     * layer + manifest) in the layout registry_server.py serves from:
+     *   blobs/<digest>   and   manifests/<tag>
+     * Returns the layer digest.
+    """
+    blobs_dir = os.path.join(workdir, "blobs")
+    manifests_dir = os.path.join(workdir, "manifests")
+    os.makedirs(blobs_dir)
+    os.makedirs(manifests_dir)
+
+    # Content-addressable IDs: blobs are stored/fetched by their sha256
+    layer_digest = "sha256:" + hashlib.sha256(payload).hexdigest()
+    config_blob = b"{}"  # minimal empty-JSON config (OCI manifests require one)
+    config_digest = "sha256:" + hashlib.sha256(config_blob).hexdigest()
+    for data, digest in ((payload, layer_digest), (config_blob, config_digest)):
+        with open(os.path.join(blobs_dir, digest), "wb") as f:
+            f.write(data)
+
+    # The manifest ties config + layer together and is looked up by tag
+    manifest = {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": config_digest,
+            "size": len(config_blob),
+        },
+        "layers": [
+            {
+                "mediaType": "application/octet-stream",
+                "digest": layer_digest,
+                "size": len(payload),
+                "annotations": {"org.opencontainers.image.title": tag},
+            }
+        ],
+    }
+    manifest_bytes = json.dumps(manifest).encode()
+    manifest_digest = "sha256:" + hashlib.sha256(manifest_bytes).hexdigest()
+    # oras clients resolve the tag first, then fetch the manifest again by
+    # its digest -- so serve the same bytes under both names
+    for name in (tag, manifest_digest):
+        with open(os.path.join(manifests_dir, name), "wb") as f:
+            f.write(manifest_bytes)
+    return layer_digest
+
+
+def _find_gnmi_container(duthost):
+    """Return the name of the gNMI/telemetry container on the DUT."""
+    # NF-based awk instead of --format '{{.Names}}': double braces would be
+    # eaten by Ansible's Jinja2 templating of module args.
+    names = duthost.shell("docker ps | awk 'NR>1 {print $NF}'")["stdout_lines"]
+    for candidate in ("gnmi", "telemetry"):
+        if candidate in names:
+            return candidate
+    pytest.skip("No gnmi/telemetry container running on DUT")
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def oras_registry(request, duthosts, rand_one_dut_hostname, ptfhost):
+    """
+     * Provide registry connection info for the ORAS pull tests.
+     *
+     * External mode (--oras_test_registry passed on the CLI): registry/
+     * repository/tag/username come from CLI options (tests/gnmi/conftest.py),
+     * password from the Ansible-managed (vaulted) secrets for the testbed
+     * via creds_on_dut() ('oras_registry_password'). No setup is performed.
+     *
+     * Local mode (default -- no CLI options needed): run a minimal
+     * pull-only OCI registry (gnmi/oras/registry_server.py, TLS + basic
+     * auth) on the PTF host, pre-loaded with a 1 MiB single-layer
+     * artifact, and trust the CA inside the DUT gnmi container. The DUT
+     * reaches it at the PTF management IP, which works on virtual and
+     * physical testbeds alike. Torn down completely at module end.
+     *
+     * Yields a dict:
+     *   registry, repository, tag, username, password,
+     *   expected_layer_digest (local mode only), expected_size (local only)
+    """
+    external_registry = (request.config.getoption("--oras_test_registry", default=None) or "").strip()
+    if external_registry:
+        duthost = duthosts[rand_one_dut_hostname]
+        creds = creds_on_dut(duthost)
+        repository = (request.config.getoption("--oras_test_repository", default=None) or "").strip()
+        tag = (request.config.getoption("--oras_test_tag", default=None) or "").strip()
+        username = (request.config.getoption("--oras_test_username", default=None) or "").strip()
+        password = (creds.get("oras_registry_password") or "").strip()
+        logger.info("Using external registry %s", external_registry)
+        yield {
+            "registry": external_registry,
+            "repository": repository,
+            "tag": tag,
+            "username": username,
+            "password": password,
+            "external": True,
+        }
+        return
+
+    duthost = duthosts[rand_one_dut_hostname]
+    ptf_ip = ptfhost.mgmt_ip
+    if not ptf_ip:
+        pytest.skip("PTF host has no IPv4 management address -- cannot host local registry")
+    registry = "{}:{}".format(ptf_ip, LOCAL_REGISTRY_PORT)
+    base_url = "https://{}".format(registry)
+    gnmi_container = _find_gnmi_container(duthost)
+
+    workdir = tempfile.mkdtemp(prefix="oras_registry_")
+    ca_bundle = "/etc/ssl/certs/ca-certificates.crt"
+    try:
+        # -- TLS certs: CA + server cert with the PTF IP in the SAN --------
+        cert_gen = TlsCertificateGenerator(server_ip=ptf_ip)
+        cert_gen.write_all(workdir)
+        ca_file = os.path.join(workdir, "ca.crt")
+
+        # -- Build the test artifact locally --------------------------------
+        # Random 1 MiB payload => unique digest per run, no stale-cache hits
+        payload = os.urandom(LOCAL_PAYLOAD_SIZE)
+        layer_digest = _write_artifact_files(workdir, payload, LOCAL_TAG)
+
+        # -- Deploy artifact + certs + server script to the PTF host --------
+        logger.info("Starting local ORAS registry at %s on PTF %s", registry, ptfhost.hostname)
+        ptfhost.shell("pkill -9 -f {}".format(PTF_REGISTRY_SCRIPT),
+                      module_ignore_errors=True)
+        ptfhost.shell("rm -rf {dir} && mkdir -p {dir}".format(dir=PTF_REGISTRY_DIR))
+        # Copying a directory (no trailing slash) copies it recursively
+        for name in ("blobs", "manifests", "server.crt", "server.key"):
+            ptfhost.copy(src=os.path.join(workdir, name),
+                         dest="{}/".format(PTF_REGISTRY_DIR))
+        ptfhost.copy(src="gnmi/oras/registry_server.py", dest=PTF_REGISTRY_SCRIPT)
+
+        # -- Start the registry server (same interpreter the gNMI CRL -------
+        #    server on the PTF already relies on)
+        ptfhost.shell(
+            "nohup /root/env-python3/bin/python {script} "
+            "--port {port} --dir {dir} --username {user} --password {pw} "
+            "> {dir}/server.log 2>&1 &".format(
+                script=PTF_REGISTRY_SCRIPT, port=LOCAL_REGISTRY_PORT,
+                dir=PTF_REGISTRY_DIR, user=LOCAL_USERNAME, pw=LOCAL_PASSWORD)
+        )
+
+        def _registry_up():
+            try:
+                # 200 = serving, 401 = serving but wants auth -- both mean "up"
+                code = requests.get("{}/v2/".format(base_url),
+                                    verify=ca_file, timeout=5).status_code
+                return code in (200, 401)
+            except Exception:
+                return False
+
+        pytest_assert(wait_until(60, 2, 0, _registry_up),
+                      "Local registry did not become ready at {}".format(base_url))
+        logger.info("Serving test artifact %s/%s:%s layer=%s size=%d",
+                    registry, LOCAL_REPOSITORY, LOCAL_TAG,
+                    layer_digest, len(payload))
+
+        # -- Trust the CA inside the DUT gnmi container ----------------------
+        #    The gNOI Oras client verifies the registry cert against the
+        #    container's system trust store; append our CA (backing up the
+        #    original bundle for teardown). Survives gnmi process restarts.
+        duthost.copy(src=ca_file, dest="/tmp/oras_test_ca.crt")
+        duthost.shell(
+            "docker exec {c} sh -c 'cp {b} {b}.oras_bak'".format(
+                c=gnmi_container, b=ca_bundle))
+        # Stream via stdin: docker cp can't reach tmpfs-backed paths like /tmp
+        duthost.shell(
+            "docker exec -i {c} sh -c 'cat >> {b}' < /tmp/oras_test_ca.crt".format(
+                c=gnmi_container, b=ca_bundle))
+
+        yield {
+            "registry": registry,
+            "repository": LOCAL_REPOSITORY,
+            "tag": LOCAL_TAG,
+            "username": LOCAL_USERNAME,
+            "password": LOCAL_PASSWORD,
+            "expected_layer_digest": layer_digest,
+            "expected_size": len(payload),
+            "external": False,
+        }
+    finally:
+        # -- Teardown: restore trust store, stop and remove registry ---------
+        duthost.shell(
+            "docker exec {c} sh -c 'mv {b}.oras_bak {b}'".format(
+                c=gnmi_container, b=ca_bundle),
+            module_ignore_errors=True)
+        duthost.shell("rm -f /tmp/oras_test_ca.crt", module_ignore_errors=True)
+        ptfhost.shell("pkill -9 -f {}".format(PTF_REGISTRY_SCRIPT),
+                      module_ignore_errors=True)
+        ptfhost.shell("rm -rf {} {}".format(PTF_REGISTRY_DIR, PTF_REGISTRY_SCRIPT),
+                      module_ignore_errors=True)
+        shutil.rmtree(workdir, ignore_errors=True)
 
 
 # ---------------------------------------------------------------------------
@@ -55,15 +284,15 @@ ORAS_LOCAL_PATH = "/tmp/oras_test_image.bin"
 # ---------------------------------------------------------------------------
 
 
-def skip_if_no_password():
+def skip_if_external_and_no_password(cfg):
     """
-     * Skip the test if ORAS_TEST_PASSWORD is not set.
-     * We don't want tests to fail just because creds weren't configured.
+     * In external-registry mode the tests need a real credential; skip
+     * if it wasn't provided. Local mode always has working credentials.
     """
-    if not ORAS_PASSWORD:
+    if cfg.get("external") and not cfg["password"]:
         pytest.skip(
-            "ORAS_TEST_PASSWORD not set -- skipping ORAS pull test. "
-            "Export the env var and re-run."
+            "External ORAS registry configured but 'oras_registry_password' "
+            "is not set in the Ansible secrets for this testbed -- skipping."
         )
 
 
@@ -72,11 +301,11 @@ def skip_if_no_password():
 # ---------------------------------------------------------------------------
 
 
-def test_gnoi_oras_pull_basic_auth(duthosts, rand_one_dut_hostname, gnmi_tls):  # noqa: F811
+def test_gnoi_oras_pull_basic_auth(duthosts, rand_one_dut_hostname, oras_registry, gnmi_tls):  # noqa: F811
     """
      * test_gnoi_oras_pull_basic_auth
      *
-     * Verify the Oras.Pull RPC can download an artifact from ACR
+     * Verify the Oras.Pull RPC can download an artifact from a registry
      * using basic (username/password) authentication.
      *
      * Steps:
@@ -86,24 +315,26 @@ def test_gnoi_oras_pull_basic_auth(duthosts, rand_one_dut_hostname, gnmi_tls):  
      *   4. Verify the file actually exists on the DUT at local_path.
      *   5. Clean up the downloaded file.
     """
-    skip_if_no_password()
+    cfg = oras_registry
+    skip_if_external_and_no_password(cfg)
 
     duthost = duthosts[rand_one_dut_hostname]
 
     # -- Step 1: Call the Pull RPC ----------------------------------------
     logger.info(
-        "Pulling {}/{}:{} -> {}".format(
-            ORAS_REGISTRY, ORAS_REPOSITORY, ORAS_TAG, ORAS_LOCAL_PATH
-        )
+        f"Pulling {cfg['registry']}/{cfg['repository']}:{cfg['tag']} "
+        f"-> {ORAS_LOCAL_PATH}"
     )
 
+    # Blocks until the server-side stream finishes; returns the list of
+    # streamed messages (started / progress / result) as parsed dicts
     responses = gnmi_tls.gnoi.oras_pull(
-        registry=ORAS_REGISTRY,
-        repository=ORAS_REPOSITORY,
+        registry=cfg["registry"],
+        repository=cfg["repository"],
         local_path=ORAS_LOCAL_PATH,
-        tag=ORAS_TAG,
-        username=ORAS_USERNAME,
-        password=ORAS_PASSWORD,
+        tag=cfg["tag"],
+        username=cfg["username"],
+        password=cfg["password"],
     )
 
     # -- Step 2: Validate PullStarted -------------------------------------
@@ -138,8 +369,19 @@ def test_gnoi_oras_pull_basic_auth(duthosts, rand_one_dut_hostname, gnmi_tls):  
     layer_digest = result.get("layerDigest", "")
     pytest_assert(
         layer_digest.startswith("sha256:"),
-        "Expected layer_digest to start with 'sha256:', got: {}".format(layer_digest)
+        f"Expected layer_digest to start with 'sha256:', got: {layer_digest}"
     )
+
+    # In local mode we know exactly what was pushed -- verify end to end.
+    if cfg.get("expected_layer_digest"):
+        pytest_assert(
+            layer_digest == cfg["expected_layer_digest"],
+            f"layer_digest {layer_digest} != pushed digest {cfg['expected_layer_digest']}"
+        )
+        pytest_assert(
+            total_bytes == cfg["expected_size"],
+            f"total_bytes {total_bytes} != pushed size {cfg['expected_size']}"
+        )
 
     bytes_written = int(result.get("bytesWritten", 0))
     pytest_assert(
@@ -168,7 +410,7 @@ def test_gnoi_oras_pull_basic_auth(duthosts, rand_one_dut_hostname, gnmi_tls):  
     logger.info("Cleanup complete")
 
 
-def test_gnoi_oras_pull_invalid_path(gnmi_tls):  # noqa: F811
+def test_gnoi_oras_pull_invalid_path(oras_registry, gnmi_tls):  # noqa: F811
     """
      * test_gnoi_oras_pull_invalid_path
      *
@@ -178,16 +420,17 @@ def test_gnoi_oras_pull_invalid_path(gnmi_tls):  # noqa: F811
      * The server should return a FailedPrecondition (or InvalidArgument)
      * gRPC error without downloading anything.
     """
-    skip_if_no_password()
+    cfg = oras_registry
+    skip_if_external_and_no_password(cfg)
 
     with pytest.raises(Exception) as exc_info:
         gnmi_tls.gnoi.oras_pull(
-            registry=ORAS_REGISTRY,
-            repository=ORAS_REPOSITORY,
+            registry=cfg["registry"],
+            repository=cfg["repository"],
             local_path="/etc/passwd",  # Not allowed!
-            tag=ORAS_TAG,
-            username=ORAS_USERNAME,
-            password=ORAS_PASSWORD,
+            tag=cfg["tag"],
+            username=cfg["username"],
+            password=cfg["password"],
         )
 
     # The error should mention permission/precondition/allowlist
@@ -199,19 +442,21 @@ def test_gnoi_oras_pull_invalid_path(gnmi_tls):  # noqa: F811
     logger.info(f"Path correctly rejected: {exc_info.value}")
 
 
-def test_gnoi_oras_pull_bad_credentials(gnmi_tls):  # noqa: F811
+def test_gnoi_oras_pull_bad_credentials(oras_registry, gnmi_tls):  # noqa: F811
     """
      * test_gnoi_oras_pull_bad_credentials
      *
      * Verify that the Oras.Pull RPC returns Unauthenticated when
      * given wrong credentials.
     """
+    cfg = oras_registry
+
     with pytest.raises(Exception) as exc_info:
         gnmi_tls.gnoi.oras_pull(
-            registry=ORAS_REGISTRY,
-            repository=ORAS_REPOSITORY,
+            registry=cfg["registry"],
+            repository=cfg["repository"],
             local_path=ORAS_LOCAL_PATH,
-            tag=ORAS_TAG,
+            tag=cfg["tag"],
             username="wrong_user",
             password="wrong_password",
         )
@@ -224,56 +469,63 @@ def test_gnoi_oras_pull_bad_credentials(gnmi_tls):  # noqa: F811
     logger.info(f"Bad credentials correctly rejected: {exc_info.value}")
 
 
-def test_gnoi_oras_pull_nonexistent_tag(gnmi_tls):  # noqa: F811
+def test_gnoi_oras_pull_nonexistent_tag(oras_registry, gnmi_tls):  # noqa: F811
     """
      * test_gnoi_oras_pull_nonexistent_tag
      *
      * Verify that the Oras.Pull RPC returns an appropriate error
      * when the requested tag does not exist in the registry.
     """
-    skip_if_no_password()
+    cfg = oras_registry
+    skip_if_external_and_no_password(cfg)
 
     with pytest.raises(Exception) as exc_info:
         gnmi_tls.gnoi.oras_pull(
-            registry=ORAS_REGISTRY,
-            repository=ORAS_REPOSITORY,
+            registry=cfg["registry"],
+            repository=cfg["repository"],
             local_path=ORAS_LOCAL_PATH,
             tag="this-tag-does-not-exist-12345",
-            username=ORAS_USERNAME,
-            password=ORAS_PASSWORD,
+            username=cfg["username"],
+            password=cfg["password"],
         )
 
     error_msg = str(exc_info.value).lower()
     pytest_assert(
-        any(term in error_msg for term in ["not found", "404", "unavailable", "unknown"]),
+        any(term in error_msg for term in ["not found", "notfound", "404", "unavailable", "unknown"]),
         f"Expected not-found error, got: {exc_info.value}"
     )
     logger.info(f"Nonexistent tag correctly rejected: {exc_info.value}")
 
 
-def test_gnoi_oras_pull_anonymous_denied(gnmi_tls):  # noqa: F811
+def test_gnoi_oras_pull_anonymous_denied(oras_registry, gnmi_tls):  # noqa: F811
     """
      * test_gnoi_oras_pull_anonymous_denied
      *
      * Verify that pulling from a private registry without credentials
      * returns an authentication error.
      *
-     * Note: This test assumes ksdatatest.azurecr.io requires auth.
-     * If the registry allows anonymous pulls, this test should be
-     * updated or skipped.
+     * The local registry fixture always requires auth; in external mode
+     * this assumes the configured registry does too.
     """
+    cfg = oras_registry
+
     with pytest.raises(Exception) as exc_info:
         gnmi_tls.gnoi.oras_pull(
-            registry=ORAS_REGISTRY,
-            repository=ORAS_REPOSITORY,
+            registry=cfg["registry"],
+            repository=cfg["repository"],
             local_path=ORAS_LOCAL_PATH,
-            tag=ORAS_TAG,
+            tag=cfg["tag"],
             # No credentials -- anonymous
         )
 
+    # Registries answering with a Bearer challenge (e.g. ACR) yield a 401
+    # ("unauthenticated"/"unauthorized"); registries with a Basic realm make
+    # oras-go fail client-side with "basic credential not found". Both mean
+    # anonymous access was denied.
     error_msg = str(exc_info.value).lower()
     pytest_assert(
-        any(term in error_msg for term in ["unauthenticated", "unauthorized", "401"]),
+        any(term in error_msg for term in
+            ["unauthenticated", "unauthorized", "401", "credential not found"]),
         f"Expected auth error for anonymous pull, got: {exc_info.value}"
     )
     logger.info(f"Anonymous pull correctly denied: {exc_info.value}")

--- a/tests/gnmi/test_gnoi_oras.py
+++ b/tests/gnmi/test_gnoi_oras.py
@@ -134,10 +134,10 @@ def _find_gnmi_container(duthost):
     # NF-based awk instead of --format '{{.Names}}': double braces would be
     # eaten by Ansible's Jinja2 templating of module args.
     names = duthost.shell("docker ps | awk 'NR>1 {print $NF}'")["stdout_lines"]
-    for candidate in ("gnmi", "telemetry"):
-        if candidate in names:
-            return candidate
-    pytest.skip("No gnmi/telemetry container running on DUT")
+    container = next((c for c in ("gnmi", "telemetry") if c in names), None)
+    if container is None:
+        pytest.skip("No gnmi/telemetry container running on DUT")
+    return container
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Add test_gnoi_oras.py with five test cases covering the ORAS Pull service end-to-end:

  - test_gnoi_oras_pull_basic_auth: happy path pull with basic auth, verifies file lands on DUT with correct size and digest.
  - test_gnoi_oras_pull_invalid_path: rejects paths outside allowlist.
  - test_gnoi_oras_pull_bad_credentials: returns Unauthenticated.
  - test_gnoi_oras_pull_nonexistent_tag: returns not-found error.
  - test_gnoi_oras_pull_anonymous_denied: rejects anonymous access to private registry.

Also adds oras_pull() helper to PtfGnoi (ptf_gnoi.py) which wraps the server-streaming grpcurl call to sonic.gnoi.oras.v1.Oras/Pull.

Tests require ORAS_TEST_PASSWORD env var; skipped otherwise.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
