### PR TITLE
Fix YANG validation empty patch input

### DIFF
--- a/tests/common/helpers/yang_utils.py
+++ b/tests/common/helpers/yang_utils.py
@@ -17,7 +17,9 @@ def run_yang_validation(duthost, stage="validation"):
     logger.info(f"Running YANG validation on {duthost.hostname} ({stage})")
     try:
         result = duthost.shell(
-            'echo "[]" | sudo config apply-patch /dev/stdin',
+            'patch_file="/home/admin/yang_validation_empty_patch.json"; '
+            'echo "[]" > "$patch_file" && sudo config apply-patch "$patch_file"; '
+            'rc=$?; rm -f "$patch_file"; exit $rc',
             module_ignore_errors=True
         )
 


### PR DESCRIPTION
### Description of PR

Summary:
Fix YANG validation helper to pass the empty JSON patch via a real file instead of `/dev/stdin`.

Related ADO PBI: 38791785

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

Note: observed on 202605 nightly; please cherry-pick to affected release branches as appropriate.

### Approach
#### What is the motivation for this PR?

Nightly metadata BGP tests failed during the pre-test YANG validation fixture on Mellanox-SN2700-A1 with `config apply-patch /dev/stdin` reporting `Expecting value: line 1 column 1 (char 0)`. This indicates `config apply-patch` received an empty patch stream instead of `[]`.

#### How did you do it?

Write the empty JSON patch to a short-lived file under `/home/admin` and pass that file path to `config apply-patch`, then remove the file and preserve the command return code.

#### How did you verify/test it?

Ran:
- `python -m py_compile tests/common/helpers/yang_utils.py`
- `python -m pre_commit run --files tests/common/helpers/yang_utils.py`

#### Any platform specific information?

Observed on Mellanox-SN2700-A1 T0 nightly runs.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A