### PR TITLE
Restart neighsyncd after setting PEER_SWITCH config

### DIFF
--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -384,6 +384,12 @@ def apply_peer_switch_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mo
         wait_until(120, 5, 5, check_config_applied),
         "Timed out waiting for PEER_SWITCH and DEVICE_METADATA configuration to remain applied after swss restart"
     )
+    # neighsyncd reads the PEER_SWITCH config only in its constructor. Restart it so the new
+    # config takes effect, unless swss was already restarted above (th2/td3) after writing it.
+    if not ((restart_swss) and (dut.get_asic_name() != 'gb')):
+        logger.info("Restarting neighsyncd to pick up the PEER_SWITCH configuration")
+        dut.shell('docker exec swss supervisorctl restart neighsyncd')
+        wait_critical_processes(dut)
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
Restart neighsyncd after the mocked dual-ToR `PEER_SWITCH` table is applied so it
picks up the peer-switch config. Corresponding swss change: sonic-net/sonic-swss#4735

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

- neighsyncd reads the dual-ToR `PEER_SWITCH` config only in its constructor.
- When `apply_peer_switch_table_to_dut` mocks `PEER_SWITCH` at runtime, the already-running
  neighsyncd never consumes it, so dual-ToR neighbor handling is not exercised correctly.

#### How did you do it?

- After the `PEER_SWITCH` table is confirmed in CONFIG_DB, restart neighsyncd via
  `docker exec swss supervisorctl restart neighsyncd` and wait for critical processes.
- Skip the extra restart on th2/td3, where swss is already restarted after writing the config.
- Change is centralized in `apply_peer_switch_table_to_dut`, so all TCs using
  `apply_mock_dual_tor_tables` inherit the fix.

#### How did you verify/test it?

HwSKU : Cisco-8102-C64
Test : dualtor/test_orchagent_standby_tor_downstream.py
Topology : t0-64

```
29/07/2026 20:17:30 dual_tor_mock.apply_peer_switch_table_to L0390 INFO   | Restarting neighsyncd to pick up the PEER_SWITCH configuration
...
29/07/2026 20:17:31 processes_utils.wait_critical_processes  L0098 INFO   | Wait until all critical processes are healthy in 300 sec
29/07/2026 20:17:31 utilities.wait_until                     L0139 DEBUG  | Wait until _all_critical_processes_healthy is True, timeout is 300 seconds, checking interval is 20, delay is 0 seconds
29/07/2026 20:17:31 utilities.wait_until                     L0149 DEBUG  | Time elapsed: 0.000000 seconds
29/07/2026 20:17:31 processes_utils._all_critical_processes_ L0065 INFO   | Check critical processes status
…
29/07/2026 20:17:35 utilities.wait_until                     L0164 DEBUG  | _all_critical_processes_healthy is True, exit early with True
```

```
2026 Jul 29 20:17:29.902625 mathilda-01 INFO swss#supervisord 2026-07-29 20:17:29,902 INFO waiting for neighsyncd to stop 
2026 Jul 29 20:17:29.903315 mathilda-01 INFO swss#supervisord 2026-07-29 20:17:29,903 WARN stopped: neighsyncd (terminated by SIGTERM)
2026 Jul 29 20:17:29.905912 mathilda-01 INFO swss#supervisord 2026-07-29 20:17:29,905 INFO spawned: 'neighsyncd' with pid 3304
2026 Jul 29 20:17:29.004462 mathilda-01 INFO swss#supervisord: message repeated 5 times: [ orchagent ]
2026 Jul 29 20:17:29.915402 mathilda-01 NOTICE swss#neighsyncd: :- NeighSync: neighsyncd: dualtor=true
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
