### PR TITLE
fdb: wait for expected LRU push count

### DIFF
--- a/tests/fdb/test_fdb_churn.py
+++ b/tests/fdb/test_fdb_churn.py
@@ -509,7 +509,7 @@ def test_fdb_mac_ping_pong(
 
     after = wait_for_stat_increase(
         duthost, FDBORCH_STATS_KEY, "lru_pushed",
-        before["lru_pushed"], timeout=STATS_PUBLISH_SEC + 60,
+        before["lru_pushed"] + cycles - 1, timeout=STATS_PUBLISH_SEC + 60,
     )
     pushed = after["lru_pushed"] - before["lru_pushed"]
     hits = after["lru_dedup_hits"] - before["lru_dedup_hits"]


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:


  The MAC ping-pong test can sample `lru_pushed` before all expected FDB LRU
  push stats have been published. Waiting for only any counter increase can let
  the test continue after a partial update and then fail the final push-count
  assertion.

  `wait_for_stat_increase()` returns when the stat is greater than the supplied
  baseline. Pass `before + cycles - 1` so the helper waits until `lru_pushed`
  reaches at least `before + cycles`, matching the later `pushed >= cycles`
  assertion.

Fixes #26236 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: day-one issue 

### Approach

#### What is the motivation for this PR?
`test_fdb_mac_ping_pong` can fail intermittently because the test waits only
  for `lru_pushed` to increase above the baseline, but later asserts that at
  least `cycles` pushes were recorded.

  In the observed failure, the test sampled only a partial counter update:

```
  before lru_pushed = 929
  sampled lru_pushed = 932
  pushed = 3
  later lru_pushed = 1031
```

  The later counter value shows that the expected FDB activity arrived, but the
  test asserted too early.

#### How did you do it?
 Changed the wait threshold from the original baseline:
`before["lru_pushed"]`

  to the expected threshold for the generated workload:

`  before["lru_pushed"] + cycles - 1`

  Because wait_for_stat_increase() returns when the stat is greater than the
  provided baseline, this waits until lru_pushed reaches at least
  before + cycles.

#### How did you verify/test it?
 Ran the affected FDB churn test repeatedly on dtAA where the issue was seen 10 times 

fdb/test_fdb_churn.py::test_fdb_repeated_learn_dedup PASSED [ 14%]
  fdb/test_fdb_churn.py::test_fdb_learn_delete_relearn PASSED [ 28%]
  fdb/test_fdb_churn.py::test_fdb_port_move_not_deduped PASSED [ 42%]
  fdb/test_fdb_churn.py::test_fdb_mac_ping_pong PASSED [ 57%]
  fdb/test_fdb_churn.py::test_fdb_distinct_macs_bulk_learn PASSED [ 71%]
  fdb/test_fdb_churn.py::test_fdb_flush_during_learn PASSED [ 85%]
  fdb/test_fdb_churn.py::test_fdb_churn_storm[100-5000-80] SKIPPED (FDB_CHURN_RUN_STORM=1 not set; skipping long-running storm test) [100%]


#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
