### PR TITLE
[HFT] Fix countersyncd process leak in run_countersyncd_and_capture_output

### DIFF
--- a/tests/high_frequency_telemetry/utilities.py
+++ b/tests/high_frequency_telemetry/utilities.py
@@ -387,11 +387,15 @@ def run_countersyncd_and_capture_output(duthost, timeout=120, stats_interval=60)
         dict: Command result with stdout, stderr, rc
     """
     countersyncd_cmd = (
-        f'timeout {timeout} docker exec swss countersyncd -e '
+        f'countersyncd -e '
         f'--max-stats-per-report 0 '
-        f'--stats-interval {stats_interval} '
+        f'--stats-interval {stats_interval}'
     )
-    result = duthost.shell(countersyncd_cmd, module_ignore_errors=True)
+    run_countersyncd_cmd = (f'timeout {timeout} docker exec swss {countersyncd_cmd}')
+    result = duthost.shell(run_countersyncd_cmd, module_ignore_errors=True)
+
+    kill_countersyncd_cmd = (f"pkill -f '{countersyncd_cmd}' || true")
+    duthost.shell(kill_countersyncd_cmd, module_ignore_errors=True)
 
     # Check if command completed successfully (timeout is expected)
     pytest_assert(


### PR DESCRIPTION
…utput

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
'timeout' kills the 'docker exec' wrapper on the host but leaves the countersyncd process running inside the swss container.
Each test left a live countersyncd process consuming ~1-2.6% memory, causing the memory_utilization plugin to fail with >20% free:used increase.
Added pkill after capture to clean up orphaned processes.


<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type:  regression <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
Stabilize high_frequency_telemetry tests which using method "run_countersyncd_and_capture_output"

#### How did you do it?
Make sure the process is not running by killing it, after capturing the results

#### How did you verify/test it?
The high_frequency_telemetry tests passed. At the end of the tests, no 'countersyncd' processes that started during the tests.


