### PR TITLE
Fix critical services check after upgrade reboot

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -91,6 +91,12 @@ class MultiAsicSonicHost(object):
 
         _features = self.facts.get('features', {})
 
+        # Query the live feature list to filter out services that no longer
+        # exist on the currently-running image (e.g. after boot_into_base_image).
+        feature_status, _ = self.sonichost.get_feature_status()
+        if feature_status:
+            _features = {k: v for k, v in _features.items() if k in feature_status}
+
         if _features.get('dhcp_relay', {}).get('state', '') == 'enabled':
             service_list.append("dhcp_relay")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
After boot_into_base_image, critical_services_fully_started fails because the critical services list is built from cached facts gathered at session start. Services like bmp that exist on the original image but not on the base image remain in the list, causing the check to wait for containers that will never start.

Query the live feature table via get_feature_status and filter the cached features dict to only include services present on the running image.
Fixes #26166
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
test_upgrade_path failed after boot_into_base_image because cached critical_services_tracking_list from the original image is used.

#### How did you do it?
Query the live feature table via get_feature_status and filter the cached features dict to only include services present on the running image.

#### How did you verify/test it?
test_upgrade_path passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
