### PR TITLE
snappi: auto-detect the PFC TX queue-group size from the tgen ports

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1577,6 +1577,11 @@ def pfc_queue_group_size(api=None, config=None, default=8):
     runs only when ``api`` is passed (fixtures do this once while building the
     testbed config); plain ``pfc_queue_group_size()`` calls return the cached
     value, or the override/default if resolution has not happened yet.
+
+    The cache is a process global that is never reset: the first resolved value
+    holds for the rest of the pytest run. That matches the one-testbed-per-run
+    model; a run spanning tgens with different queue-group sizes would keep the
+    first size only.
     """
     global _pfc_queue_group_size
     if _pfc_queue_group_size is not None:

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1478,6 +1478,7 @@ def get_pfc_count(duthost, port):
     return pfc_dict
 
 
+@lru_cache
 def get_pfcQueueGroupSize(default=8):
     testbed_name = get_testbed_from_args()
     is_override, override_data = parse_override(testbed_name, 'pfcQueueGroupSize')
@@ -1563,6 +1564,47 @@ def get_queue_scheduler_weight_dict(host_ans, asic_value=None, port=None,
             "dscp": queue_to_dscp.get(int(q)),
         }
     return result
+
+
+_pfc_queue_group_size = None  # session cache for pfc_queue_group_size()
+
+
+def pfc_queue_group_size(api=None, config=None, default=8):
+    """PFC TX queue-group size for the tgen ports.
+
+    Resolution order: per-testbed override > size detected from the live tgen
+    port > ``default``. The resolved value is cached for the session. Detection
+    runs only when ``api`` is passed (fixtures do this once while building the
+    testbed config); plain ``pfc_queue_group_size()`` calls return the cached
+    value, or the override/default if resolution has not happened yet.
+    """
+    global _pfc_queue_group_size
+    if _pfc_queue_group_size is not None:
+        return _pfc_queue_group_size
+
+    size = get_pfcQueueGroupSize(default=0) or None  # 0 = no override; never a real size
+    if size is not None:
+        logger.info("pfcQueueGroupSize=%s from testbed override (auto-detect skipped)", size)
+    elif api is not None:
+        # Imported here: snappi_helpers imports common_helpers at module level.
+        from tests.common.snappi_tests.snappi_helpers import fetch_pfc_queue_group_size
+        size = fetch_pfc_queue_group_size(api, config)
+        if size is None:
+            size = default  # cache it: detection will not succeed on a later attempt either
+            logger.warning("pfcQueueGroupSize: auto-detect unavailable; using default %d. Set the "
+                           "per-testbed override in tests/snappi_tests/variables.override.yml if the "
+                           "tgen ports honor only 4 PFC TX queue groups.", default)
+        elif size != default:
+            logger.warning("pfcQueueGroupSize: selecting %d over default %d — the tgen port honors %d "
+                           "PFC TX queue groups; with %d, pause frames for priorities mapped above "
+                           "queue %d would not be honored", size, default, size, default, size - 1)
+        else:
+            logger.info("pfcQueueGroupSize: auto-detected %d (matches default)", size)
+
+    if size is None:
+        return default  # consumer call before resolution: fall back without caching
+    _pfc_queue_group_size = size
+    return size
 
 
 @lru_cache

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -17,12 +17,12 @@ from tests.common.errors import RunAnsibleModuleFail
 from ipaddress import ip_address, IPv4Address, IPv6Address
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
 from tests.common.snappi_tests.common_helpers import get_addrs_in_subnet, get_peer_snappi_chassis, \
-    get_ipv6_addrs_in_subnet, parse_override
+    get_ipv6_addrs_in_subnet, parse_override, pfc_queue_group_size
 from tests.common.snappi_tests.snappi_helpers import SnappiFanoutManager, get_snappi_port_location, \
     get_macs, get_ip_addresses, subnet_mask_from_hosts   # noqa: F401
 from tests.common.snappi_tests.port import SnappiPortConfig, SnappiPortType
 from tests.common.helpers.assertions import pytest_assert, pytest_require   # noqa: F811
-from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict, dut_ip_start, snappi_ip_start, \
+from tests.common.snappi_tests.variables import pfcQueueValueDict, dut_ip_start, snappi_ip_start, \
     prefix_length, dut_ipv6_start, snappi_ipv6_start, v6_prefix_length, dut_ip_for_non_macsec_port
 from tests.common.macsec.macsec_config_helper import set_macsec_profile, enable_macsec_port, disable_macsec_port, \
     delete_macsec_profile
@@ -507,6 +507,16 @@ def is_pfc_enabled(duthosts, rand_one_dut_front_end_hostname):
     return False
 
 
+def _config_pfc_classes(api, config, pfc):
+    """Program the PFC class -> TX queue mapping using the queue-group size the
+    tgen port honors (testbed override > detected from the port > default 8):
+    identity mapping for 8, folded per pfcQueueValueDict for 4."""
+    size = pfc_queue_group_size(api=api, config=config)
+    pytest_assert(size in (4, 8), 'pfcQueueGroupSize value is not 4 or 8')
+    for prio in range(8):
+        setattr(pfc, 'pfc_class_{}'.format(prio), prio if size == 8 else pfcQueueValueDict[prio])
+
+
 @pytest.fixture(scope="function")
 def snappi_testbed_config(conn_graph_facts, fanout_graph_facts,     # noqa: F811
                           duthosts, rand_one_dut_hostname, is_pfc_enabled,
@@ -602,26 +612,7 @@ def snappi_testbed_config(conn_graph_facts, fanout_graph_facts,     # noqa: F811
     if is_pfc_enabled:
         pfc = l1_config.flow_control.ieee_802_1qbb
         pfc.pfc_delay = 0
-        if pfcQueueGroupSize == 8:
-            pfc.pfc_class_0 = 0
-            pfc.pfc_class_1 = 1
-            pfc.pfc_class_2 = 2
-            pfc.pfc_class_3 = 3
-            pfc.pfc_class_4 = 4
-            pfc.pfc_class_5 = 5
-            pfc.pfc_class_6 = 6
-            pfc.pfc_class_7 = 7
-        elif pfcQueueGroupSize == 4:
-            pfc.pfc_class_0 = pfcQueueValueDict[0]
-            pfc.pfc_class_1 = pfcQueueValueDict[1]
-            pfc.pfc_class_2 = pfcQueueValueDict[2]
-            pfc.pfc_class_3 = pfcQueueValueDict[3]
-            pfc.pfc_class_4 = pfcQueueValueDict[4]
-            pfc.pfc_class_5 = pfcQueueValueDict[5]
-            pfc.pfc_class_6 = pfcQueueValueDict[6]
-            pfc.pfc_class_7 = pfcQueueValueDict[7]
-        else:
-            pytest_assert(False, 'pfcQueueGroupSize value is not 4 or 8')
+        _config_pfc_classes(snappi_api, config, pfc)
     else:
         logger.info('PFC is not enabled on the DUT, skipping PFC configuration on TGEN')
 
@@ -1166,26 +1157,7 @@ def snappi_multi_base_config(duthost_list,
                 l1_config.auto_negotiation.rs_fec = True
                 pfc = l1_config.flow_control.ieee_802_1qbb
                 pfc.pfc_delay = 0
-            if pfcQueueGroupSize == 8:
-                pfc.pfc_class_0 = 0
-                pfc.pfc_class_1 = 1
-                pfc.pfc_class_2 = 2
-                pfc.pfc_class_3 = 3
-                pfc.pfc_class_4 = 4
-                pfc.pfc_class_5 = 5
-                pfc.pfc_class_6 = 6
-                pfc.pfc_class_7 = 7
-            elif pfcQueueGroupSize == 4:
-                pfc.pfc_class_0 = pfcQueueValueDict[0]
-                pfc.pfc_class_1 = pfcQueueValueDict[1]
-                pfc.pfc_class_2 = pfcQueueValueDict[2]
-                pfc.pfc_class_3 = pfcQueueValueDict[3]
-                pfc.pfc_class_4 = pfcQueueValueDict[4]
-                pfc.pfc_class_5 = pfcQueueValueDict[5]
-                pfc.pfc_class_6 = pfcQueueValueDict[6]
-                pfc.pfc_class_7 = pfcQueueValueDict[7]
-            else:
-                pytest_assert(False, 'pfcQueueGroupSize value is not 4 or 8')
+                _config_pfc_classes(snappi_api, config, pfc)
 
     port_config_list = []
 
@@ -1238,26 +1210,7 @@ def snappi_dut_base_config(duthost_list,
 
     pfc = l1_config.flow_control.ieee_802_1qbb
     pfc.pfc_delay = 0
-    if pfcQueueGroupSize == 8:
-        pfc.pfc_class_0 = 0
-        pfc.pfc_class_1 = 1
-        pfc.pfc_class_2 = 2
-        pfc.pfc_class_3 = 3
-        pfc.pfc_class_4 = 4
-        pfc.pfc_class_5 = 5
-        pfc.pfc_class_6 = 6
-        pfc.pfc_class_7 = 7
-    elif pfcQueueGroupSize == 4:
-        pfc.pfc_class_0 = pfcQueueValueDict[0]
-        pfc.pfc_class_1 = pfcQueueValueDict[1]
-        pfc.pfc_class_2 = pfcQueueValueDict[2]
-        pfc.pfc_class_3 = pfcQueueValueDict[3]
-        pfc.pfc_class_4 = pfcQueueValueDict[4]
-        pfc.pfc_class_5 = pfcQueueValueDict[5]
-        pfc.pfc_class_6 = pfcQueueValueDict[6]
-        pfc.pfc_class_7 = pfcQueueValueDict[7]
-    else:
-        pytest_assert(False, 'pfcQueueGroupSize value is not 4 or 8')
+    _config_pfc_classes(snappi_api, config, pfc)
 
     port_config_list = []
 

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1143,6 +1143,12 @@ def snappi_multi_base_config(duthost_list,
         logger.info('Rx and  Tx ports have different link speeds')
     [config.ports.port(name='Port {}'.format(sp['port_id']), location=sp['location']) for sp in new_snappi_ports]
 
+    # Resolve the PFC queue-group size once, while the config holds only ports
+    # (detection applies it to bring the session vports up), instead of from
+    # inside the per-port loop below where only part of the L1 config exists.
+    # The _config_pfc_classes calls then read the cached value.
+    pfc_queue_group_size(api=snappi_api, config=config)
+
     # Generating L1 config for both the snappi_ports.
     for port in config.ports:
         for index, snappi_port in enumerate(new_snappi_ports):

--- a/tests/common/snappi_tests/snappi_helpers.py
+++ b/tests/common/snappi_tests/snappi_helpers.py
@@ -368,6 +368,56 @@ def fetch_snappi_flow_metrics(api, flow_names):
     return flow_metrics
 
 
+def fetch_pfc_queue_group_size(api, config=None):
+    """
+    Fetches the PFC TX queue-group size (4 or 8) the tgen ports honor from the
+    corresponding snappi session; None when it cannot be determined (e.g. not an
+    IxNetwork-backed session). The framework models one size per session: should
+    ports ever report different sizes, 4 is used — every port honors the folded
+    mapping, only 4-group ports break on the identity one.
+
+    Args:
+    api: snappi api
+    config: snappi config; applied first so vports exist (optional)
+
+    Returns:
+    size (int): 4 or 8, or None when undetermined
+    """
+    try:
+        if config is not None:
+            api.set_config(config)  # the first apply also establishes the IxNetwork session
+        vports = api._ixnetwork.Vport.find()  # _ixnetwork exists only after the session does
+    except AttributeError:
+        logger.info("pfcQueueGroupSize detection: not an IxNetwork-backed session")
+        return None
+    except Exception as e:
+        logger.warning("pfcQueueGroupSize detection failed applying config: %s", e)
+        return None
+    try:
+        sizes = {}
+        for vport in vports:
+            # Fcoe (the PFC attributes) is a child of the active card-type object,
+            # e.g. L1Config.AresOneM.Fcoe. CurrentType names it in camelCase, with
+            # an 'Fcoe' suffix in FCoE mode (as snappi_ixnetwork._set_vport_type sets).
+            card = vport.L1Config.CurrentType
+            card = card[0].upper() + card[1:]
+            if card.endswith('Fcoe'):
+                card = card[:-len('Fcoe')]
+            raw = getattr(vport.L1Config, card).Fcoe.PfcQueueGroupSize
+            sizes[vport.Name] = int(str(raw).rsplit('-', 1)[-1])
+        logger.info("fetch_pfc_queue_group_size: %s", sizes)
+    except Exception as e:
+        logger.warning("pfcQueueGroupSize detection failed: %s", e)
+        return None
+    if not sizes or not set(sizes.values()) <= {4, 8}:
+        logger.warning("pfcQueueGroupSize detection: unexpected readback %s", sizes)
+        return None
+    if len(set(sizes.values())) > 1:
+        logger.warning("pfcQueueGroupSize: ports report different sizes %s; using 4", sizes)
+        return 4
+    return sizes.popitem()[1]
+
+
 def is_traffic_converged(snappi_api, flow_names=[], threshold_perentage=0.01):
     """
     Returns true if traffic has converged within the threshold

--- a/tests/common/snappi_tests/snappi_helpers.py
+++ b/tests/common/snappi_tests/snappi_helpers.py
@@ -8,6 +8,7 @@ chassis instead of reading it from fanout_graph_facts fixture.
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi_tests.common_helpers import ansible_stdout_to_str, get_peer_snappi_chassis
 from ixnetwork_restpy.assistants.statistics.statviewassistant import StatViewAssistant
+import re
 import time
 import ipaddr
 import math
@@ -383,6 +384,11 @@ def fetch_pfc_queue_group_size(api, config=None):
     Returns:
     size (int): 4 or 8, or None when undetermined
     """
+    if 'ixnetwork' not in type(api).__module__.lower():
+        # Checked before any apply: other OTG backends must keep today's path,
+        # without the set_config below as a side effect.
+        logger.info("pfcQueueGroupSize detection: not an IxNetwork-backed session")
+        return None
     try:
         if config is not None:
             api.set_config(config)  # the first apply also establishes the IxNetwork session
@@ -404,7 +410,14 @@ def fetch_pfc_queue_group_size(api, config=None):
             if card.endswith('Fcoe'):
                 card = card[:-len('Fcoe')]
             raw = getattr(vport.L1Config, card).Fcoe.PfcQueueGroupSize
-            sizes[vport.Name] = int(str(raw).rsplit('-', 1)[-1])
+            # Readback is '<enum>-<n>' or a bare number; require trailing digits
+            # rather than assuming, so an unexpected format is logged, not raised.
+            match = re.search(r'(\d+)$', str(raw).strip())
+            if match is None:
+                logger.warning("pfcQueueGroupSize detection: unparseable readback %r on %s",
+                               raw, vport.Name)
+                return None
+            sizes[vport.Name] = int(match.group(1))
         logger.info("fetch_pfc_queue_group_size: %s", sizes)
     except Exception as e:
         logger.warning("pfcQueueGroupSize detection failed: %s", e)

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -21,7 +21,8 @@ from tests.common.snappi_tests.common_helpers import config_capture_settings, ge
 from tests.common.snappi_tests.port import select_ports, select_tx_port
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics, \
     fetch_flow_metrics_for_macsec    # noqa: F401
-from .variables import pfcQueueGroupSize, pfcQueueValueDict
+from .variables import pfcQueueValueDict
+from .common_helpers import pfc_queue_group_size
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 from tests.common.cisco_data import is_cisco_device
 from tests.common.reboot import reboot
@@ -226,7 +227,7 @@ def generate_test_flows(testbed_config,
             test_flow.packet.ethernet().ipv4()
             ip = test_flow.packet[-1]
             eth = test_flow.packet[-2]
-            if pfcQueueGroupSize == 8:
+            if pfc_queue_group_size() == 8:
                 eth.pfc_queue.value = prio
             else:
                 eth.pfc_queue.value = pfcQueueValueDict[prio]
@@ -252,7 +253,7 @@ def generate_test_flows(testbed_config,
 
             eth.src.value = base_flow_config["tx_mac"]
             eth.dst.value = base_flow_config["rx_mac"]
-            if pfcQueueGroupSize == 8:
+            if pfc_queue_group_size() == 8:
                 eth.pfc_queue.value = prio
             else:
                 eth.pfc_queue.value = pfcQueueValueDict[prio]
@@ -360,7 +361,7 @@ def generate_background_flows(testbed_config,
             bg_flow.packet.ethernet().ipv4()
             ip = bg_flow.packet[-1]
             eth = bg_flow.packet[-2]
-            if pfcQueueGroupSize == 8:
+            if pfc_queue_group_size() == 8:
                 eth.pfc_queue.value = prio
             else:
                 eth.pfc_queue.value = pfcQueueValueDict[prio]
@@ -384,7 +385,7 @@ def generate_background_flows(testbed_config,
 
             eth.src.value = base_flow_config["tx_mac"]
             eth.dst.value = base_flow_config["rx_mac"]
-            if pfcQueueGroupSize == 8:
+            if pfc_queue_group_size() == 8:
                 eth.pfc_queue.value = prio
             else:
                 eth.pfc_queue.value = pfcQueueValueDict[prio]

--- a/tests/common/snappi_tests/variables.py
+++ b/tests/common/snappi_tests/variables.py
@@ -1,5 +1,8 @@
 from tests.common.snappi_tests.common_helpers import get_pfcQueueGroupSize
 
+# Deprecated: use common_helpers.pfc_queue_group_size(), which additionally
+# auto-detects the size from the tgen port where supported (IxNetwork), and
+# falls back to this same override/default resolution otherwise.
 pfcQueueGroupSize = get_pfcQueueGroupSize(default=8)  # can have values 4 or 8
 pfcQueueValueDict = {0: 0,
                      1: 1,

--- a/tests/snappi_tests/README.md
+++ b/tests/snappi_tests/README.md
@@ -199,12 +199,14 @@ Before running **RDMA-related tests** (e.g., PFC, ECN, PFCWD), ensure the follow
 
 🛠️ The PFCWD configuration should be present in the DUT’s `config_db.json` file to ensure it is active on boot.
 
-In case you're testing with **Aresone** hardware, set the PFC queue size to `4` by updating the `variable.py` file in the following location:
+The PFC TX queue-group size (8, or 4 on e.g. high-speed **AresOne** port modes) is auto-detected from the connected tgen ports — no configuration is needed. To pin the value explicitly (or on a tgen where detection is unavailable, e.g. a non-IxNetwork OTG backend), set the per-testbed override in `~/sonic-mgmt/tests/snappi_tests/variables.override.yml`:
 
-**File:** `~/sonic-mgmt/tests/common/snappi_tests/variable.py`
+```yaml
+<testbed_name>:
+  pfcQueueGroupSize: 4
+```
 
-- Locate the line where the PFC queue size is defined and set it to `4`:
-- pfcQueueGroupSize = 4
+The override takes precedence over auto-detection. The test log states which source decided the value. (Editing `pfcQueueGroupSize` in `tests/common/snappi_tests/variables.py` no longer has any effect.)
 
 ## Running the test
 

--- a/tests/snappi_tests/dataplane/files/helper.py
+++ b/tests/snappi_tests/dataplane/files/helper.py
@@ -384,6 +384,11 @@ def create_snappi_l1config(snappi_api, get_snappi_ports, snappi_extra_params):
     snappi_ports = get_snappi_ports
     config = snappi_api.config()
     _ = [config.ports.port(name=f"Port_{p['port_id']}", location=p["location"]) for p in snappi_ports]
+    if any(pconfig.get("is_rdma", False) for pconfig in snappi_extra_params.protocol_config.values()):
+        # Resolve the PFC queue-group size (override > detect > default) once,
+        # while the config holds only ports: detection applies it to bring the
+        # session vports up. The consumer calls below read the cached value.
+        pfc_queue_group_size(api=snappi_api, config=config)
     for role, pconfig in snappi_extra_params.protocol_config.items():
         for index, port_data in enumerate(pconfig['ports']):
             layer1 = config.layer1.layer1()[-1]

--- a/tests/snappi_tests/dataplane/files/helper.py
+++ b/tests/snappi_tests/dataplane/files/helper.py
@@ -397,10 +397,10 @@ def create_snappi_l1config(snappi_api, get_snappi_ports, snappi_extra_params):
             if pconfig.get("is_rdma", False):
                 pfc = layer1.flow_control.ieee_802_1qbb
                 pfc.pfc_delay = 0
-                if pfcQueueGroupSize == 8:
+                if pfc_queue_group_size() == 8:
                     for i in range(8):
                         setattr(pfc, f'pfc_class_{i}', i)
-                elif pfcQueueGroupSize == 4:
+                elif pfc_queue_group_size() == 4:
                     for i in range(8):
                         setattr(pfc, f'pfc_class_{i}', pfcQueueValueDict[i])
     return config

--- a/tests/snappi_tests/dataplane/imports.py
+++ b/tests/snappi_tests/dataplane/imports.py
@@ -42,6 +42,7 @@ from ixnetwork_restpy import SessionAssistant, BatchUpdate, BatchAdd
 from ixnetwork_restpy.assistants.statistics.statviewassistant import (
     StatViewAssistant,
 )   # noqa: F403, F401, F405
+from tests.common.snappi_tests.common_helpers import pfc_queue_group_size
 
 # ==============================
 #  Common Test Utilities
@@ -175,7 +176,6 @@ from tests.common.snappi_tests.variables import (
     dut_ipv6_start,
     snappi_ipv6_start,
     v6_prefix_length,
-    pfcQueueGroupSize,
     pfcQueueValueDict,
 )   # noqa: F403, F401, F405
 
@@ -239,7 +239,7 @@ __all__ = [
     # Variables
     "dut_ip_start", "snappi_ip_start", "prefix_length",
     "dut_ipv6_start", "snappi_ipv6_start", "v6_prefix_length",
-    "pfcQueueGroupSize", "pfcQueueValueDict",
+    "pfc_queue_group_size", "pfcQueueValueDict",
     # MAC management
     "get_macs",
 ]

--- a/tests/snappi_tests/pfc/files/lossless_response_to_external_pause_storms_helper.py
+++ b/tests/snappi_tests/pfc/files/lossless_response_to_external_pause_storms_helper.py
@@ -14,7 +14,8 @@ from tests.common.snappi_tests.port import select_ports                         
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, verify_pause_flow, \
      setup_base_traffic_config                                 # noqa: F401
-from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.variables import pfcQueueValueDict
+from tests.common.snappi_tests.common_helpers import pfc_queue_group_size
 from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
@@ -353,7 +354,7 @@ def __gen_data_flow(testbed_config,
         eth.src.value = tx_mac
         eth.dst.value = rx_mac
 
-        if pfcQueueGroupSize == 8:
+        if pfc_queue_group_size() == 8:
             if 'Background Flow' in flow.name:
                 eth.pfc_queue.value = 0
             elif 'Test Flow 1 -> 0' in flow.name:

--- a/tests/snappi_tests/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
+++ b/tests/snappi_tests/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
@@ -15,7 +15,8 @@ from tests.common.snappi_tests.port import select_ports                         
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, verify_pause_flow, \
      setup_base_traffic_config                                      # noqa: F401
-from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.variables import pfcQueueValueDict
+from tests.common.snappi_tests.common_helpers import pfc_queue_group_size
 from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
@@ -362,7 +363,7 @@ def __gen_data_flow(testbed_config,
         eth.src.value = tx_mac
         eth.dst.value = rx_mac
 
-        if pfcQueueGroupSize == 8:
+        if pfc_queue_group_size() == 8:
             if 'Background Flow' in flow.name:
                 eth.pfc_queue.value = 0
             elif 'Test Flow 1 -> 0' in flow.name:

--- a/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -9,7 +9,8 @@ from tests.common.snappi_tests.port import select_ports                         
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, \
      setup_base_traffic_config          # noqa: F401
-from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.variables import pfcQueueValueDict
+from tests.common.snappi_tests.common_helpers import pfc_queue_group_size
 from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
@@ -518,7 +519,7 @@ def __gen_data_flow(testbed_config,
     eth.src.value = tx_mac
     eth.dst.value = rx_mac
 
-    if pfcQueueGroupSize == 8:
+    if pfc_queue_group_size() == 8:
         if 'Background Flow' in flow.name:
             eth.pfc_queue.value = 1
         elif 'Test Flow 1 -> 0' in flow.name:

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -14,7 +14,8 @@ from tests.common.snappi_tests.port import select_ports                         
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, \
      run_traffic                                         # noqa: F401
-from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.variables import pfcQueueValueDict
+from tests.common.snappi_tests.common_helpers import pfc_queue_group_size
 from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
@@ -311,7 +312,7 @@ def __gen_data_flow(testbed_config,
     eth.src.value = tx_mac
     eth.dst.value = rx_mac
     flow.duration.fixed_seconds.delay.nanoseconds = int(sec_to_nanosec(DATA_FLOW_DELAY_SEC))
-    if pfcQueueGroupSize == 8:
+    if pfc_queue_group_size() == 8:
         if 'Background Flow' in flow.name:
             eth.pfc_queue.value = 1
         elif 'Test Flow 1 -> 0' in flow.name:

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -14,7 +14,8 @@ from tests.common.snappi_tests.port import select_ports                         
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, \
      setup_base_traffic_config                      # noqa: F401
-from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.variables import pfcQueueValueDict
+from tests.common.snappi_tests.common_helpers import pfc_queue_group_size
 from tests.common.portstat_utilities import parse_portstat                              # noqa: F401
 from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
@@ -346,7 +347,7 @@ def __gen_data_flow(testbed_config,
     # else:
     #     eth.pfc_queue.value = 3
 
-    if pfcQueueGroupSize == 8:
+    if pfc_queue_group_size() == 8:
         if 'Background Flow' in flow.name:
             eth.pfc_queue.value = 1
         else:

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossy_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossy_helper.py
@@ -14,7 +14,8 @@ from tests.common.snappi_tests.port import select_ports                         
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, \
      run_traffic                                               # noqa: F401
-from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.variables import pfcQueueValueDict
+from tests.common.snappi_tests.common_helpers import pfc_queue_group_size
 from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
@@ -348,7 +349,7 @@ def __gen_data_flow(testbed_config,
     eth.src.value = tx_mac
     eth.dst.value = rx_mac
 
-    if pfcQueueGroupSize == 8:
+    if pfc_queue_group_size() == 8:
         if 'Test Flow' in flow.name:
             eth.pfc_queue.value = 1
         elif 'Background Flow 1 -> 0' in flow.name:

--- a/tests/snappi_tests/pfc/test_lossless_response_to_throttling_pause_storms.py
+++ b/tests/snappi_tests/pfc/test_lossless_response_to_throttling_pause_storms.py
@@ -12,7 +12,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
 from tests.snappi_tests.pfc.files.lossless_response_to_throttling_pause_storms_helper import (
     run_lossless_response_to_throttling_pause_storms_test)
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict     # noqa: F401
+from tests.common.snappi_tests.variables import pfcQueueValueDict     # noqa: F401
 from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]

--- a/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless_lossy.py
+++ b/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless_lossy.py
@@ -13,7 +13,7 @@ from tests.snappi_tests.pfc.files.m2o_oversubscribe_lossless_lossy_helper import
      run_pfc_m2o_oversubscribe_lossless_lossy_test
     )                                                             # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams            # noqa: F401
-from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict        # noqa: F401
+from tests.common.snappi_tests.variables import pfcQueueValueDict        # noqa: F401
 from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]

--- a/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
@@ -11,7 +11,8 @@ from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
 from tests.common.snappi_tests.port import select_ports, select_tx_port                           # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp                                 # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.variables import pfcQueueValueDict
+from tests.common.snappi_tests.common_helpers import pfc_queue_group_size
 from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
@@ -322,7 +323,7 @@ def __gen_traffic(testbed_config,
 
             eth.src.value = tx_mac
             eth.dst.value = rx_mac
-            if pfcQueueGroupSize == 8:
+            if pfc_queue_group_size() == 8:
                 eth.pfc_queue.value = prio
             else:
                 eth.pfc_queue.value = pfcQueueValueDict[prio]

--- a/tests/snappi_tests/pfcwd/files/pfcwd_burst_storm_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_burst_storm_helper.py
@@ -10,7 +10,8 @@ from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
 from tests.common.snappi_tests.port import select_ports, select_tx_port           # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.variables import pfcQueueValueDict
+from tests.common.snappi_tests.common_helpers import pfc_queue_group_size
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 logger = logging.getLogger(__name__)
@@ -190,7 +191,7 @@ def __gen_traffic(testbed_config,
 
             eth.src.value = tx_mac
             eth.dst.value = rx_mac
-            if pfcQueueGroupSize == 8:
+            if pfc_queue_group_size() == 8:
                 eth.pfc_queue.value = prio
             else:
                 eth.pfc_queue.value = pfcQueueValueDict[prio]

--- a/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
@@ -11,7 +11,8 @@ from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
 from tests.common.snappi_tests.port import select_ports                                           # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp                                 # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.variables import pfcQueueValueDict
+from tests.common.snappi_tests.common_helpers import pfc_queue_group_size
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 logger = logging.getLogger(__name__)
@@ -438,7 +439,7 @@ def __gen_data_flow(testbed_config,
 
     eth.src.value = tx_mac
     eth.dst.value = rx_mac
-    if pfcQueueGroupSize == 8:
+    if pfc_queue_group_size() == 8:
         eth.pfc_queue.value = flow_prio
     else:
         eth.pfc_queue.value = pfcQueueValueDict[flow_prio]

--- a/tests/snappi_tests/pfcwd/files/pfcwd_runtime_traffic_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_runtime_traffic_helper.py
@@ -7,7 +7,8 @@ from tests.common.snappi_tests.common_helpers import start_pfcwd, stop_pfcwd, se
 from tests.common.snappi_tests.port import select_ports, select_tx_port       # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.variables import pfcQueueValueDict
+from tests.common.snappi_tests.common_helpers import pfc_queue_group_size
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 
@@ -165,7 +166,7 @@ def __gen_traffic(testbed_config,
 
             eth.src.value = tx_mac
             eth.dst.value = rx_mac
-            if pfcQueueGroupSize == 8:
+            if pfc_queue_group_size() == 8:
                 eth.pfc_queue.value = prio
             else:
                 eth.pfc_queue.value = pfcQueueValueDict[prio]


### PR DESCRIPTION
### Description of PR

Summary:
The snappi framework assumes tgen ports honor 8 PFC TX queue groups unless a per-testbed override says otherwise (`pfcQueueGroupSize` in `tests/common/snappi_tests/variables.py`, default 8). On load modules that honor only 4 (e.g. high-speed Keysight AresOne-family port modes), the default silently maps PFC classes to non-existent TX queues: the tgen does not honor pause frames for the affected priorities, and pause-storm tests (pfcwd, pfc) fail intermittently with loss-rate assertions — nothing in the logs points at the queue-group mismatch. This PR makes the framework resolve the size automatically from the connected ports, with explicit logging of which source decided the value and why.

Fixes #26174

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

Debugging intermittent PFCWD basic test failures on a 400G testbed, we found the tgen transmitting straight through PFC pause storms for some priorities: the port honors 4 PFC TX queue groups, the framework had programmed the 8-group identity class map, so class-N pause frames paused queues that don't exist on the hardware. The configuration is accepted without error and the mismatch only surfaces as unexplained test failures (details in #26174).

#### How did you do it?

- `snappi_helpers.fetch_pfc_queue_group_size(api, config)`: reads the queue-group size every session vport honors via `L1Config.<CardType>.Fcoe.PfcQueueGroupSize`, deriving the card-type object the same way snappi_ixnetwork's own `_set_vport_type` does (strip the `Fcoe` suffix from `CurrentType`); verified against all 12 Fcoe-eligible card families in ixnetwork_restpy 1.10.0. Non-IxNetwork OTG backends return None and keep today's behavior. If ports report different sizes, the folded size 4 is used (every port honors the folded mapping; only 4-group ports break on the identity one).
- `common_helpers.pfc_queue_group_size()`: resolves once per session — testbed override > detected size > default 8 — caches the result, and logs the deciding source. Detection runs from the base-config fixtures (vports exist only after the first set_config); consumer calls just read the cached value.
- `snappi_fixtures._config_pfc_classes()`: collapses the three duplicated 20-line L1 `pfc_class` programming blocks into one helper that resolves then programs (this also fixes an indentation issue in the multidut block where the class programming sat outside the port-match loop).
- All consumers (traffic_generation and the pfcwd/pfc/dataplane helpers) move from the import-time `variables.pfcQueueGroupSize` constant — frozen before any tgen session exists, so it can never reflect hardware — to the accessor. The constant remains as a deprecated shim for out-of-tree users. The existing per-testbed override keeps highest precedence, so current testbeds are unaffected.

#### How did you verify/test it?

On a 4x400G AresOne-M snappi testbed with a Broadcom-DNX DUT, PFCWD basic tests at full traffic rate pass with:

- Detection path (no override configured):
  `fetch_pfc_queue_group_size: {'Port 0': 4, 'Port 1': 4, 'Port 2': 4, 'Port 3': 4}`
  `pfcQueueGroupSize: selecting 4 over default 8 — the tgen port honors 4 PFC TX queue groups; with 8, pause frames for priorities mapped above queue 3 would not be honored`
- Override path: `pfcQueueGroupSize=4 from testbed override (auto-detect skipped)` — detection bypassed, existing testbed behavior unchanged.
- flake8 clean on all changed files with the repo pre-commit flags.

#### Any platform specific information?

Tgen-side only; no DUT-side changes. Detection is IxNetwork-specific (`api._ixnetwork`, same access pattern as the existing capture configuration code), guarded so other OTG backends fall back to the override/default resolution used today.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

Deprecation note added on `variables.pfcQueueGroupSize` pointing to the accessor.