### PR TITLE
add inter-packet pacing to dummy-MAC seeding loop

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -42,6 +42,7 @@ DUMMY_MAC_COUNT_SLIM = 2
 FDB_POPULATE_SLEEP_TIMEOUT = 2
 FDB_CLEAN_UP_SLEEP_TIMEOUT = 2
 FDB_WAIT_EXPECTED_PACKET_TIMEOUT = 20
+FDB_WAIT_BETWEEN_PACKETS_TIMEOUT = 0.1
 PKT_TYPES = ["ethernet", "arp_request", "arp_reply", "cleanup"]
 
 logger = logging.getLogger(__name__)
@@ -277,7 +278,7 @@ def setup_fdb(ptfadapter, vlan_table, router_mac, pkt_type, dummy_mac_count):
                         send_arp_reply(ptfadapter, port_index, dummy_mac, router_mac, vlan_id)
                     else:
                         pytest.fail("Unknown option '{}'".format(pkt_type))
-
+                    time.sleep(FDB_WAIT_BETWEEN_PACKETS_TIMEOUT)
                 # put in set learned dummy MACs
                 fdb[port_index].update(dummy_macs)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add inter-packet pacing (100 ms) to setup_fdb's dummy-MAC seeding loop in tests/fdb/test_fdb.py. This makes the precondition self-check (dummy_mac_count == configured_dummay_mac_count * vlan_member_count) reliably pass on setups where the LAG-side FDB learn pipeline can be transiently oversubscribed by an unpaced burst.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: regression

### Approach
#### What is the motivation for this PR?
Before [sonic-net/sonic-mgmt#11170](https://github.com/sonic-net/sonic-mgmt/pull/11170), setup_fdb seeded MACs only on member['port_index'][0] of each PortChannel — so for a 2-member LAG × 2 VLANs layout the LAG bridge-port received dummy_mac_count packets in total. #11170 PR changed the loop to iterate over every LAG member so the fanout populates its L2 tables on every link; as a side effect, the same LAG bridge-port now sees a back-to-back burst of dummy_mac_count × #members × #VLANs packets with no spacing.

That consolidated burst is well-tolerated by some FDB-learn pipelines and less so by others, which makes the precondition self-check dummy_mac_count == configured_dummay_mac_count * vlan_member_count flaky in environments where the burst is large enough to briefly saturate the learn path. The test actually verifies the forwarding correctness on dynamically-learned entries (send_recv_eth), not learn-rate capacity or burst learning.

#### How did you do it?
Added a 100 ms sleep at the end of the innermost dummy-packet loop in setup_fdb (post send_eth / send_arp_request / send_arp_reply). This restores roughly the same effective per-bridge-port arrival rate the test had prior to #11170 (one packet per ingress event with a small gap) while preserving #11170's correctness fix — every LAG member still sends learning traffic, in the same order and count #11170 introduced.

How did you verify/test it?
#### How did you verify/test it?
Ran pytest fdb/test_fdb.py::test_fdb across t0 topologies on Nvidia setups.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
