### PR TITLE
[dhcp_relay] fix dual-tor Option-82 SubOption 5 value+order for sonic-relay-agent

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -176,9 +176,6 @@ class DHCPTest(DataplaneBaseTest):
         self.max_hop_count = self.test_params.get('max_hop_count', None)
         self.client_vrf = self.test_params.get('client_vrf', None)
         self.dhcpv4_disable_flag = self.test_params.get('dhcpv4_disable_flag', None)
-        if self.relay_agent == "sonic-relay-agent":
-            if (self.link_selection and self.source_interface) or self.server_vrf:
-                self.link_selection_ip = self.test_params['link_selection_ip']
 
         self.uplink_mac = self.test_params['uplink_mac']
 

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -218,14 +218,10 @@ class DHCPTest(DataplaneBaseTest):
             #  Byte 0: Suboption number, always set to 5
             #  Byte 1: Length of suboption data (4 bytes for IPv4)
             #  Bytes 2–5: The link selection IP address (in byte format)
-            # The relay (sonic-dhcp-relay dhcp4relay.cpp) encodes link-selection (SubOption 5)
-            # when is_dualTor OR link-selection is enabled, BEFORE SubOption 11 (server-override),
-            # with value = link_address & netmask (the VLAN subnet network address). Match that here
-            # so dual-tor (incl. server_id_override) runs no longer byte-mismatch on order/value.
+            # ISC encodes the receiving VLAN address in Link Selection. Keep SONiC aligned
+            # and emit SubOption 5 before SubOption 11 (server-override).
             if self.dual_tor or (self.link_selection and self.source_interface) or self.server_vrf:
-                ip_octets = list(map(int, self.relay_iface_ip.split('.')))
-                mask_octets = list(map(int, self.test_params['relay_iface_netmask'].split('.')))
-                link_selection_ip = bytes([ip_octets[i] & mask_octets[i] for i in range(4)])
+                link_selection_ip = bytes(list(map(int, self.relay_iface_ip.split('.'))))
                 self.option82 += struct.pack('BB', self.LINK_SELECTION_SUBOPTION, 4)
                 self.option82 += link_selection_ip
                 link_selection_added = True

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -221,8 +221,14 @@ class DHCPTest(DataplaneBaseTest):
             #  Byte 0: Suboption number, always set to 5
             #  Byte 1: Length of suboption data (4 bytes for IPv4)
             #  Bytes 2–5: The link selection IP address (in byte format)
-            if (self.link_selection and self.source_interface) or self.server_vrf:
-                link_selection_ip = bytes(list(map(int, self.link_selection_ip.split('.'))))
+            # The relay (sonic-dhcp-relay dhcp4relay.cpp) encodes link-selection (SubOption 5)
+            # when is_dualTor OR link-selection is enabled, BEFORE SubOption 11 (server-override),
+            # with value = link_address & netmask (the VLAN subnet network address). Match that here
+            # so dual-tor (incl. server_id_override) runs no longer byte-mismatch on order/value.
+            if self.dual_tor or (self.link_selection and self.source_interface) or self.server_vrf:
+                ip_octets = list(map(int, self.relay_iface_ip.split('.')))
+                mask_octets = list(map(int, self.test_params['relay_iface_netmask'].split('.')))
+                link_selection_ip = bytes([ip_octets[i] & mask_octets[i] for i in range(4)])
                 self.option82 += struct.pack('BB', self.LINK_SELECTION_SUBOPTION, 4)
                 self.option82 += link_selection_ip
                 link_selection_added = True
@@ -253,8 +259,9 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 0: Suboption number, always set to 5
         #  Byte 1: Length of suboption data in bytes, always set to 4 (ipv4 addr has 4 bytes)
         #  Bytes 2+: vlan ip addr
-        # Relay emits link-selection (SubOption 5) once; skip this legacy dual-tor
-        # copy if the block above already added it (see commit msg).
+        # Legacy dual-tor SubOption 5, now only for the non-sonic-relay-agent (isc) path:
+        # the sonic-relay-agent block above already adds SubOption 5 for dual-tor (setting
+        # link_selection_added), so this only runs when that gate was not entered (isc).
         if self.dual_tor and not link_selection_added:
             link_selection = bytes(
                 list(map(int, self.relay_iface_ip.split('.'))))


### PR DESCRIPTION
### Description of PR

Summary:
Correct the SONiC dual-ToR Option 82 Link Selection value and suboption order used by the DHCP relay PTF model.

For `sonic-relay-agent`, SONiC emits the receiving VLAN address as Link Selection before Server-ID Override. The previous expected bytes placed Server-ID Override first and used the old subnet-network value, causing the corrected test to reject every relayed DISCOVER packet.

Companion product fix: https://github.com/sonic-net/sonic-dhcp-relay/pull/121

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: https://msazure.visualstudio.com/One/_workitems/edit/38778666
Failure type: day-one test expectation defect plus relay-behavior alignment

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: official CI must be rerun after merged sonic-dhcp-relay PR #121 reaches the test image; the current failing job used a pre-#121 image that still emits the old masked value.
- 202605: exact PR head `7d9ee37f0bad7d495e4dfe4c70bf3b260bffc523` was included in the combined `internal-202605` validation stack with a relay artifact containing PR #121. On physical m0 and dual-ToR testbeds running `SONiC.20260510.06`, `test_dhcp_relay_default` and `test_dhcp_relay_unicast_mac` passed for both ISC and SONiC relay agents. `test_dhcp_relay_default[sonic-relay-agent]` also passed five consecutive runs on each topology.

### Approach
#### What is the motivation for this PR?

The PTF expected raw Option 82 bytes. In the dual-ToR Server-ID Override case it expected:

`Circuit-ID -> Remote-ID -> Server-ID Override -> Link Selection`

SONiC emits:

`Circuit-ID -> Remote-ID -> Link Selection -> Server-ID Override`

ISC does not emit Server-ID Override in this path. Both implementations use the receiving VLAN address for Link Selection.

#### How did you do it?

- Construct Link Selection in the SONiC-specific block before Server-ID Override.
- Use the receiving VLAN interface address, matching ISC and merged sonic-dhcp-relay PR #121.
- Retain `link_selection_added` so the generic dual-ToR block cannot add a duplicate.
- Leave the ISC path unchanged.

#### How did you verify/test it?

The exact head was exercised through the full default and unicast DHCP relay flows on physical m0 and dual-ToR 202605 testbeds with the companion product fix installed.

#### Any platform specific information?

Applies to dual-ToR DHCPv4 relay testing.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

The comments beside the Option 82 construction document the intended agent behavior.

##### Work item tracking

- Microsoft ADO **(number only)**: 38778666
