### PR TITLE
[drop_packets] Xfail 7050CX3 202605 drop counter regression

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1351,6 +1351,13 @@ drop_packets/test_drop_counters.py:
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/21571 and 't0-isolated-d256u256s2' in topo_name"
 
+drop_packets/test_drop_counters.py::test_(dst_ip_absent|dst_ip_is_loopback_addr|ip_is_zero_addr|ip_pkt_with_exceeded_mtu|not_expected_vlan_tag_drop|src_ip_is_loopback_addr|src_ip_is_multicast_addr|unicast_ip_incorrect_eth_dst):
+  regex: true
+  xfail:
+    reason: "Arista 7050CX3 202605 does not increment expected RX_DRP/RX_ERR counters for these drop scenarios"
+    conditions:
+      - "https://github.com/aristanetworks/sonic-qual.msft/issues/1339 and release in ['202605'] and hwsku in ['Arista-7050CX3-32S-C32'] and topo_type in ['t0']"
+
 drop_packets/test_drop_counters.py::test_acl_egress_drop:
   xfail:
     reason: "xfail for IPv6-only topologies, issue with valid_ipv4"


### PR DESCRIPTION
### Description of PR

Summary:
Add a narrow conditional xfail for a 202605 Arista 7050CX3 drop-counter regression tracked by Arista issue #1339.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
https://github.com/aristanetworks/sonic-qual.msft/issues/1339
Failure type: regression

### Approach
#### What is the motivation for this PR?
`drop_packets/test_drop_counters.py` consistently fails on Arista-7050CX3-32S-C32 t0 with 202605 images because expected RX_DRP/RX_ERR drop counters are not incrementing. Kusto comparison shows the same test family passes on 202511 without this failure signature.

#### How did you do it?
Add a narrow issue-linked conditional xfail for the affected drop-counter cases, scoped to release 202605, HWSKU Arista-7050CX3-32S-C32, and t0 topology.

#### How did you verify/test it?
YAML parse and `git diff --check` passed locally. Elastictest validation is in progress:
- 202511 image + internal-202605 test code: https://elastictest.org/scheduler/testplan/6a558916f446b375ff1010ad

#### Any platform specific information?
Arista-7050CX3-32S-C32, t0, Broadcom, internal-202605.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
