### PR TITLE
[platform_tests]: Remove cisco-8000 skip for test_reload_configuration_checks

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4271,10 +4271,6 @@ platform_tests/test_reload_config.py::test_reload_configuration:
       - "https://github.com/sonic-net/sonic-buildimage/issues/24543 and asic_type in ['mellanox'] and 'sn4280' in platform"
 
 platform_tests/test_reload_config.py::test_reload_configuration_checks:
-  skip:
-    reason: "Skip test_reload_configuration_checks on Cisco platform due to unstable results"
-    conditions:
-      - "asic_type in ['cisco-8000']"
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo or smartswitch platform"
     conditions_logical_operator: or

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1554,12 +1554,11 @@ platform_tests/test_reload_config.py::test_reload_configuration:
 
 platform_tests/test_reload_config.py::test_reload_configuration_checks:
   skip:
-    reason: "Unsupported platform API / Service watchdog-control can not load on kvm testbed / Skip test_reload_configuration_checks testcase due to flaky timing issue for Cisco 8000."
+    reason: "Unsupported platform API / Service watchdog-control can not load on kvm testbed."
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['barefoot'] and hwsku in ['newport']"
       - "https://github.com/sonic-net/sonic-buildimage/issues/19879 and asic_type in ['vs']"
-      - "asic_type in ['cisco-8000']"
 
 #######################################
 ######  test_secure_upgrade.py  #######


### PR DESCRIPTION
### Description of PR

Summary:
Remove the `asic_type in ['cisco-8000']` skip condition for `platform_tests/test_reload_config.py::test_reload_configuration_checks` from both conditional_mark YAML files, re-enabling this test on Cisco 8000 platforms.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type:

### Approach
#### What is the motivation for this PR?

`platform_tests/test_reload_config.py::test_reload_configuration_checks` was unconditionally skipped on Cisco 8000 (`asic_type in ['cisco-8000']`). This PR removes that skip so the test runs on Cisco 8000 platforms again.

#### How did you do it?

- `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`: removed the `skip` block whose only condition was `asic_type in ['cisco-8000']`, leaving the existing `xfail` block untouched.
- `tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml`: removed the `asic_type in ['cisco-8000']` entry from the `skip` conditions list and dropped the now-stale Cisco 8000 clause from the `reason`. The remaining `barefoot`/`newport` and `vs` skip conditions are unchanged.

#### How did you verify/test it?

- Confirmed both YAML files parse successfully with PyYAML.
- Ran the `check-conditional-mark-sort` pre-commit hook against both files (exit 0, ordering preserved).

#### Any platform specific information?

Affects Cisco 8000 (`asic_type = cisco-8000`) platforms — the test is no longer skipped there.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case.

### Documentation

N/A
