### PR TITLE
[upgrade_image]: guard against missing PDU manager during power cycle

### DIFF
--- a/.azure-pipelines/upgrade_image.py
+++ b/.azure-pipelines/upgrade_image.py
@@ -199,10 +199,15 @@ def main(args):
     if args.always_power_cycle:
         logger.info("Always do power cycle before upgrade")
         for hostname, pdu_manager in pdu_managers.items():
+            if pdu_manager is None:
+                logger.warning("No PDU manager for {}, skipping power off".format(hostname))
+                continue
             logger.info("Turn off power outlets to {}".format(hostname))
             pdu_manager.turn_off_outlet()
         localhost.pause(seconds=30, prompt="Pause between power off/on")
         for hostname, pdu_manager in pdu_managers.items():
+            if pdu_manager is None:
+                continue
             logger.info("Turn on power outlets to {}".format(hostname))
             pdu_manager.turn_on_outlet()
         localhost.pause(seconds=180, prompt="Add some sleep to allow power cycled DUTs to come back")
@@ -215,8 +220,15 @@ def main(args):
         power_cycle_performed = False
         for hostname, host_reachable in hosts_reachability.items():
             if not host_reachable:
+                pdu_manager = pdu_managers.get(hostname)
+                if pdu_manager is None:
+                    logger.warning(
+                        "No PDU manager configured for unreachable host {}, "
+                        "cannot power cycle; manual recovery required".format(hostname)
+                    )
+                    continue
                 logger.info("Trying to power off {}".format(hostname))
-                pdu_managers[hostname].turn_off_outlet()
+                pdu_manager.turn_off_outlet()
                 power_cycle_performed = True
 
         if power_cycle_performed:
@@ -224,8 +236,11 @@ def main(args):
 
         for hostname, host_reachable in hosts_reachability.items():
             if not host_reachable:
+                pdu_manager = pdu_managers.get(hostname)
+                if pdu_manager is None:
+                    continue
                 logger.info("Trying to power on {}".format(hostname))
-                pdu_managers[hostname].turn_on_outlet()
+                pdu_manager.turn_on_outlet()
 
         if power_cycle_performed:
             localhost.pause(seconds=180, prompt="Add some sleep to allow power cycled DUTs to come back")


### PR DESCRIPTION
### Description of PR
Summary:
Fix an `AttributeError: 'NoneType' object has no attribute 'turn_off_outlet'` crash in `.azure-pipelines/upgrade_image.py` when a testbed that has no PDU manager becomes unreachable during image upgrade. The power-cycle recovery now skips hosts with no PDU (logging a clear warning) instead of dereferencing `None`, so the step falls through to the existing `RC_HOSTS_UNREACHABLE` exit and fails cleanly with a meaningful reason.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
During a nightly upgrade (`8800.t2.202405_NightlyTest`, test plan `6a5636f5b2ac8cdc8af95349`, 2026-07-14), the Cisco 8800 T2 chassis testbeds `tbtk5-t2-8800-1` and `vms69-t2-8800-1` went unreachable after the PREV-image reboot. On the recovery retries, `upgrade_image.py` tried to power-cycle them, but these chassis have no PDU configured, so `pdu_managers[hostname]` was `None` and the script crashed instead of failing cleanly. The recovery aborts on an unhandled exception before it can even report why the host is unreachable, and it crashes identically on every retry:

```
2026-07-14 14:08:09,941 upgrade_image.py#122 INFO - Trying to power off strtk5-8800-lc1-1
Traceback (most recent call last):
  File "../.azure-pipelines/upgrade_image.py", line 345, in <module>
    main(args)
  File "../.azure-pipelines/upgrade_image.py", line 123, in main
    pdu_managers[hostname].turn_off_outlet()
AttributeError: 'NoneType' object has no attribute 'turn_off_outlet'
```

The reachability probe at the time confirmed the whole chassis was down (both ICMP and SSH, IPv4 and IPv6):

```
2026-07-14 14:11:35 common.py#63 INFO - Hosts reachability: {
  "strtk5-8800-lc1-1": false,
  "strtk5-8800-lc2-1": false,
  "strtk5-8800-lc3-1": false,
  "strtk5-8800-sup-1": false }
ssh: connect to host 2603:10e2:140:3000::1d1 port 22: Connection timed out
```

#### How did you do it?
Guard the PDU manager lookup in both power-cycle paths in `main()`:
- `power_cycle_unreachable`: use `pdu_managers.get(hostname)`; when it is `None`, log a warning (`No PDU manager configured for unreachable host ...; manual recovery required`) and `continue` instead of dereferencing it.
- `always_power_cycle`: skip hosts whose `pdu_manager` is `None`.

For testbeds that do have a PDU the behavior is unchanged. For a testbed with no PDU, the script now logs and continues, then hits the existing gate `if not all(hosts_reachability.values()): sys.exit(RC_HOSTS_UNREACHABLE)`, so no image upgrade is attempted on an unreachable host and the failure is reported cleanly.

#### How did you verify/test it?
- `python3 -m py_compile .azure-pipelines/upgrade_image.py` passes.
- Confirmed the PDU-present path is behavior-preserving (`pdu_managers.get(hostname)` returns the same manager object as `pdu_managers[hostname]`), and the no-PDU path now logs, continues, and exits via `RC_HOSTS_UNREACHABLE` instead of raising `AttributeError`. This also removes a latent hazard where the original crashed mid power-off loop and could leave a DUT powered off but never powered back on.

#### Any platform specific information?
Surfaced on Cisco 8800 T2 modular chassis testbeds that have no PDU wired into the connection graph, but the fix is platform-agnostic: any testbed without a PDU manager that goes unreachable during upgrade previously hit this crash.

#### Supported testbed topology if it's a new test case?
N/A (not a new test case).

### Documentation
N/A