### PR TITLE
xfail test_watchdog_bmc_integration on BMC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1065,6 +1065,12 @@ platform_tests/daemon:
     conditions:
       - "asic_type in ['vs']"
 
+platform_tests/daemon/test_bmc_watchdog.py::TestBmcWatchdog::test_watchdog_bmc_integration:
+  xfail:
+    reason: "BMC watchdog not supported yet: watchdog-keepalive.sh persistent log sink is missing"
+    conditions:
+      - "'bmc' in topo_type and https://github.com/sonic-net/sonic-buildimage/issues/28185"
+
 platform_tests/daemon/test_chassisd.py:
   skip:
     reason: "chassisd platform daemon introduced in 202106 / Temporarily skip in PR testing"


### PR DESCRIPTION
### Description of PR
Summary: xfail test_watchdog_bmc_integration on BMC
Fixes # (issue)


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
BMC watchdog is not supported yet: the watchdog-keepalive.sh persistent log sink (/host/bmc/watchdog.log) is missing, so  test_watchdog_bmc_integration fails on BMC topologies.

#### How did you do it?
Mark it as xfail on BMC topologies, tracked by https://github.com/sonic-net/sonic-buildimage/issues/28185.

#### How did you verify/test it?
N/A

#### Any platform specific information?
BMC

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
