### PR TITLE
[dualtor] detect Docker IPv6 NAT rules dynamically

### DIFF
--- a/tests/dualtor/test_mux_port_iptables_entries.py
+++ b/tests/dualtor/test_mux_port_iptables_entries.py
@@ -150,9 +150,11 @@ def generate_nat_expected_rules(duthost):
 
     debian_version = duthost.command("grep VERSION_CODENAME /etc/os-release")['stdout'].lower()
     if "trixie" in debian_version:
-        ip6tables_natrules.append("-N DOCKER")
-        ip6tables_natrules.append("-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER")
-        ip6tables_natrules.append("-A OUTPUT ! -d ::1/128 -m addrtype --dst-type LOCAL -j DOCKER")
+        existing_ip6tables_rules = duthost.command("sudo ip6tables -t nat -S")['stdout'].splitlines()
+        if "-N DOCKER" in existing_ip6tables_rules:
+            ip6tables_natrules.append("-N DOCKER")
+            ip6tables_natrules.append("-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER")
+            ip6tables_natrules.append("-A OUTPUT ! -d ::1/128 -m addrtype --dst-type LOCAL -j DOCKER")
 
     config_facts = duthost.get_running_config_facts()
 


### PR DESCRIPTION
### Description of PR
Fix `test_mux_port_iptables_entries` on Debian trixie images where the Docker IPv6 NAT chain is not installed. The test previously assumed all trixie images have Docker ip6tables NAT rules and failed when `ip6tables -t nat -S` legitimately only contained default policies.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/38770841
Failure type: regression

### Tested branch
<!-- Select each branch where the change was tested. -->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
N/A - validated by code inspection / log analysis; see Approach > "How did you verify/test it?".

### Approach
#### What is the motivation for this PR?
Nightly PBI 38770841 failed on master baseline because expected IPv6 NAT rules included `-N DOCKER` and Docker jumps based only on `VERSION_CODENAME=trixie`, while the DUT's actual `ip6tables -t nat -S` output did not contain a Docker chain.

#### How did you do it?
Keep the trixie special handling, but add Docker IPv6 NAT rules to the expected list only when the current ip6tables NAT table actually contains the Docker chain.

#### How did you verify/test it?
Verified by code inspection against the captured ElasticTest log: the failing DUT returned only default ip6tables NAT policies, so the updated expected-rule generation no longer adds absent Docker rules.

#### Any platform specific information?
Observed on vlab dualtor baseline; the logic is platform-neutral.

#### Supported testbed topology if it's a new test case?
DUALTOR.

### Documentation
N/A.
