### PR TITLE
[acl] Add topology-agnostic ECN ACL marking CP+DP test

### DIFF
--- a/ansible/roles/test/files/ptftests/ecn_acl_ptftest.py
+++ b/ansible/roles/test/files/ptftests/ecn_acl_ptftest.py
@@ -6,63 +6,78 @@ from ptf.base_tests import BaseTest
 
 
 class ECNMarkingTest(BaseTest):
-    """Verify an ingress ACL SET_ECN action marks routed traffic with ECN=CE (3).
+    """Verify an ingress ACL SET_ECN action marks matching routed traffic with
+    ECN=CE (3) and leaves non-matching traffic unchanged.
 
     Topology/family-agnostic: all ports, IPs, MAC and IP version are supplied
     as params by the sonic-mgmt test, so the same PTF test runs on IPv4 or IPv6
     topologies (Mellanox, Broadcom, etc.). A packet is injected with ECN=00 on
     the ingress port (which carries the ECN ACL); the DUT routes it to the
-    egress port; the egress copy must have ECN bits = 3 (CE).
+    egress port. Traffic whose UDP source port matches the rule must egress
+    with ECN=3 (CE); traffic with a non-matching source port must egress with
+    its ECN left unchanged (0).
     """
 
     def setUp(self):
         BaseTest.setUp(self)
         self.dataplane = ptf.dataplane_instance
         p = testutils.test_params_get()
-        self.ip_version = p['ip_version']
-        self.src_port = int(p['src_port'])
-        self.dst_port = int(p['dst_port'])
-        self.router_mac = p['router_mac']
-        self.src_ip = p['src_ip']
-        self.dst_ip = p['dst_ip']
-        self.udp_sport = int(p.get('udp_sport', 5000))
-        self.udp_dport = int(p.get('udp_dport', 6000))
+        self.ip_version = p["ip_version"]
+        self.src_port = int(p["src_port"])
+        self.dst_port = int(p["dst_port"])
+        self.router_mac = p["router_mac"]
+        self.src_ip = p["src_ip"]
+        self.dst_ip = p["dst_ip"]
+        self.udp_sport = int(p.get("udp_sport", 5000))
+        self.udp_dport = int(p.get("udp_dport", 6000))
+        self.non_match_udp_sport = int(p.get("non_match_udp_sport", 5001))
 
-    def runTest(self):
-        if self.ip_version == 'ipv6':
+    def _build(self, udp_sport, exp_ecn):
+        """Build (injected_pkt, masked_expected_pkt) for a UDP source port; the
+        expected packet carries exp_ecn (0..3) in the ECN bits (DSCP stays 0)."""
+        if self.ip_version == "ipv6":
             pkt = testutils.simple_udpv6_packet(
-                eth_dst=self.router_mac, eth_src='00:11:22:33:44:55',
+                eth_dst=self.router_mac, eth_src="00:11:22:33:44:55",
                 ipv6_src=self.src_ip, ipv6_dst=self.dst_ip,
                 ipv6_hlim=64, ipv6_tc=0,
-                udp_sport=self.udp_sport, udp_dport=self.udp_dport)
+                udp_sport=udp_sport, udp_dport=self.udp_dport)
             exp = testutils.simple_udpv6_packet(
                 ipv6_src=self.src_ip, ipv6_dst=self.dst_ip,
-                ipv6_hlim=63, ipv6_tc=3,
-                udp_sport=self.udp_sport, udp_dport=self.udp_dport)
+                ipv6_hlim=63, ipv6_tc=exp_ecn,
+                udp_sport=udp_sport, udp_dport=self.udp_dport)
             m = Mask(exp)
-            m.set_do_not_care_scapy(scapy.Ether, 'dst')
-            m.set_do_not_care_scapy(scapy.Ether, 'src')
-            m.set_do_not_care_scapy(scapy.IPv6, 'hlim')
-            m.set_do_not_care_scapy(scapy.IPv6, 'fl')
+            m.set_do_not_care_scapy(scapy.Ether, "dst")
+            m.set_do_not_care_scapy(scapy.Ether, "src")
+            m.set_do_not_care_scapy(scapy.IPv6, "hlim")
+            m.set_do_not_care_scapy(scapy.IPv6, "fl")
         else:
             pkt = testutils.simple_udp_packet(
-                eth_dst=self.router_mac, eth_src='00:11:22:33:44:55',
+                eth_dst=self.router_mac, eth_src="00:11:22:33:44:55",
                 ip_src=self.src_ip, ip_dst=self.dst_ip,
                 ip_ttl=64, ip_tos=0,
-                udp_sport=self.udp_sport, udp_dport=self.udp_dport)
+                udp_sport=udp_sport, udp_dport=self.udp_dport)
             exp = testutils.simple_udp_packet(
                 ip_src=self.src_ip, ip_dst=self.dst_ip,
-                ip_ttl=63, ip_tos=3,
-                udp_sport=self.udp_sport, udp_dport=self.udp_dport)
+                ip_ttl=63, ip_tos=exp_ecn,
+                udp_sport=udp_sport, udp_dport=self.udp_dport)
             m = Mask(exp)
-            m.set_do_not_care_scapy(scapy.Ether, 'dst')
-            m.set_do_not_care_scapy(scapy.Ether, 'src')
-            m.set_do_not_care_scapy(scapy.IP, 'ttl')
-            m.set_do_not_care_scapy(scapy.IP, 'chksum')
-            m.set_do_not_care_scapy(scapy.IP, 'id')
+            m.set_do_not_care_scapy(scapy.Ether, "dst")
+            m.set_do_not_care_scapy(scapy.Ether, "src")
+            m.set_do_not_care_scapy(scapy.IP, "ttl")
+            m.set_do_not_care_scapy(scapy.IP, "chksum")
+            m.set_do_not_care_scapy(scapy.IP, "id")
+        return pkt, m
 
+    def runTest(self):
+        # Matching UDP source port -> ECN marked to CE (3).
+        pkt, exp = self._build(self.udp_sport, 3)
         testutils.send_packet(self, self.src_port, pkt)
-        testutils.verify_packet(self, m, self.dst_port)
+        testutils.verify_packet(self, exp, self.dst_port)
+
+        # Non-matching UDP source port -> forwarded but ECN left unchanged (0).
+        pkt, exp = self._build(self.non_match_udp_sport, 0)
+        testutils.send_packet(self, self.src_port, pkt)
+        testutils.verify_packet(self, exp, self.dst_port)
 
     def tearDown(self):
         BaseTest.tearDown(self)

--- a/ansible/roles/test/files/ptftests/ecn_acl_ptftest.py
+++ b/ansible/roles/test/files/ptftests/ecn_acl_ptftest.py
@@ -1,0 +1,68 @@
+import ptf
+import ptf.packet as scapy
+import ptf.testutils as testutils
+from ptf.mask import Mask
+from ptf.base_tests import BaseTest
+
+
+class ECNMarkingTest(BaseTest):
+    """Verify an ingress ACL SET_ECN action marks routed traffic with ECN=CE (3).
+
+    Topology/family-agnostic: all ports, IPs, MAC and IP version are supplied
+    as params by the sonic-mgmt test, so the same PTF test runs on IPv4 or IPv6
+    topologies (Mellanox, Broadcom, etc.). A packet is injected with ECN=00 on
+    the ingress port (which carries the ECN ACL); the DUT routes it to the
+    egress port; the egress copy must have ECN bits = 3 (CE).
+    """
+
+    def setUp(self):
+        BaseTest.setUp(self)
+        self.dataplane = ptf.dataplane_instance
+        p = testutils.test_params_get()
+        self.ip_version = p['ip_version']
+        self.src_port = int(p['src_port'])
+        self.dst_port = int(p['dst_port'])
+        self.router_mac = p['router_mac']
+        self.src_ip = p['src_ip']
+        self.dst_ip = p['dst_ip']
+        self.udp_sport = int(p.get('udp_sport', 5000))
+        self.udp_dport = int(p.get('udp_dport', 6000))
+
+    def runTest(self):
+        if self.ip_version == 'ipv6':
+            pkt = testutils.simple_udpv6_packet(
+                eth_dst=self.router_mac, eth_src='00:11:22:33:44:55',
+                ipv6_src=self.src_ip, ipv6_dst=self.dst_ip,
+                ipv6_hlim=64, ipv6_tc=0,
+                udp_sport=self.udp_sport, udp_dport=self.udp_dport)
+            exp = testutils.simple_udpv6_packet(
+                ipv6_src=self.src_ip, ipv6_dst=self.dst_ip,
+                ipv6_hlim=63, ipv6_tc=3,
+                udp_sport=self.udp_sport, udp_dport=self.udp_dport)
+            m = Mask(exp)
+            m.set_do_not_care_scapy(scapy.Ether, 'dst')
+            m.set_do_not_care_scapy(scapy.Ether, 'src')
+            m.set_do_not_care_scapy(scapy.IPv6, 'hlim')
+            m.set_do_not_care_scapy(scapy.IPv6, 'fl')
+        else:
+            pkt = testutils.simple_udp_packet(
+                eth_dst=self.router_mac, eth_src='00:11:22:33:44:55',
+                ip_src=self.src_ip, ip_dst=self.dst_ip,
+                ip_ttl=64, ip_tos=0,
+                udp_sport=self.udp_sport, udp_dport=self.udp_dport)
+            exp = testutils.simple_udp_packet(
+                ip_src=self.src_ip, ip_dst=self.dst_ip,
+                ip_ttl=63, ip_tos=3,
+                udp_sport=self.udp_sport, udp_dport=self.udp_dport)
+            m = Mask(exp)
+            m.set_do_not_care_scapy(scapy.Ether, 'dst')
+            m.set_do_not_care_scapy(scapy.Ether, 'src')
+            m.set_do_not_care_scapy(scapy.IP, 'ttl')
+            m.set_do_not_care_scapy(scapy.IP, 'chksum')
+            m.set_do_not_care_scapy(scapy.IP, 'id')
+
+        testutils.send_packet(self, self.src_port, pkt)
+        testutils.verify_packet(self, m, self.dst_port)
+
+    def tearDown(self):
+        BaseTest.tearDown(self)

--- a/docs/testplan/ECN-ACL-Marking-test-plan.md
+++ b/docs/testplan/ECN-ACL-Marking-test-plan.md
@@ -95,9 +95,11 @@ Verify matching traffic is ECN-marked in hardware.
 
 #### Test steps
 
-- PTF sends a routed UDP packet (source port 5000) with `ECN=0` to the DUT.
-- Verify the packet forwarded out of the egress uplink has `ECN=3` (CE), with the
-  rest of the packet unchanged.
+- PTF sends a routed UDP packet with the matching source port and `ECN=0`; verify
+  the packet forwarded out of the egress uplink has `ECN=3` (CE), with the rest of
+  the packet unchanged.
+- PTF sends a routed UDP packet with a non-matching source port and `ECN=0`; verify
+  it is still forwarded but its `ECN` is left unchanged (`0`).
 
 ### Test case 3: SRv6 uN coexistence
 
@@ -123,8 +125,6 @@ both `SET_ECN` and SRv6 uN (`th5`/`th6`/`spc5`/`spc6`).
 
 ## Future work / platform limitations
 
-- **SRv6 decap (uDT) interaction:** not hardware-supported yet (Spectrum-5 /
-  Tomahawk-5 SAI/SDK reject `uDT4`/`uDT6`/`uDT46`). By code review SONiC leaves
-  the decap tunnel's ECN mode at the RFC 6040 default, so marking `CE` on
-  to-be-decapped traffic would drop Not-ECT inner packets per RFC 6040 - a
-  caveat to validate once an ASIC supports SRv6 decap.
+- **SRv6 decap (uDT) interaction:** not yet covered. Marking ECN on traffic that is
+  later SRv6-decapsulated also interacts with RFC 6040 decap behaviour, to be
+  validated once SRv6 decap is available.

--- a/docs/testplan/ECN-ACL-Marking-test-plan.md
+++ b/docs/testplan/ECN-ACL-Marking-test-plan.md
@@ -1,0 +1,103 @@
+# ECN Marking ACL Test Plan
+
+- [Overview](#overview)
+  - [Scope](#scope)
+  - [Testbed](#testbed)
+- [Setup configuration](#setup-configuration)
+- [Test cases](#test-cases)
+  - [test_ecn_acl_control_plane](#test-case-1-control-plane)
+  - [test_ecn_acl_data_plane](#test-case-2-data-plane)
+- [TODO](#todo)
+
+## Overview
+
+Verify the `ECN_ACTION` ACL action, which rewrites the ECN field (the low 2 bits
+of the IPv4 TOS / IPv6 Traffic Class byte) of matching packets in hardware, per
+[RFC 3168](https://www.rfc-editor.org/rfc/rfc3168). `ECN_ACTION` takes a value in
+`[0..3]` (`0`=Non-ECT, `1`=ECT(1), `2`=ECT(0), `3`=CE) and maps to the SAI
+attribute `SAI_ACL_ENTRY_ATTR_ACTION_SET_ECN`. See the
+[ACL High Level Design](https://github.com/sonic-net/SONiC/blob/master/doc/acl/ACL-High-Level-Design.md)
+for the feature design.
+
+The test is implemented in
+[`acl/test_ecn_acl.py`](../../tests/acl/test_ecn_acl.py); the data-plane packet
+check runs in the PTF test
+[`ecn_acl_ptftest.ECNMarkingTest`](../../ansible/roles/test/files/ptftests/ecn_acl_ptftest.py).
+
+### Scope
+
+The test verifies that an ingress `L3`/`L3V6` ACL rule carrying `ECN_ACTION` is
+programmed to hardware (control plane) and that matching traffic is ECN-marked on
+egress (data plane). It does not cover WRED/ECN congestion marking, which lives
+under [`docs/testplan/ecn/`](ecn/).
+
+### Testbed
+
+Supported topologies: `t0`, `t1`, `t2`.
+
+`ECN_ACTION` depends on SAI support for `SAI_ACL_ENTRY_ATTR_ACTION_SET_ECN`. The
+test is gated by
+[`conditional_mark`](../../tests/common/plugins/conditional_mark) to ECN-capable
+ASIC generations (validated on Broadcom Tomahawk-5 and NVIDIA Spectrum-5) and is
+skipped on platforms that do not advertise the capability.
+
+## Setup configuration
+
+No pre-configuration is required. The test discovers two routed uplink ports from
+the minigraph (IPv4 preferred, else IPv6), applies an ingress ACL table and rule,
+and removes them on teardown. The rule is applied via two parametrized methods:
+
+- **operator** &ndash; `config acl add table` followed by a GCU
+  `config apply-patch`, which also exercises the `sonic-acl` YANG `ECN_ACTION`
+  leaf validation.
+- **configdb** &ndash; a direct `CONFIG_DB` write (`sonic-cfggen --write-to-db`),
+  isolating the orchagent / ASIC path from YANG and GCU.
+
+Example rule &ndash; an `L3`/`L3V6` table bound to the ingress uplink, matching
+UDP source port 5000, action `ECN_ACTION: 3` (CE):
+
+```json
+{
+    "ACL_RULE": {
+        "ECN_TEST|MARK_UDP_5000": {
+            "PRIORITY": "9990",
+            "L4_SRC_PORT": "5000",
+            "ECN_ACTION": "3"
+        }
+    }
+}
+```
+
+## Test cases
+
+### Test case 1: control plane
+
+`test_ecn_acl_control_plane`
+
+#### Test objective
+
+Verify the rule is accepted and programmed to hardware.
+
+#### Test steps
+
+- Apply the ECN rule via the **operator** and **configdb** methods.
+- Verify `show acl rule` renders the action as `ECN: 3` (not the raw
+  `ECN_ACTION` key) and the rule reports `Active`.
+
+### Test case 2: data plane
+
+`test_ecn_acl_data_plane`
+
+#### Test objective
+
+Verify matching traffic is ECN-marked in hardware.
+
+#### Test steps
+
+- PTF sends a routed UDP packet (source port 5000) with `ECN=0` to the DUT.
+- Verify the packet forwarded out of the egress uplink has `ECN=3` (CE), with the
+  rest of the packet unchanged.
+
+## TODO
+
+- ECN marking interaction with SRv6 forwarding (encap / decap / transit).

--- a/docs/testplan/ECN-ACL-Marking-test-plan.md
+++ b/docs/testplan/ECN-ACL-Marking-test-plan.md
@@ -7,7 +7,8 @@
 - [Test cases](#test-cases)
   - [test_ecn_acl_control_plane](#test-case-1-control-plane)
   - [test_ecn_acl_data_plane](#test-case-2-data-plane)
-- [TODO](#todo)
+  - [test_srv6_ecn_marking_uN](#test-case-3-srv6-un-coexistence)
+- [Future work / platform limitations](#future-work--platform-limitations)
 
 ## Overview
 
@@ -98,13 +99,32 @@ Verify matching traffic is ECN-marked in hardware.
 - Verify the packet forwarded out of the egress uplink has `ECN=3` (CE), with the
   rest of the packet unchanged.
 
-## TODO
+### Test case 3: SRv6 uN coexistence
 
-- **SRv6 forwarding interaction** (see [`srv6/test_srv6_ecn_acl.py`](../../tests/srv6/test_srv6_ecn_acl.py)):
-  - *Transit (uN):* validated — `ECN_ACTION` marks the SRv6 outer ECN and uN forwarding is
-    unaffected (uN only rewrites the destination address + hop-limit). Tested by
-    `test_srv6_ecn_marking_uN` with a negative control.
-  - *Decap (uDT):* not hardware-supported yet (Spectrum-5 / Tomahawk-5 SAI/SDK). By code review
-    SONiC leaves the decap tunnel's ECN mode at the RFC 6040 default, so marking `CE` on
-    to-be-decapped traffic would drop Not-ECT inner packets per RFC 6040 — a caveat to verify
-    once an ASIC supports SRv6 decap.
+`test_srv6_ecn_marking_uN` (see [`srv6/test_srv6_ecn_acl.py`](../../tests/srv6/test_srv6_ecn_acl.py))
+
+#### Test objective
+
+Verify `ECN_ACTION` marking and SRv6 uN forwarding coexist: an ingress `L3V6`
+ACL marks the SRv6 outer ECN while the DUT still performs the uN uSID shift.
+
+#### Test steps
+
+- PTF sends an SRv6 (IPv6-in-IPv6) packet with outer `ECN=0` whose outer
+  destination hits the DUT's uN SID.
+- Verify the uN-forwarded packet leaves with the outer destination shifted, the
+  hop limit decremented, and outer `ECN=3` (CE) set by the ACL.
+- A negative control (`test_srv6_ecn_negative_control`) sends a non-matching
+  packet and confirms it is still uN-forwarded but its outer ECN stays `0`,
+  proving the marking comes from the ACL and not from SRv6.
+
+This scenario is gated by `conditional_mark` to ASIC generations that support
+both `SET_ECN` and SRv6 uN (`th5`/`th6`/`spc5`/`spc6`).
+
+## Future work / platform limitations
+
+- **SRv6 decap (uDT) interaction:** not hardware-supported yet (Spectrum-5 /
+  Tomahawk-5 SAI/SDK reject `uDT4`/`uDT6`/`uDT46`). By code review SONiC leaves
+  the decap tunnel's ECN mode at the RFC 6040 default, so marking `CE` on
+  to-be-decapped traffic would drop Not-ECT inner packets per RFC 6040 - a
+  caveat to validate once an ASIC supports SRv6 decap.

--- a/docs/testplan/ECN-ACL-Marking-test-plan.md
+++ b/docs/testplan/ECN-ACL-Marking-test-plan.md
@@ -100,4 +100,11 @@ Verify matching traffic is ECN-marked in hardware.
 
 ## TODO
 
-- ECN marking interaction with SRv6 forwarding (encap / decap / transit).
+- **SRv6 forwarding interaction** (see [`srv6/test_srv6_ecn_acl.py`](../../tests/srv6/test_srv6_ecn_acl.py)):
+  - *Transit (uN):* validated — `ECN_ACTION` marks the SRv6 outer ECN and uN forwarding is
+    unaffected (uN only rewrites the destination address + hop-limit). Tested by
+    `test_srv6_ecn_marking_uN` with a negative control.
+  - *Decap (uDT):* not hardware-supported yet (Spectrum-5 / Tomahawk-5 SAI/SDK). By code review
+    SONiC leaves the decap tunnel's ECN mode at the RFC 6040 default, so marking `CE` on
+    to-be-decapped traffic would drop Not-ECT inner packets per RFC 6040 — a caveat to verify
+    once an ASIC supports SRv6 decap.

--- a/tests/acl/test_ecn_acl.py
+++ b/tests/acl/test_ecn_acl.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('t0', 't1', 't2')]
 
 ACL_TABLE_NAME = "ECN_TEST"
-ACL_TABLE_TYPE = "ECN_TEST_TYPE"
 ACL_RULE_NAME = "MARK_UDP_5000"
 UDP_SPORT = 5000
 UDP_DPORT = 6000
@@ -54,24 +53,17 @@ def setup_ecn(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     fam, ing, egr = _discover_uplinks(duthost, tbinfo)
     router_mac = duthost.facts['router_mac']
-    ip_match = "SRC_IPV6" if fam == 'ipv6' else "SRC_IP"
 
-    # Use a custom ACL table type that explicitly declares the ECN action.
-    # This works on every platform, including those where the built-in L3
-    # table action list is mandatory at creation (e.g. Broadcom); COUNTER is
-    # included because a per-rule counter is created by default.
+    # Use a built-in L3 / L3V6 table so orchagent handles the platform
+    # difference itself: on a platform with a mandatory action list it seeds
+    # SET_ECN from defaultAclActionList (exercising that fix); elsewhere the
+    # action is accepted directly. No custom table type is needed.
+    acl_table_type = "L3V6" if fam == 'ipv6' else "L3"
     cfg = {
-        "ACL_TABLE_TYPE": {
-            ACL_TABLE_TYPE: {
-                "MATCHES": [ip_match, "L4_SRC_PORT"],
-                "ACTIONS": ["PACKET_ACTION", "ECN_ACTION", "COUNTER"],
-                "BIND_POINTS": ["PORT"],
-            }
-        },
         "ACL_TABLE": {
             ACL_TABLE_NAME: {
                 "policy_desc": "ECN marking test",
-                "type": ACL_TABLE_TYPE,
+                "type": acl_table_type,
                 "stage": "ingress",
                 "ports": [ing['port']],
             }
@@ -101,8 +93,6 @@ def setup_ecn(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     duthost.shell("redis-cli -n 4 DEL 'ACL_RULE|{}|{}'".format(ACL_TABLE_NAME, ACL_RULE_NAME),
                   module_ignore_errors=True)
     duthost.shell("redis-cli -n 4 DEL 'ACL_TABLE|{}'".format(ACL_TABLE_NAME),
-                  module_ignore_errors=True)
-    duthost.shell("redis-cli -n 4 DEL 'ACL_TABLE_TYPE|{}'".format(ACL_TABLE_TYPE),
                   module_ignore_errors=True)
     duthost.shell("rm -f /tmp/ecn_acl.json", module_ignore_errors=True)
 

--- a/tests/acl/test_ecn_acl.py
+++ b/tests/acl/test_ecn_acl.py
@@ -15,6 +15,7 @@ ACL_TABLE_NAME = "ECN_TEST"
 ACL_RULE_NAME = "MARK_UDP_5000"
 UDP_SPORT = 5000
 UDP_DPORT = 6000
+NON_MATCH_UDP_SPORT = 5001
 
 
 def _discover_uplinks(duthost, tbinfo):
@@ -125,6 +126,7 @@ def test_ecn_acl_data_plane(ptfhost, setup_ecn):
         'dst_ip': setup_ecn['dst_ip'],
         'udp_sport': UDP_SPORT,
         'udp_dport': UDP_DPORT,
+        'non_match_udp_sport': NON_MATCH_UDP_SPORT,
     }
     logger.info("PTF params: %s", params)
     ptf_runner(

--- a/tests/acl/test_ecn_acl.py
+++ b/tests/acl/test_ecn_acl.py
@@ -46,6 +46,7 @@ def _discover_uplinks(duthost, tbinfo):
                         fam, cand[fam][0], cand[fam][1])
             return fam, cand[fam][0], cand[fam][1]
     pytest.skip("No two routed uplink ports with neighbors found for ECN DP test")
+    return None
 
 
 @pytest.fixture(scope="module")

--- a/tests/acl/test_ecn_acl.py
+++ b/tests/acl/test_ecn_acl.py
@@ -52,12 +52,6 @@ def _discover_uplinks(duthost, tbinfo):
 def setup_ecn(request, duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     apply_method = request.param
     duthost = duthosts[rand_one_dut_hostname]
-    cap = duthost.shell(
-        "sonic-db-cli STATE_DB HGET 'ACL_STAGE_CAPABILITY_TABLE|INGRESS' action_list",
-        module_ignore_errors=True)['stdout']
-    if 'ECN_ACTION' not in cap:
-        pytest.skip("Switch does not support ACL ECN_ACTION (ECN marking not present on this "
-                    "image/platform); supported ingress actions: {}".format(cap))
     fam, ing, egr = _discover_uplinks(duthost, tbinfo)
     router_mac = duthost.facts['router_mac']
 

--- a/tests/acl/test_ecn_acl.py
+++ b/tests/acl/test_ecn_acl.py
@@ -1,0 +1,138 @@
+import pytest
+import time
+import json
+import logging
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.ptf_runner import ptf_runner
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.topology('t0', 't1', 't2')]
+
+ACL_TABLE_NAME = "ECN_TEST"
+ACL_TABLE_TYPE = "ECN_TEST_TYPE"
+ACL_RULE_NAME = "MARK_UDP_5000"
+UDP_SPORT = 5000
+UDP_DPORT = 6000
+
+
+def _discover_uplinks(duthost, tbinfo):
+    """Pick two routed physical ports (same IP family) with reachable neighbors.
+
+    Topology/platform-agnostic: derives everything from minigraph facts instead
+    of hard-coding port names or neighbor IPs, so the test fits any topo. IPv4
+    is preferred when available, otherwise IPv6.
+    Returns (ip_version, ingress_dict, egress_dict) where each dict has
+    port / peer / ptf_idx.
+    """
+    mg = duthost.get_extended_minigraph_facts(tbinfo)
+    ptf_idx = mg['minigraph_ptf_indices']
+    cand = {'ipv4': [], 'ipv6': []}
+    for intf in mg.get('minigraph_interfaces', []):
+        port = intf.get('attachto')
+        addr = str(intf.get('addr', ''))
+        peer = intf.get('peer_addr')
+        if not port or not peer or port not in ptf_idx:
+            continue
+        fam = 'ipv6' if ':' in addr else 'ipv4'
+        if any(c['port'] == port for c in cand[fam]):
+            continue
+        cand[fam].append({'port': port, 'peer': str(peer), 'ptf_idx': ptf_idx[port]})
+    for fam in ('ipv4', 'ipv6'):
+        if len(cand[fam]) >= 2:
+            logger.info("ECN DP using %s uplinks: ingress=%s egress=%s",
+                        fam, cand[fam][0], cand[fam][1])
+            return fam, cand[fam][0], cand[fam][1]
+    pytest.skip("No two routed uplink ports with neighbors found for ECN DP test")
+
+
+@pytest.fixture(scope="module")
+def setup_ecn(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
+    fam, ing, egr = _discover_uplinks(duthost, tbinfo)
+    router_mac = duthost.facts['router_mac']
+    ip_match = "SRC_IPV6" if fam == 'ipv6' else "SRC_IP"
+
+    # Use a custom ACL table type that explicitly declares the ECN action.
+    # This works on every platform, including those where the built-in L3
+    # table action list is mandatory at creation (e.g. Broadcom); COUNTER is
+    # included because a per-rule counter is created by default.
+    cfg = {
+        "ACL_TABLE_TYPE": {
+            ACL_TABLE_TYPE: {
+                "MATCHES": [ip_match, "L4_SRC_PORT"],
+                "ACTIONS": ["PACKET_ACTION", "ECN_ACTION", "COUNTER"],
+                "BIND_POINTS": ["PORT"],
+            }
+        },
+        "ACL_TABLE": {
+            ACL_TABLE_NAME: {
+                "policy_desc": "ECN marking test",
+                "type": ACL_TABLE_TYPE,
+                "stage": "ingress",
+                "ports": [ing['port']],
+            }
+        },
+        "ACL_RULE": {
+            "{}|{}".format(ACL_TABLE_NAME, ACL_RULE_NAME): {
+                "PRIORITY": "9990",
+                "L4_SRC_PORT": str(UDP_SPORT),
+                "ECN_ACTION": "3",
+            }
+        },
+    }
+    duthost.copy(content=json.dumps(cfg), dest="/tmp/ecn_acl.json")
+    duthost.shell("sudo sonic-cfggen -j /tmp/ecn_acl.json --write-to-db")
+    time.sleep(3)
+
+    yield {
+        "duthost": duthost,
+        "ip_version": fam,
+        "router_mac": router_mac,
+        "src_idx": ing['ptf_idx'],
+        "dst_idx": egr['ptf_idx'],
+        "src_ip": ing['peer'],   # ingress neighbor -> uRPF-friendly source
+        "dst_ip": egr['peer'],   # egress neighbor  -> deterministic egress port
+    }
+
+    duthost.shell("redis-cli -n 4 DEL 'ACL_RULE|{}|{}'".format(ACL_TABLE_NAME, ACL_RULE_NAME),
+                  module_ignore_errors=True)
+    duthost.shell("redis-cli -n 4 DEL 'ACL_TABLE|{}'".format(ACL_TABLE_NAME),
+                  module_ignore_errors=True)
+    duthost.shell("redis-cli -n 4 DEL 'ACL_TABLE_TYPE|{}'".format(ACL_TABLE_TYPE),
+                  module_ignore_errors=True)
+    duthost.shell("rm -f /tmp/ecn_acl.json", module_ignore_errors=True)
+
+
+def test_ecn_acl_control_plane(setup_ecn):
+    duthost = setup_ecn['duthost']
+    out = duthost.shell("show acl rule {} {}".format(ACL_TABLE_NAME, ACL_RULE_NAME))['stdout']
+    logger.info("show acl rule:\n%s", out)
+    # ECN_ACTION must render as "ECN: <val>" under Action (acl_loader fix), not
+    # leak as the raw key, and the rule must be programmed to hardware (Active).
+    pytest_assert("ECN: 3" in out, "ECN action not shown under Action column: %s" % out)
+    pytest_assert("ECN_ACTION" not in out, "raw ECN_ACTION key leaked into display: %s" % out)
+    pytest_assert("Active" in out, "ECN rule not Active (ASIC not programmed): %s" % out)
+
+
+def test_ecn_acl_data_plane(ptfhost, setup_ecn):
+    params = {
+        'ip_version': setup_ecn['ip_version'],
+        'src_port': setup_ecn['src_idx'],
+        'dst_port': setup_ecn['dst_idx'],
+        'router_mac': setup_ecn['router_mac'],
+        'src_ip': setup_ecn['src_ip'],
+        'dst_ip': setup_ecn['dst_ip'],
+        'udp_sport': UDP_SPORT,
+        'udp_dport': UDP_DPORT,
+    }
+    logger.info("PTF params: %s", params)
+    ptf_runner(
+        ptfhost,
+        "ptftests",
+        "ecn_acl_ptftest.ECNMarkingTest",
+        platform_dir="ptftests",
+        params=params,
+        log_file="/tmp/ecn_acl_ptftest.log")

--- a/tests/acl/test_ecn_acl.py
+++ b/tests/acl/test_ecn_acl.py
@@ -56,8 +56,8 @@ def setup_ecn(request, duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
         "sonic-db-cli STATE_DB HGET 'ACL_STAGE_CAPABILITY_TABLE|INGRESS' action_list",
         module_ignore_errors=True)['stdout']
     if 'ECN_ACTION' not in cap:
-        pytest.skip("ECN_ACTION not in the switch's ingress ACL capability; "
-                    "ECN marking is not supported on this image/platform")
+        pytest.skip("Switch does not support ACL ECN_ACTION (ECN marking not present on this "
+                    "image/platform); supported ingress actions: {}".format(cap))
     fam, ing, egr = _discover_uplinks(duthost, tbinfo)
     router_mac = duthost.facts['router_mac']
 

--- a/tests/acl/test_ecn_acl.py
+++ b/tests/acl/test_ecn_acl.py
@@ -52,6 +52,12 @@ def _discover_uplinks(duthost, tbinfo):
 def setup_ecn(request, duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     apply_method = request.param
     duthost = duthosts[rand_one_dut_hostname]
+    cap = duthost.shell(
+        "sonic-db-cli STATE_DB HGET 'ACL_STAGE_CAPABILITY_TABLE|INGRESS' action_list",
+        module_ignore_errors=True)['stdout']
+    if 'ECN_ACTION' not in cap:
+        pytest.skip("ECN_ACTION not in the switch's ingress ACL capability; "
+                    "ECN marking is not supported on this image/platform")
     fam, ing, egr = _discover_uplinks(duthost, tbinfo)
     router_mac = duthost.facts['router_mac']
 

--- a/tests/acl/test_ecn_acl.py
+++ b/tests/acl/test_ecn_acl.py
@@ -48,8 +48,9 @@ def _discover_uplinks(duthost, tbinfo):
     return None
 
 
-@pytest.fixture(scope="module")
-def setup_ecn(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
+@pytest.fixture(scope="module", params=["operator", "configdb"])
+def setup_ecn(request, duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
+    apply_method = request.param
     duthost = duthosts[rand_one_dut_hostname]
     fam, ing, egr = _discover_uplinks(duthost, tbinfo)
     router_mac = duthost.facts['router_mac']
@@ -59,25 +60,31 @@ def setup_ecn(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     # SET_ECN from defaultAclActionList (exercising that fix); elsewhere the
     # action is accepted directly. No custom table type is needed.
     acl_table_type = "L3V6" if fam == 'ipv6' else "L3"
-    cfg = {
-        "ACL_TABLE": {
-            ACL_TABLE_NAME: {
-                "policy_desc": "ECN marking test",
-                "type": acl_table_type,
-                "stage": "ingress",
-                "ports": [ing['port']],
-            }
-        },
-        "ACL_RULE": {
-            "{}|{}".format(ACL_TABLE_NAME, ACL_RULE_NAME): {
-                "PRIORITY": "9990",
-                "L4_SRC_PORT": str(UDP_SPORT),
-                "ECN_ACTION": "3",
-            }
-        },
+    table_val = {
+        "policy_desc": "ECN marking test",
+        "type": acl_table_type,
+        "stage": "ingress",
+        "ports": [ing['port']],
     }
-    duthost.copy(content=json.dumps(cfg), dest="/tmp/ecn_acl.json")
-    duthost.shell("sudo sonic-cfggen -j /tmp/ecn_acl.json --write-to-db")
+    rule_key = "{}|{}".format(ACL_TABLE_NAME, ACL_RULE_NAME)
+    rule_val = {"PRIORITY": "9990", "L4_SRC_PORT": str(UDP_SPORT), "ECN_ACTION": "3"}
+
+    logger.info("Applying ECN ACL config via '%s' path", apply_method)
+    if apply_method == "operator":
+        # Operator path: create the table with the CLI, then add the ECN rule
+        # with a GCU patch. config apply-patch runs YANG validation, so this
+        # also exercises the sonic-acl YANG ECN_ACTION leaf end to end.
+        duthost.shell("sudo config acl add table {} {} --stage ingress --ports {}".format(
+            ACL_TABLE_NAME, acl_table_type, ing['port']))
+        patch = [{"op": "add", "path": "/ACL_RULE/{}".format(rule_key), "value": rule_val}]
+        duthost.copy(content=json.dumps(patch), dest="/tmp/ecn_patch.json")
+        duthost.shell("sudo config apply-patch /tmp/ecn_patch.json")
+    else:
+        # Direct CONFIG_DB write: isolates orchagent / data-plane behaviour from
+        # YANG and GCU, so a failure here points at the ASIC path, not validation.
+        cfg = {"ACL_TABLE": {ACL_TABLE_NAME: table_val}, "ACL_RULE": {rule_key: rule_val}}
+        duthost.copy(content=json.dumps(cfg), dest="/tmp/ecn_acl.json")
+        duthost.shell("sudo sonic-cfggen -j /tmp/ecn_acl.json --write-to-db")
     time.sleep(3)
 
     yield {
@@ -94,7 +101,7 @@ def setup_ecn(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
                   module_ignore_errors=True)
     duthost.shell("redis-cli -n 4 DEL 'ACL_TABLE|{}'".format(ACL_TABLE_NAME),
                   module_ignore_errors=True)
-    duthost.shell("rm -f /tmp/ecn_acl.json", module_ignore_errors=True)
+    duthost.shell("rm -f /tmp/ecn_acl.json /tmp/ecn_patch.json", module_ignore_errors=True)
 
 
 def test_ecn_acl_control_plane(setup_ecn):

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_acl.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_acl.yaml
@@ -1190,3 +1190,9 @@ acl/test_acl.py::TestIncrementalAcl::test_udp_source_ip_match_dropped[ipv6-egres
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+
+acl/test_ecn_acl.py:
+  skip:
+    reason: "ECN ACL marking (SAI SET_ECN) is validated on th5/th6/spc5/spc6; skip on other ASIC generations (incl. KVM)"
+    conditions:
+      - "asic_gen not in ['th5', 'th6', 'spc5', 'spc6']"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_acl.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_acl.yaml
@@ -1196,3 +1196,9 @@ acl/test_ecn_acl.py:
     reason: "ECN ACL marking (SAI SET_ECN) is validated on th5/th6/spc5/spc6; skip on other ASIC generations (incl. KVM)"
     conditions:
       - "asic_gen not in ['th5', 'th6', 'spc5', 'spc6']"
+
+srv6/test_srv6_ecn_acl.py:
+  skip:
+    reason: "ECN ACL marking x SRv6 uN coexistence; needs a SET_ECN-capable ASIC (th5/th6/spc5/spc6) and SRv6 uN support; skip elsewhere (incl. KVM)"
+    conditions:
+      - "asic_gen not in ['th5', 'th6', 'spc5', 'spc6']"

--- a/tests/srv6/test_srv6_ecn_acl.py
+++ b/tests/srv6/test_srv6_ecn_acl.py
@@ -1,0 +1,204 @@
+"""
+ECN ACL marking x SRv6 forwarding interaction test.
+
+This is a self-contained, additive wrapper around the existing SRv6 dataplane
+infrastructure: it reuses the shared SRv6 helpers (locator / SID config,
+neighbor / port discovery, send-verify) and only adds an ingress ECN ACL layer
+on top. It does not modify any existing SRv6 or ACL test. Removing this file
+(and its conditional_mark entry) leaves all pre-existing tests unchanged.
+
+Scenario 1 - coexistence on uN forwarding:
+    The DUT is an SRv6 uN endpoint. An ingress L3V6 ACL marks ECN=3 (CE) on the
+    outer IPv6 header of the SRv6 packet. We verify the uN-forwarded packet
+    (outer DA shifted, hop limit decremented) egresses with outer ECN=3, i.e.
+    ECN ACL marking and SRv6 uN forwarding coexist without clobbering each other.
+"""
+import json
+import logging
+
+import pytest
+from scapy.all import Raw
+from scapy.layers.inet6 import IPv6, UDP
+from scapy.layers.l2 import Ether
+import ptf.packet as packet
+from ptf.mask import Mask
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+from tests.srv6.srv6_utils import runSendReceive, get_neighbor_mac, verify_asic_db_sid_entry_exist
+from tests.srv6.test_srv6_dataplane import get_ptf_src_port_and_dut_port_and_neighbor
+from tests.common.helpers.srv6_helper import (
+    create_srv6_locator, del_srv6_locator, create_srv6_sid, del_srv6_sid,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.asic("mellanox", "broadcom"),
+    pytest.mark.topology("t0", "t1"),
+]
+
+LOCATOR = "ecnloc"
+LOCATOR_PREFIX = "fcbb:bbbb:1::"
+SID = "fcbb:bbbb:1::"                 # /48 uN SID
+UN_DA = "fcbb:bbbb:1:2::"            # incoming outer DA (hits the uN SID)
+UN_DA_SHIFTED = "fcbb:bbbb:2::"     # outer DA after the uN uSID shift
+FWD_ROUTE = "fcbb:bbbb:2::/48"
+BLACKHOLE = "fcbb:bbbb::/32"
+OUTER_SRC = "1000::1"
+ACL_TABLE = "ECN_SRV6_TEST"
+ACL_RULE = "MARK_SRV6"
+ECN_MARK = 3
+
+
+@pytest.fixture(scope="module")
+def setup_srv6_ecn(duthosts, rand_one_dut_hostname, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
+    dut_mac = duthost.facts["router_mac"]
+
+    ingress_intf, ptf_src_ports, neighbor = \
+        get_ptf_src_port_and_dut_port_and_neighbor(duthost, tbinfo)
+
+    neighbor_ip = None
+    for line in duthost.command("show ipv6 bgp summary")["stdout"].split("\n"):
+        if neighbor in line:
+            neighbor_ip = line.split()[0]
+    pytest_assert(neighbor_ip, "Could not find IPv6 for neighbor {}".format(neighbor))
+
+    # resolve the forwarding egress interface (portchannel if applicable)
+    fwd_intf = ingress_intf
+    pc_info = duthost.command("show int portchannel")["stdout"]
+    if ingress_intf in pc_info:
+        for line in pc_info.split("\n"):
+            if ingress_intf in line:
+                fwd_intf = line.split()[1]
+                break
+
+    db = "sonic-db-cli"
+
+    # --- SRv6 uN setup (reuse existing helpers) ---
+    create_srv6_locator(duthost, LOCATOR, LOCATOR_PREFIX)
+    create_srv6_sid(duthost, LOCATOR, SID, action="uN", decap_dscp_mode="pipe")
+    duthost.command(db + " CONFIG_DB HSET STATIC_ROUTE\\|default\\|{} nexthop {} ifname {}"
+                    .format(FWD_ROUTE, neighbor_ip, fwd_intf))
+    duthost.command(db + " CONFIG_DB HSET STATIC_ROUTE\\|default\\|{} blackhole true"
+                    .format(BLACKHOLE))
+    pytest_assert(wait_until(20, 5, 0, verify_asic_db_sid_entry_exist, duthost, db),
+                  "SRv6 MY_SID entry missing in ASIC_DB")
+
+    # --- ingress ECN ACL (L3V6) bound to the ingress interface ---
+    cfg = {
+        "ACL_TABLE": {
+            ACL_TABLE: {
+                "policy_desc": "ECN SRv6 coexistence",
+                "type": "L3V6",
+                "stage": "ingress",
+                "ports": [ingress_intf],
+            }
+        },
+        "ACL_RULE": {
+            "{}|{}".format(ACL_TABLE, ACL_RULE): {
+                "PRIORITY": "9990",
+                "SRC_IPV6": OUTER_SRC + "/128",
+                "ECN_ACTION": str(ECN_MARK),
+            }
+        },
+    }
+    duthost.copy(content=json.dumps(cfg), dest="/tmp/ecn_srv6_acl.json")
+    duthost.shell("sudo sonic-cfggen -j /tmp/ecn_srv6_acl.json --write-to-db")
+
+    def _rule_active():
+        out = duthost.shell("show acl rule {} {}".format(ACL_TABLE, ACL_RULE),
+                            module_ignore_errors=True)["stdout"]
+        return "ECN: {}".format(ECN_MARK) in out and "Active" in out
+    pytest_assert(wait_until(30, 5, 0, _rule_active),
+                  "ECN ACL rule was not programmed Active")
+
+    yield {
+        "duthost": duthost,
+        "dut_mac": dut_mac,
+        "ptf_src_ports": ptf_src_ports,
+        "neighbor_ip": neighbor_ip,
+    }
+
+    duthost.command(db + " CONFIG_DB DEL 'ACL_RULE|{}|{}'".format(ACL_TABLE, ACL_RULE),
+                    module_ignore_errors=True)
+    duthost.command(db + " CONFIG_DB DEL 'ACL_TABLE|{}'".format(ACL_TABLE),
+                    module_ignore_errors=True)
+    del_srv6_sid(duthost, LOCATOR, SID)
+    del_srv6_locator(duthost, LOCATOR)
+    duthost.command(db + " CONFIG_DB DEL STATIC_ROUTE\\|default\\|{}".format(FWD_ROUTE),
+                    module_ignore_errors=True)
+    duthost.command(db + " CONFIG_DB DEL STATIC_ROUTE\\|default\\|{}".format(BLACKHOLE),
+                    module_ignore_errors=True)
+    duthost.shell("rm -f /tmp/ecn_srv6_acl.json", module_ignore_errors=True)
+
+
+def test_srv6_ecn_marking_uN(setup_srv6_ecn, ptfadapter):
+    info = setup_srv6_ecn
+    duthost = info["duthost"]
+    dut_mac = info["dut_mac"]
+    ptf_src_ports = info["ptf_src_ports"]
+    ptf_src_port = ptf_src_ports[0]
+    src_mac = ptfadapter.dataplane.get_mac(0, ptf_src_port).decode()
+
+    # SRv6 uN packet (IPv6-in-IPv6), outer ECN=0 on ingress.
+    injected = Ether(dst=dut_mac, src=src_mac) \
+        / IPv6(src=OUTER_SRC, dst=UN_DA, tc=0) \
+        / IPv6() / UDP(dport=4791) / Raw(load="ecnsrv6test")
+
+    # After uN forwarding the outer DA is shifted and hop limit decremented; the
+    # ingress ACL must additionally set outer ECN=3 (DSCP unchanged -> tc=0x03).
+    exp = injected.copy()
+    exp["Ether"].dst = get_neighbor_mac(duthost, info["neighbor_ip"])
+    exp["Ether"].src = dut_mac
+    exp["IPv6"].dst = UN_DA_SHIFTED
+    exp["IPv6"].hlim -= 1
+    exp["IPv6"].tc = (0 << 2) | ECN_MARK
+
+    masked = Mask(exp)
+    masked.set_do_not_care_packet(packet.Ether, "dst")
+    masked.set_do_not_care_packet(packet.Ether, "src")
+    masked.set_do_not_care_packet(packet.IPv6, "fl")
+
+    passed = runSendReceive(injected, ptf_src_port, masked, ptf_src_ports, True, ptfadapter)
+    pytest_assert(
+        passed,
+        "SRv6 uN packet was not received with outer ECN=3; ECN ACL marking and "
+        "SRv6 uN forwarding do not coexist as expected.")
+
+
+def test_srv6_ecn_negative_control(setup_srv6_ecn, ptfadapter):
+    """Fact-check: an SRv6 packet whose outer SRC_IPV6 does NOT match the ACL
+    rule must still be uN-forwarded but must NOT be ECN-marked (stays ECN=0).
+    This proves the ECN=3 seen in test_srv6_ecn_marking_uN comes from the ACL
+    match specifically, not from SRv6 processing or any other artifact."""
+    info = setup_srv6_ecn
+    duthost = info["duthost"]
+    dut_mac = info["dut_mac"]
+    ptf_src_ports = info["ptf_src_ports"]
+    ptf_src_port = ptf_src_ports[0]
+    src_mac = ptfadapter.dataplane.get_mac(0, ptf_src_port).decode()
+
+    non_match_src = "2000::1"  # not covered by the ACL rule (SRC_IPV6 1000::1/128)
+    injected = Ether(dst=dut_mac, src=src_mac) \
+        / IPv6(src=non_match_src, dst=UN_DA, tc=0) \
+        / IPv6() / UDP(dport=4791) / Raw(load="ecnsrv6neg")
+
+    exp = injected.copy()
+    exp["Ether"].dst = get_neighbor_mac(duthost, info["neighbor_ip"])
+    exp["Ether"].src = dut_mac
+    exp["IPv6"].dst = UN_DA_SHIFTED
+    exp["IPv6"].hlim -= 1
+    exp["IPv6"].tc = 0  # ECN must stay 0 - rule did not match
+
+    masked = Mask(exp)
+    masked.set_do_not_care_packet(packet.Ether, "dst")
+    masked.set_do_not_care_packet(packet.Ether, "src")
+    masked.set_do_not_care_packet(packet.IPv6, "fl")
+
+    passed = runSendReceive(injected, ptf_src_port, masked, ptf_src_ports, True, ptfadapter)
+    pytest_assert(
+        passed,
+        "Non-matching SRv6 packet was not received with outer ECN=0; the ECN ACL "
+        "is marking traffic it should not, or SRv6 forwarding alters ECN.")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The Goal is to test new ECN marking through ACL feature.
Add tests/acl/test_ecn_acl.py and the ecn_acl_ptftest.py PTF test for the ECN_ACTION ACL marking feature.

The test is IP-family-agnostic: it discovers two routed uplinks and their neighbors from minigraph facts and uses a custom ACL_TABLE_TYPE, so the same test runs on IPv4 and IPv6 topologies. It validates the control plane (show acl rule renders "ECN: 3" and the rule is Active) and the data plane (ingress ECN=00 becomes egress ECN=3/CE after the ASIC marks it).
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
To test new ECN marking through ACL feature

#### How did you do it?
It will test both the control plan and data plan. Make sure both works as expected.

#### How did you verify/test it?
Tested on testbed to verify.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
