### PR TITLE
[202511] Fix packet trimming regression related to trim drop counter

### DIFF
--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -14,7 +14,7 @@ from tests.packet_trimming.packet_trimming_helper import (
     verify_trimmed_packet, reboot_dut, check_connected_route_ready, get_switch_trim_counters_json,
     get_port_trim_counters_json, disable_egress_data_plane, enable_egress_data_plane,
     verify_queue_and_port_trim_counter_consistency, get_queue_trim_counters_json, compare_counters,
-    check_trim_drop_counter_zero, has_non_zero_trim_counters,
+    check_trim_drop_counter_zero, is_trim_drop_counter_stable, has_non_zero_trim_counters,
     configure_port_mirror_session, remove_port_mirror_session)
 
 logger = logging.getLogger(__name__)
@@ -419,19 +419,24 @@ class BasePacketTrimming:
                                       f"Trim drop counter on port {port} is not greater than 0")
 
             finally:
+                errors = []
                 # Enable the trimmed queue with original scheduler
                 for port in trim_counter_params['egress_ports']:
                     for dut_member in port['dut_members']:
                         original_scheduler = original_schedulers.get(dut_member)
                         enable_egress_data_plane(duthost, dut_member, trim_queue, original_scheduler)
-                        # Known limitation: TRIM_DRP_PKTS is a calculated counter (TRIM_PKTS - TRIM_TX_PKTS)
-                        # rather than a real hardware counter. After restoring the blocked trim queue,
-                        # queued packets drain out and TRIM_DRP_PKTS gradually decreases to 0.
-                        # Wait for it to stabilize before reading baseline counters for the next step.
-                        pytest_assert(
-                            wait_until(30, 2, 0, check_trim_drop_counter_zero, duthost, dut_member),
-                            f"TRIM_DRP_PKTS on port {dut_member} did not stabilize to 0"
-                        )
+                        if is_mellanox_device(duthost):
+                            # Known limitation: TRIM_DRP_PKTS is a calculated counter (TRIM_PKTS - TRIM_TX_PKTS)
+                            # rather than a real hardware counter. After restoring the blocked trim queue,
+                            # queued packets drain out and TRIM_DRP_PKTS gradually decreases to 0.
+                            # Wait for it to stabilize before reading baseline counters for the next step.
+                            if not wait_until(30, 2, 0, check_trim_drop_counter_zero, duthost, dut_member):
+                                errors.append(f"TRIM_DRP_PKTS on port {dut_member} did not stabilize to 0")
+                        elif not is_trim_drop_counter_stable(duthost, dut_member):
+                            errors.append(f"TRIM_DRP_PKTS on unblocked port {dut_member} is still increasing")
+
+                # assert after loop to ensure all ports get unblocked
+                pytest_assert(not errors, "\n".join(errors))
 
     def test_trimming_counters_with_feature_toggle(self, duthost, ptfadapter, test_params, trim_counter_params):
         """

--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -2896,6 +2896,29 @@ def check_trim_drop_counter_zero(duthost, port):
     return trim_drop == 0
 
 
+def is_trim_drop_counter_stable(duthost, port):
+    """
+    Check if TRIM_DRP_PKTS counter remains constant on the specified port
+
+    Args:
+        duthost: DUT host object
+        port (str): port name, e.g. "Ethernet96"
+
+    Returns:
+        bool: True if TRIM_DRP_PKTS counter stops increasing, otherwise False
+    """
+    start_time = time.time()
+    while time.time() - start_time < 30:
+        prev_trim_drop = get_port_trim_counters_json(duthost, port)['TRIM_DRP_PKTS']
+        # Ensure there is enough time to poll for an updated value from the ASIC
+        time.sleep(2 * (TRIMMING_COUNTER_INTERVAL / 1000))
+        curr_trim_drop = get_port_trim_counters_json(duthost, port)['TRIM_DRP_PKTS']
+        if prev_trim_drop == curr_trim_drop:
+            return True
+
+    return False
+
+
 def has_non_zero_trim_counters(duthost, port):
     """
     Checks if port level trim counters are non-zero.


### PR DESCRIPTION
### Description of PR

Summary:
Manual pick of fix provided by Arista: Fixes packet trimming regression related to the `TRIM_DRP_PKTS` (trim drop) counter in the `test_trimming_counters` test case, on the 202511 branch only.

The original counter-stabilization logic was introduced by #22807. On master, that code path was later removed/reworked by #24578 ("Update trimming case to support queue-level TrimSent and TrimDrop counters"), so master no longer needs this fix. However, 202511 does not include #24578, so the regression still exists there and must be fixed independently on 202511.

This PR ports the fix from #24137 to 202511: it makes the post-test cleanup differentiate between Mellanox and non-Mellanox devices when validating the trim drop counter after restoring the blocked trim queue.

This is a **202511-only** change and is intentionally not applicable to master.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: regression

### Approach
#### What is the motivation for this PR?
`TRIM_DRP_PKTS` is a calculated counter (`TRIM_PKTS - TRIM_TX_PKTS`) rather than a real hardware counter. After the blocked trim queue is restored during cleanup in `test_trimming_counters`, queued packets drain out and the counter behaves differently across platforms:
- On Mellanox devices it gradually decreases back to 0.
- On non-Mellanox devices it simply stops increasing.

The previous logic asserted the counter must stabilize to 0 for all platforms, which caused false failures on non-Mellanox devices. This regression is present on 202511 because 202511 does not have the counter rework from #24578 that is already on master.

#### How did you do it?
- Added a new helper `is_trim_drop_counter_stable()` in `tests/packet_trimming/packet_trimming_helper.py` that polls `TRIM_DRP_PKTS` and returns `True` once the counter stops increasing.
- Updated the `finally` block of `test_trimming_counters` in  `tests/packet_trimming/base_packet_trimming.py` to branch by device type after restoring the queue:
  - Mellanox: wait for the counter to stabilize to 0 (`check_trim_drop_counter_zero`).
  - Non-Mellanox: verify the counter is no longer increasing (`is_trim_drop_counter_stable`).
- Collected any validation errors and asserted after the loop so that all ports get unblocked before the assertion runs.

#### How did you verify/test it?
Ran `test_trimming_counters` in the `packet_trimming` suite on the 202511 branch and confirmed the cleanup validation passes for both Mellanox and non-Mellanox devices.

#### Any platform specific information?
The validation path differs by vendor: Mellanox expects the drop counter to return to 0, while other platforms only require the counter to stop increasing.

#### Supported testbed topology if it's a new test case?
N/A (existing test case fix).

### Documentation
N/A