### PR TITLE
Fix pytest rootdir so tests/pytest.ini is loaded

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -192,7 +192,8 @@ function setup_test_options()
         show_help_and_exit 1
     fi
 
-    PYTEST_COMMON_OPTS="--inventory ${INVENTORY} \
+    PYTEST_COMMON_OPTS="-c pytest.ini \
+                      --inventory ${INVENTORY} \
                       --host-pattern ${DUT_NAME} \
                       --dpu-pattern ${DPU_NAME} \
                       --testbed ${TESTBED_NAME} \


### PR DESCRIPTION
### Description of PR
Pytest rootdir can float from `sonic-mgmt/tests/` to `sonic-mgmt/` (e.g. when inventory paths pull discovery upward). That means `tests/pytest.ini` is not loaded, so:
- `junit_family=xunit1` is not applied (defaults to xunit2, which strips `file`/`line` from JUnit XML)
- conditional-mark nodeids pick up a `tests/` prefix and no longer match `tests/`-relative keys, so skips silently no-op

Fix: pass `-c pytest.ini` on the pytest command line in `run_tests.sh` so rootdir stays `tests/` and the config file is always read.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: regression — conditional_mark skips no-op when rootdir floats above `tests/`

### Approach
#### What is the motivation for this PR?

Test runs are not honoring conditional skips (e.g. `test_syslog_source_ip.py`) because pytest rootdir no longer points at `tests/`, so mark condition keys do not match. The same rootdir drift also drops `junit_family=xunit1` from `pytest.ini`.

#### How did you do it?

Add `-c pytest.ini` to `PYTEST_COMMON_OPTS` in `tests/run_tests.sh`.

#### How did you verify/test it?

Verified that `-c pytest.ini` is present in `setup_test_options` and restores rootdir/`pytest.ini` discovery.

#### Any platform specific information?

N/A — framework change for all platforms.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
N/A