### PR TITLE
Add PSU load sharing test

### DIFF
--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import time
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import chassis, psu
@@ -10,7 +11,13 @@ from .platform_api_test_base import PlatformApiTestBase
 from tests.common.utilities import skip_release_for_platform, wait_until
 from tests.platform_tests.api.conftest import skip_absent_psu
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service    # noqa: F401
-
+from tests.platform_tests.utils import (
+    daemon_start,
+    daemon_stop,
+    start_cpu_stress,
+    stop_cpu_stress,
+    is_pddf_supported_and_enabled,
+)
 
 ###################################################
 # TODO: Remove this after we transition to Python 3
@@ -308,6 +315,110 @@ class TestPsuApi(PlatformApiTestBase):
 
         if psus_skipped == self.num_psus:
             pytest.skip("skipped as all chassis psus' temperature sensor is not supported")
+
+        self.assert_expectations()
+
+    @pytest.mark.disable_loganalyzer
+    def test_load_sharing(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
+        """PSU load sharing test"""
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
+
+        LOAD_BALANCE_TOLERANCE_FROM_AVERAGE_POWER = 0.20  # +/- 20% of max rated power
+        SAMPLE_WINDOW_FOR_AVERAGE_POWER_S = 0.5
+
+        def get_psu_max_power_ratings():
+            """Get max power rating for each PSU"""
+            psu_max_powers = {}
+            for psu_id in range(self.num_psus):
+                if skip_absent_psu(psu_id, platform_api_conn, self.psu_skip_list, logger):
+                    continue
+                name = psu.get_name(platform_api_conn, psu_id)
+                max_power = psu.get_maximum_supplied_power(platform_api_conn, psu_id)
+                if max_power is not None:
+                    logger.info(f"{name} max power rating: {max_power}W")
+                    psu_max_powers[name] = max_power
+                else:
+                    logger.warning(f"Failed to retrieve {name} max power rating")
+            return psu_max_powers
+
+        def get_psu_powers():
+            """Get power readings from all PSUs"""
+            psu_powers = {}
+            for psu_id in range(self.num_psus):
+                if skip_absent_psu(psu_id, platform_api_conn, self.psu_skip_list, logger):
+                    continue
+                name = psu.get_name(platform_api_conn, psu_id)
+                power = psu.get_power(platform_api_conn, psu_id)
+                if self.expect(power is not None, "Unable to retrieve PSU {} power".format(psu_id)):
+                    psu_powers[name] = power
+            return psu_powers
+
+        def get_average_power_per_psu():
+            sample_window_s = SAMPLE_WINDOW_FOR_AVERAGE_POWER_S
+            sample_interval_s = 0.02
+            num_samples = int(sample_window_s / sample_interval_s)
+
+            power_totals = {}
+            for _ in range(num_samples):
+                psu_powers = get_psu_powers()
+                for name, power in psu_powers.items():
+                    power_totals[name] = power_totals.get(name, 0.0) + power
+                time.sleep(sample_interval_s)
+
+            return {name: total / num_samples for name, total in power_totals.items()}
+
+        def check_load_sharing(psu_max_powers):
+            average_power_per_psu = get_average_power_per_psu()
+            average_power_all_psus = sum(average_power_per_psu.values()) / len(average_power_per_psu)
+
+            logger.info(f"Average power output of all Power Supplies: {average_power_all_psus: .2f}W")
+
+            for name, power in average_power_per_psu.items():
+                if name not in psu_max_powers:
+                    pytest.fail(f"No max power rating found for PSU '{name}'")
+                max_deviation = psu_max_powers[name] * LOAD_BALANCE_TOLERANCE_FROM_AVERAGE_POWER
+                logger.info(f"{name} Power: {power: .2f}W")
+                deviation = abs(power - average_power_all_psus)
+                logger.info(f"{name} power {power: .2f}W deviates {deviation: .2f}W from average")
+                logger.info(f"Allowable deviation from average: {max_deviation: .2f}W")
+                self.expect(
+                    deviation <= max_deviation,
+                    f"{name} power deviation of {deviation: .2f}W "
+                    f"exceeds allowable tolerance of {max_deviation: .2f}W",
+                )
+
+        psu_max_powers = get_psu_max_power_ratings()
+
+        logger.info("Nominal Operation Load Sharing Check")
+        check_load_sharing(psu_max_powers)
+
+        if not is_pddf_supported_and_enabled(duthost):
+            logger.info("Skipping increased load test - platform does not support PDDF")
+            self.assert_expectations()
+            return
+
+        logger.info("Increased Power Consumption Load Sharing Check")
+        logger.info("Increasing fan speed")
+        if not self.expect(daemon_stop(duthost, "thermalctld"), "Failed to stop thermalctld daemon"):
+            logger.warning("Skipping high load test - thermalctld could not be stopped")
+            self.assert_expectations()
+            return
+
+        TIME_TO_WAIT_FOR_FAN_SPEED_CHANGE_SEC = 5
+
+        try:
+            duthost.shell("sudo pddf_fanutil setspeed 100", module_ignore_errors=True)
+            logger.info("Increasing CPU Load")
+            max_stress_duration_s = (int)(TIME_TO_WAIT_FOR_FAN_SPEED_CHANGE_SEC+SAMPLE_WINDOW_FOR_AVERAGE_POWER_S) * 2
+            start_cpu_stress(duthost, max_stress_duration_s)
+            time.sleep(TIME_TO_WAIT_FOR_FAN_SPEED_CHANGE_SEC)
+
+            check_load_sharing(psu_max_powers)
+        finally:
+            stop_cpu_stress(duthost)
+            if not self.expect(daemon_start(duthost, "thermalctld"), "Failed to start thermalctld daemon"):
+                logger.warning("thermalctld could not be started after test")
 
         self.assert_expectations()
 

--- a/tests/platform_tests/utils.py
+++ b/tests/platform_tests/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 import yaml
 
 from tests.common.helpers.assertions import pytest_assert
@@ -66,6 +67,50 @@ def get_config_from_yaml(file_path):
     return config
 
 
+def _verify_daemon_status(duthost, daemon_name, expected_status):
+    max_wait_sec = 10
+    retry_interval_sec = 0.5
+    max_retries = int(max_wait_sec / retry_interval_sec)
+    for _ in range(max_retries):
+        status_result = duthost.shell(f"docker exec pmon supervisorctl status {daemon_name}", module_ignore_errors=True)
+        if expected_status in status_result.get("stdout", ""):
+            return True
+        time.sleep(retry_interval_sec)
+    return False
+
+
+def daemon_stop(duthost, daemon_name):
+    logger.info(f"Stopping {daemon_name}")
+    try:
+        result = duthost.shell(f"docker exec pmon supervisorctl stop {daemon_name}", module_ignore_errors=True)
+        logger.info(
+            f"Stop {daemon_name} result: rc={result.get('rc', 'N/A')}, \
+                stdout='{result.get('stdout', '')}', stderr='{result.get('stderr', '')}'"
+        )
+
+        return _verify_daemon_status(duthost, daemon_name, "STOPPED")
+
+    except Exception as e:
+        logger.error(f"Exception while stopping {daemon_name}: {e}")
+        return False
+
+
+def daemon_start(duthost, daemon_name):
+    logger.info(f"Starting {daemon_name}")
+    try:
+        result = duthost.shell(f"docker exec pmon supervisorctl start {daemon_name}", module_ignore_errors=True)
+        logger.info(
+            f"Start {daemon_name} result: rc={result.get('rc', 'N/A')}, \
+                stdout='{result.get('stdout', '')}', stderr='{result.get('stderr', '')}'"
+        )
+
+        return _verify_daemon_status(duthost, daemon_name, "RUNNING")
+
+    except Exception as e:
+        logger.error(f"Exception while starting {daemon_name}: {e}")
+        return False
+
+
 def fanout_hosts_and_ports(fanouthosts, duts_and_ports):
     """
     Use cases:
@@ -93,6 +138,26 @@ def fanout_hosts_and_ports(fanouthosts, duts_and_ports):
             else:
                 fanout_and_ports[fanout] = {fanout_port}
     return fanout_and_ports
+
+
+def start_cpu_stress(duthost, timeout_duration_s=30):
+    """Start CPU stress on all cores"""
+    logger.info("Starting CPU stress on all cores")
+    try:
+        num_cores = int(duthost.shell("nproc")["stdout"].strip())
+        for i in range(num_cores):
+            duthost.shell(f"timeout -k 10 {timeout_duration_s} yes > /dev/null &", module_ignore_errors=True)
+        time.sleep(2)  # Allow stress to ramp up
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to start CPU stress: {e}")
+        return False
+
+
+def stop_cpu_stress(duthost):
+    """Stop CPU stress"""
+    logger.info("Stopping CPU stress")
+    duthost.shell("pkill yes", module_ignore_errors=True)
 
 
 def links_down(fanout, ports):


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
  Verifies PSU output current/power stays balanced within tolerance,
  then increases system power draw (fan speed, CPU) and re-verifies.
  Limits fan-speed-based load increase to pddf-based platforms.
  
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
Fixes: https://github.com/sonic-net/sonic-mgmt/issues/28012

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

Add a test to verify that load is shared evenly across a system's power supplies, and that sharing holds up as power draw increases. Uneven PSU load sharing can mean a PSU is operating outside its rated range or degrading — this catches that class of hardware issue before it becomes a larger problem.

#### How did you do it?
Added `test_load_sharing` in `tests/platform_tests/api/test_psu.py`:
  - Samples PSU output power over a 500ms window and checks each PSU's average power draw is within 20% of the average across all PSUs (nominal load).
  - On PDDF-supported platforms, increases system power draw by stopping `thermalctld`, ramping fan speed to 100% via `pddf_fanutil`, and adding CPU stress, then re-checks load sharing under the higher load.
  - Added `daemon_stop`/`daemon_start` and CPU stress helpers to `tests/platform_tests/utils.py` in support of the above.

#### How did you verify/test it?
Verified on hardware: an NH-4010 (2× CSU2400AT-3-100, 2400W rated) 
Image main.Nexthop.199054-bd6e06da87, t0-8 topology. 
`test_psu.py::TestPsuApi::test_load_sharing` passed. 

Under nominal load the PSUs averaged 181.25W each (PSU1 171.25W, PSU2 191.25W, 10.00W deviation from average); with fans forced to 100% and CPU stress applied the average rose to 328.69W each (PSU1 317.32W, PSU2 340.06W, 11.37W deviation), both well inside the 480W allowance (20% of rated max). thermalctld was stopped for the increased-load phase and restarted successfully afterwards.
  
Ran `test_load_sharing` against physical hardware:
  - NH-4010 — passed (nominal load-sharing check, and increased-load check via fan speed   + CPU stress on a PDDF platform).
  - Tested that it correctly failed when PSU2 was in an unhealthy state (0V output),   confirming the test catches real imbalance.

#### Any platform specific information?

Increased load tested only on PDDF systems.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
