### PR TITLE
[202511] tests/ssh: fix SSH cipher test failure diagnostics and prompt matching

### DIFF
--- a/tests/ssh/test_ssh_ciphers.py
+++ b/tests/ssh/test_ssh_ciphers.py
@@ -8,7 +8,8 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('any'),
-    pytest.mark.device_type('vs')
+    pytest.mark.device_type('vs'),
+    pytest.mark.device_type('vpp'),
 ]
 
 
@@ -20,6 +21,9 @@ def connect_with_specified_ciphers(duthosts, rand_one_dut_hostname, specified_ci
     sonic_admin_alt_passwords = creds["ansible_altpasswords"]
     dut_passwords = [dutpass, sonic_admin_alt_password] + sonic_admin_alt_passwords
     dutip = duthost.mgmt_ip
+
+    # Use actual system hostname for prompt matching (may differ from inventory name)
+    dut_hostname = duthost.shell("hostname", module_ignore_errors=True)["stdout"].strip() or duthost.hostname
 
     if typename == "enc":
         ssh_cipher_option = "-c {}".format(specified_cipher)
@@ -40,7 +44,7 @@ def connect_with_specified_ciphers(duthosts, rand_one_dut_hostname, specified_ci
             connect.sendline(dutpass)
 
             i = connect.expect(
-                '{}@{}:'.format(dutuser, duthost.hostname), timeout=10)
+                '{}@{}:'.format(dutuser, dut_hostname), timeout=10)
             pytest_assert(i == 0, "Failed to connect")
             return
         except Exception as e:
@@ -48,7 +52,7 @@ def connect_with_specified_ciphers(duthosts, rand_one_dut_hostname, specified_ci
             if "Permission denied" in output:
                 continue
             else:
-                pytest.fail(e)
+                pytest.fail(str(e))
     pytest.fail("Cannot connect to DUT host via SSH")
 
 


### PR DESCRIPTION
Targeted backport to `202511` of the `tests/ssh/test_ssh_ciphers.py` hunk from #25279 (merged to master).

### Why
Nightly is flagging `ssh.test_ssh_ciphers::test_ssh_enc_ciphers` on Nokia-7215 (image 20251110, release 202511) with the opaque `TypeError: Failed expected string ... got 'TIMEOUT'`. 202511 still carries the pre-fix code (`pytest.fail(e)` + `duthost.hostname`).

### What
- `pytest.fail(e)` -> `pytest.fail(str(e))` so the real exception message is reported instead of a `TypeError`.
- Match the SSH prompt against the DUT's actual system hostname instead of the inventory name, which can differ.

### Scope
Only the `test_ssh_ciphers.py` hunk is backported. A full cherry-pick of #25279 conflicts on `.azure-pipelines/pr_test_scripts.yaml` because 202511's `t1-lag-vpp:` section differs from master. That file plus the other SSH changes are VPP-CI enablement and are not needed to fix the hardware nightly. This is the targeted backport suggested by @augusdn in https://github.com/sonic-net/sonic-mgmt/pull/25279#issuecomment-4913857505.

Original PR: #25279


Signed-off-by: Aaron Bernardino <aaronber@microsoft.com>