### PR TITLE
kubesonic: include Arista-7060X6-64PE-B-C512S2 in is_the_sku_need_to_remove_node_ip_param

### DIFF
--- a/tests/kubesonic/test_k8s_join_disjoin.py
+++ b/tests/kubesonic/test_k8s_join_disjoin.py
@@ -192,7 +192,11 @@ def is_the_sku_need_to_remove_node_ip_param(duthost):
         # Fallback query (ignore errors gracefully)
         result = duthost.shell("sonic-cfggen -d -v DEVICE_METADATA.localhost.hwsku", module_ignore_errors=True)
         hwsku = result.get("stdout", "").strip()
-    return hwsku in ("Arista-7060X6-16PE-384C-B-O128S2", "Arista-7060CX-32S-C32")
+    return hwsku in (
+        "Arista-7060X6-16PE-384C-B-O128S2",
+        "Arista-7060CX-32S-C32",
+        "Arista-7060X6-64PE-B-C512S2",
+    )
 
 
 def remove_node_ip_param(duthost):


### PR DESCRIPTION
### Description of PR

Extends the SKU allowlist in `is_the_sku_need_to_remove_node_ip_param` within `tests/kubesonic/test_k8s_join_disjoin.py` to include **Arista-7060X6-64PE-B-C512S2**.

This applies the existing kubelet `--node-ip=::` normalization workaround already used for `Arista-7060X6-16PE-384C-B-O128S2` to the additional Arista SKU during kubesonic join/disjoin testing.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

The `Arista-7060X6-64PE-B-C512S2` SKU ships kubelet configured with `--node-ip=::`, which prevents the DUT from joining the Kubernetes cluster cleanly during the join/disjoin test flow.

The same workaround already applied to `Arista-7060X6-16PE-384C-B-O128S2` is required for this SKU as well.

#### How did you do it?

Updated the SKU check from a single equality comparison to an allowlist tuple membership check:

```diff
-    return hwsku == "Arista-7060X6-16PE-384C-B-O128S2"
+    return hwsku in ("Arista-7060X6-16PE-384C-B-O128S2", "Arista-7060X6-64PE-B-C512S2")
```

No behavior changes for any other SKU. `remove_node_ip_param` and `restore_node_ip_param` continue to no-op for unsupported platforms.

#### How did you verify/test it?

- Validated logic path for both supported Arista SKUs

#### Any platform specific information?

Applies specifically to:
- `Arista-7060X6-16PE-384C-B-O128S2`
- `Arista-7060X6-64PE-B-C512S2`

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
