### PR TITLE
Fix autostate CMIS loganalyzer ignore

### DIFF
--- a/tests/vlan/test_autostate_disabled.py
+++ b/tests/vlan/test_autostate_disabled.py
@@ -26,6 +26,14 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
         ]
         loganalyzer[duthost.hostname].ignore_regex.extend(loganalyzer_ignore_regex)
 
+    if loganalyzer:
+        loganalyzer_ignore_regex = [
+            ".*ERR pmon#CmisManagerTask.*: .*no suitable app for the port appl .*host_lane_count .*host_speed.*",
+        ]
+        for duthost in duthosts.frontend_nodes:
+            if duthost.facts.get("asic_type") == "cisco-8000":
+                loganalyzer[duthost.hostname].ignore_regex.extend(loganalyzer_ignore_regex)
+
     yield
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes loganalyzer teardown failures in `vlan/test_autostate_disabled.py::TestAutostateDisabled::test_autostate_disabled` when Cisco-8000 DUTs emit expected CMIS `CmisManagerTask` messages while VLAN member ports are shut down/restored.

Related ADO PBI: 38768312

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

Note: the observed failure is on branch 20260510; please cherry-pick to the 202605 release branch if applicable.

### Approach
#### What is the motivation for this PR?

The nightly PBI 38768312 tracks `test_autostate_disabled` failures on Cisco-8101C01-C32 dualtor. The functional test passes, but loganalyzer fails during teardown because `pmon#CmisManagerTask` emits `no suitable app for the port appl ... host_lane_count 4 host_speed 100000` while the test shuts down/restores VLAN member ports.

This CMIS application selection message is an expected transient for Cisco-8000 optics during interface state changes and is unrelated to VLAN autostate validation.

#### How did you do it?

Added a Cisco-8000-specific loganalyzer ignore regex for the `CmisManagerTask` `no suitable app for the port appl` message in the autostate test fixture, applied to all frontend DUTs so both dualtor sides are covered.

#### How did you verify/test it?

Ran pre-commit on the changed file:

`python -m pre_commit run --files tests/vlan/test_autostate_disabled.py`

All hooks passed, including flake8.

#### Any platform specific information?

Observed on Cisco-8101C01-C32 dualtor, branch 20260510 image 20260510.04.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.