### PR TITLE
[cSONiC] Make CsonicHost hashable (fix unhashable type CsonicHost)

### DIFF
--- a/tests/common/devices/csonic.py
+++ b/tests/common/devices/csonic.py
@@ -43,6 +43,24 @@ class CsonicHost(NeighborDevice):
     def __repr__(self):
         return self.__str__()
 
+    def __hash__(self):
+        # CsonicHost is stored as the ['host'] value of a NeighborDevice and is
+        # used interchangeably with EosHost/SonicHost, which are hashable plain
+        # objects. CsonicHost inherits NeighborDevice(dict), which Python marks
+        # unhashable (dict subclasses get __hash__ = None), so some tests (e.g.
+        # iface_loopback_action) that place neighbor hosts in a set or use them
+        # as dict keys raise "unhashable type: 'CsonicHost'" while cEOS/EosHost
+        # neighbors pass. Identity is the container name, so hashing/eq on that
+        # keeps host objects hashable and distinct without relying on dict
+        # contents.
+        return hash(self.container_name)
+
+    def __eq__(self, other):
+        return isinstance(other, CsonicHost) and self.container_name == other.container_name
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def _docker_exec(self, cmd, **kwargs):
         """Run a command inside the Docker container via docker exec."""
         docker_cmd = ['docker', 'exec', self.container_name, 'bash', '-c', cmd]


### PR DESCRIPTION
### What / Why

`CsonicHost` is used interchangeably with `EosHost`/`SonicHost` as a neighbor host object. Unlike those plain objects, it inherits `NeighborDevice`, which subclasses `dict`. Python marks `dict` subclasses **unhashable** (`__hash__ = None`), so any test that places a neighbor host in a `set` or uses it as a `dict` key (e.g. `iface_loopback_action`) fails under cSONiC with:

```
TypeError: unhashable type: 'CsonicHost'
```

while passing with cEOS/`EosHost` neighbors. This is a cSONiC-only parity gap.

### Fix

Define `__hash__`/`__eq__`/`__ne__` keyed on the container name (the neighbor's stable identity), matching how `EosHost` behaves by identity. No functional change to command execution.

### Test

Verified that a `dict`-subclass instance is unhashable by default and that adding these dunders makes the object hashable, set-dedupe correct, and usable as a dict key. flake8-clean (max-line-length 120), syntax-checked.

> Opened as **draft** per standing preference.
