### PR TITLE
[vm_set/golden_config/port_utils]: Converged LT2 (NH-4210-F-O256 / lt2-u32d128) testbed bring-up fixes

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -1113,7 +1113,7 @@ class GenerateGoldenConfigDBModule(object):
         is handled separately by override_port_table_from_platform().
         """
         SUPPORTED_TOPO = ["ft2-64", "ft2-16", "lt2-p32o64", "lt2-o128", "lt2-o128-d110u14",
-                          "ft2-o128", "lt2-o256-u32d224"]
+                          "ft2-o128", "lt2-o256-u32d224", "lt2-u32d128"]
         if self.topo_name not in SUPPORTED_TOPO:
             return "{}"
         SUPPORTED_PORT_SPEED = ["200000", "400000", "800000"]

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -144,6 +144,11 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             for i in range(33, 65):
                 for x, j in zip([1, 3, 5, 7], ["a", "b", "c", "d"]):
                     port_alias_to_name_map["etp%d%s" % (i, j)] = "Ethernet%d" % ((i - 1) * 8 + x - 1)
+        elif hwsku in ["NH-4210-F-O256"]:
+            for i in range(1, 129):
+                for x, j in zip([1, 5], ["a", "b"]):
+                    port_alias_to_name_map["etp%d%s" % (i, j)] = "Ethernet%d" % ((i - 1) * 8 + x - 1)
+            port_alias_to_name_map["etp129"] = "Ethernet1024"
         elif hwsku == "Arista-7060X6-64PE-256x200G":
             for i in range(1, 65):
                 for j in [1, 3, 5, 7]:

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -210,6 +210,8 @@
       fp_mtu: "{{ fp_mtu_size }}"
       max_fp_num: "{{ max_fp_num }}"
       netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
+      multi_vrf: "{{ topo_is_multi_vrf }}"
+      multi_vrf_data: "{{ convergence_data|default({}) }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
     become: yes
     when: "'bmc' not in topo"


### PR DESCRIPTION
### Description of PR
Summary: Three framework fixes needed to bring up and run nightly on converged LT2 testbeds using the Nexthop NH-4210-F-O256 SKU (topology `lt2-u32d128`). These are generic (non-lab-specific) and apply to any converged (`use_converged_peers`) testbed and to any `lt2-u32d128` deployment.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Bringing up the converged LT2 physical testbed (NH-4210, SKU `NH-4210-F-O256`, topology `lt2-u32d128`) surfaced three framework gaps that blocked `restart-ptf`, `deploy-mg`, and nightly `pretest`:

1. **`renumber_topo.yml` dropped `multi_vrf` on the renumber path** — the `vm_topology cmd=renumber` call omitted `multi_vrf`/`multi_vrf_data`, so on converged testbeds `restart-ptf` skipped `add_bp_port_with_vlans_to_docker` and never built the exabgp backplane VLAN subinterfaces. All exabgp→cEOS sessions stayed `Active`, so no exabgp-announced routes (incl. the default route) reached the DUT, failing pretest `check_bgp`.
2. **`generate_golden_config_db.py` omitted `lt2-u32d128` from confederation `SUPPORTED_TOPO`** — the topology defines `dut_confed_asn`/`dut_confed_peers`, but `deploy-mg` produced no `BGP_DEVICE_GLOBAL.CONFED` entry, so the DUT presented its member AS and all 128 downstream T1 sessions were rejected with `OPEN Message Error/Bad Peer AS`.
3. **`port_utils.py` had no `NH-4210-F-O256` port-alias map** — testbed operations that read the DUT minigraph (e.g. `restart-ptf` on an `lt2-u32d128` testbed) failed with `Did not find port for Ethernet128 ... hwsku NH-4210-F-O256`.

#### How did you do it?
1. Mirror `add_topo.yml` by passing `multi_vrf: "{{ topo_is_multi_vrf }}"` and `multi_vrf_data: "{{ convergence_data|default({}) }}"` on the renumber `vm_topology` call.
2. Add `lt2-u32d128` to `SUPPORTED_TOPO` in `generate_lt2_ft2_golden_config_db()`.
3. Add the `NH-4210-F-O256` SKU (128 physical ports × 2 sub-ports `etp<N>a/b` → `Ethernet0..1020` step 4, plus `etp129` → `Ethernet1024`; 257 ports) to `get_port_alias_to_name_map()`.

#### How did you verify/test it?
Validated end-to-end on a physical converged `lt2-u32d128` testbed (NH-4210-F-O256): full nightly `PREPARE_TESTBED` (checkout → restart-ptf renumber → deploy-mg) completed, `test_pretest.py` passed (12 passed / 3 skipped, `check_bgp` green), BGP came up 288/288 (144 v4 + 144 v6) with the default route present, and the suite proceeded into the test modules.

#### Any platform specific information?
The port-alias map entry is specific to the Nexthop `NH-4210-F-O256` SKU. The other two fixes are generic to converged testbeds and to the `lt2-u32d128` topology.

#### Supported testbed topology if it's a new test case?
N/A (framework fixes, not a new test case).

### Documentation
N/A
