### PR TITLE
Fix NHOP group resource assertion when capacity is saturated

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -459,12 +459,16 @@ def test_nhop_group_member_count(duthost, tbinfo, loganalyzer):
     # verify the test used up all the NHOP group resources
     # skip this check on Mellanox as ASIC resources are shared
     if is_cisco_device(duthost) or is_high_scale_platform(duthost):
+        expected_available_nhop_grp = max(
+            crm_before["available_nhop_grp"] - nhop_group_count, 0
+        )
         pytest_assert(
-            crm_after["available_nhop_grp"] + nhop_group_count == crm_before["available_nhop_grp"],
-            "Unused NHOP group resource:{}, used:{}, nhop_group_count:{}, Unused NHOP group resource before:{}".format(
-                crm_after["available_nhop_grp"], crm_after["used_nhop_grp"], nhop_group_count,
+            crm_after["available_nhop_grp"] == expected_available_nhop_grp,
+            "Unexpected available NHOP group resources:{}, expected:{}, used:{}, "
+            "nhop_group_count:{}, available before:{}".format(
+                crm_after["available_nhop_grp"], expected_available_nhop_grp,
+                crm_after["used_nhop_grp"], nhop_group_count,
                 crm_before["available_nhop_grp"]
-
             )
         )
     elif is_mellanox_device(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the `test_nhop_group_member_count` regression introduced by PR [#24524](https://github.com/sonic-net/sonic-mgmt/pull/24524), correcting the expected available next-hop group resource calculation when the test deliberately requests more groups than the ASIC can allocate.

Fixes # (issue): N/A
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: regression

### Approach
#### What is the motivation for this PR?

The test programs `MAX_NEXTHOP_GROUP_COUNT + 10` next-hop groups to verify that all available ASIC resources are consumed. PR [#24524](https://github.com/sonic-net/sonic-mgmt/pull/24524) broadened the special high-scale code path from a specific platform family to any platform exposing at least 128 interfaces. This unintentionally caused lower-capacity platforms that meet the interface-count condition to use an assertion that assumes every requested group consumes a resource.

For example, if 253 groups are initially available and the test requests 265 groups, hardware can allocate only 253 groups. The correct final available count is zero. The old assertion instead evaluated `0 + 265 == 253`, causing the test to fail even though resource saturation succeeded.

#### How did you do it?

Calculate the expected available count as:

```python
max(available_before - requested_group_count, 0)
```

Then compare the CRM-reported available count directly with that value. Clamping at zero handles intentional over-programming while preserving the existing behavior when hardware capacity exceeds the requested count. The assertion still fails if resources unexpectedly remain available.

#### How did you verify/test it?

- Confirmed the original testcase consistently failed at the resource assertion after CRM reported zero available next-hop groups.
- Ran `ipfwd/test_nhop_group.py::test_nhop_group_member_count` on a physical Broadcom DUT with this change.
- Result: `1 passed` in approximately 12 minutes.
- Verified Python compilation and critical flake8 checks for the modified file.

#### Any platform specific information?

The regression affects platforms that satisfy the high-scale interface-count check but have fewer available next-hop groups than the number deliberately requested by the test.

#### Supported testbed topology if it's a new test case?

N/A. This PR does not add a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

N/A. No documentation changes are required.
