### PR TITLE
Bump flake8 pre-commit hook 6.0.0 -> 7.1.1 to fix f-string false positives

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: check-ast
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
         args: ["--max-line-length=120"]


### PR DESCRIPTION
### Description of PR

Bump the `flake8` pre-commit hook from `6.0.0` to `7.1.1` to fix false-positive `E231`/`E221` pycodestyle errors on f-strings under Python 3.12+.

Fixes #26065

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework (new/improved control, data plane infrastructure)
- [ ] New Test case
- [ ] Test case improvement
- [ ] Documentation

### Back port request

- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach

#### What is the motivation for this PR?

The pre-commit static-analysis check produces false-positive `E231` ("missing whitespace after ':'") and `E221` ("multiple spaces before operator") errors on well-formed f-string expressions, blocking PRs on code the author never touched (see #25430).

Root cause: `.pre-commit-config.yaml` pins `flake8==6.0.0`, which bundles `pycodestyle==2.10.0`. pycodestyle 2.10 predates Python 3.12's f-string tokenizer change (PEP 701). Under Python < 3.12 an f-string was a single opaque STRING token, so nothing inside `{...}` was linted. Under Python 3.12+ the tokenizer exposes f-string internals, and pycodestyle 2.10 mis-tokenizes them, emitting bogus errors on lines like:

    src_ip = f"20.0.0.{1 + index}/32" if index % 3 else f"2001::{1 + index}/128"

Because pre-commit lints whole touched files (not just the diff), any PR touching a file that contains older f-strings inherits these false positives. Nothing in the repo config changed; the CI/dev image's Python moved to 3.12+, activating the latent incompatibility.

#### How did you do it?

Bumped the flake8 pre-commit hook rev from `6.0.0` to `7.1.1`, which bundles `pycodestyle==2.12.1`. pycodestyle 2.11 added f-string-aware handling, eliminating the false positives.

#### How did you verify/test it?

Ran the pre-commit `flake8` hook locally with the bumped rev against the exact files that fail on #25430 (`tests/cacl/test_cacl_application.py`, `tests/generic_config_updater/test_cacl.py`) - the hook now passes cleanly.

A full-repo comparison scan (pycodestyle 2.10 vs 2.12, main-hook scope) confirms the bump removes ~1060 false positives (dominated by f-string E231) and surfaces no new false positives. It does surface a small number of legitimate pre-existing findings (E721 type comparisons, redundant backslashes, comma-continuation E231) in whole-file linting of touched files; those are handled in a separate follow-up cleanup PR so this bump stays minimal and reviewable.

#### Any platform specific information?

No. Tooling/CI change only, platform generic.

#### Supported testbed topology if it's a new test case?

N/A
