### PR TITLE
Fix configuration in packet trimming test for Arista-7060X6-64PE-B-P32V128 and Arista-7060X6-64PE-B-P32O64

### DIFF
--- a/tests/packet_trimming/test_packet_trimming_config_asymmetric.py
+++ b/tests/packet_trimming/test_packet_trimming_config_asymmetric.py
@@ -57,6 +57,8 @@ def setup_env(duthost):
         th5_queue = {
             'Arista-7060X6-64PE-B-C448O16': 4,
             'Arista-7060X6-64PE-B-C512S2': 4,
+            'Arista-7060X6-64PE-B-P32V128': 7,
+            'Arista-7060X6-64PE-B-P32O64': 7,
         }
 
         # TH5 trim queue defaults to 9 unless otherwise configured

--- a/tests/packet_trimming/test_packet_trimming_config_symmetric.py
+++ b/tests/packet_trimming/test_packet_trimming_config_symmetric.py
@@ -54,6 +54,8 @@ def setup_env(duthost):
         th5_queue = {
             'Arista-7060X6-64PE-B-C448O16': 4,
             'Arista-7060X6-64PE-B-C512S2': 4,
+            'Arista-7060X6-64PE-B-P32V128': 7,
+            'Arista-7060X6-64PE-B-P32O64': 7,
         }
 
         # TH5 trim queue defaults to 9 unless otherwise configured


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #26172
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

202511: Kusto ID f42b1397-7797-44fd-a040-cc1f3f388fba

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
These tests were failing on 202511 with error message `Failed to validate queue index: value(9) is out of range: 0 <= index <= 7`

#### How did you do it?
Made a change to override the queue index being configured in the test for the affected hwskus.

#### How did you verify/test it?
Ran the tests manually, passing with the change

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
