### PR TITLE
Fix pycodestyle E721/E502 findings surfaced by flake8 7.1.1 bump

### DIFF
--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -67,7 +67,7 @@ def recover_testbed(sonichosts, conn_graph_facts, localhost, image_url, hwsku):
         for i in range(3):
             dut_ssh = duthost_ssh(sonichost)
 
-            if type(dut_ssh) == tuple:
+            if isinstance(dut_ssh, tuple):
                 logger.info("SSH success.")
 
                 # May recover from boot loader, need to delete image file

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: check-ast
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
         args: ["--max-line-length=120"]

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1303,7 +1303,7 @@ def fib_t2_lag(topo, ptf_ip, action="announce", topo_routes={}):
     # T3 VMs per linecard(asic) - key is the dut index, and value is a list of T3 VMs
     t3_vms = {}
     for key, value in vms.items():
-        if type(value['vlans'][0]) == int:
+        if isinstance(value['vlans'][0], int):
             dut_index = 0
         else:
             m = re.match(r"(\d+)\.(\d+)@(\d+)", value['vlans'][0])

--- a/ansible/plugins/action/apswitch.py
+++ b/ansible/plugins/action/apswitch.py
@@ -41,7 +41,7 @@ class ActionModule(ActionBase):
         _timeout = self._task.args.get('timeout', None)
         _os_name = self._task.args.get('os_name', '')
 
-        if (type(_login) == unicode):
+        if isinstance(_login, unicode):
             _login = ast.literal_eval(_login)
 
         login = {'user': [], 'enable': _login['enable']}

--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -146,7 +146,7 @@ def _password_retry(func):
         ssh_args = args[0]
         # Change the IPv4 host in the ssh_args to IPv6
         for idx in range(len(ssh_args)):
-            if type(ssh_args[idx]) == bytes and ssh_args[idx].decode() == self.host:
+            if isinstance(ssh_args[idx], bytes) and ssh_args[idx].decode() == self.host:
                 ssh_args[idx] = new_host
         self.host = new_host
         self.set_option("host", new_host)
@@ -168,7 +168,7 @@ def _password_retry(func):
             ipv4_addr_unavailable = (CONNECTION_TIMEOUT_ERR_FLAG1 in e.message) or \
                                     (CONNECTION_TIMEOUT_ERR_FLAG2 in e.message)
 
-            try_ipv6_addr = orig_host != hostv6 and (type(e) != AnsibleAuthenticationFailure) and \
+            try_ipv6_addr = orig_host != hostv6 and (not isinstance(e, AnsibleAuthenticationFailure)) and \
                 ipv4_addr_unavailable and hostv6
             if not try_ipv6_addr:
                 raise e

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -557,7 +557,7 @@ class FibTest(BaseTest):
     def check_same_asic(self, src_port, exp_port_list):
         updated_exp_port_list = list()
         for port in exp_port_list:
-            if type(port) == list:
+            if isinstance(port, list):
                 per_port_list = list()
                 for per_port in port:
                     if self.ptf_test_port_map[str(per_port)]['target_dut'] \
@@ -600,7 +600,7 @@ class FibTest(BaseTest):
             asic_list['voq'] = dest_port_list
         else:
             for port in dest_port_list:
-                if type(port) == list:
+                if isinstance(port, list):
                     port_map = self.ptf_test_port_map[str(port[0])]
                     asic_id = port_map.get('asic_idx', 0)
                     member = asic_list.get(asic_id)

--- a/tests/common/configlet/utils.py
+++ b/tests/common/configlet/utils.py
@@ -292,10 +292,10 @@ def cmp_value(orig_val, clet_val):
     if orig_val == clet_val:
         return True
 
-    if type(orig_val) == str:
+    if isinstance(orig_val, str):
         return cmp_str(orig_val, clet_val)
 
-    if type(orig_val) == dict:
+    if isinstance(orig_val, dict):
         for fld, val in orig_val.items():
             if fld not in clet_val:
                 return False

--- a/tests/common/devices/cisco.py
+++ b/tests/common/devices/cisco.py
@@ -316,7 +316,7 @@ class CiscoHost(AnsibleHostBase):
         err_out = False
         if 'stdout' in cmd_output_obj:
             stdout = cmd_output_obj['stdout']
-            msg = stdout[-1] if type(stdout) == list else stdout
+            msg = stdout[-1] if isinstance(stdout, list) else stdout
             err_out = 'Cannot advertise' in msg
 
         return ('failed' in cmd_output_obj and cmd_output_obj['failed']) or err_out

--- a/tests/common/devices/duthosts.py
+++ b/tests/common/devices/duthosts.py
@@ -179,7 +179,7 @@ class DutHosts(object):
             [MultiAsicSonicHost]: Returns the specified duthost in duthosts. It is an instance of MultiAsicSonicHost.
         """
         unicode_type = str if sys.version_info.major >= 3 else unicode      # noqa: F821
-        if type(index) == int:
+        if isinstance(index, int) and not isinstance(index, bool):
             return self.nodes[index]
         elif type(index) in [str, unicode_type] or isinstance(index, str):
             for node in self.nodes:

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -701,7 +701,7 @@ class EosHost(AnsibleHostBase):
         err_out = False
         if 'stdout' in cmd_output_obj:
             stdout = cmd_output_obj['stdout']
-            msg = stdout[-1] if type(stdout) == list else stdout
+            msg = stdout[-1] if isinstance(stdout, list) else stdout
             err_out = 'Cannot advertise' in msg
 
         return ('failed' in cmd_output_obj and cmd_output_obj['failed']) or err_out

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -160,14 +160,14 @@ class MultiAsicSonicHost(object):
         else:
             asic_complex_args = copy.deepcopy(complex_args)
             asic_index = asic_complex_args.pop("asic_index")
-            if type(asic_index) == int:
+            if isinstance(asic_index, int):
                 # Specific ASIC/namespace
                 if self.sonichost.facts['num_asic'] == 1:
                     if asic_index != 0:
                         raise ValueError("Trying to run module '{}' against asic_index '{}' on a single asic dut '{}'"
                                          .format(multi_asic_attr, asic_index, self.sonichost.hostname))
                 return getattr(self.asic_instance(asic_index), multi_asic_attr)(*module_args, **asic_complex_args)
-            elif type(asic_index) == str and asic_index.lower() == "all":
+            elif isinstance(asic_index, str) and asic_index.lower() == "all":
                 # All ASICs/namespace
                 return [getattr(asic, multi_asic_attr)(*module_args, **asic_complex_args) for asic in self.asics]
             else:

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -312,7 +312,7 @@ def force_active_tor():
 
     def force_active_tor_fn(dut, intf):
         logger.info('Setting {} as active for intfs {}'.format(dut, intf))
-        if type(intf) == str:
+        if isinstance(intf, str):
             cmds = ["config muxcable mode active {}; true".format(intf)]
             forced_intfs.append((dut, intf))
         else:
@@ -339,7 +339,7 @@ def force_standby_tor():
 
     def force_standby_tor_fn(dut, intf):
         logger.info('Setting {} as standby for intfs {}'.format(dut, intf))
-        if type(intf) == str:
+        if isinstance(intf, str):
             cmds = ["config muxcable mode standby {}; true".format(intf)]
             forced_intfs.append((dut, intf))
         else:

--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -225,7 +225,7 @@ def _toggle_cmd(dut, intfs, state):
     toggled_intfs = []
 
     logger.info('Setting {} as {} for intfs {}'.format(dut, state, intfs))
-    if type(intfs) == str:
+    if isinstance(intfs, str):
         cmds = ["config muxcable mode {} {}; true".format(state, intfs)]
         toggled_intfs.append((dut, intfs))
     else:

--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -587,7 +587,7 @@ def _prepare_background_traffic_params(duthost, queues, selected_test_ports, tes
     dst_ips = []
     for selected_test_port in selected_test_ports:
         selected_test_port_info = test_ports_info[selected_test_port]
-        if type(selected_test_port_info["rx_port_id"]) == list:
+        if isinstance(selected_test_port_info["rx_port_id"], list):
             src_ports.append(selected_test_port_info["rx_port_id"][0])
         else:
             src_ports.append(selected_test_port_info["rx_port_id"])
@@ -934,7 +934,7 @@ def send_tx_egress(traffic_inst, action, verify, async_mode=False, pkt_count=Non
     that the expected PFC watchdog action (forward/drop) is observed on egress."""
     logger.info("Check for egress {} on Tx port {} (verify={})".format(action, traffic_inst.pfc_wd_test_port, verify))
     dst_port = "[" + str(traffic_inst.pfc_wd_test_port_id) + "]"
-    if action == "forward" and type(traffic_inst.pfc_wd_test_port_ids) == list:
+    if action == "forward" and isinstance(traffic_inst.pfc_wd_test_port_ids, list):
         dst_port = "".join(str(traffic_inst.pfc_wd_test_port_ids)).replace(',', '')
     ptf_params = {'router_mac': traffic_inst.router_mac,
                   'vlan_mac': traffic_inst.vlan_mac,

--- a/tests/common/ixia/ixia_helpers.py
+++ b/tests/common/ixia/ixia_helpers.py
@@ -100,7 +100,7 @@ class IxiaFanoutManager ():
                 format(self.ip_address, fanout_port, peer_port, peer_device, speed)
             retval.append(string)
 
-        return(retval)
+        return (retval)
 
     def get_fanout_device_details(self, device_number):
         """With the help of this function you can select the chassis you want
@@ -153,7 +153,7 @@ class IxiaFanoutManager ():
         Returns:
             Details of the chassis connection as dictionary format.
         """
-        return(self.last_device_connection_details)
+        return (self.last_device_connection_details)
 
     def get_chassis_ip(self):
         """This function returns IP address of a particular chassis
@@ -630,7 +630,7 @@ def create_ipv4_traffic(session,
         traffic_config.TransmissionControl.update(Type='fixedFrameCount', FrameCount=pkt_count)
 
     elif duration is not None:
-        if type(duration) != int or duration <= 0:
+        if not isinstance(duration, int) or duration <= 0:
             logger.error('Invalid duration value {} (positive integer only)'.format(duration))
             return None
         else:
@@ -723,7 +723,7 @@ def create_pause_traffic(session, name, source, pkt_per_sec, pkt_count=None,
             FrameCount=pkt_count)
 
     elif duration is not None:
-        if type(duration) != int or duration <= 0:
+        if not isinstance(duration, int) or duration <= 0:
             logger.error('Invalid duration value {} (positive integer only)'.format(duration))
 
             return None

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -685,7 +685,7 @@ def get_intf_by_sub_intf(sub_intf, vlan_id=None):
     Returns:
         str: interface name, e.g. Ethernet100
     """
-    if type(sub_intf) != str:
+    if not isinstance(sub_intf, str):
         sub_intf = str(sub_intf)
 
     if not vlan_id:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2226,7 +2226,9 @@ _hosts_per_hwsku_per_module = {}
 _rand_one_asic_per_module = {}
 _rand_one_frontend_asic_per_module = {}
 _macsec_frontend_hosts_per_hwsku_per_module = {}
-def pytest_generate_tests(metafunc):        # noqa: E302
+
+
+def pytest_generate_tests(metafunc):
     # The topology always has atleast 1 dut
     dut_fixture_name = None
     duts_selected = None
@@ -3099,7 +3101,7 @@ def restore_config_db_and_config_reload(duts_data, duthosts, request):
 
 
 def compare_running_config(pre_running_config, cur_running_config):
-    if type(pre_running_config) != type(cur_running_config):
+    if type(pre_running_config) is not type(cur_running_config):
         return False
     if pre_running_config == cur_running_config:
         return True

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -324,7 +324,7 @@ def gen_setup_information(dutHost, downStreamDutHost, upStreamDutHost, tbinfo, t
                 "vlan_mac": upstream_vlan_mac,
                 "src_port": downstream_ports[0],
                 # DUT whose downstream are servers doesn't have lag connect to server
-                "src_port_lag_name": "Not Applicable" \
+                "src_port_lag_name": "Not Applicable"
                 if topo_type in DOWNSTREAM_SERVER_TOPO else downstream_dest_lag_name[0],
                 "src_port_ptf_id": str(mg_facts_list[0]["minigraph_ptf_indices"][downstream_ports[0]]),
                 "dest_port": upstream_dest_ports,
@@ -936,7 +936,7 @@ class BaseEverflowTest(object):
             if not session_info:
                 session_info = BaseEverflowTest.mirror_session_info("test_session_1", duthost.facts["asic_type"])
             # Skip IPv6 mirror session due to issue #19096
-            if duthost.facts['platform'] in ('x86_64-arista_7260cx3_64', 'x86_64-arista_7060_cx32s') and erspan_ip_ver == 6: # noqa E501
+            if duthost.facts['platform'] in ('x86_64-arista_7260cx3_64', 'x86_64-arista_7060_cx32s') and erspan_ip_ver == 6:  # noqa E501
                 pytest.skip("Skip IPv6 mirror session on unsupported platforms")
 
             # Skip if the ASIC does not support bidirectional port mirroring (issue #22661).

--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -267,7 +267,7 @@ class SendVerifyTraffic():
         on the number of ports. Send extra in case of imperfect hashing.
         """
         factor = 1
-        num_dst_ports = 1 if type(self.pfc_wd_test_port_ids) != list else len(self.pfc_wd_test_port_ids)
+        num_dst_ports = 1 if not isinstance(self.pfc_wd_test_port_ids, list) else len(self.pfc_wd_test_port_ids)
         if num_dst_ports > 1:
             factor = 1.25 * num_dst_ports
         return factor
@@ -281,7 +281,7 @@ class SendVerifyTraffic():
             action(string) : PTF test action
         """
         logger.info("Check for ingress {} on Rx port {}".format(action, self.pfc_wd_test_port))
-        if type(self.pfc_wd_rx_port_id) == list:
+        if isinstance(self.pfc_wd_rx_port_id, list):
             dst_port = "".join(str(self.pfc_wd_rx_port_id)).replace(',', '')
         else:
             dst_port = "[ " + str(self.pfc_wd_rx_port_id) + " ]"

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -560,7 +560,7 @@ class SendVerifyTraffic():
         """
         logger.info("Check for egress {} on Tx port {}".format(action, self.pfc_wd_test_port))
         dst_port = "[" + str(self.pfc_wd_test_port_id) + "]"
-        if action == "forward" and type(self.pfc_wd_test_port_ids) == list:
+        if action == "forward" and isinstance(self.pfc_wd_test_port_ids, list):
             dst_port = "".join(str(self.pfc_wd_test_port_ids)).replace(',', '')
         ptf_params = {'router_mac': self.router_mac,
                       'vlan_mac': self.vlan_mac,
@@ -590,7 +590,7 @@ class SendVerifyTraffic():
             action(string) : PTF test action
         """
         logger.info("Check for ingress {} on Rx port {}".format(action, self.pfc_wd_test_port))
-        if type(self.pfc_wd_rx_port_id) == list:
+        if isinstance(self.pfc_wd_rx_port_id, list):
             dst_port = "".join(str(self.pfc_wd_rx_port_id)).replace(',', '')
         else:
             dst_port = "[ " + str(self.pfc_wd_rx_port_id) + " ]"
@@ -618,7 +618,7 @@ class SendVerifyTraffic():
         Send traffic on the other PFC queue (not in storm) and verify that the packets get forwarded
         """
         logger.info("Send packets via {} to verify other PFC queue is not affected".format(self.pfc_wd_test_port))
-        if type(self.pfc_wd_test_port_ids) == list:
+        if isinstance(self.pfc_wd_test_port_ids, list):
             dst_port = "".join(str(self.pfc_wd_test_port_ids)).replace(',', '')
         else:
             dst_port = "[ " + str(self.pfc_wd_test_port_ids) + " ]"
@@ -652,7 +652,7 @@ class SendVerifyTraffic():
         Send traffic on the other PFC PG (not in storm) and verify that the packets get forwarded
         """
         logger.info("Send packets to {} to verify other PFC pg is not affected".format(self.pfc_wd_test_port))
-        if type(self.pfc_wd_rx_port_id) == list:
+        if isinstance(self.pfc_wd_rx_port_id, list):
             dst_port = "".join(str(self.pfc_wd_rx_port_id)).replace(',', '')
         else:
             dst_port = "[ " + str(self.pfc_wd_rx_port_id) + " ]"

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -265,7 +265,7 @@ class SendVerifyTraffic(object):
         """
         logger.info("Check for egress {} on Tx port {}".format(wd_action, self.pfc_wd_test_port))
         dst_port = "[" + str(self.pfc_wd_test_port_id) + "]"
-        if wd_action == "forward" and type(self.pfc_wd_test_port_ids) == list:
+        if wd_action == "forward" and isinstance(self.pfc_wd_test_port_ids, list):
             dst_port = "".join(str(self.pfc_wd_test_port_ids)).replace(',', '')
         ptf_params = {'router_mac': self.router_mac,
                       'queue_index': self.queue,
@@ -290,7 +290,7 @@ class SendVerifyTraffic(object):
             wd_action(string): pfcwd action expected on that port and queue (valid values: drop, forward)
         """
         logger.info("Check for ingress {} on Rx port {}".format(wd_action, self.pfc_wd_test_port))
-        if type(self.pfc_wd_rx_port_id) == list:
+        if isinstance(self.pfc_wd_rx_port_id, list):
             dst_port = "".join(str(self.pfc_wd_rx_port_id)).replace(',', '')
         else:
             dst_port = "[ " + str(self.pfc_wd_rx_port_id) + " ]"

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -45,9 +45,9 @@ from switch import (switch_init,          # noqa F401
                     sai_thrift_read_port_voq_counters,
                     sai_thrift_get_voq_port_id
                     )
-from switch_sai_thrift.ttypes import (sai_thrift_attribute_value_t, # noqa F401
+from switch_sai_thrift.ttypes import (sai_thrift_attribute_value_t,  # noqa F401
                                       sai_thrift_attribute_t)
-from switch_sai_thrift.sai_headers import SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID # noqa F401
+from switch_sai_thrift.sai_headers import SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID  # noqa F401
 from scapy.layers.inet6 import ICMPv6ND_NS, ICMPv6NDOptDstLLAddr
 
 
@@ -2989,7 +2989,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         switch_init(self.clients)
         initialize_diag_counter(self)
         last_pfc_counter = 0  # noqa F841
-        recv_port_counters = [] # noqa F841
+        recv_port_counters = []  # noqa F841
         transmit_port_counters = []  # noqa F841
 
         # Parse input parameters
@@ -5397,7 +5397,7 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
             else:
                 print("Did not find a second flow in mode '{}'".format(
                     self.flow_config), file=sys.stderr)
-                assert self.flow_config == "shared",\
+                assert self.flow_config == "shared", \
                     "Failed to find a flow that uses a second queue despite being in mode '{}'"\
                     .format(self.flow_config)
             # Cleanup for multi-flow test
@@ -7253,7 +7253,7 @@ class FullMeshTrafficSanity(sai_base_test.ThriftInterfaceDataPlane):
         sai_base_test.ThriftInterfaceDataPlane.tearDown(self)
 
     def config_traffic(self, dst_port_id, dscp, ecn_bit):
-        if type(ecn_bit) == bool:
+        if isinstance(ecn_bit, bool):
             ecn_bit = 1 if ecn_bit else 0
         self.dscp = dscp
         self.dst_port_id = dst_port_id


### PR DESCRIPTION
### Description of PR

Clean up the pre-existing legitimate pycodestyle findings (E721 type comparisons, E502, and co-located whitespace nits) that whole-file linting now surfaces after the flake8 bump to 7.1.1 / pycodestyle 2.12 (#26072, merged; fixes #26065).

These are not new false positives; pycodestyle 2.10 flagged most of them too. They only surface when a PR touches the affected file (pre-commit lints whole files), so cleaning them up now unblocks unrelated future PRs that happen to touch these files.

Note: this branch was originally opened combined with the flake8 bump. The bump has since merged separately via #26072, so the effective change here is the cleanup. Retaining this PR thread to preserve the existing review/approval.

Related: #26072 (flake8 bump, merged), #26065 (root-cause issue).

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework (new/improved control, data plane infrastructure)
- [ ] New Test case
- [ ] Test case improvement
- [ ] Documentation

### Back port request

- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach

#### What is the motivation for this PR?

After #26072 bumped flake8 to 7.1.1 (pycodestyle 2.12), the pre-commit static-analysis check lints whole touched files under the newer pycodestyle. This surfaces pre-existing legitimate findings in a number of files. Fixing them proactively keeps unrelated future PRs that touch these files from being blocked by errors they did not introduce.

#### How did you do it?

Cleaned up all E721/E502 findings tree-wide plus co-located findings in the same files so each touched file is fully clean:

- E721 (33 sites): `type(x) == T` -> `isinstance(x, T)`, `type(x) != T` -> `not isinstance(x, T)`.
  - `tests/common/devices/duthosts.py` index lookup preserves exact int semantics (`isinstance(index, int) and not isinstance(index, bool)`) since a bool index would be semantically wrong (True->1/False->0).
  - `tests/conftest.py` `type(a) != type(b)` compares two runtime types against each other, so isinstance does not apply; uses `is not` (the E721-approved exact-type form).
  - `ansible/plugins/action/apswitch.py` `type(_login) == unicode` -> `isinstance(_login, unicode)` (unicode is aliased to str under a py3 guard at module top).
- E275 (2): `return(` -> `return (`
- E302 (1): blank lines before `pytest_generate_tests` (dropped a now-stale `# noqa: E302`)
- E502 (1): removed redundant backslash inside a dict literal
- E261 (4): two spaces before inline comment
- E231 (1): whitespace after comma before line continuation

Note: `ansible/roles/test/files/ptftests/py3/fib_test.py` is a symlink to `../fib_test.py`, so the target paths resolve to 21 unique files.

A separate follow-up PR will handle the remaining ~255 `E231` comma-continuation findings across the rest of the tree (large, purely mechanical), kept out of this PR to keep it reviewable.

#### How did you verify/test it?

- Ran `pycodestyle 2.12 --max-line-length=120` tree-wide: zero E721/E502 remaining.
- Ran the pre-commit `flake8` hook (rev 7.1.1, matching CI) on all touched files: passes.

#### Any platform specific information?

No. Lint cleanup, platform generic. No functional behavior change (type checks preserve semantics).

#### Supported testbed topology if it's a new test case?

N/A
