### PR TITLE
[loganalyzer]: Ignore transient thermalctld thermal-manager init JSONDecodeError

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -109,6 +109,11 @@ r, ".* ERR monit.*Unix socket /var/run/monit.sock connection error.*"
 # https://dev.azure.com/msazure/One/_workitems/edit/14233936
 r, ".* ERR pmon#thermalctld.*Caught exception while running thermal policy - AttributeError.*"
 
+# Transient boot-time race: thermalctld initializes the thermal manager before the
+# platform is fully ready and reads an empty policy, raising JSONDecodeError once at
+# startup, then recovers. Benign; thermalctld runs normally afterwards.
+r, ".* ERR pmon#thermalctld.*Caught exception while initializing thermal manager - JSONDecodeError.*"
+
 # https://dev.azure.com/msazure/One/_workitems/edit/14233549
 r, ".* ERR pmon#ycable.*executing the cli for prbs thread.*"
 


### PR DESCRIPTION
### Description of PR
Summary:
Add a LogAnalyzer common-ignore regex for the transient, benign `thermalctld`
thermal-manager initialization `JSONDecodeError` emitted once at boot.

On some platforms (observed on Arista-7060X6-64PE) `thermalctld` initializes the
thermal manager before the platform is fully ready, reads an empty policy, and
raises a one-time `JSONDecodeError('Expecting value: line 1 column 1 (char 0)')`
at startup, then recovers and runs normally. Because this ERR line persists in
syslog, the `loganalyzer` fixture matches it at **teardown** and fails otherwise
passing tests. Observed on `internal-202511` nightlies causing
`pfcwd/test_pfcwd_timer_accuracy` and `stress/test_stress_routes` to error on
teardown (`match: 1 expected_match: 0`).

This adds a common-ignore entry, consistent with the existing
`thermalctld ... running thermal policy - AttributeError` ignore. The underlying
`thermalctld` init exception is a separate product-side issue tracked
independently.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`thermalctld` logs a benign, transient `JSONDecodeError` while initializing the
thermal manager at boot on some platforms. The message stays in syslog, so the
`loganalyzer` teardown check matches it and errors unrelated, otherwise-passing
tests (e.g. `pfcwd/test_pfcwd_timer_accuracy[IPv6]`,
`stress/test_stress_routes::test_announce_withdraw_route`).

#### How did you do it?
Added a regex to
`ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt`
(consumed by the pytest `loganalyzer` plugin via a symlink and
`load_common_config()`):

```
r, ".* ERR pmon#thermalctld.*Caught exception while initializing thermal manager - JSONDecodeError.*"
```

#### How did you verify/test it?
- Validated the regex matches the exact syslog line and does not over-match
  unrelated `thermalctld` lines.
- Traced the consumption path: `load_common_config()` -> `COMMON_IGNORE`
  (symlink to the edited file) -> `create_msg_regex` -> `ignore_regex` ->
  compiled `ignore_messages_regex` used by `analyze()`.
- Confirmed on the DUT that `thermalctld` is running normally after the one-time
  init exception (benign/transient).

#### Any platform specific information?
Observed on Arista-7060X6-64PE (broadcom). The ignore is generic to the
`thermalctld` init `JSONDecodeError` message and is not platform-restricted,
matching the convention of the adjacent `thermalctld` ignore entry.

#### Supported testbed topology if it's a new test case?
N/A (not a new test case).

### Documentation
N/A
