### PR TITLE
[HFT] Avoid disruptive SWSS recovery in tests

### DIFF
--- a/tests/high_frequency_telemetry/conftest.py
+++ b/tests/high_frequency_telemetry/conftest.py
@@ -1,7 +1,10 @@
-import pytest
+import json
 import logging
 import time
-from datetime import datetime, timezone
+from datetime import datetime
+
+import pytest
+
 from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
@@ -95,40 +98,71 @@ def ignore_expected_loganalyzer_exceptions(duthosts, enum_rand_one_per_hwsku_hos
 def ensure_swss_ready(duthosts, enum_rand_one_per_hwsku_hostname):
     """Ensure swss container is running and stable for at least 10 seconds.
 
-    Function-level fixture that runs before each test to ensure swss is ready,
-    as tests may affect the container state.
+    Fail the test instead of restarting swss when the container state cannot be
+    verified. A transient inspection error must not disrupt syncd or the SDK.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     def get_swss_uptime_seconds():
         """Get swss container uptime in seconds via docker inspect."""
+        inspect_result = duthost.shell(
+            "docker inspect swss",
+            module_ignore_errors=True
+        )
+        if inspect_result['rc'] != 0:
+            pytest.fail(
+                "Failed to inspect swss container: {}".format(
+                    inspect_result.get('stderr', '').strip()
+                )
+            )
+
         try:
-            # Step 1: Get container start time from docker inspect JSON
-            result = duthost.shell(
-                "docker inspect swss | grep StartedAt | head -1 | cut -d'\"' -f4",
-                module_ignore_errors=True
+            state = json.loads(inspect_result['stdout'])[0]['State']
+            running = state['Running']
+            started_at = state['StartedAt']
+        except (json.JSONDecodeError, IndexError, KeyError, TypeError) as err:
+            pytest.fail(
+                "Unexpected docker inspect output for swss: {}".format(err)
             )
-            if result['rc'] != 0 or not result['stdout'].strip():
-                return 0
-            started_at = result['stdout'].strip()
 
-            # Step 2: Convert start time to epoch seconds on DUT
-            result = duthost.shell(
-                f'date -ud "{started_at}" +%s',
-                module_ignore_errors=True
+        if running is not True:
+            pytest.fail(
+                "swss container is not running "
+                "(State.Running={})".format(running)
             )
-            if result['rc'] != 0 or not result['stdout'].strip():
-                return 0
 
-            # Step 3: Calculate uptime = current UTC epoch - start epoch
-            started_epoch = int(result['stdout'].strip())
-            now_epoch = int(datetime.now(timezone.utc).timestamp())
-            uptime = now_epoch - started_epoch
-            logger.debug(f"swss container uptime: {uptime}s")
-            return uptime
-        except Exception as e:
-            logger.warning(f"Failed to get swss uptime: {e}")
-            return 0
+        try:
+            started_epoch = int(datetime.fromisoformat(
+                started_at.replace('Z', '+00:00')
+            ).timestamp())
+        except (AttributeError, TypeError, ValueError) as err:
+            pytest.fail("Invalid swss container start time: {}".format(err))
+
+        uptime_result = duthost.shell(
+            'date -u +%s',
+            module_ignore_errors=True
+        )
+        if uptime_result['rc'] != 0:
+            pytest.fail(
+                "Failed to calculate swss container uptime: {}".format(
+                    uptime_result.get('stderr', '').strip()
+                )
+            )
+
+        try:
+            uptime = int(uptime_result['stdout'].strip()) - started_epoch
+        except ValueError:
+            pytest.fail(
+                "Unexpected swss container uptime: {!r}".format(
+                    uptime_result['stdout'].strip()
+                )
+            )
+
+        if uptime < 0:
+            pytest.fail("swss container start time is in the future")
+
+        logger.debug(f"swss container uptime: {uptime}s")
+        return uptime
 
     logger.info("Checking swss container status...")
 
@@ -136,30 +170,7 @@ def ensure_swss_ready(duthosts, enum_rand_one_per_hwsku_hostname):
     uptime = get_swss_uptime_seconds()
     min_uptime = 10  # Require at least 10 seconds uptime
 
-    if uptime == 0:
-        logger.warning("swss container is not running, attempting to start...")
-
-        # Try to restart swss service
-        duthost.shell('sudo systemctl restart swss',
-                      module_ignore_errors=True)
-
-        # Wait for container to start and stabilize
-        max_wait = 40  # Total wait time
-        logger.info(f"Waiting up to {max_wait} seconds for swss container "
-                    f"to start and stabilize...")
-
-        for i in range(max_wait):
-            time.sleep(1)
-            current_uptime = get_swss_uptime_seconds()
-            if current_uptime >= min_uptime:
-                logger.info(f"swss container is stable "
-                            f"(uptime: {current_uptime}s)")
-                break
-        else:
-            raise RuntimeError(f"swss container failed to stabilize "
-                               f"after {max_wait} seconds")
-
-    elif uptime < min_uptime:
+    if uptime < min_uptime:
         wait_time = min_uptime - uptime + 1  # +1 for safety margin
         logger.info(f"swss container uptime is {uptime}s, "
                     f"waiting {wait_time}s for stability...")
@@ -184,7 +195,8 @@ def ensure_swss_ready(duthosts, enum_rand_one_per_hwsku_hostname):
 
 @pytest.fixture(scope="function")
 def cleanup_high_frequency_telemetry(
-    duthosts, enum_rand_one_per_hwsku_hostname, ensure_swss_ready
+    duthosts, enum_rand_one_per_hwsku_hostname, ensure_swss_ready,
+    suppress_otel_debug_logging
 ):
     """
     Function-level fixture to clean up high frequency telemetry
@@ -258,56 +270,3 @@ def cleanup_high_frequency_telemetry(
             f"High frequency telemetry cleanup completed. "
             f"Total keys deleted: {total_deleted}"
         )
-
-
-@pytest.fixture(scope="function")
-def disable_flex_counters(
-    duthosts, enum_rand_one_per_hwsku_hostname,
-    cleanup_high_frequency_telemetry,
-    suppress_otel_debug_logging
-):
-    """
-    Function-level fixture to disable all flex counters and restore
-    them after each test.
-    Depends on cleanup_high_frequency_telemetry to ensure clean state.
-    """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-
-    # Get all flex counter tables
-    flex_counter_keys = duthost.shell(
-        'redis-cli -n 4 keys "FLEX_COUNTER_TABLE|*"',
-        module_ignore_errors=False
-    )['stdout_lines']
-
-    # Store original states
-    original_states = {}
-    for key in flex_counter_keys:
-        if key.strip():  # Skip empty lines
-            table_name = key.strip()
-            status = duthost.shell(
-                f'redis-cli -n 4 HGET "{table_name}" "FLEX_COUNTER_STATUS"',
-                module_ignore_errors=False
-            )['stdout'].strip()
-            original_states[table_name] = status
-
-            # Disable the flex counter
-            duthost.shell(
-                f'redis-cli -n 4 HSET "{table_name}" '
-                f'"FLEX_COUNTER_STATUS" "disable"',
-                module_ignore_errors=False
-            )
-
-    logger.info(f"Disabled {len(original_states)} flex counters")
-
-    yield
-
-    # Restore original states
-    for table_name, status in original_states.items():
-        if status:  # Only restore if there was an original status
-            duthost.shell(
-                f'redis-cli -n 4 HSET "{table_name}" '
-                f'"FLEX_COUNTER_STATUS" "{status}"',
-                module_ignore_errors=False
-            )
-
-    logger.info("Restored all flex counters to original states")

--- a/tests/high_frequency_telemetry/test_hft_end_to_end.py
+++ b/tests/high_frequency_telemetry/test_hft_end_to_end.py
@@ -32,8 +32,10 @@ INFLUXDB_PORT = 8181
 INFLUXDB_BUCKET = "home"
 
 
-def test_hft_end_to_end_influxdb(duthosts, enum_rand_one_per_hwsku_hostname,
-                                 disable_flex_counters, tbinfo, ptfhost):
+def test_hft_end_to_end_influxdb(
+    duthosts, enum_rand_one_per_hwsku_hostname,
+    cleanup_high_frequency_telemetry, tbinfo, ptfhost
+):
     """
     End-to-end test for High Frequency Telemetry.
 

--- a/tests/high_frequency_telemetry/test_high_frequency_telemetry.py
+++ b/tests/high_frequency_telemetry/test_high_frequency_telemetry.py
@@ -34,7 +34,7 @@ pytestmark = [
 
 
 def test_hft_port_counters(duthosts, enum_rand_one_per_hwsku_hostname,
-                           disable_flex_counters, tbinfo):
+                           cleanup_high_frequency_telemetry, tbinfo):
     """Test high frequency telemetry for port counters.
 
     This test:
@@ -128,7 +128,7 @@ def test_hft_port_counters(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_hft_full_queue_counters(duthosts, enum_rand_one_per_hwsku_hostname,
-                                 disable_flex_counters):
+                                 cleanup_high_frequency_telemetry):
     """
     Test high frequency telemetry for every configured queue.
 
@@ -188,8 +188,10 @@ def test_hft_full_queue_counters(duthosts, enum_rand_one_per_hwsku_hostname,
         cleanup_hft_config(duthost, profile_name)
 
 
-def test_hft_full_ingress_priority_group_counters(duthosts, enum_rand_one_per_hwsku_hostname,
-                                                  disable_flex_counters):
+def test_hft_full_ingress_priority_group_counters(
+    duthosts, enum_rand_one_per_hwsku_hostname,
+    cleanup_high_frequency_telemetry
+):
     """Test high frequency telemetry for all configured buffer queues (ingress priority groups)."""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     profile_name = "ingress_pg_profile"
@@ -232,8 +234,10 @@ def test_hft_full_ingress_priority_group_counters(duthosts, enum_rand_one_per_hw
         cleanup_hft_config(duthost, profile_name)
 
 
-def test_hft_full_buffer_pool_counters(duthosts, enum_rand_one_per_hwsku_hostname,
-                                       disable_flex_counters):
+def test_hft_full_buffer_pool_counters(
+    duthosts, enum_rand_one_per_hwsku_hostname,
+    cleanup_high_frequency_telemetry
+):
     """Test high frequency telemetry for all configured buffer pools."""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     profile_name = "buffer_pool_profile"
@@ -278,7 +282,7 @@ def test_hft_full_buffer_pool_counters(duthosts, enum_rand_one_per_hwsku_hostnam
 
 @pytest.mark.skip(reason="Full counters HFT isn't supported")
 def test_hft_full_counters(duthosts, enum_rand_one_per_hwsku_hostname,
-                           disable_flex_counters, tbinfo):
+                           cleanup_high_frequency_telemetry, tbinfo):
     """Test high frequency telemetry for all supported object types in one profile."""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     profile_name = "full_hft_profile"
@@ -337,7 +341,7 @@ def test_hft_full_counters(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_hft_full_port_counters(duthosts, enum_rand_one_per_hwsku_hostname,
-                                disable_flex_counters, tbinfo):
+                                cleanup_high_frequency_telemetry, tbinfo):
     """
     Test high frequency telemetry with all available ports and all
     available counter types.
@@ -447,7 +451,7 @@ def test_hft_full_port_counters(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_hft_disabled_stream(duthosts, enum_rand_one_per_hwsku_hostname,
-                             disable_flex_counters, tbinfo):
+                             cleanup_high_frequency_telemetry, tbinfo):
     """
     Test high frequency telemetry with disabled stream state transitions.
 
@@ -558,7 +562,7 @@ def test_hft_disabled_stream(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_hft_config_deletion_stream(duthosts, enum_rand_one_per_hwsku_hostname,
-                                    disable_flex_counters, tbinfo):
+                                    cleanup_high_frequency_telemetry, tbinfo):
     """
     Test high frequency telemetry with configuration deletion transitions.
 
@@ -661,9 +665,11 @@ def test_hft_config_deletion_stream(duthosts, enum_rand_one_per_hwsku_hostname,
     (10000000, 0.1),   # 10000ms -> 0.1 Msg/s
 ])
 @pytest.mark.skip(reason="Some intervals may not be supported")
-def test_hft_poll_interval_validation(duthosts, enum_rand_one_per_hwsku_hostname,
-                                      disable_flex_counters, tbinfo,
-                                      poll_interval_us, expected_msg_per_sec):
+def test_hft_poll_interval_validation(
+    duthosts, enum_rand_one_per_hwsku_hostname,
+    cleanup_high_frequency_telemetry, tbinfo,
+    poll_interval_us, expected_msg_per_sec
+):
     """Test high frequency telemetry with different poll intervals.
 
     Validates Msg/s output.
@@ -805,8 +811,10 @@ def test_hft_poll_interval_validation(duthosts, enum_rand_one_per_hwsku_hostname
         cleanup_hft_config(duthost, profile_name, [group_name])
 
 
-def test_hft_port_shutdown_stream(duthosts, enum_rand_one_per_hwsku_hostname,
-                                  disable_flex_counters, tbinfo, ptfadapter):
+def test_hft_port_shutdown_stream(
+    duthosts, enum_rand_one_per_hwsku_hostname,
+    cleanup_high_frequency_telemetry, tbinfo, ptfadapter
+):
     """
     Test high frequency telemetry with port shutdown/startup transitions during continuous traffic.
 


### PR DESCRIPTION
### Description of PR

Summary:
Make HFT SWSS readiness checks observational and remove unnecessary global flex-counter state changes.

Fixes #26149

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: #26149
Failure type: day-one issue

### Approach
#### What is the motivation for this PR?

The HFT `ensure_swss_ready` fixture automatically restarted SWSS whenever it could not calculate container uptime. This treated an inspection or parsing error as proof that SWSS was stopped. In the linked 202511 run, a healthy `Up About an hour` container was restarted, syncd was terminated, and the Nvidia SDK emitted an SDK watchdog while all 514 ports were recreated.

PR #23162 replaced the original `docker ps` text parser with `docker inspect`, but it retained the unsafe recovery behavior and did not verify `State.Running`. HFT tests also disabled every flex counter before each case even though HFT uses separate configuration tables and does not require global flex-counter state changes.

#### How did you do it?

- Parse the full `docker inspect swss` JSON and explicitly require `State.Running` to be true.
- Calculate uptime from `State.StartedAt` and the DUT's current UTC epoch, avoiding runner/DUT clock differences.
- Fail setup with a diagnostic error when Docker state or timestamps cannot be verified instead of restarting SWSS.
- Remove the `disable_flex_counters` fixture and make HFT cases depend directly on the existing HFT cleanup fixture.
- Preserve the module-scoped OTEL logging suppression through the cleanup fixture dependency.

#### How did you verify/test it?

- `pre-commit run --files tests/high_frequency_telemetry/conftest.py tests/high_frequency_telemetry/test_high_frequency_telemetry.py tests/high_frequency_telemetry/test_hft_end_to_end.py`
- `python3 -m compileall -q tests/high_frequency_telemetry`
- `python3 -m flake8 --select=F,E999` on the three changed files
- `git diff --check`
- Validated the parser against live `docker inspect swss` JSON from the affected Mellanox-SN5640 DUT; it reported `State.Running=true` and a positive stable uptime without changing DUT state.

Full pytest collection was not run on the development host because that host Python environment does not provide pytest. No DUT test was triggered to avoid changing the shared testbed during this fix.

#### Any platform specific information?

The failure was observed on Mellanox-SN5640-C512S2 (Nvidia SPC5), but the fixture is platform-independent.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
