### PR TITLE
[tests/vxlan]: Set VXLAN tunnel ttl_mode=pipe for cisco-8000 platforms

### DIFF
--- a/tests/acl/test_src_mac_rewrite.py
+++ b/tests/acl/test_src_mac_rewrite.py
@@ -182,7 +182,8 @@ def fixture_setUp(rand_selected_dut, tbinfo, ptfadapter):
         tunnel_name=data['vxlan_tunnel_name'],
         src_ip=data['loopback_src_ip'],
         portchannel_name=selected_pc,
-        router_mac=rand_selected_dut.facts['router_mac']
+        router_mac=rand_selected_dut.facts['router_mac'],
+        asic_type=rand_selected_dut.facts.get('asic_type')
     )
 
     def _check_vnet_route(duthost):
@@ -474,7 +475,8 @@ def remove_acl_rules(duthost):
     pytest_assert(exists_output.strip() == "0", f"ACL rule {state_db_key} still exists in STATE_DB")
 
 
-def create_vxlan_vnet_config(duthost, tunnel_name, src_ip, portchannel_name="PortChannel101", router_mac=None):
+def create_vxlan_vnet_config(duthost, tunnel_name, src_ip, portchannel_name="PortChannel101", router_mac=None,
+                             asic_type=None):
     # --- VXLAN parameters ---
     vnet_base = VXLAN_VNI
     ptf_vtep = PTF_VTEP_IP
@@ -483,10 +485,16 @@ def create_vxlan_vnet_config(duthost, tunnel_name, src_ip, portchannel_name="Por
     ecmp_utils.Constants['KEEP_TEMP_FILES'] = True
     ecmp_utils.Constants['DEBUG'] = False
 
+    vxlan_tunnel_entry = {"src_ip": dut_vtep}
+    # On cisco-8000, base topology IP-in-IP decap tunnels may already use pipe TTL mode.
+    # Set VXLAN decap ttl_mode to pipe so orchagent passes DECAP_TTL_MODE consistently.
+    if asic_type == "cisco-8000":
+        vxlan_tunnel_entry["ttl_mode"] = "pipe"
+
     # --- Build overlay config JSON ---
     dut_json = {
         "VXLAN_TUNNEL": {
-            tunnel_name: {"src_ip": dut_vtep}
+            tunnel_name: vxlan_tunnel_entry
         },
         "VNET": {
             "Vnet1": {

--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -329,7 +329,7 @@ def test_vxlan_mac_vni(ptfhost, one_vnet_setup_teardown):
 
     # --- Build deterministic MAC list ---
     # 52:54:00:00:xx:yy (unique per endpoint)
-    mac_list = [f"52:54:00:{i//256:02x}:{i%256:02x}:aa" for i in range(num_endpoints)]
+    mac_list = [f"52:54:00:{i//256:02x}:{i % 256:02x}:aa" for i in range(num_endpoints)]
     mac_list_str = ",".join(mac_list)
     updated_vni = 5001
 
@@ -483,7 +483,7 @@ def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
     time.sleep(5)
 
     # Step 2 — Initial MAC list
-    mac_list = [f"52:54:00:{i//256:02x}:{i%256:02x}:aa" for i in range(num)]
+    mac_list = [f"52:54:00:{i//256:02x}:{i % 256:02x}:aa" for i in range(num)]
     mac_string = ",".join(mac_list)
 
     # Push initial MAC list
@@ -492,7 +492,7 @@ def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
 
     # Step 3 — Random index to modify
     mod_idx = random.randint(0, num - 1)
-    new_mac = f"52:54:99:{mod_idx//256:02x}:{mod_idx%256:02x}:cc"
+    new_mac = f"52:54:99:{mod_idx//256:02x}:{mod_idx % 256:02x}:cc"
     logger.info(f"Modifying MAC for endpoint index {mod_idx}: new MAC = {new_mac}")
 
     # Update the list

--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -127,7 +127,12 @@ def vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
 
     dut_vtep = get_loopback_ip(cfg_facts)
     logger.info(f"Creating VXLAN tunnel {TUNNEL_NAME} with source {dut_vtep}")
-    apply_chunk(duthost, {"VXLAN_TUNNEL": {TUNNEL_NAME: {"src_ip": dut_vtep}}}, "vxlan_tunnel")
+    vxlan_tunnel_entry = {"src_ip": dut_vtep}
+    # On cisco-8000, base topology IP-in-IP decap tunnels may already use pipe TTL mode.
+    # Set VXLAN decap ttl_mode to pipe so orchagent passes DECAP_TTL_MODE consistently.
+    if duthost.facts.get("asic_type") == "cisco-8000":
+        vxlan_tunnel_entry["ttl_mode"] = "pipe"
+    apply_chunk(duthost, {"VXLAN_TUNNEL": {TUNNEL_NAME: vxlan_tunnel_entry}}, "vxlan_tunnel")
     apply_chunk(duthost, {"VNET": {VNET_NAME: {"vni": str(VNI), "vxlan_tunnel": TUNNEL_NAME}}}, "vnet")
 
     ptf_port_index = port_indexes[ingress_if]

--- a/tests/vxlan/test_vnet_decap.py
+++ b/tests/vxlan/test_vnet_decap.py
@@ -106,7 +106,8 @@ def setup(request, duthosts, rand_one_dut_hostname, tbinfo, inner_ip_version, ou
     topo = tbinfo["topo"]["type"].upper()
     vnet_interface = ecmp_utils.select_required_interfaces(duthost, 1, minigraph_facts, outer_ip_version_str,
                                                            topo=topo)[0]
-    vxlan_tunnel = ecmp_utils.create_vxlan_tunnel(duthost, minigraph_facts, outer_ip_version_str)
+    vxlan_tunnel = ecmp_utils.create_vxlan_tunnel(duthost, minigraph_facts, outer_ip_version_str,
+                                                   ttl_mode="pipe" if asic_type == "cisco-8000" else None)
     inner_ip_version_str = f"v{inner_ip_version}"
     encap_type = f"{inner_ip_version_str}_in_{outer_ip_version_str}"
     vnet = next(iter(ecmp_utils.create_vnets(duthost, vxlan_tunnel,

--- a/tests/vxlan/test_vnet_decap.py
+++ b/tests/vxlan/test_vnet_decap.py
@@ -107,7 +107,7 @@ def setup(request, duthosts, rand_one_dut_hostname, tbinfo, inner_ip_version, ou
     vnet_interface = ecmp_utils.select_required_interfaces(duthost, 1, minigraph_facts, outer_ip_version_str,
                                                            topo=topo)[0]
     vxlan_tunnel = ecmp_utils.create_vxlan_tunnel(duthost, minigraph_facts, outer_ip_version_str,
-                                                   ttl_mode="pipe" if asic_type == "cisco-8000" else None)
+                                                  ttl_mode="pipe" if asic_type == "cisco-8000" else None)
     inner_ip_version_str = f"v{inner_ip_version}"
     encap_type = f"{inner_ip_version_str}_in_{outer_ip_version_str}"
     vnet = next(iter(ecmp_utils.create_vnets(duthost, vxlan_tunnel,

--- a/tests/vxlan/test_vxlan_bfd_tsa.py
+++ b/tests/vxlan/test_vxlan_bfd_tsa.py
@@ -165,7 +165,8 @@ def fixture_setUp(duthosts,
         tunnel_names[outer_layer_version] = ecmp_utils.create_vxlan_tunnel(
             data['duthost'],
             minigraph_data=minigraph_facts,
-            af=outer_layer_version)
+            af=outer_layer_version,
+            ttl_mode="pipe" if data['duthost'].facts.get("asic_type") == "cisco-8000" else None)
 
     payload_version = ecmp_utils.get_payload_version(encap_type)
     encap_type = "{}_in_{}".format(payload_version, outer_layer_version)

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -84,12 +84,17 @@ def generate_vxlan_config_files(duthost, mg_facts):
         pytest.fail("ipv4 lo interface not found")
 
     # Generate vxlan tunnel config json file on DUT
+    vxlan_tunnel_entry = {
+        "src_ip": loopback_ip,
+        "dst_ip": VTEP2_IP
+    }
+    # On cisco-8000, base topology IP-in-IP decap tunnels may already use pipe TTL mode.
+    # Set VXLAN decap ttl_mode to pipe so orchagent passes DECAP_TTL_MODE consistently.
+    if duthost.facts.get("asic_type") == "cisco-8000":
+        vxlan_tunnel_entry["ttl_mode"] = "pipe"
     vxlan_tunnel_cfg = {
         "VXLAN_TUNNEL": {
-            "tlVxlan": {
-                "src_ip": loopback_ip,
-                "dst_ip": VTEP2_IP
-            }
+            "tlVxlan": vxlan_tunnel_entry
         }
     }
     duthost.copy(content=json.dumps(vxlan_tunnel_cfg, indent=2),

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -252,7 +252,8 @@ def fixture_setUp(duthosts,
         tunnel_names[outer_layer_version] = ecmp_utils.create_vxlan_tunnel(
             data['duthost'],
             minigraph_data=minigraph_facts,
-            af=outer_layer_version)
+            af=outer_layer_version,
+            ttl_mode="pipe" if data['duthost'].facts.get("asic_type") == "cisco-8000" else None)
 
     payload_version = ecmp_utils.get_payload_version(encap_type)
     encap_type = "{}_in_{}".format(payload_version, outer_layer_version)

--- a/tests/vxlan/test_vxlan_ecmp_switchover.py
+++ b/tests/vxlan/test_vxlan_ecmp_switchover.py
@@ -134,7 +134,8 @@ def fixture_setUp(duthosts,
         tunnel_names[outer_layer_version] = ecmp_utils.create_vxlan_tunnel(
             data['duthost'],
             minigraph_data=minigraph_facts,
-            af=outer_layer_version)
+            af=outer_layer_version,
+            ttl_mode="pipe" if data['duthost'].facts.get("asic_type") == "cisco-8000" else None)
 
     payload_version = ecmp_utils.get_payload_version(encap_type)
     encap_type = "{}_in_{}".format(payload_version, outer_layer_version)

--- a/tests/vxlan/test_vxlan_route_advertisement.py
+++ b/tests/vxlan/test_vxlan_route_advertisement.py
@@ -131,7 +131,8 @@ def fixture_setUp(duthosts,
         tunnel_names[outer_layer_version] = ecmp_utils.create_vxlan_tunnel(
             data['duthost'],
             minigraph_data=minigraph_facts,
-            af=outer_layer_version)
+            af=outer_layer_version,
+            ttl_mode="pipe" if data['duthost'].facts.get("asic_type") == "cisco-8000" else None)
 
     payload_version = ecmp_utils.get_payload_version(encap_type)
     encap_type = "{}_in_{}".format(payload_version, outer_layer_version)

--- a/tests/vxlan/test_vxlan_tunnel_route_scale.py
+++ b/tests/vxlan/test_vxlan_tunnel_route_scale.py
@@ -218,7 +218,12 @@ def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
     dut_vtep = get_loopback_ip(cfg_facts)
     ptf_vtep = PTF_VTEP
     vxlan_tun = TUNNEL_NAME
-    apply_chunk(duthost, {"VXLAN_TUNNEL": {vxlan_tun: {"src_ip": dut_vtep}}}, "vxlan_tunnel")
+    vxlan_tunnel_entry = {"src_ip": dut_vtep}
+    # On cisco-8000, base topology IP-in-IP decap tunnels may already use pipe TTL mode.
+    # Set VXLAN decap ttl_mode to pipe so orchagent passes DECAP_TTL_MODE consistently.
+    if duthost.facts.get("asic_type") == "cisco-8000":
+        vxlan_tunnel_entry["ttl_mode"] = "pipe"
+    apply_chunk(duthost, {"VXLAN_TUNNEL": {vxlan_tun: vxlan_tunnel_entry}}, "vxlan_tunnel")
 
     vnet_ptf_map = {}
 

--- a/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
+++ b/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
@@ -619,10 +619,13 @@ def setup_vnets(duthost, ptfhost, num_vnets, tunnel, base_vni):
 
 
 def setup_vxlan_tunnel(duthost, ptfhost, name, src_ip):
+    tunnel_entry = {"src_ip": src_ip}
+    # On cisco-8000, base topology IP-in-IP decap tunnels may already use pipe TTL mode.
+    # Set VXLAN decap ttl_mode to pipe so orchagent passes DECAP_TTL_MODE consistently.
+    if duthost.facts.get("asic_type") == "cisco-8000":
+        tunnel_entry["ttl_mode"] = "pipe"
     gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/VXLAN_TUNNEL", {
-        name: {
-            "src_ip": src_ip
-        }
+        name: tunnel_entry
     }, "vxlan")
 
 

--- a/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
+++ b/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
@@ -532,7 +532,7 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, ba
                 gnmi_set_update_config_db_json(
                     duthost,
                     ptfhost,
-                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}|{dut_ips[j][i].replace('/','~1')}",
+                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}|{dut_ips[j][i].replace('/', '~1')}",
                     {},
                     f"{subintf_name}_ip")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
On cisco-8000, the base topology IP-in-IP decap tunnels already use pipe TTL mode. When VxLAN DECAP_TTL_MODE is not set consistently, orchagent fails to program the tunnel correctly. This change sets ttl_mode=pipe in the VXLAN_TUNNEL config entry whenever the DUT's asic_type is cisco-8000.

Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested on Cisco 8122
[test_vnet_decap_2026-07-17-06-26-11.log](https://github.com/user-attachments/files/30133129/test_vnet_decap_2026-07-17-06-26-11.log)
[test_vxlan_decap_2026-07-27-23-59-10.log](https://github.com/user-attachments/files/30438080/test_vxlan_decap_2026-07-27-23-59-10.log)



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
