### PR TITLE
[test_nbr_health] Handle cSONiC (docker-sonic-vs) neighbors

### DIFF
--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -5,6 +5,12 @@ import logging
 from .common.helpers.assertions import pytest_assert
 from .common.devices.eos import EosHost
 from .common.devices.sonic import SonicHost
+try:
+    # cSONiC (docker-sonic-vs) neighbors are reached via docker exec, not SSH.
+    # Guard the import so upstream trees without CsonicHost are unaffected.
+    from .common.devices.csonic import CsonicHost
+except ImportError:
+    CsonicHost = None
 
 logger = logging.getLogger(__name__)
 
@@ -141,6 +147,17 @@ def test_neighbors_health(duthosts, localhost, nbrhosts, eos, sonic, enum_fronte
             if failmsg:
                 fails.append(failmsg)
 
+            failmsg = check_sonic_bgp_facts(k, nbrhost)
+            if failmsg:
+                fails.append(failmsg)
+
+        elif CsonicHost is not None and isinstance(nbrhost, CsonicHost):
+            # A cSONiC (docker-sonic-vs) neighbor is reached via 'docker exec',
+            # not SSH: by design it has no dedicated management IP and no
+            # SNMP-over-mgmt endpoint (see CsonicHost docstring). The mgmt-addr
+            # and SNMP checks used for EOS/SonicHost neighbors therefore do not
+            # apply. Its health is verified by confirming BGP is configured
+            # correctly via vtysh (the same check used for SonicHost neighbors).
             failmsg = check_sonic_bgp_facts(k, nbrhost)
             if failmsg:
                 fails.append(failmsg)

--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -5,14 +5,7 @@ import logging
 from .common.helpers.assertions import pytest_assert
 from .common.devices.eos import EosHost
 from .common.devices.sonic import SonicHost
-try:
-    # cSONiC (docker-sonic-vs) neighbors are reached via docker exec, not SSH.
-    # Guard the import so upstream trees without CsonicHost are unaffected.
-    from .common.devices.csonic import CsonicHost
-    CSONIC_IMPORT_ERROR = None
-except ImportError as err:
-    CsonicHost = None
-    CSONIC_IMPORT_ERROR = err
+from .common.devices.csonic import CsonicHost
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +146,7 @@ def test_neighbors_health(duthosts, localhost, nbrhosts, eos, sonic, enum_fronte
             if failmsg:
                 fails.append(failmsg)
 
-        elif CsonicHost is not None and isinstance(nbrhost, CsonicHost):
+        elif isinstance(nbrhost, CsonicHost):
             # A cSONiC (docker-sonic-vs) neighbor is reached via 'docker exec',
             # not SSH: by design it has no dedicated management IP and no
             # SNMP-over-mgmt endpoint (see CsonicHost docstring). The mgmt-addr
@@ -165,9 +158,6 @@ def test_neighbors_health(duthosts, localhost, nbrhosts, eos, sonic, enum_fronte
                 fails.append(failmsg)
 
         else:
-            if CSONIC_IMPORT_ERROR is not None:
-                logger.debug("CsonicHost import failed; treating cSONiC neighbors as unavailable: %r",
-                             CSONIC_IMPORT_ERROR)
             failmsg = "neighbor type {} is unknown".format(k)
             fails.append(failmsg)
 

--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -9,8 +9,10 @@ try:
     # cSONiC (docker-sonic-vs) neighbors are reached via docker exec, not SSH.
     # Guard the import so upstream trees without CsonicHost are unaffected.
     from .common.devices.csonic import CsonicHost
-except ImportError:
+    CSONIC_IMPORT_ERROR = None
+except ImportError as err:
     CsonicHost = None
+    CSONIC_IMPORT_ERROR = err
 
 logger = logging.getLogger(__name__)
 
@@ -163,6 +165,9 @@ def test_neighbors_health(duthosts, localhost, nbrhosts, eos, sonic, enum_fronte
                 fails.append(failmsg)
 
         else:
+            if CSONIC_IMPORT_ERROR is not None:
+                logger.debug("CsonicHost import failed; treating cSONiC neighbors as unavailable: %r",
+                             CSONIC_IMPORT_ERROR)
             failmsg = "neighbor type {} is unknown".format(k)
             fails.append(failmsg)
 


### PR DESCRIPTION
### Description of PR

Summary:
Make `tests/test_nbr_health.py::test_neighbors_health` handle cSONiC
(`docker-sonic-vs`) neighbors.

`test_neighbors_health` branches on the neighbor host class
(`isinstance(EosHost)` / `SonicHost`) and hard-fails in `else:` with
`neighbor type X is unknown` for any other type. A cSONiC neighbor is a
`CsonicHost(NeighborDevice)` - neither `EosHost` nor `SonicHost` - so all
neighbors report "unknown" and the test fails. cEOS side-steps this via the
`EosHost` branch.

Fix: import `CsonicHost` and add a `CsonicHost` branch that verifies
neighbor health via the existing `check_sonic_bgp_facts` (vtysh
`show ip bgp summary` -> "Unicast Summary"). The mgmt-addr / SNMP-over-mgmt
checks used for EOS/SonicHost don't apply to a docker-exec neighbor (no mgmt
IP, no SNMP-over-mgmt by design).

Fixes # (N/A - no separate tracking issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master (docker-sonic-vs / vlab-01 testbed, cSONiC neighbors): verified live -
  vtysh returns "IPv4 Unicast Summary" and the new `CsonicHost` branch passes
  for all neighbors, where previously every neighbor reported
  "neighbor type ... is unknown". EOS / SonicHost neighbors are unchanged (they
  take the pre-existing branches).
