### PR TITLE
enable wred counters for lt2

### DIFF
--- a/tests/wred/test_wred_counters.py
+++ b/tests/wred/test_wred_counters.py
@@ -10,7 +10,7 @@ from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback
 from ptf.mask import Mask
 
 
-pytestmark = [pytest.mark.topology("t0", "t1")]
+pytestmark = [pytest.mark.topology("t0", "t1", "lt2")]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Enhance https://github.com/sonic-net/sonic-mgmt/pull/24277 to support LT2 device.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Include LT2 in the topology to be run.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
On a LT2 TH6 it was found that ECN counters dont work and are marked as N/A. 
The problem was traced to ECN counter capability not enabled on the SAI side.
https://github.com/sonic-net/sonic-buildimage/issues/28105 was raised to track this issue and the current PR is to make sure WRED/ECN counter test cases run on LT2.

#### How did you do it?
Make the code change required to include lt2, however the test is expected to fail until the counter capability is enabled on SAI side.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
