### PR TITLE
tests/platform_tests/api/test_thermal_leak_sensor.py fixes

### DIFF
--- a/tests/platform_tests/api/test_thermal_leak_sensor.py
+++ b/tests/platform_tests/api/test_thermal_leak_sensor.py
@@ -36,6 +36,13 @@ class TestLeakSensorApi(PlatformApiTestBase):
     num_leak_sensors = 0
 
     @pytest.fixture(scope="function", autouse=True)
+    def assert_test_expectations(self):
+        """Ensure accumulated self.expect() checks are asserted per test."""
+        del self.failed_expectations[:]
+        yield
+        self.assert_expectations()
+
+    @pytest.fixture(scope="function", autouse=True)
     def resolve_num_leak_sensors(self, platform_api_conn):  # noqa: F811
         try:
             self.num_leak_sensors = int(liquid_cooling.get_num_leak_sensors(platform_api_conn))
@@ -106,12 +113,12 @@ class TestLeakSensorApi(PlatformApiTestBase):
 
             # get_leak_max_minor_duration_sec() on the profile
             max_dur = leak_sensor.get_leak_max_minor_duration_sec(platform_api_conn, sensor_index)
-            if max_dur is None:
-                logger.info(f"Sensor {sensor_index} get_leak_max_minor_duration_sec() returned None "
+            if max_dur is None or max_dur == 0:
+                logger.info(f"Sensor {sensor_index} get_leak_max_minor_duration_sec() returned None or 0"
                             f"- platform does not support this attribute")
             else:
                 self.expect(isinstance(max_dur, (int, float)) and max_dur > 0,
-                            f"Sensor {sensor_index} max_minor_duration_sec={max_dur} should be non-zero")
+                            f"Sensor {sensor_index} max_minor_duration_sec={max_dur} should be non-negative")
 
         # get_all_profiles() on LiquidCoolingBase
         all_profiles = liquid_cooling.get_all_profiles(platform_api_conn)


### PR DESCRIPTION
max_minor_duration_sec allow 0 and added the assertion fixture

### Description of PR
This PR adds the assertion fixture to be autoused in the tests and call the base class code
Also it allows max_minor_duration_sec to be 0, per tests design.

Fixes: https://github.com/sonic-net/sonic-mgmt/issues/26226

Summary:

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605


### Approach
#### What is the motivation for this PR?
Fix the test bugs

#### How did you do it?
Added the assertion fixture similar to other subclasses

#### How did you verify/test it?
Ran the test, and it failed with max_minor_duration_sec == 0 since the assertion was made that time correctly.
Fixed the test to allow max_minor_duration_sec == 0

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation