### PR TITLE
test_bmcctld.py fixes for leak-driven power off tests

### DIFF
--- a/tests/platform_tests/daemon/test_bmcctld.py
+++ b/tests/platform_tests/daemon/test_bmcctld.py
@@ -252,18 +252,42 @@ class TestBmcctldDaemon:
                            f'{SYSTEM_LEAK_STATUS_TABLE}|system',
                            device_leak_status='CRITICAL')
                 logger.info("Trigger 2b [STATE_DB SYSTEM_LEAK_STATUS]: device_leak_status → CRITICAL")
-                wait_host_on(host)
+                pytest_assert(wait_host_off(host, delay=5), "Switch-Host did not power-off in Trigger 2b")
+                redis_hset(self.duthost, STATE_DB,
+                           f'{SYSTEM_LEAK_STATUS_TABLE}|system',
+                           device_leak_status=orig_leak)
+                # WA shutdown to make sure to clear the oper_status
+                pytest_assert(self.duthost.shell(
+                    "config chassis modules shutdown SWITCH-HOST",
+                    module_ignore_errors=True
+                )["stdout"].strip() == "Shutting down chassis module SWITCH-HOST",
+                "Failed to command shutdown Switch-Host")
+                pytest_assert(self.duthost.shell(
+                    "config chassis modules startup SWITCH-HOST",
+                    module_ignore_errors=True
+                )["stdout"].strip() == "Starting up chassis module SWITCH-HOST",
+                "Failed to command startup Switch-Host")
+                pytest_assert(wait_host_on(host), "Switch-Host did not power-on in Trigger 2b")
                 verify_bmc_initiated_reboot(host, pre_boot)
                 trigger_results['SYSTEM_LEAK_STATUS_CRITICAL'] = True
             finally:
+                redis_del(self.duthost, CONFIG_DB, 'LEAK_CONTROL_POLICY|system')
                 redis_hset(self.duthost, STATE_DB,
                            f'{SYSTEM_LEAK_STATUS_TABLE}|system',
                            device_leak_status=orig_leak)
                 # Best-effort recovery if Switch-Host did not auto-power-on.
-                self.duthost.shell(
-                    "config chassis modules startup SWITCH-HOST",
-                    module_ignore_errors=True
-                )
+                if wait_host_off(host, delay=5):
+                    # shutdown to make sure to clear the oper_status
+                    self.duthost.shell(
+                        "config chassis modules shutdown SWITCH-HOST",
+                        module_ignore_errors=True
+                    )
+                    pytest_assert(self.duthost.shell(
+                        "config chassis modules startup SWITCH-HOST",
+                        module_ignore_errors=True
+                    )["stdout"].strip() == "Starting up chassis module SWITCH-HOST",
+                    "Failed to command startup Switch-Host in best-effort recovery")
+                pytest_assert(wait_host_on(host), "Switch-Host did not power-on after Trigger 2b")
 
         # --- Trigger 3: STATE_DB RACK_MANAGER_ALERT MINOR severity ---
         # Handler logs "RACK_MGR_MINOR_EVENT"; default action is syslog_only (no power action).
@@ -386,8 +410,18 @@ class TestBmcctldDaemon:
                 redis_hset(self.duthost, STATE_DB,
                            f'{SYSTEM_LEAK_STATUS_TABLE}|system',
                            device_leak_status=orig_leak)
-                self.duthost.shell("config chassis modules startup SWITCH-HOST",
-                                   module_ignore_errors=True)
+                if wait_host_off(host, delay=5):
+                    # shutdown to make sure to clear the oper_status
+                    self.duthost.shell(
+                        "config chassis modules shutdown SWITCH-HOST",
+                        module_ignore_errors=True
+                    )
+                    pytest_assert(self.duthost.shell(
+                        "config chassis modules startup SWITCH-HOST",
+                        module_ignore_errors=True
+                    )["stdout"].strip() == "Starting up chassis module SWITCH-HOST",
+                    "Failed to command startup Switch-Host after critical leak blocking POWER_ON")
+                pytest_assert(wait_host_on(host), "Switch-Host did not power-on after critical leak blocking POWER_ON")
 
         # --- Scenario 5: Unknown command rejected without dispatching power action ---
         # Handler logs "Unknown Rack Manager command: ..." and sets status=FAILED; paired Switch-Host must stay up.


### PR DESCRIPTION
### Description of PR

Fix `test_bmcctld.py` recovery after leak-driven Switch-Host power-off so tests do not assume the host auto-restarts.

After a CRITICAL leak triggers `power_off`, the paired Switch-Host stays powered off until an operator (or test) explicitly brings it back. The previous recovery path called `config chassis modules startup SWITCH-HOST` directly, which could leave `oper_status` in a bad state and cause later tests to fail because the CPU never came back cleanly.

This change:
- Waits for the Switch-Host to power off after a CRITICAL leak injection.
- Clears the injected leak state and `LEAK_CONTROL_POLICY|system` before recovery.
- Sends `config chassis modules shutdown SWITCH-HOST` first when needed, then `startup`, to reset module state before powering the host back on.
- Applies the same shutdown→startup recovery pattern in the `finally` blocks for Trigger 2b and the critical-leak POWER_ON rejection scenario.

Summary:
- Handle leak-driven power-off correctly: do not expect automatic restart.
- Send shutdown first when needed, then startup, to recover the Switch-Host for downstream tests.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: regression

### Approach

#### What is the motivation for this PR?

`test_bmcctld_event_trigger` (Trigger 2b) and `test_bmcctld_rack_manager_command` (Scenario 4: POWER_ON blocked by CRITICAL leak) inject a CRITICAL leak that powers off the Switch-Host. The old recovery logic assumed the host would come back with a single `startup` command. On sonicBMC, leak-driven power-off is intentional and the host does not auto-restart; a shutdown is also needed first to clear `oper_status` before startup succeeds.

This caused `test_bmcctld_rack_manager_command` to pass in isolation but leave the Switch-Host in a bad state, breaking subsequent tests (e.g. `test_bmcctld_power_on_delay`).

#### How did you do it?

In `tests/platform_tests/daemon/test_bmcctld.py`:

1. **Trigger 2b (`test_bmcctld_event_trigger`)**
   - Assert `wait_host_off()` after CRITICAL leak injection.
   - Restore original leak status, then run shutdown → startup before asserting `wait_host_on()` and `verify_bmc_initiated_reboot()`.
   - In `finally`: delete `LEAK_CONTROL_POLICY|system`, restore leak status, and if the host is still off, run shutdown → startup before asserting the host is back online.

2. **Scenario 4 (`test_bmcctld_rack_manager_command`)**
   - Replace bare `startup` recovery with the same shutdown → startup sequence when the host remains off after the critical-leak POWER_ON rejection test.

#### How did you verify/test it?

- Ran `platform_tests/daemon/test_bmcctld.py` on BMC topology.
- Confirmed Trigger 2b waits for power-off, recovers via shutdown → startup, and verifies BMC-initiated reboot.
- Confirmed `test_bmcctld_rack_manager_command` no longer leaves the Switch-Host in a state that breaks later tests.

#### Any platform specific information?

- Affects sonicBMC (`topology('bmc')`) with a paired Switch-Host and liquid-cooling leak enforcement enabled.
- Recovery depends on `config chassis modules shutdown/startup SWITCH-HOST` CLI being available on the BMC.

#### Supported testbed topology if it's a new test case?

- BMC topology only (`pytest.mark.topology('bmc')`).

### Documentation

No documentation changes. Test-only fix; no new feature or test case added.