### PR TITLE
[hash_test] Extend sporadic-loss retry to Vxlan/Nvgre hash tests

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -402,7 +402,6 @@ class HashTest(BaseTest):
         '''
         @summary: Check IPv4 route works.
         '''
-        class_name = self.__class__.__name__
         ip_src = self.src_ip_interval.get_random_ip(
         ) if hash_key == 'src-ip' else self.src_ip_interval.get_first_ip()
         ip_dst = self.dst_ip_interval.get_random_ip(
@@ -451,7 +450,7 @@ class HashTest(BaseTest):
             ip_dst=ip_dst,
             ip_proto=ip_proto
         )
-        if class_name == 'HashTest':
+        if isinstance(self, HashTest):
             rcvd_port, rcvd_pkt = retry_call(
                 self.send_and_verify_packets,
                 fargs=[src_port, pkt, masked_exp_pkt, dst_port_lists, logs],
@@ -466,7 +465,6 @@ class HashTest(BaseTest):
         '''
         @summary: Check IPv6 route works.
         '''
-        class_name = self.__class__.__name__
         ip_src = self.src_ip_interval.get_random_ip(
         ) if hash_key == 'src-ip' else self.src_ip_interval.get_first_ip()
         ip_dst = self.dst_ip_interval.get_random_ip(
@@ -517,7 +515,7 @@ class HashTest(BaseTest):
             ip_proto=ip_proto,
             version='IPv6'
         )
-        if class_name == 'HashTest':
+        if isinstance(self, HashTest):
             rcvd_port, rcvd_pkt = retry_call(
                 self.send_and_verify_packets,
                 fargs=[src_port, pkt, masked_exp_pkt, dst_port_lists, logs],


### PR DESCRIPTION
check_ipv4_route/check_ipv6_route wrap send_and_verify_packets in retry_call(tries=2, delay=2) only when `class_name == 'HashTest'`, i.e. the plain test_hash. The encap subclasses (VxlanHashTest, NvgreHashTest, IPinIPHashTest) have class_name 'VxlanHashTest'/'NvgreHashTest'/..., so they fell through to a single send with no retry. On virtual testbeds a single ~0.5% sporadic packet drop then fails the test on the first miss, reported misleadingly as "Did not receive expected packet on any of ports [x, y]".

Use `isinstance(self, HashTest)` so all hash-test variants get the same retry. A genuine blackhole still fails both attempts, so no real coverage is lost.

Validated on Mellanox-SN5640 testbed: test_vxlan_hash and test_nvgre_hash went from 16/24 failing to 40/40 passing over --count=5.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
