### PR TITLE
[tests/console] Stabilize reverse SSH session handling

### DIFF
--- a/tests/common/helpers/console_helper.py
+++ b/tests/common/helpers/console_helper.py
@@ -25,9 +25,9 @@ def create_ssh_client(ip, user, pwd):
     return client
 
 
-def ensure_console_session_up(client, line):
+def ensure_console_session_up(client, line, escape_char='a'):
     client.expect_exact('Successful connection to line [{}]'.format(line))
-    client.expect_exact('Press ^A ^X to disconnect')
+    client.expect_exact('Press ^{} ^X to disconnect'.format(escape_char.upper()))
 
 
 def get_target_lines(duthost):

--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -6,11 +6,11 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.console_helper import (
     check_target_line_status,
     disconnect_console_client,
+    ensure_console_session_up,
     get_dut_console_lines,
     get_host_ip_and_creds,
     wait_for_line_idle,
 )
-from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.topology('c0', 'c0-lo', 'bmc')
@@ -88,10 +88,9 @@ def test_console_reversessh_connectivity(duthost, creds, conn_graph_facts):  # n
         client.expect('[Pp]assword:')
         client.sendline(dutpass)
 
-        # Wait for the DUT to register the console session as BUSY (avoid
-        # client/DUT race: sendline returns before picocom is spawned).
+        ensure_console_session_up(client, target_line)
         pytest_assert(
-            wait_until(3, 1, 0, check_target_line_status, duthost, target_line, "BUSY"),
+            check_target_line_status(duthost, target_line, "BUSY"),
             "Target line {} is idle while reverse SSH session is up".format(target_line))
     except Exception as e:
         pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
@@ -121,34 +120,36 @@ def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts):  
     ressh_user = "{}:{}".format(dutuser, target_line)
     client = None
     try:
-        client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-                               .format(ressh_user, dutip))
-        client.expect('[Pp]assword:')
-        client.sendline(dutpass)
+        try:
+            client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+                                   .format(ressh_user, dutip))
+            client.expect('[Pp]assword:')
+            client.sendline(dutpass)
 
-        # Wait for the DUT to register the console session as BUSY (avoid
-        # client/DUT race: sendline returns before picocom is spawned).
-        pytest_assert(
-            wait_until(3, 1, 0, check_target_line_status, duthost, target_line, "BUSY"),
-            "Target line {} is idle while reverse SSH session is up".format(target_line))
-    except Exception as e:
-        pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
+            ensure_console_session_up(client, target_line)
+            pytest_assert(
+                check_target_line_status(duthost, target_line, "BUSY"),
+                "Target line {} is idle while reverse SSH session is up".format(target_line))
+        except Exception as e:
+            pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
 
-    try:
-        # Force clear line from DUT
-        duthost.shell('sudo sonic-clear line {}'.format(target_line))
-    except Exception as e:
-        pytest.fail("Not able to do clear line for DUT: {}".format(e))
+        try:
+            # Force clear line from DUT
+            duthost.shell('sudo sonic-clear line {}'.format(target_line))
+        except Exception as e:
+            pytest.fail("Not able to do clear line for DUT: {}".format(e))
 
-    # Check the session ended within 5s and the line state is idle
-    wait_for_line_idle(
-        duthost, target_line, timeout_sec=5,
-        error_msg="Target line {} not toggle to IDLE state after force clear command sent".format(target_line))
+        # Check the session ended within 5s and the line state is idle
+        wait_for_line_idle(
+            duthost, target_line, timeout_sec=5,
+            error_msg="Target line {} not toggle to IDLE state after force clear command sent".format(target_line))
 
-    try:
-        client.expect("Picocom was killed")
-    except Exception as e:
-        pytest.fail("Console session not exit correctly: {}".format(e))
+        try:
+            client.expect("Picocom was killed")
+        except Exception as e:
+            pytest.fail("Console session not exit correctly: {}".format(e))
+    finally:
+        disconnect_console_client(client)
 
 
 # Custom default-escape characters to exercise. Each letter is sent as
@@ -184,16 +185,16 @@ def test_console_reversessh_custom_default_escape_character(duthost, creds, conn
         "Target line {} is busy before reverse SSH session start".format(target_line))
 
     ressh_user = "{}:{}".format(dutuser, target_line)
+    client = None
     try:
         client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
                                .format(ressh_user, dutip))
         client.expect('[Pp]assword:')
         client.sendline(dutpass)
 
-        # Wait for the DUT to register the console session as BUSY (avoid
-        # client/DUT race: sendline returns before picocom is spawned).
+        ensure_console_session_up(client, target_line, custom_default_escape_char)
         pytest_assert(
-            wait_until(3, 1, 0, check_target_line_status, duthost, target_line, "BUSY"),
+            check_target_line_status(duthost, target_line, "BUSY"),
             "Target line {} is idle while reverse SSH session is up".format(target_line))
 
         # Try to send default escape sequence (ctrl-A + ctrl-X) - should NOT exit
@@ -205,11 +206,11 @@ def test_console_reversessh_custom_default_escape_character(duthost, creds, conn
             check_target_line_status(duthost, target_line, "BUSY"),
             "Target line {} exited with default escape keys when custom escape char is set".format(target_line))
 
-        # Send custom escape sequence (Ctrl-<escape_char> + Ctrl-X) - should exit
-        client.sendcontrol(custom_default_escape_char)
-        client.sendcontrol('x')
     except Exception as e:
         pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
+    finally:
+        # Send custom escape sequence (Ctrl-<escape_char> + Ctrl-X) to exit.
+        disconnect_console_client(client, custom_default_escape_char)
 
     # Check the session ended and the line state is idle
     wait_for_line_idle(

--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -30,13 +30,16 @@ def _dut_lowest_console_line(conn_graph_facts, duthost):  # noqa: F811
 
 
 @pytest.fixture(scope="function")
-def custom_default_escape_char(duthost, escape_char):
+def custom_default_escape_char(duthost, request):
     """
-    Fixture that sets ``escape_char`` (supplied by ``@pytest.mark.parametrize``)
-    as the DUT-side default console escape character and restores the
-    pre-test value on teardown so ``core_dump_and_config_check`` doesn't
-    flag drift on ``CONSOLE_SWITCH|console_mgmt.default_escape_char``.
+    Set the indirectly parametrized escape character and restore it after the
+    console session fixture has disconnected its client.
     """
+    escape_char = getattr(request, 'param', None)
+    if escape_char is None:
+        yield 'a'
+        return
+
     # Capture pre-test default_escape_char so we can restore it; empty
     # string means the field is absent from CONFIG_DB and we should
     # ``clear`` instead of setting a value back.
@@ -66,7 +69,29 @@ def custom_default_escape_char(duthost, escape_char):
         pytest.fail("Not able to restore custom default escape character: {}".format(e))
 
 
-def test_console_reversessh_connectivity(duthost, creds, conn_graph_facts):  # noqa: F811
+@pytest.fixture(scope="function")
+def console_session(custom_default_escape_char):
+    sessions = []
+
+    def create(duthost, dutip, ressh_user, dutpass, target_line):
+        client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+                               .format(ressh_user, dutip))
+        sessions.append((client, duthost, target_line))
+        client.expect('[Pp]assword:')
+        client.sendline(dutpass)
+        ensure_console_session_up(client, target_line, custom_default_escape_char)
+        return client
+
+    yield create
+
+    for client, duthost, target_line in sessions:
+        disconnect_console_client(client, custom_default_escape_char)
+        wait_for_line_idle(
+            duthost, target_line,
+            error_msg="Target line {} is busy after exited reverse SSH session".format(target_line))
+
+
+def test_console_reversessh_connectivity(duthost, creds, conn_graph_facts, console_session):  # noqa: F811
     """
     Test reverse SSH is working as expect.
     Verify serial session is available after connect DUT via reverse SSH.
@@ -81,29 +106,16 @@ def test_console_reversessh_connectivity(duthost, creds, conn_graph_facts):  # n
         "Target line {} is busy before reverse SSH session start".format(target_line))
 
     ressh_user = "{}:{}".format(dutuser, target_line)
-    client = None
     try:
-        client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-                               .format(ressh_user, dutip))
-        client.expect('[Pp]assword:')
-        client.sendline(dutpass)
-
-        ensure_console_session_up(client, target_line)
+        console_session(duthost, dutip, ressh_user, dutpass, target_line)
         pytest_assert(
             check_target_line_status(duthost, target_line, "BUSY"),
             "Target line {} is idle while reverse SSH session is up".format(target_line))
     except Exception as e:
         pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
-    finally:
-        # Send escape sequence to exit reverse SSH session
-        disconnect_console_client(client)
-
-    wait_for_line_idle(
-        duthost, target_line,
-        error_msg="Target line {} is busy after exited reverse SSH session".format(target_line))
 
 
-def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts):  # noqa: F811
+def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts, console_session):  # noqa: F811
     """
     Test reverse SSH is working as expect.
     Verify active serial session can be shut by DUT.
@@ -118,38 +130,29 @@ def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts):  
         "Target line {} is busy before reverse SSH session start".format(target_line))
 
     ressh_user = "{}:{}".format(dutuser, target_line)
-    client = None
     try:
-        try:
-            client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-                                   .format(ressh_user, dutip))
-            client.expect('[Pp]assword:')
-            client.sendline(dutpass)
+        client = console_session(duthost, dutip, ressh_user, dutpass, target_line)
+        pytest_assert(
+            check_target_line_status(duthost, target_line, "BUSY"),
+            "Target line {} is idle while reverse SSH session is up".format(target_line))
+    except Exception as e:
+        pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
 
-            ensure_console_session_up(client, target_line)
-            pytest_assert(
-                check_target_line_status(duthost, target_line, "BUSY"),
-                "Target line {} is idle while reverse SSH session is up".format(target_line))
-        except Exception as e:
-            pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
+    try:
+        # Force clear line from DUT
+        duthost.shell('sudo sonic-clear line {}'.format(target_line))
+    except Exception as e:
+        pytest.fail("Not able to do clear line for DUT: {}".format(e))
 
-        try:
-            # Force clear line from DUT
-            duthost.shell('sudo sonic-clear line {}'.format(target_line))
-        except Exception as e:
-            pytest.fail("Not able to do clear line for DUT: {}".format(e))
+    # Check the session ended within 5s and the line state is idle
+    wait_for_line_idle(
+        duthost, target_line, timeout_sec=5,
+        error_msg="Target line {} not toggle to IDLE state after force clear command sent".format(target_line))
 
-        # Check the session ended within 5s and the line state is idle
-        wait_for_line_idle(
-            duthost, target_line, timeout_sec=5,
-            error_msg="Target line {} not toggle to IDLE state after force clear command sent".format(target_line))
-
-        try:
-            client.expect("Picocom was killed")
-        except Exception as e:
-            pytest.fail("Console session not exit correctly: {}".format(e))
-    finally:
-        disconnect_console_client(client)
+    try:
+        client.expect("Picocom was killed")
+    except Exception as e:
+        pytest.fail("Console session not exit correctly: {}".format(e))
 
 
 # Custom default-escape characters to exercise. Each letter is sent as
@@ -168,9 +171,9 @@ def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts):  
 CUSTOM_ESCAPE_CHARS = ["b", "e", "f", "g", "k", "n", "p", "y"]
 
 
-@pytest.mark.parametrize("escape_char", CUSTOM_ESCAPE_CHARS)
+@pytest.mark.parametrize("custom_default_escape_char", CUSTOM_ESCAPE_CHARS, indirect=True)
 def test_console_reversessh_custom_default_escape_character(duthost, creds, conn_graph_facts,  # noqa: F811
-                                                            escape_char, custom_default_escape_char):
+                                                            custom_default_escape_char, console_session):
     """
     Test reverse SSH with custom escape character.
     Verify that default escape keys don't work when escape character is changed,
@@ -185,14 +188,8 @@ def test_console_reversessh_custom_default_escape_character(duthost, creds, conn
         "Target line {} is busy before reverse SSH session start".format(target_line))
 
     ressh_user = "{}:{}".format(dutuser, target_line)
-    client = None
     try:
-        client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-                               .format(ressh_user, dutip))
-        client.expect('[Pp]assword:')
-        client.sendline(dutpass)
-
-        ensure_console_session_up(client, target_line, custom_default_escape_char)
+        client = console_session(duthost, dutip, ressh_user, dutpass, target_line)
         pytest_assert(
             check_target_line_status(duthost, target_line, "BUSY"),
             "Target line {} is idle while reverse SSH session is up".format(target_line))
@@ -208,12 +205,3 @@ def test_console_reversessh_custom_default_escape_character(duthost, creds, conn
 
     except Exception as e:
         pytest.fail("Not able to do reverse SSH to remote host via DUT: {}".format(e))
-    finally:
-        # Send custom escape sequence (Ctrl-<escape_char> + Ctrl-X) to exit.
-        disconnect_console_client(client, custom_default_escape_char)
-
-    # Check the session ended and the line state is idle
-    wait_for_line_idle(
-        duthost, target_line,
-        error_msg="Target line {} is busy after exited reverse SSH session with custom escape keys".format(
-            target_line))


### PR DESCRIPTION
### Description of PR

Summary: Stabilize reverse SSH tests by waiting for the console-ready banner and centralizing session cleanup.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: Flaky test

### Approach
#### What is the motivation for this PR?

The test checked line state immediately after sending the SSH password. Session setup could still be in progress, causing a false `IDLE` result and leaking a later `BUSY` session into following cases.

#### How did you do it?

Wait for the successful connection and escape-key banners before checking `BUSY`. A fixture now owns session creation and teardown, uses the configured escape key, and waits for the line to return to `IDLE`.

#### How did you verify/test it?

Ran the full module three times across `c0` and `c0-lo`; all runs passed 10/10 cases.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.