### PR TITLE
Ignore amd driver error log

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -501,3 +501,7 @@ r, ".* ERR auditd.*: auditd queue full reporting limit reached - ending dropped 
 # ctrmgrd k8s join warnings (old k8s version incompatibility with Docker 28.x)
 r, ".* ERR ctrmgrd\.py: Refer file .* for troubleshooting tips.*"
 r, ".* ERR ctrmgrd\.py:.*\[WARNING SystemVerification\]:.*Docker version is not on the list of validated versions.*"
+
+# Ignore flaky AMD driver error
+r, ".*ERR kernel:.* platform AMDI\d+:\d+: AMD\-Vi: \[Firmware Bug\]: No ACPI device matched UID, but \d+ devices matched HID\..*"
+r, ".*ERR kernel:.* amd\-tee driver: tee not present.*"

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -502,6 +502,6 @@ r, ".* ERR auditd.*: auditd queue full reporting limit reached - ending dropped 
 r, ".* ERR ctrmgrd\.py: Refer file .* for troubleshooting tips.*"
 r, ".* ERR ctrmgrd\.py:.*\[WARNING SystemVerification\]:.*Docker version is not on the list of validated versions.*"
 
-# Ignore flaky AMD driver error
+# Ignore AMD firmware/driver boot errors on Arista-7060X6 (see #26222)
 r, ".*ERR kernel:.* platform AMDI\d+:\d+: AMD\-Vi: \[Firmware Bug\]: No ACPI device matched UID, but \d+ devices matched HID\..*"
 r, ".*ERR kernel:.* amd\-tee driver: tee not present.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #26222 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
We were seeing loganalyzer failures due to firmware related error logs such as:
```
ERR kernel: [    0.361098] platform AMDI0020:00: AMD-Vi: [Firmware Bug]: No ACPI device matched UID, but 4 devices matched HID.
```
#### How did you do it?
Ignored the logs as they don't seem to have any implications on test results.

#### How did you verify/test it?
Verified manually that loganalyzer no longer fails with the change.

#### Any platform specific information?
This is specific to the Arista-7060X6 platforms

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
