### PR TITLE
[cacl] Tolerate both INPUT and FORWARD chain rules for multi-asic control-plane ACLs

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -495,7 +495,19 @@ def append_midplane_traffic_rules(duthost, iptables_rules):
         iptables_rules.append("-A INPUT -s {}/32 -d {}/32 -j ACCEPT".format(midplane_ip, midplane_ip))
 
 
-def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby):
+def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby,
+                            use_forward_chain_for_multiasic=False):
+    """
+    Args:
+        ...
+        use_forward_chain_for_multiasic: When True (and asic_index is not None), generate the newer
+            expected iptables rules that use the FORWARD chain (instead of INPUT) for control-plane
+            ACL rules on multi-asic platforms, matching caclmgrd's namespace-to-host forwarding
+            security patch. Kept as an opt-in flag (default False) so callers/tests can build both
+            the pre-patch and post-patch expected rule sets and tolerate either one on the DUT,
+            avoiding a hard dependency between this test change and the caclmgrd code change landing
+            in lock-step.
+    """
     iptables_rules = []
     ip6tables_rules = []
 
@@ -628,6 +640,21 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
     # Generate control plane rules from device config
     rules_applied_from_config = 0
 
+    # On multi-asic platforms, caclmgrd forwards namespace-originated control-plane traffic
+    # for select services (e.g. SSH/SNMP) to the host via the FORWARD chain. Explicitly allow
+    # that forwarded traffic when the newer FORWARD-chain-based behavior is expected.
+    if asic_index is not None and use_forward_chain_for_multiasic:
+        for acl_service, acl_service_info in ACL_SERVICES.items():
+            if acl_service_info["multi_asic_ns_to_host_fwd"]:
+                for ip_protocol in acl_service_info["ip_protocols"]:
+                    for dst_port in acl_service_info["dst_ports"]:
+                        iptables_rules.append(
+                            "-A FORWARD -s {}/32 -p {} -m {} --sport {} -j ACCEPT"
+                            .format(docker_network['bridge']['IPv4Address'], ip_protocol, ip_protocol, dst_port))
+                        ip6tables_rules.append(
+                            "-A FORWARD -s {}/128 -p {} -m {} --sport {} -j ACCEPT"
+                            .format(docker_network['bridge']['IPv6Address'], ip_protocol, ip_protocol, dst_port))
+
     cacl_tables = get_cacl_tables_and_rules(duthost)
 
     # Walk the ACL tables and generate an iptables rule for each rule
@@ -675,7 +702,10 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
                 # Apply the rule to the default protocol(s) for this ACL service
                 for ip_protocol in ip_protocols:
                     for dst_port in dst_ports:
-                        new_iptables_rule = "-A INPUT"
+                        if asic_index is not None and use_forward_chain_for_multiasic:
+                            new_iptables_rule = "-A FORWARD"
+                        else:
+                            new_iptables_rule = "-A INPUT"
 
                         iface_cidr = None
                         if table_ip_version == 6 and "SRC_IPV6" in rule and rule["SRC_IPV6"]:
@@ -728,6 +758,9 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
         # Default drop rules
         iptables_rules.append("-A INPUT -j DROP")
         ip6tables_rules.append("-A INPUT -j DROP")
+        if asic_index is not None and use_forward_chain_for_multiasic:
+            iptables_rules.append("-A FORWARD -j DROP")
+            ip6tables_rules.append("-A FORWARD -j DROP")
 
     # IP Table rule to allow eth1-midplane traffic for chassis
     if asic_index is None:
@@ -1078,23 +1111,45 @@ def verify_cacl_show_acl_rule(duthost, acl_file):
 
 def verify_cacl(duthost, tbinfo, localhost, creds, docker_network,
                 expected_dhcp_rules_for_standby=None, asic_index=None):
-    expected_iptables_rules, expected_ip6tables_rules = \
-        generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby)
+    # Build two variants of the expected rules: the "legacy" INPUT-chain based rules, and the
+    # newer FORWARD-chain based rules used by caclmgrd's multi-asic namespace-to-host forwarding
+    # security patch (restricting SSH/SNMP/etc. namespace->host forwarding to specific IP ranges).
+    # On single-asic platforms (asic_index is None) both variants are identical. Accepting either
+    # variant lets this test change merge independently of the caclmgrd code change landing,
+    # avoiding a cyclic cross-repo merge-order dependency between the two PRs.
+    expected_iptables_rules_legacy, expected_ip6tables_rules_legacy = \
+        generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby,
+                                use_forward_chain_for_multiasic=False)
+    expected_iptables_rules_fwd, expected_ip6tables_rules_fwd = \
+        generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby,
+                                use_forward_chain_for_multiasic=True)
 
     stdout = duthost.get_asic_or_sonic_host(asic_index).command("iptables -S")["stdout"]
     actual_iptables_rules = stdout.strip().split("\n")
 
-    # Ensure all expected iptables rules are present on the DuT
-    logger.info("Number of expected iptable rules:{}, number of actual iptables rules:{}"
-                .format(len(set(expected_iptables_rules)), len(set(actual_iptables_rules))))
-    missing_iptables_rules = set(expected_iptables_rules) - set(actual_iptables_rules)
-    pytest_assert(len(missing_iptables_rules) == 0, "Missing expected iptables rules: {}"
-                  .format(repr(missing_iptables_rules)))
+    logger.info("Number of expected iptable rules (legacy/forward-chain):{}/{}, number of actual iptables rules:{}"
+                .format(len(set(expected_iptables_rules_legacy)), len(set(expected_iptables_rules_fwd)),
+                        len(set(actual_iptables_rules))))
 
-    # Ensure there are no unexpected iptables rules present on the DuT
-    unexpected_iptables_rules = set(actual_iptables_rules) - set(expected_iptables_rules)
-    pytest_assert(len(unexpected_iptables_rules) == 0, "Unexpected iptables rules: {}"
-                  .format(repr(unexpected_iptables_rules)))
+    # Ensure the actual iptables rules match either the legacy or the FORWARD-chain expected rule set
+    missing_iptables_rules_legacy = set(expected_iptables_rules_legacy) - set(actual_iptables_rules)
+    unexpected_iptables_rules_legacy = set(actual_iptables_rules) - set(expected_iptables_rules_legacy)
+    missing_iptables_rules_fwd = set(expected_iptables_rules_fwd) - set(actual_iptables_rules)
+    unexpected_iptables_rules_fwd = set(actual_iptables_rules) - set(expected_iptables_rules_fwd)
+
+    iptables_rules_match_legacy = len(missing_iptables_rules_legacy) == 0 and \
+        len(unexpected_iptables_rules_legacy) == 0
+    iptables_rules_match_fwd = len(missing_iptables_rules_fwd) == 0 and len(unexpected_iptables_rules_fwd) == 0
+
+    pytest_assert(
+        iptables_rules_match_legacy or iptables_rules_match_fwd,
+        "iptables rules did not match either the legacy (pre multi-asic FORWARD-chain security patch) or "
+        "the newer (post-patch) expected rule set.\n"
+        "Legacy variant - missing: {}, unexpected: {}\n"
+        "FORWARD-chain variant - missing: {}, unexpected: {}"
+        .format(repr(missing_iptables_rules_legacy), repr(unexpected_iptables_rules_legacy),
+                repr(missing_iptables_rules_fwd), repr(unexpected_iptables_rules_fwd))
+    )
 
     # TODO: caclmgrd currently applies the "block_ip2me" rules in the order it gathers the interfaces and
     #       their IPs from Config DB, which is indeterminate. We first need to modify caclmgrd to sort
@@ -1107,17 +1162,29 @@ def verify_cacl(duthost, tbinfo, localhost, creds, docker_network,
     stdout = duthost.get_asic_or_sonic_host(asic_index).command("ip6tables -S")["stdout"]
     actual_ip6tables_rules = stdout.strip().split("\n")
 
-    # Ensure all expected ip6tables rules are present on the DuT
-    logger.info("Number of expected ip6table rules:{}, number of actual ip6tables rules:{}"
-                .format(len(set(expected_ip6tables_rules)), len(set(actual_ip6tables_rules))))
-    missing_ip6tables_rules = set(expected_ip6tables_rules) - set(actual_ip6tables_rules)
-    pytest_assert(len(missing_ip6tables_rules) == 0, "Missing expected ip6tables rules: {}"
-                  .format(repr(missing_ip6tables_rules)))
+    logger.info("Number of expected ip6table rules (legacy/forward-chain):{}/{}, number of actual ip6tables rules:{}"
+                .format(len(set(expected_ip6tables_rules_legacy)), len(set(expected_ip6tables_rules_fwd)),
+                        len(set(actual_ip6tables_rules))))
 
-    # Ensure there are no unexpected ip6tables rules present on the DuT
-    unexpected_ip6tables_rules = set(actual_ip6tables_rules) - set(expected_ip6tables_rules)
-    pytest_assert(len(unexpected_ip6tables_rules) == 0, "Unexpected ip6tables rules: {}"
-                  .format(repr(unexpected_ip6tables_rules)))
+    # Ensure the actual ip6tables rules match either the legacy or the FORWARD-chain expected rule set
+    missing_ip6tables_rules_legacy = set(expected_ip6tables_rules_legacy) - set(actual_ip6tables_rules)
+    unexpected_ip6tables_rules_legacy = set(actual_ip6tables_rules) - set(expected_ip6tables_rules_legacy)
+    missing_ip6tables_rules_fwd = set(expected_ip6tables_rules_fwd) - set(actual_ip6tables_rules)
+    unexpected_ip6tables_rules_fwd = set(actual_ip6tables_rules) - set(expected_ip6tables_rules_fwd)
+
+    ip6tables_rules_match_legacy = len(missing_ip6tables_rules_legacy) == 0 and \
+        len(unexpected_ip6tables_rules_legacy) == 0
+    ip6tables_rules_match_fwd = len(missing_ip6tables_rules_fwd) == 0 and len(unexpected_ip6tables_rules_fwd) == 0
+
+    pytest_assert(
+        ip6tables_rules_match_legacy or ip6tables_rules_match_fwd,
+        "ip6tables rules did not match either the legacy (pre multi-asic FORWARD-chain security patch) or "
+        "the newer (post-patch) expected rule set.\n"
+        "Legacy variant - missing: {}, unexpected: {}\n"
+        "FORWARD-chain variant - missing: {}, unexpected: {}"
+        .format(repr(missing_ip6tables_rules_legacy), repr(unexpected_ip6tables_rules_legacy),
+                repr(missing_ip6tables_rules_fwd), repr(unexpected_ip6tables_rules_fwd))
+    )
 
     # TODO: caclmgrd currently applies the "block_ip2me" rules in the order it gathers the interfaces and
     #       their IPs from Config DB, which is indeterminate. We first need to modify caclmgrd to sort


### PR DESCRIPTION
## Description
caclmgrd is being updated to forward namespace-originated control-plane traffic (e.g. SSH/SNMP) to the host via the `FORWARD` chain instead of the `INPUT` chain on multi-asic platforms, restricting that forwarded traffic to a specific IP range as part of a security hardening change. Ref PR: https://github.com/sonic-net/sonic-buildimage/pull/28061

This creates a cyclic cross-repo merge-order dependency:
- Updating `test_cacl_application.py` to *require* the new `FORWARD`-chain rules would fail CI today, before the caclmgrd change has landed.
- Landing the caclmgrd change first would break this test, since it currently hard-requires the legacy `INPUT`-chain-only rule set.

## What this PR does
Breaks the cycle using an **expand-then-contract** approach:
- `generate_expected_rules()` gets a new opt-in `use_forward_chain_for_multiasic` flag (default `False`), which builds the `FORWARD`-chain based rule set (new ACCEPT rules for services with `multi_asic_ns_to_host_fwd=True`, `FORWARD` instead of `INPUT` for per-rule actions, and `FORWARD -j DROP`) only when explicitly requested. All existing callers/behavior are unaffected by default.
- `verify_cacl()` now builds **both** the legacy and `FORWARD`-chain variants and accepts the DUT's actual iptables/ip6tables state if it matches *either* variant.

This lets the test change merge independently of the caclmgrd code change, in either order. Once the caclmgrd change has landed and soaked across supported branches, a follow-up PR can tighten `verify_cacl()` to require only the `FORWARD`-chain variant on multi-asic platforms.

## How I did it
- Modified `tests/cacl/test_cacl_application.py`:
  - `generate_expected_rules(..., use_forward_chain_for_multiasic=False)`
  - `verify_cacl()` now computes and tolerates both rule-set variants for both `iptables` and `ip6tables`.

## How to verify it
- `flake8 --max-line-length=120 tests/cacl/test_cacl_application.py` — clean
- Verified the branching logic standalone (mocked ACL table with an SSH rule) confirms:
  - `use_forward_chain_for_multiasic=False` + `asic_index` set → `-A INPUT ... --dport 22` and `-A INPUT -j DROP` (legacy, unchanged)
  - `use_forward_chain_for_multiasic=True` + `asic_index` set → adds `-A FORWARD -s <bridge_ip> ... --sport 22 -j ACCEPT`, uses `-A FORWARD ... --dport 22`, and adds `-A FORWARD -j DROP`
  - `asic_index=None` (single-asic) → identical output regardless of the new flag (no behavior change for single-asic platforms)

## Which release branch to backport (leave blank if none)

## Description for the changelog
Make test_cacl_application tolerant of both legacy INPUT-chain and upcoming FORWARD-chain multi-asic control-plane ACL rules, to unblock the corresponding caclmgrd security patch from a cyclic test/code merge-order dependency.