### PR TITLE
[loganalyzer] Ignore rsyslog-collapsed "collectData: Failed to get port attr" logs

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -509,7 +509,7 @@ r, ".* ERR swss\d*#orchagent:.*getPortLinkTrainingFailure: Failed to get LT fail
 # https://github.com/sonic-net/sonic-mgmt/issues/24023
 r, ".* ERR syncd\d*#syncd:.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn:\d+ RX signal detect status get \d+ attrib \d+ failed with error Feature unavailable \(0xfffffff0\).*"
 r, ".* ERR syncd\d*#syncd:.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn:\d+ bcm_port_phy_control_get rx snr failed with error Feature unavailable \(0xfffffff0\).*"
-r, ".* ERR syncd\d*#syncd: :- collectData: Failed to get port attr for VID 0x[0-9a-fA-F]+, RID:0x[0-9a-fA-F]+: -\d+.*"
+r, ".* ERR syncd\d*#syncd:.*collectData: Failed to get port attr for VID 0x[0-9a-fA-F]+, RID:0x[0-9a-fA-F]+: -\d+.*"
 
 # https://github.com/sonic-net/sonic-mgmt/issues/19347
 r, ".* ERR auditd.*: queue to plugins is full - dropping event"


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #24023

The LogAnalyzer ignore rule for the benign syncd `collectData: Failed to get port attr for VID ... RID ...: -<code>` error anchored on the literal substring `#syncd: :- collectData`. rsyslog deduplicates repeated identical lines into a summary of the form:

```
ERR syncd#syncd: message repeated N times: [ :- collectData: Failed to get port attr for VID 0x..., RID:0x...: -8]
```

Because `message repeated N times: [ ` sits between `#syncd:` and `:- collectData`, the rigid anchor does not match the collapsed line. LogAnalyzer then flags it and QoS SAI cases error on teardown (observed on Broadcom 7060x6 ft2/lt2 nightlies, e.g. `str4-7060x6-512-4`, image `20251110.38` — 14 QoS SAI teardown errors in a single nightly).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: #24023
Failure type: day-one issue (test infrastructure — the collapsed-log form was never covered by the ignore rule)

### Approach
#### What is the motivation for this PR?
Eliminate false-positive LogAnalyzer teardown failures on Broadcom 7060x6 nightlies. A previous fix generalized the error code (`-2` -> `-\d+`), but the rule still only matched the un-collapsed line, so rsyslog's `message repeated N times: [ ... ]` summary continued to trip LogAnalyzer and error the QoS SAI cases at teardown.

#### How did you do it?
Replaced the rigid `#syncd: :- collectData` anchor with `#syncd:.*collectData` in `loganalyzer_common_ignore.txt`, so both the direct and the rsyslog-collapsed forms are ignored. The rest of the pattern (VID/RID hex and `-\d+` error code) is unchanged, keeping the rule scoped to this specific benign error.

#### How did you verify/test it?
Validated the new regex against the exact lines from the failing nightly: it matches both the direct line and the `message repeated N times: [ ... ]` collapsed line, matches multi-asic `syncd0`, and does not match unrelated `collectData` errors.

#### Any platform specific information?
Broadcom 7060x6 (ft2/lt2 topologies). The SAI return code observed on this platform is `-8`; the log volume triggers rsyslog message collapsing.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case.

### Documentation
N/A — no documentation change required.
