### PR TITLE
Enhance Cisco-8000 ecn config checks

### DIFF
--- a/tests/qos/test_ecn_config.py
+++ b/tests/qos/test_ecn_config.py
@@ -213,14 +213,26 @@ def test_verify_ecn_marking_config(duthosts, rand_one_dut_hostname, request):
                         age_quant_len = len(voq_drop_data[0][1])
 
                 if voq_mark_data:
+                    # Validate the per-cell ECN mark probabilities stored in voq_mark_prob_g 
+                    # depending on what is exposed by the asic.
+                    wm_prob = data.get("wm_prob")
+                    mark_list = data.get("mark_list")
+                    have_wm_prob = isinstance(wm_prob, list)
+                    have_mark_list = isinstance(mark_list, list)
                     for g_idx in range(sms_quant_len):
                         for voq_idx in range(voq_quant_len):
                             for age_idx in range(age_quant_len):
-                                actual_value = round(voq_mark_data[g_idx][voq_idx][age_idx], 2)
-                                # Validate value is a probability
-                                assert 0.0 <= actual_value <= 1.0, "Invalid probability "
-                                # Q200 enqueue marking validation
-                                if "wm_prob" in data:
+                                raw_value = voq_mark_data[g_idx][voq_idx][age_idx]
+
+                                # All ASICs: the reported value must be a valid probability.
+                                assert 0.0 <= raw_value <= 1.0, (
+                                    "Invalid marking probability for Port {} PG {} at "
+                                    "SMS/VoQ/Age region {}/{}/{}: {}".format(
+                                        port, pg_to_test, g_idx, voq_idx, age_idx, raw_value))
+
+                                # Cisco-8102 enqueue WRED: exact 4-level mapping.
+                                if have_wm_prob:
+                                    actual_value = round(raw_value, 2)
                                     if age_idx == 0:
                                         mark_level = 0
                                     elif (voq_idx >= 1 and age_idx == 1):
@@ -231,7 +243,7 @@ def test_verify_ecn_marking_config(duthosts, rand_one_dut_hostname, request):
                                         mark_level = 3
                                     else:
                                         mark_level = 0
-                                    expected_value = round(data["wm_prob"][mark_level], 2)
+                                    expected_value = round(wm_prob[mark_level], 2)
                                     assert (
                                             actual_value == expected_value
                                     ), '''
@@ -239,14 +251,13 @@ def test_verify_ecn_marking_config(duthosts, rand_one_dut_hostname, request):
                                             at SMS/VoQ/Age region {}/{}/{} Expected: {} Actual: {}
                                          '''.format(port, pg_to_test, g_idx, voq_idx,
                                                     age_idx, expected_value, actual_value)
-                                # Q200 and G200 dequeue marking validation
-                                if "mark_list" in data:
-                                    # Validate observed value is present in the dequeue list
-                                    assert any(abs(actual_value - level) < 1e-6 for level in prob_list), '''
-                                            Marking Probability not in mark_prob_list for Port {} PG {}
-                                            at SMS/VoQ/Age region {}/{}/{} Value: {} mark_prob_list: {}
+                                # Cisco-8122 palette membership (compared unrounded).
+                                elif have_mark_list:
+                                    assert any(abs(raw_value - level) < 1e-6 for level in mark_list), '''
+                                            Marking Probability not in mark_list for Port {} PG {}
+                                            at SMS/VoQ/Age region {}/{}/{} Value: {} mark_list: {}
                                          '''.format(port, pg_to_test, g_idx, voq_idx,
-                                                    age_idx, actual_value, prob_list)
+                                                    age_idx, raw_value, mark_list)
 
                 ''' Verify drop is 7 for last quant only'''
                 if voq_drop_data:

--- a/tests/qos/test_ecn_config.py
+++ b/tests/qos/test_ecn_config.py
@@ -213,24 +213,35 @@ def test_verify_ecn_marking_config(duthosts, rand_one_dut_hostname, request):
                         age_quant_len = len(voq_drop_data[0][1])
 
                 if voq_mark_data:
-                    # "mark_prob_list" is the uniform ECN mark-probability palette that every
-                    # cell of "voq_mark_prob_g" resolves to. Q200/G200 expose a discrete,
-                    # monotonically-increasing palette (a level-indexed lookup table); P200
-                    # programs a probability per cell directly (la_voq_cgm_action_profile) and
-                    # reports "N/A". When a palette is present, every resolved probability must
-                    # be one of its entries.
-                    prob_list = data.get("mark_prob_list")
-                    if prob_list in (None, "N/A"):
-                        logging.info("mark_prob_list is N/A for Port {} PG {}; skipping "
-                                     "palette membership check".format(port, pg_to_test))
-                    else:
-                        assert prob_list == sorted(prob_list), (
-                            "mark_prob_list is not monotonically non-decreasing for Port {} "
-                            "PG {}: {}".format(port, pg_to_test, prob_list))
-                        for g_idx in range(sms_quant_len):
-                            for voq_idx in range(voq_quant_len):
-                                for age_idx in range(age_quant_len):
-                                    actual_value = voq_mark_data[g_idx][voq_idx][age_idx]
+                    for g_idx in range(sms_quant_len):
+                        for voq_idx in range(voq_quant_len):
+                            for age_idx in range(age_quant_len):
+                                actual_value = round(voq_mark_data[g_idx][voq_idx][age_idx], 2)
+                                # Validate value is a probability
+                                assert 0.0 <= actual_value <= 1.0, "Invalid probability "
+                                # Q200 enqueue marking validation
+                                if "wm_prob" in data:
+                                    if age_idx == 0:
+                                        mark_level = 0
+                                    elif (voq_idx >= 1 and age_idx == 1):
+                                        mark_level = 1
+                                    elif (voq_idx >= 1 and age_idx == 2):
+                                        mark_level = 2
+                                    elif (voq_idx >= 1 and age_idx >= 3):
+                                        mark_level = 3
+                                    else:
+                                        mark_level = 0
+                                    expected_value = round(data["wm_prob"][mark_level], 2)
+                                    assert (
+                                            actual_value == expected_value
+                                    ), '''
+                                            Marking Probability not as expected for Port {} PG {}
+                                            at SMS/VoQ/Age region {}/{}/{} Expected: {} Actual: {}
+                                         '''.format(port, pg_to_test, g_idx, voq_idx,
+                                                    age_idx, expected_value, actual_value)
+                                # Q200 and G200 dequeue marking validation
+                                if "mark_list" in data:
+                                    # Validate observed value is present in the dequeue list
                                     assert any(abs(actual_value - level) < 1e-6 for level in prob_list), '''
                                             Marking Probability not in mark_prob_list for Port {} PG {}
                                             at SMS/VoQ/Age region {}/{}/{} Value: {} mark_prob_list: {}

--- a/tests/qos/test_ecn_config.py
+++ b/tests/qos/test_ecn_config.py
@@ -213,10 +213,25 @@ def test_verify_ecn_marking_config(duthosts, rand_one_dut_hostname, request):
                         age_quant_len = len(voq_drop_data[0][1])
 
                 if voq_mark_data:
+                    # "wm_prob" is the legacy 4-level ECN mark-probability quantization
+                    # exposed only by older ASICs (e.g. Q200 family). Newer ASICs such as
+                    # Graphene2 (G200) and Palladium2 (P200) use a different congestion
+                    # management model that emits a continuous per-region marking
+                    # probability surface in "voq_mark_prob_g" and do not expose "wm_prob".
+                    # For those devices the 4-level mapping does not apply, so validate that
+                    # each value is a valid probability instead.
+                    wm_prob = data.get("wm_prob")
                     for g_idx in range(sms_quant_len):
                         for voq_idx in range(voq_quant_len):
                             for age_idx in range(age_quant_len):
                                 actual_value = round(voq_mark_data[g_idx][voq_idx][age_idx], 2)
+                                if wm_prob is None:
+                                    assert 0.0 <= actual_value <= 1.0, '''
+                                            Marking Probability out of range for Port {} PG {}
+                                            at SMS/VoQ/Age region {}/{}/{} Value: {}
+                                         '''.format(port, pg_to_test, g_idx, voq_idx,
+                                                    age_idx, actual_value)
+                                    continue
                                 if age_idx == 0:
                                     mark_level = 0
                                 elif (voq_idx >= 1 and age_idx == 1):
@@ -227,7 +242,7 @@ def test_verify_ecn_marking_config(duthosts, rand_one_dut_hostname, request):
                                     mark_level = 3
                                 else:
                                     mark_level = 0
-                                expected_value = round(data["wm_prob"][mark_level], 2)
+                                expected_value = round(wm_prob[mark_level], 2)
                                 assert (
                                         actual_value == expected_value
                                 ), '''

--- a/tests/qos/test_ecn_config.py
+++ b/tests/qos/test_ecn_config.py
@@ -213,60 +213,29 @@ def test_verify_ecn_marking_config(duthosts, rand_one_dut_hostname, request):
                         age_quant_len = len(voq_drop_data[0][1])
 
                 if voq_mark_data:
-                    # "voq_mark_prob_g" always holds the resolved ECN mark *probabilities*
-                    # (not level indices), but how those probabilities are configured differs
-                    # per ASIC congestion-management model:
-                    #   * Legacy ASICs (e.g. Q200/Gibraltar) expose a small mark-probability
-                    #     lookup table under "wm_prob"; each cell resolves to one of 4 levels via
-                    #     an age/byte-region -> level mapping, verified below.
-                    #   * Graphene2 (G200) uses the same level-index -> probability indirection but
-                    #     with more levels, and dumps that lookup table under "mark_list" instead of
-                    #     "wm_prob". Every resolved value must therefore be one of the "mark_list"
-                    #     entries.
-                    #   * Palladium2 (P200) drops the lookup-table scheme and programs a per-cell
-                    #     probability directly (la_voq_cgm_action_profile), so no discrete level
-                    #     table is emitted; only validate the values are valid probabilities.
-                    wm_prob = data.get("wm_prob")
-                    mark_list = data.get("mark_list")
-                    for g_idx in range(sms_quant_len):
-                        for voq_idx in range(voq_quant_len):
-                            for age_idx in range(age_quant_len):
-                                raw_value = voq_mark_data[g_idx][voq_idx][age_idx]
-                                if wm_prob is None:
-                                    if mark_list is not None:
-                                        # G200: resolved probability must belong to the configured LUT
-                                        assert any(abs(raw_value - level) < 1e-6 for level in mark_list), '''
-                                                Marking Probability not in configured mark_list for Port {} PG {}
-                                                at SMS/VoQ/Age region {}/{}/{} Value: {} mark_list: {}
-                                             '''.format(port, pg_to_test, g_idx, voq_idx,
-                                                        age_idx, raw_value, mark_list)
-                                    else:
-                                        # P200: continuous per-cell probability, no discrete levels
-                                        assert 0.0 <= raw_value <= 1.0, '''
-                                                Marking Probability out of range for Port {} PG {}
-                                                at SMS/VoQ/Age region {}/{}/{} Value: {}
-                                             '''.format(port, pg_to_test, g_idx, voq_idx,
-                                                        age_idx, raw_value)
-                                    continue
-                                actual_value = round(raw_value, 2)
-                                if age_idx == 0:
-                                    mark_level = 0
-                                elif (voq_idx >= 1 and age_idx == 1):
-                                    mark_level = 1
-                                elif (voq_idx >= 1 and age_idx == 2):
-                                    mark_level = 2
-                                elif (voq_idx >= 1 and age_idx >= 3):
-                                    mark_level = 3
-                                else:
-                                    mark_level = 0
-                                expected_value = round(wm_prob[mark_level], 2)
-                                assert (
-                                        actual_value == expected_value
-                                ), '''
-                                        Marking Probability not as expected for Port {} PG {}
-                                        at SMS/VoQ/Age region {}/{}/{} Expected: {} Actual: {}
-                                     '''.format(port, pg_to_test, g_idx, voq_idx,
-                                                age_idx, expected_value, actual_value)
+                    # "mark_prob_list" is the uniform ECN mark-probability palette that every
+                    # cell of "voq_mark_prob_g" resolves to. Q200/G200 expose a discrete,
+                    # monotonically-increasing palette (a level-indexed lookup table); P200
+                    # programs a probability per cell directly (la_voq_cgm_action_profile) and
+                    # reports "N/A". When a palette is present, every resolved probability must
+                    # be one of its entries.
+                    prob_list = data.get("mark_prob_list")
+                    if prob_list in (None, "N/A"):
+                        logging.info("mark_prob_list is N/A for Port {} PG {}; skipping "
+                                     "palette membership check".format(port, pg_to_test))
+                    else:
+                        assert prob_list == sorted(prob_list), (
+                            "mark_prob_list is not monotonically non-decreasing for Port {} "
+                            "PG {}: {}".format(port, pg_to_test, prob_list))
+                        for g_idx in range(sms_quant_len):
+                            for voq_idx in range(voq_quant_len):
+                                for age_idx in range(age_quant_len):
+                                    actual_value = voq_mark_data[g_idx][voq_idx][age_idx]
+                                    assert any(abs(actual_value - level) < 1e-6 for level in prob_list), '''
+                                            Marking Probability not in mark_prob_list for Port {} PG {}
+                                            at SMS/VoQ/Age region {}/{}/{} Value: {} mark_prob_list: {}
+                                         '''.format(port, pg_to_test, g_idx, voq_idx,
+                                                    age_idx, actual_value, prob_list)
 
                 ''' Verify drop is 7 for last quant only'''
                 if voq_drop_data:

--- a/tests/qos/test_ecn_config.py
+++ b/tests/qos/test_ecn_config.py
@@ -213,7 +213,7 @@ def test_verify_ecn_marking_config(duthosts, rand_one_dut_hostname, request):
                         age_quant_len = len(voq_drop_data[0][1])
 
                 if voq_mark_data:
-                    # Validate the per-cell ECN mark probabilities stored in voq_mark_prob_g 
+                    # Validate the per-cell ECN mark probabilities stored in voq_mark_prob_g
                     # depending on what is exposed by the asic.
                     wm_prob = data.get("wm_prob")
                     mark_list = data.get("mark_list")

--- a/tests/qos/test_ecn_config.py
+++ b/tests/qos/test_ecn_config.py
@@ -213,25 +213,42 @@ def test_verify_ecn_marking_config(duthosts, rand_one_dut_hostname, request):
                         age_quant_len = len(voq_drop_data[0][1])
 
                 if voq_mark_data:
-                    # "wm_prob" is the legacy 4-level ECN mark-probability quantization
-                    # exposed only by older ASICs (e.g. Q200 family). Newer ASICs such as
-                    # Graphene2 (G200) and Palladium2 (P200) use a different congestion
-                    # management model that emits a continuous per-region marking
-                    # probability surface in "voq_mark_prob_g" and do not expose "wm_prob".
-                    # For those devices the 4-level mapping does not apply, so validate that
-                    # each value is a valid probability instead.
+                    # "voq_mark_prob_g" always holds the resolved ECN mark *probabilities*
+                    # (not level indices), but how those probabilities are configured differs
+                    # per ASIC congestion-management model:
+                    #   * Legacy ASICs (e.g. Q200/Gibraltar) expose a small mark-probability
+                    #     lookup table under "wm_prob"; each cell resolves to one of 4 levels via
+                    #     an age/byte-region -> level mapping, verified below.
+                    #   * Graphene2 (G200) uses the same level-index -> probability indirection but
+                    #     with more levels, and dumps that lookup table under "mark_list" instead of
+                    #     "wm_prob". Every resolved value must therefore be one of the "mark_list"
+                    #     entries.
+                    #   * Palladium2 (P200) drops the lookup-table scheme and programs a per-cell
+                    #     probability directly (la_voq_cgm_action_profile), so no discrete level
+                    #     table is emitted; only validate the values are valid probabilities.
                     wm_prob = data.get("wm_prob")
+                    mark_list = data.get("mark_list")
                     for g_idx in range(sms_quant_len):
                         for voq_idx in range(voq_quant_len):
                             for age_idx in range(age_quant_len):
-                                actual_value = round(voq_mark_data[g_idx][voq_idx][age_idx], 2)
+                                raw_value = voq_mark_data[g_idx][voq_idx][age_idx]
                                 if wm_prob is None:
-                                    assert 0.0 <= actual_value <= 1.0, '''
-                                            Marking Probability out of range for Port {} PG {}
-                                            at SMS/VoQ/Age region {}/{}/{} Value: {}
-                                         '''.format(port, pg_to_test, g_idx, voq_idx,
-                                                    age_idx, actual_value)
+                                    if mark_list is not None:
+                                        # G200: resolved probability must belong to the configured LUT
+                                        assert any(abs(raw_value - level) < 1e-6 for level in mark_list), '''
+                                                Marking Probability not in configured mark_list for Port {} PG {}
+                                                at SMS/VoQ/Age region {}/{}/{} Value: {} mark_list: {}
+                                             '''.format(port, pg_to_test, g_idx, voq_idx,
+                                                        age_idx, raw_value, mark_list)
+                                    else:
+                                        # P200: continuous per-cell probability, no discrete levels
+                                        assert 0.0 <= raw_value <= 1.0, '''
+                                                Marking Probability out of range for Port {} PG {}
+                                                at SMS/VoQ/Age region {}/{}/{} Value: {}
+                                             '''.format(port, pg_to_test, g_idx, voq_idx,
+                                                        age_idx, raw_value)
                                     continue
+                                actual_value = round(raw_value, 2)
                                 if age_idx == 0:
                                     mark_level = 0
                                 elif (voq_idx >= 1 and age_idx == 1):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enhance Cisco-8000 ecn config checks to validate depending on what asic capabilities are available.


<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Add test-case support for 8223 and 8122 Cisco asics. 

#### How did you do it?
Maintain pre-existing Cisco-8102-specific checks, but add other checks for different asics as appropriate.

#### How did you verify/test it?
```
- [ ] Validate against Cisco-8102 `=== 2 passed, 1 warning in 303.34s (0:05:03) ===`
- [ ] Validate against Cisco-8223 `=== 2 passed, 1 warning in 227.87s (0:03:47) ===`


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
