### PR TITLE
Add bmc-shared-mgmt topology

### DIFF
--- a/ansible/vars/topo_bmc-shared-mgmt.yml
+++ b/ansible/vars/topo_bmc-shared-mgmt.yml
@@ -1,0 +1,7 @@
+topology:
+  console_interfaces:
+    - 0.115200.0
+
+configuration_properties:
+  common:
+    dut_type: NetworkBmc


### PR DESCRIPTION
### Description of PR

Adds a `bmc-shared-mgmt` topology var file for BMC devices that only has one mgmt interface. 

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
We need a topology definition for BMC devices that use a shared management network.

#### How did you do it?
Added `ansible/vars/topo_bmc-shared-mgmt.yml`, following the existing `bmc-dual-mgmt` topology.

#### How did you verify/test it?
No testbed yet. Adding topo definition first.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
No doc change needed.
