### PR TITLE
[bgp]: Move ping neighbor skip to conditional mark

### DIFF
--- a/tests/bgp/test_ping_bgp_neighbor.py
+++ b/tests/bgp/test_ping_bgp_neighbor.py
@@ -10,9 +10,6 @@ def test_ping_bgp_neighbor(duthosts, enum_frontend_dut_hostname, enum_asic_index
     """Check ping connectivity to all BGP neighbors across all ASICs of the given DUT"""
 
     duthost = duthosts[enum_frontend_dut_hostname]
-    if enum_asic_index is None:
-        pytest.skip(f"Skipping test since {duthost.hostname} is not a multi-ASIC device.")
-
     bgp_facts = duthost.bgp_facts(instance_id=enum_asic_index)['ansible_facts']
     namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
     asic_info = f"(namespace: {namespace})" if namespace else ""

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -715,7 +715,7 @@ bgp/test_bgpmon_v6.py::test_bgpmon_no_ipv6_resolve_via_default:
 
 bgp/test_ping_bgp_neighbor.py:
   skip:
-    reason: "Only supported on multi-ASIC devices. Tracking ADO: https://msazure.visualstudio.com/One/_workitems/edit/38768311"
+    reason: "Only supported on multi-ASIC devices. Tracking issue: https://github.com/sonic-net/sonic-mgmt/issues/26208"
     conditions:
       - "is_multi_asic==False"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -713,6 +713,12 @@ bgp/test_bgpmon_v6.py::test_bgpmon_no_ipv6_resolve_via_default:
     conditions:
       - "platform in ['x86_64-arista_7280dr3am_36']"
 
+bgp/test_ping_bgp_neighbor.py:
+  skip:
+    reason: "Only supported on multi-ASIC devices. Tracking ADO: https://msazure.visualstudio.com/One/_workitems/edit/38768311"
+    conditions:
+      - "is_multi_asic==False"
+
 bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_supervisor_abnormal_reboot:
   skip:
     reason: "Not supported on T2 single node topology"


### PR DESCRIPTION
### Description of PR
Summary: Move the non-multi-ASIC skip for `bgp/test_ping_bgp_neighbor.py` from test runtime into conditional marks so unsupported devices are skipped during collection before setup runs.
Fixes #26208
ADO: https://msazure.visualstudio.com/One/_workitems/edit/38768311

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: #26208 (ADO 38768311)
Failure type: SONiC nightly setup failure (`EOFError`) on unsupported non-multi-ASIC topology

### Approach
#### What is the motivation for this PR?
`test_ping_bgp_neighbor.py` is only supported on multi-ASIC devices, but the skip was inside the test body. On non-multi-ASIC devices, fixtures/setup can still run before the test-level skip is reached, causing setup failures. This was tracked by the linked ADO.

#### How did you do it?
Added a conditional mark to skip `bgp/test_ping_bgp_neighbor.py` when `is_multi_asic==False`, and removed the in-test `pytest.skip` branch.

#### How did you verify/test it?
Validated the conditional mark YAML, ran the conditional mark sort hook, compiled `tests/bgp/test_ping_bgp_neighbor.py`, and ran `git diff --check`.

#### Any platform specific information?
Applies to non-multi-ASIC devices.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A