### PR TITLE
[cacl] Skip redfish container when building expected caclmgrd bridge rules

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -551,7 +551,7 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
         # Allow Communication among docker containers
         for k, v in list(docker_network['container'].items()):
             # network mode for dhcp_server container is bridge, but this rule is not expected to be seen
-            if k == "dhcp_server":
+            if k in ("dhcp_server", "redfish"):
                 continue
             iptables_rules.append("-A INPUT -s {}/32 -d {}/32 -j ACCEPT"
                                   .format(docker_network['bridge']['IPv4Address'],


### PR DESCRIPTION
Summary: Skip redfish container when building expected caclmgrd bridge rules
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608 

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
The `generate_expected_rules()` expects a caclmgrd ACCEPT rule for every container attached to the docker 'bridge' network. However caclmgrd only programs these per-container bridge rules for ASIC-namespace dockers on multi-ASIC devices; on a single-ASIC device it installs none. **'redfish'** is a bridge-attached container present on BMC, so the test predicts rules that caclmgrd never adds and the assertion fails.

#### How did you do it?
This is the same situation already handled for 'dhcp_server', a bridge container caclmgrd does not program. Add 'redfish' to that skip list so the test's expectation matches caclmgrd's actual behaviour.

#### How did you verify/test it?
Regression

#### Any platform specific information?
BMC

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
