### PR TITLE
Release warm-reboot test on isolated topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -261,8 +261,6 @@ arp/test_wr_arp.py:
       - "https://github.com/sonic-net/sonic-buildimage/issues/16502 and 'dualtor' in topo_name"
       - "'standalone' in topo_name"
       - "is_mgmt_ipv6_only==True" # Does not support ipv6 mgmt ip on dut, specially the ferret server
-      - "'isolated' in topo_name"
-      - *lossyTopos
       - "topo_type not in ['t0']"
       - "'f2' in topo_name"
 
@@ -587,7 +585,7 @@ bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot:
     conditions_logical_operator: or
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56'] and https://github.com/sonic-net/sonic-mgmt/issues/9201"
-      - "'backend' in topo_name or 'mgmttor' in topo_name or 'isolated' in topo_name"
+      - "'backend' in topo_name or 'mgmttor' in topo_name"
       - "hwsku in ['Arista-7050CX3-32S-C28S4']"
       - "'f2' in topo_name"
 
@@ -3075,7 +3073,6 @@ gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm:
     conditions:
       - "topo_type not in ['t0']"
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
-      - "'isolated' in topo_name"
       - "release in ['202412']"
       - "'f2' in topo_name"
 
@@ -3395,12 +3392,11 @@ hash/test_generic_hash.py::test_nexthop_flap[CRC_CCITT-IP_PROTOCOL-ipv4-None-Non
 
 hash/test_generic_hash.py::test_reboot:
   skip:
-    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm. For broadcom, ECMP/LAG hash not supported in broadcom SAI. Marvell-Teralynx uses unified hash fields for ECMP and LAG. Warm reboot is not supported on x86_64-nvidia_sn5640-r0.'
+    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm. For broadcom, ECMP/LAG hash not supported in broadcom SAI. Marvell-Teralynx uses unified hash fields for ECMP and LAG.'
     conditions_logical_operator: or
     conditions:
       - "asic_gen == 'spc1'"
       - "asic_type in ['broadcom', 'marvell-teralynx']"
-      - "platform in ['x86_64-nvidia_sn5640-r0']"
 
 hash/test_generic_hash.py::test_reboot[CRC-INNER_IP_PROTOCOL:
   skip:
@@ -4214,17 +4210,11 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info:
     conditions:
     - "https://github.com/sonic-net/sonic-buildimage/issues/23426 and ('sn4700' in platform or 'sn4280' in platform)"
 
-platform_tests/test_advanced_reboot.py:
-  skip:
-    reason: "Advanced reboot tests are not supported on lossy topologies."
+platform_tests/counterpoll/test_counterpoll_watermark.py:
+  xfail:
+    reason: "Testcase fails sporadically due to github issue: https://github.com/sonic-net/sonic-mgmt/issues/24900"
     conditions:
-      - *lossyTopos
-
-platform_tests/test_cont_warm_reboot.py:
-  skip:
-    reason: "Continuous warm reboot tests are not supported on lossy topologies."
-    conditions:
-      - *lossyTopos
+    - "https://github.com/sonic-net/sonic-mgmt/issues/24900 and 'ptf' in topo_name and 'sn5640' in platform"
 
 platform_tests/test_intf_fec.py::test_verify_fec_stats_counters:
   skip:
@@ -5063,11 +5053,10 @@ sflow/test_sflow.py::TestReboot::testFastreboot:
 
 sflow/test_sflow.py::TestReboot::testWarmreboot:
   skip:
-    reason: "Dualtor topology doesn't support advanced-reboot or Warmreboot is not supported on sn5640 SP5 platform."
+    reason: "Dualtor topology doesn't support advanced-reboot"
     conditions_logical_operator: or
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
-      - "platform in ['x86_64-nvidia_sn5640-r0']"
   xfail:
     reason: "testWarmreboot sflow failure: VS SAI warm reboot bug (sonic-net/sonic-buildimage#26594)"
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -261,10 +261,9 @@ arp/test_wr_arp.py:
       - "https://github.com/sonic-net/sonic-buildimage/issues/16502 and 'dualtor' in topo_name"
       - "'standalone' in topo_name"
       - "is_mgmt_ipv6_only==True" # Does not support ipv6 mgmt ip on dut, specially the ferret server
-      - "'isolated' in topo_name"
-      - *lossyTopos
       - "topo_type not in ['t0']"
       - "'f2' in topo_name"
+      - "'-v6-' in topo_name"
 
 ########################################
 ######        autorestart          #####
@@ -587,7 +586,7 @@ bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot:
     conditions_logical_operator: or
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56'] and https://github.com/sonic-net/sonic-mgmt/issues/9201"
-      - "'backend' in topo_name or 'mgmttor' in topo_name or 'isolated' in topo_name"
+      - "'backend' in topo_name or 'mgmttor' in topo_name"
       - "hwsku in ['Arista-7050CX3-32S-C28S4']"
       - "'f2' in topo_name"
 
@@ -3075,7 +3074,6 @@ gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm:
     conditions:
       - "topo_type not in ['t0']"
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
-      - "'isolated' in topo_name"
       - "release in ['202412']"
       - "'f2' in topo_name"
 
@@ -3395,12 +3393,11 @@ hash/test_generic_hash.py::test_nexthop_flap[CRC_CCITT-IP_PROTOCOL-ipv4-None-Non
 
 hash/test_generic_hash.py::test_reboot:
   skip:
-    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm. For broadcom, ECMP/LAG hash not supported in broadcom SAI. Marvell-Teralynx uses unified hash fields for ECMP and LAG. Warm reboot is not supported on x86_64-nvidia_sn5640-r0.'
+    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm. For broadcom, ECMP/LAG hash not supported in broadcom SAI. Marvell-Teralynx uses unified hash fields for ECMP and LAG.'
     conditions_logical_operator: or
     conditions:
       - "asic_gen == 'spc1'"
       - "asic_type in ['broadcom', 'marvell-teralynx']"
-      - "platform in ['x86_64-nvidia_sn5640-r0']"
 
 hash/test_generic_hash.py::test_reboot[CRC-INNER_IP_PROTOCOL:
   skip:
@@ -4214,17 +4211,11 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info:
     conditions:
     - "https://github.com/sonic-net/sonic-buildimage/issues/23426 and ('sn4700' in platform or 'sn4280' in platform)"
 
-platform_tests/test_advanced_reboot.py:
-  skip:
-    reason: "Advanced reboot tests are not supported on lossy topologies."
+platform_tests/counterpoll/test_counterpoll_watermark.py:
+  xfail:
+    reason: "Testcase fails sporadically due to github issue: https://github.com/sonic-net/sonic-mgmt/issues/24900"
     conditions:
-      - *lossyTopos
-
-platform_tests/test_cont_warm_reboot.py:
-  skip:
-    reason: "Continuous warm reboot tests are not supported on lossy topologies."
-    conditions:
-      - *lossyTopos
+    - "https://github.com/sonic-net/sonic-mgmt/issues/24900 and 'ptf' in topo_name and 'sn5640' in platform"
 
 platform_tests/test_intf_fec.py::test_verify_fec_stats_counters:
   skip:
@@ -5063,11 +5054,10 @@ sflow/test_sflow.py::TestReboot::testFastreboot:
 
 sflow/test_sflow.py::TestReboot::testWarmreboot:
   skip:
-    reason: "Dualtor topology doesn't support advanced-reboot or Warmreboot is not supported on sn5640 SP5 platform."
+    reason: "Dualtor topology doesn't support advanced-reboot"
     conditions_logical_operator: or
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
-      - "platform in ['x86_64-nvidia_sn5640-r0']"
   xfail:
     reason: "testWarmreboot sflow failure: VS SAI warm reboot bug (sonic-net/sonic-buildimage#26594)"
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1256,7 +1256,6 @@ platform_tests/test_advanced_reboot.py:
       - "platform in ['x86_64-arista_7050_qx32s']"
       - "'dualtor' in topo_name and release in ['202012']"
       - "asic_type in ['vs']"
-      - "'isolated' in topo_name"
       - "'f2' in topo_name"
       - "topo_type not in ['t0','t0-sonic']"
 
@@ -1277,7 +1276,6 @@ platform_tests/test_advanced_reboot.py::test_fast_reboot_from_other_vendor:
       - "https://github.com/sonic-net/sonic-mgmt/issues/6794"
       - "platform in ['x86_64-arista_7050_qx32s']"
       - "'dualtor' in topo_name and release in ['202012']"
-      - "'isolated' in topo_name"
       - "'f2' in topo_name"
 
 platform_tests/test_advanced_reboot.py::test_warm_reboot:
@@ -1286,7 +1284,6 @@ platform_tests/test_advanced_reboot.py::test_warm_reboot:
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vs'] and 't0' not in topo_name"
-      - "'isolated' in topo_name"
       - "is_smartswitch==True"
       - "'f2' in topo_name"
 
@@ -1296,7 +1293,6 @@ platform_tests/test_advanced_reboot.py::test_warm_reboot_mac_jump:
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vs']"
-      - "'isolated' in topo_name"
       - "'f2' in topo_name"
 
 platform_tests/test_advanced_reboot.py::test_warm_reboot_sad:
@@ -1305,7 +1301,6 @@ platform_tests/test_advanced_reboot.py::test_warm_reboot_sad:
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vs']"
-      - "'isolated' in topo_name"
       - "'f2' in topo_name"
       - "is_smartswitch==True"
 
@@ -1338,7 +1333,6 @@ platform_tests/test_cont_warm_reboot.py:
     conditions_logical_operator: or
     conditions:
       - "'dualtor' in topo_name"
-      - "'isolated' in topo_name"
       - "topo_type not in ['t0']"
       - "is_smartswitch==True"
 
@@ -1518,7 +1512,6 @@ platform_tests/test_reboot.py::test_warm_reboot:
       - "topo_type in ['m0', 'mx', 'm1', 't1', 't2', 'lrh', 'urh', 'lt2', 'ft2', 'c0']"
       - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-buildimage/issues/16502"
       - "hwsku in ['Arista-7050CX3-32S-C28S4']"
-      - "'isolated' in topo_name"
       - "'f2' in topo_name"
   xfail:
     reason: "case failed and waiting for fix"


### PR DESCRIPTION

### Description of PR
Release warm-reboot test on isolated topology
Based on the design code change:
https://github.com/sonic-net/sonic-buildimage/pull/27860
Based on the sonic-mgmt code change:
https://github.com/sonic-net/sonic-mgmt/pull/25779
https://github.com/sonic-net/sonic-mgmt/pull/25778

There is a dedicate PR for the changes in 202605:
https://github.com/sonic-net/sonic-mgmt/pull/28057

Summary:
Fixes # (issue)


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
- master: pass

### Approach
#### What is the motivation for this PR?
Due to the support of warm-reboot on isolated topology at Mellanox SN5640.
https://github.com/sonic-net/sonic-buildimage/pull/27860

#### How did you do it?
Remove the warm-reboot skip condition on isolated topology
#### How did you verify/test it?
Run it locally
#### Any platform specific information?
Mellanox SN5640 + isolated topology
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
