### PR TITLE
[202511] Skip dhcp_relay Tests for Isolated Topologies (#22642)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -904,9 +904,9 @@ decap/test_subnet_decap.py::test_vlan_subnet_decap:
 #######################################
 dhcp_relay:
   skip:
-    reason: "It is skipped for '202412' for now"
+    reason: "Not applicable to isolated topologies."
     conditions:
-      - "release in ['202412']"
+      - "'isolated' in topo_name"
 
 dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress:
   xfail:


### PR DESCRIPTION
### Description of PR
Summary: The DHCP Relay tests are not applicable to the isolated topologies, so skip them.
Fixes https://github.com/sonic-net/sonic-mgmt/issues/26001

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The DHCP Relay tests should be skipped for isolated topologies.

#### How did you do it?
Added a skip condition to the tests_mark_conditions file for isolated topologies.

#### How did you verify/test it?
Ran dhcp_relay tests against an isolated topology and confirmed that all the tests are skipped.