### PR TITLE
[snmp] Fix test_snmp_loopback with cSONiC (docker-sonic-vs) neighbors

### DIFF
--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -5,6 +5,10 @@ from tests.common.utilities import wait_until
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.devices.eos import EosHost
+try:
+    from tests.common.devices.csonic import CsonicHost
+except ImportError:  # pragma: no cover - csonic module optional in some trees
+    CsonicHost = None
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +102,31 @@ def get_snmp_output(ip, duthost, nbr, creds_all_duts, oid='.1.3.6.1.2.1.1.1.0'):
         eos_snmpget = "bash {} snmpget -v2c -c {} {} {}".format(
             vrf_prefix, creds_all_duts[duthost.hostname]['snmp_rocommunity'], ip, oid)
         out = nbr['host'].eos_command(commands=[eos_snmpget])
+    elif CsonicHost is not None and isinstance(nbr["host"], CsonicHost):
+        # cSONiC (docker-sonic-vs) neighbor: CsonicHost already runs commands
+        # inside the neighbor container, so run net-snmp's snmpwalk directly
+        # there. The legacy "docker exec snmp ..." wrapper assumes a nested snmp
+        # container and fails with rc=127 'docker: command not found' (cEOS
+        # avoids this via the EosHost branch above).
+        community = creds_all_duts[duthost.hostname]['snmp_rocommunity']
+        # The neighbor Loopback is not routable back from the DUT, so bind the
+        # query to the DUT-facing PortChannel1 global address via --clientaddr.
+        if isinstance(ipaddr, ipaddress.IPv6Address):
+            addr_family, iface_grep = "-6", "inet6 fc"
+        else:
+            addr_family, iface_grep = "-4", "inet 10."
+        src_lookup = (
+            "ip {af} -o addr show PortChannel1 2>/dev/null | "
+            "grep -m1 '{grep}' | awk '{{print $4}}' | cut -d/ -f1"
+        ).format(af=addr_family, grep=iface_grep)
+        src_out = nbr['host'].command(src_lookup, module_ignore_errors=True)
+        client_addr = ""
+        src_stdout = src_out.get('stdout', '') if isinstance(src_out, dict) else ""
+        if src_stdout and src_stdout.strip():
+            client_addr = "--clientaddr={} ".format(src_stdout.strip())
+        command = "snmpwalk -v 2c -c {} {}{} {}".format(
+            community, client_addr, ip, oid)
+        out = nbr['host'].command(command)
     else:
         command = "docker exec snmp snmpwalk -v 2c -c {} {} {}".format(
                   creds_all_duts[duthost.hostname]['snmp_rocommunity'], ip, oid)

--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -6,10 +6,7 @@ from tests.common.utilities import wait_until
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.devices.eos import EosHost
-try:
-    from tests.common.devices.csonic import CsonicHost
-except ImportError:  # pragma: no cover - csonic module optional in some trees
-    CsonicHost = None
+from tests.common.devices.csonic import CsonicHost
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +100,7 @@ def get_snmp_output(ip, duthost, nbr, creds_all_duts, oid='.1.3.6.1.2.1.1.1.0'):
         eos_snmpget = "bash {} snmpget -v2c -c {} {} {}".format(
             vrf_prefix, creds_all_duts[duthost.hostname]['snmp_rocommunity'], ip, oid)
         out = nbr['host'].eos_command(commands=[eos_snmpget])
-    elif CsonicHost is not None and isinstance(nbr["host"], CsonicHost):
+    elif isinstance(nbr["host"], CsonicHost):
         # cSONiC (docker-sonic-vs) neighbor: CsonicHost already runs commands
         # inside the neighbor container, so run net-snmp's snmpwalk directly
         # there. The legacy "docker exec snmp ..." wrapper assumes a nested snmp

--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -111,14 +111,14 @@ def get_snmp_output(ip, duthost, nbr, creds_all_duts, oid='.1.3.6.1.2.1.1.1.0'):
         community = creds_all_duts[duthost.hostname]['snmp_rocommunity']
         # The neighbor Loopback is not routable back from the DUT, so bind the
         # query to the DUT-facing PortChannel1 global address via --clientaddr.
-        if isinstance(ipaddr, ipaddress.IPv6Address):
-            addr_family, iface_grep = "-6", "inet6 fc"
-        else:
-            addr_family, iface_grep = "-4", "inet 10."
+        addr_family = "-6" if isinstance(ipaddr, ipaddress.IPv6Address) else "-4"
+        # Pick the first globally-scoped address on the DUT-facing PortChannel1
+        # regardless of its prefix (IPv4 need not be in 10/8, IPv6 ULAs may be
+        # fc.. or fd..), then strip the /mask.
         src_lookup = (
-            "ip {af} -o addr show PortChannel1 2>/dev/null | "
-            "grep -m1 '{grep}' | awk '{{print $4}}' | cut -d/ -f1"
-        ).format(af=addr_family, grep=iface_grep)
+            "ip {af} -o addr show PortChannel1 scope global 2>/dev/null | "
+            "awk '{{print $4}}' | head -n1 | cut -d/ -f1"
+        ).format(af=addr_family)
         src_out = nbr['host'].command(src_lookup, module_ignore_errors=True)
         client_addr = ""
         src_stdout = src_out.get('stdout', '') if isinstance(src_out, dict) else ""

--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -1,5 +1,6 @@
 import logging
 import ipaddress
+import shlex
 
 from tests.common.utilities import wait_until
 from tests.common.errors import RunAnsibleModuleFail
@@ -123,9 +124,10 @@ def get_snmp_output(ip, duthost, nbr, creds_all_duts, oid='.1.3.6.1.2.1.1.1.0'):
         client_addr = ""
         src_stdout = src_out.get('stdout', '') if isinstance(src_out, dict) else ""
         if src_stdout and src_stdout.strip():
-            client_addr = "--clientaddr={} ".format(src_stdout.strip())
+            client_addr = "--clientaddr={} ".format(shlex.quote(src_stdout.strip()))
         command = "snmpwalk -v 2c -c {} {}{} {}".format(
-            community, client_addr, ip, oid)
+            shlex.quote(community), client_addr, shlex.quote(str(ip)),
+            shlex.quote(oid))
         out = nbr['host'].command(command)
     else:
         command = "docker exec snmp snmpwalk -v 2c -c {} {} {}".format(


### PR DESCRIPTION
### Description of PR

Summary:
Fix `test_snmp_loopback` on cSONiC (`docker-sonic-vs`) neighbors, where it
fails with `rc=127 docker: command not found`.

`get_snmp_output` runs `docker exec snmp snmpwalk` on the neighbor. A cSONiC
neighbor (`docker-sonic-vs`) is itself a container and `CsonicHost.command`
already `docker exec`s into it, so the inner `docker` is a nested call that
does not exist -> both IPv4 and IPv6 fail. cEOS side-steps this via the
`EosHost` branch.

Fix: for `CsonicHost`, run `snmpwalk` directly in-container, sourcing from the
DUT-facing PortChannel address via `--clientaddr` (the neighbor Loopback is not
routable back).

Fixes # (N/A - no separate tracking issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master (docker-sonic-vs / vlab-01 testbed, cSONiC neighbors): validated live -
  both IPv4 and IPv6 `snmpwalk` return the DUT sysDescr through the new
  `CsonicHost` branch, where previously both failed with
  `rc=127 docker: command not found`. Non-cSONiC (EOS / other) paths are
  unchanged.
