### PR TITLE
Fix dualtor link down standby duplication tolerance

### DIFF
--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -115,15 +115,19 @@ def test_active_link_down_downstream_active(
 def test_active_link_down_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa: F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa: F811
-    shutdown_fanout_upper_tor_intfs                                     # noqa: F811
+    shutdown_fanout_upper_tor_intfs,                                    # noqa: F811
+    link_down_downstream_active_duplication_setting                     # noqa: F811
 ):
     """
     Send traffic from T1 to standby ToR and shutdown the active ToR link.
     Verify switchover and disruption lasts < 1 second
     """
+    allowed_duplication, merge_duplications = link_down_downstream_active_duplication_setting
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
+        allowed_disruption=3, allowed_duplication=allowed_duplication,
+        action=shutdown_fanout_upper_tor_intfs,
+        merge_duplications_into_disruptions=merge_duplications
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,


### PR DESCRIPTION
### Description of PR
Fixes `dualtor_io.test_link_failure::test_active_link_down_downstream_standby` by applying the same platform-specific duplication tolerance used by the downstream active/downlink standby cases. On Cisco/Mellanox platforms, downstream link-down traffic may be flooded briefly during switchover; these duplicate packets should be merged/allowed instead of failing on the default max duplicate count of 2.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Approach
#### What is the motivation for this PR?
Nightly PBI 38768328 failed on Cisco-8101C01-C32 with `Traffic on server 192.168.0.3 with packet id 7 has 15 duplications. Allowed max number of duplication count: 2`.

#### How did you do it?
Passed `link_down_downstream_active_duplication_setting` into `test_active_link_down_downstream_standby` and forwarded `allowed_duplication` / `merge_duplications_into_disruptions` to `send_t1_to_server_with_action`.

#### How did you verify/test it?
- `python -m py_compile tests\dualtor_io\test_link_failure.py`

#### Any platform specific information?
Observed on Cisco-8101C01-C32 DUALTOR, branch 20260510.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A