### PR TITLE
Fix `crm_resources` duthost fixture to use `enum_rand_one_per_hwsku_frontend_hostname`

### DIFF
--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -321,7 +321,7 @@ def cleanup_ptf_interface(duthosts, ip_ver, enum_rand_one_per_hwsku_frontend_hos
 
 
 @pytest.fixture(scope="module", autouse=True)
-def crm_resources(duthosts, rand_one_dut_hostname, set_polling_interval):
+def crm_resources(duthosts, enum_rand_one_per_hwsku_frontend_hostname, set_polling_interval):
     """
     Parse the CRM resource table from the 'crm show resources all' command output,
     retrying if CRM counters are not ready.
@@ -330,7 +330,7 @@ def crm_resources(duthosts, rand_one_dut_hostname, set_polling_interval):
         "ipv4_route": {"used": 6475, "available": 140981},
     }
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     resources = {}
 
     def get_crm_resources(resources_dict):


### PR DESCRIPTION

### Description of PR
`crm_resources` used `rand_one_dut_hostname` which could select a chassis supervisor.
But all other crm fixtures use `enum_rand_one_per_hwsku_frontend_hostname` which is only LCs.
If `rand_one_dut_hostname` selected a supervisor the crm tests would fail with:
`Failed: CRM counters are not ready after multiple retries.`

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] msft-202601
- [x] 202605

### Approach
#### What is the motivation for this PR?
If all crm fixtures don't use the same duthost fixture then on chassis we can see some fixtures run on LCs and others on Supervisors.
E.G.
`set_polling_interval` runs on LC
`crm_resources` runs on supervisor
Causes failure: `Failed: CRM counters are not ready after multiple retries.`

#### How did you do it?
Updated `crm_resources` to use `enum_rand_one_per_hwsku_frontend_hostname` to match the other crm fixtures

#### How did you verify/test it?
Ran `test_crm.py` on chassis and saw it passes now.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
