### PR TITLE
Fix serial type mismatch in test_chassis compare_value_with_device_facts

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -108,6 +108,7 @@ class TestChassisApi(PlatformApiTestBase):
         pytest_assert(expected_value is not None,
                       "Unable to get expected value for '{}' from inventory file".format(key))
 
+        expected_value = str(expected_value).strip()
         if case_sensitive:
             pytest_assert(value == expected_value,
                           "'{}' value is incorrect. Got '{}', expected '{}'".format(key, value, expected_value))

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -125,7 +125,7 @@ def test_platform_serial_no(duthosts, enum_rand_one_per_hwsku_hostname, dut_vars
 
     logging.info("Verifying output of '{}' on '{}' ...".format(get_serial_no_cmd, duthost.hostname))
     get_serial_no_output = get_serial_no_cmd["stdout"].replace('\x00', '')
-    expected_serial_no = dut_vars.get('serial', "")
+    expected_serial_no = str(dut_vars.get('serial', "")).strip()
 
     pytest_assert(get_serial_no_output == expected_serial_no,
                   "Expected serial_no '{}' is not matching with {} in syseeprom on '{}'".


### PR DESCRIPTION

Summary: Fix serial type mismatch in test_chassis compare_value_with_device_facts
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [x] 202608

Tracking issue/work item for backport/cherry-pick request:


### Approach
#### What is the motivation for this PR?
Ansible parses an all-numeric inventory serial (e.g. '1331826040003') as an int, while the platform API returns a string, so `value == expected_value` fails even though both print identically.

#### How did you do it?
Convert the type before compare data

#### How did you verify/test it?
Regression pass

#### Any platform specific information?
All

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
