### PR TITLE
[bgp/test_traffic_shift]: Increase TSB route re-announce wait to 600s/poll 10s

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -154,12 +154,12 @@ def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrho
     cur_v6_routes = {}
     # Verify that all routes advertised to neighbor at the start of the test
     if not is_v6_topo:
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(600, 10, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
             if not check_and_log_routes_diff(duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
                 pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-    if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+    if not wait_until(600, 10, 0, verify_current_routes_announced_to_neighs,
                       duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
         if not check_and_log_routes_diff(duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
             pytest.fail("Not all ipv6 routes are announced to neighbors")
@@ -226,12 +226,12 @@ def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_ho
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
         if not is_v6_topo:
-            if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+            if not wait_until(600, 10, 0, verify_current_routes_announced_to_neighs,
                               duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
                 if not check_and_log_routes_diff(duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
                     pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(600, 10, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
             if not check_and_log_routes_diff(duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
@@ -300,12 +300,12 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
         if not is_v6_topo:
-            if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+            if not wait_until(600, 10, 0, verify_current_routes_announced_to_neighs,
                               duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
                 if not check_and_log_routes_diff(duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
                     pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(600, 10, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
             if not check_and_log_routes_diff(duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
@@ -375,12 +375,12 @@ def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsk
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
         if not is_v6_topo:
-            if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+            if not wait_until(600, 10, 0, verify_current_routes_announced_to_neighs,
                               duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
                 if not check_and_log_routes_diff(duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
                     pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(600, 10, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
             if not check_and_log_routes_diff(duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
                 pytest.fail("Not all ipv6 routes are announced to neighbors")


### PR DESCRIPTION
### Description of PR
Summary:
Increase the post-`TSB` route re-announcement wait in `bgp/test_traffic_shift.py` from `timeout=300s / poll=3s` to `timeout=600s / poll=10s`, to fix intermittent `Failed: Not all ipv4 routes are announced to neighbors` failures on slower platforms.

Fixes # (N/A)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_TSB`, `test_TSA_B_C_with_no_neighbors`, `test_TSA_TSB_with_config_reload` and `test_load_minigraph_with_traffic_shift_away` verify, in their `finally` recovery block, that every route is re-announced to the BGP neighbors after `TSB`. The verification used `wait_until(300, 3, 0, verify_current_routes_announced_to_neighs, ...)`.

On slower platforms, BGP re-convergence after a `config reload` / `load_minigraph` can take longer than the previous 300s budget, so the strict `cur == orig` route comparison has not settled when the timeout expires, producing intermittent `Failed: Not all ipv4 routes are announced to neighbors`. Nightly history shows this failing intermittently on Cisco-8101-O8C48 across multiple images/branches while faster SKUs (e.g. Cisco-8102-C64) consistently pass.

#### How did you do it?
Changed the 8 `wait_until(... verify_current_routes_announced_to_neighs ...)` calls (the IPv4 and IPv6 waits in each of the 4 tests) from `timeout=300s / poll=3s` to `timeout=600s / poll=10s`. Each poll fans out `received-routes` queries to all EOS neighbors via `parallel_run`, so the larger poll interval also reduces neighbor load and log volume, with negligible loss of precision (BGP convergence is on a tens-of-seconds scale). No other `wait_until` calls (the `TSA/TSB` state checks, BGP-session check) were touched.

#### How did you verify/test it?
Re-ran the previously-failing tests on the affected Cisco-8101-O8C48 t1 testbed with the increased 600s timeout; `test_TSA_TSB_with_config_reload` and `test_load_minigraph_with_traffic_shift_away` pass. `python -m py_compile` and `flake8 --max-line-length=120` on the file both pass.

#### Any platform specific information?
The intermittent failure was observed on Cisco-8101-O8C48 (t1). The change itself is platform-agnostic — it only enlarges the wait budget and poll interval and does not skip any platform.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case. These are existing tests marked `topology('t1', 'm1')`.

### Documentation
No documentation change required.
