### PR TITLE
Fixed a test failure in `qos/test_ecn_config.py`

### DIFF
--- a/tests/qos/qos_fixtures.py
+++ b/tests/qos/qos_fixtures.py
@@ -74,3 +74,30 @@ def lossless_prio_list(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum
 
     result = [int(x) for x in port_qos_map[intf]['pfc_enable'].split(',')]
     return result
+
+
+@pytest.fixture(scope="module")
+def all_queues_list(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index):
+    """
+    This fixture returns the list of all queues
+
+    Args:
+       duthosts (pytest fixture) : list of DUTs
+       enum_rand_one_per_hwsku_frontend_hostname (pytest fixture): DUT hostname
+
+    Returns:
+        All queues (list)
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
+    config_facts = duthost.config_facts(host=duthost.hostname, asic_index=asichost.asic_index,
+                                        source="running")['ansible_facts']
+
+    tc_to_queue_maps = config_facts.get("TC_TO_QUEUE_MAP", {})
+    if not tc_to_queue_maps:
+        return []
+    # Assuming that all mappings have the same set of queue values.
+    mapping_name = next(iter(tc_to_queue_maps))
+    tc_to_queue_map = tc_to_queue_maps[mapping_name]
+    queues = [int(q) for q in list(tc_to_queue_map.values())]
+    return list(set(queues))

--- a/tests/qos/test_ecn_config.py
+++ b/tests/qos/test_ecn_config.py
@@ -302,37 +302,40 @@ def test_ecn_config_utility(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                 ecn_list[key.strip()] = value.strip()
     logging.info("ecn config : {}".format(ecn_list))
 
-    # Verify ecnconfig status on lossless queue
-    test_prio_list = lossless_prio_list
-    for prio in test_prio_list:
-        cmd = 'sudo ecnconfig {} -q {}'.format(asic, prio)
-        result = duthost.command(cmd)
-        assert result['rc'] == 0, f"Missing ecn configuration : {result['stderr']}"
-        if 'queue' in result['stdout_lines'][1]:
+    if lossless_prio_list:
+        # Verify ecnconfig status on lossless queue
+        test_prio_list = lossless_prio_list
+        for prio in test_prio_list:
+            cmd = 'sudo ecnconfig {} -q {}'.format(asic, prio)
+            result = duthost.command(cmd)
+            assert result['rc'] == 0, f"Missing ecn configuration : {result['stderr']}"
+            if 'queue' in result['stdout_lines'][1]:
+                status = result['stdout_lines'][1].split(':')
+                logging.info("{} status is {}".format(status[0], status[1]))
+            try:
+                # toggle the ecn status on prio queue
+                if status[1] == "off":
+                    cmd = 'sudo ecnconfig {} -q {} on'.format(asic, prio)
+                else:
+                    cmd = 'sudo ecnconfig {} -q {} off'.format(asic, prio)
+                result = duthost.command(cmd)
+            except Exception as e:
+                logging.info("Error on setting ecn queue : {}".format(e))
+            assert result['rc'] == 0, 'Set wred_profile command failed '
+
+        # revert the changes
+        for prio in test_prio_list:
+            cmd = 'sudo ecnconfig {} -q {}'.format(asic, prio)
+            result = duthost.command(cmd)
             status = result['stdout_lines'][1].split(':')
-            logging.info("{} status is {}".format(status[0], status[1]))
-        try:
-            # toggle the ecn status on prio queue
             if status[1] == "off":
                 cmd = 'sudo ecnconfig {} -q {} on'.format(asic, prio)
             else:
                 cmd = 'sudo ecnconfig {} -q {} off'.format(asic, prio)
             result = duthost.command(cmd)
-        except Exception as e:
-            logging.info("Error on setting ecn queue : {}".format(e))
-        assert result['rc'] == 0, 'Set wred_profile command failed '
-
-    # revert the changes
-    for prio in test_prio_list:
-        cmd = 'sudo ecnconfig {} -q {}'.format(asic, prio)
-        result = duthost.command(cmd)
-        status = result['stdout_lines'][1].split(':')
-        if status[1] == "off":
-            cmd = 'sudo ecnconfig {} -q {} on'.format(asic, prio)
-        else:
-            cmd = 'sudo ecnconfig {} -q {} off'.format(asic, prio)
-        result = duthost.command(cmd)
-        assert result['rc'] == 0, 'Set wred_profile command failed '
+            assert result['rc'] == 0, 'Set wred_profile command failed '
+    else:
+        logging.info("The DUT has no lossless priorities. Skipping the ecnconfig test.")
 
     # Verify counterpoll CLI for enabling and disabling ecn statistics
     # WRED_ECN_QUEUE_STAT

--- a/tests/qos/test_ecn_config.py
+++ b/tests/qos/test_ecn_config.py
@@ -7,7 +7,7 @@ import logging
 import time
 import pytest
 import json
-from tests.qos.qos_fixtures import lossless_prio_list  # noqa F401
+from tests.qos.qos_fixtures import all_queues_list  # noqa F401
 
 
 pytestmark = [
@@ -276,7 +276,7 @@ def test_verify_ecn_marking_config(duthosts, rand_one_dut_hostname, request):
 
 
 def test_ecn_config_utility(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                            enum_rand_one_frontend_asic_index, lossless_prio_list):  # noqa: F811
+                            enum_rand_one_frontend_asic_index, all_queues_list):  # noqa: F811
 
     # Verify the ecn config utility CLI's
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
@@ -302,40 +302,37 @@ def test_ecn_config_utility(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                 ecn_list[key.strip()] = value.strip()
     logging.info("ecn config : {}".format(ecn_list))
 
-    if lossless_prio_list:
-        # Verify ecnconfig status on lossless queue
-        test_prio_list = lossless_prio_list
-        for prio in test_prio_list:
-            cmd = 'sudo ecnconfig {} -q {}'.format(asic, prio)
-            result = duthost.command(cmd)
-            assert result['rc'] == 0, f"Missing ecn configuration : {result['stderr']}"
-            if 'queue' in result['stdout_lines'][1]:
-                status = result['stdout_lines'][1].split(':')
-                logging.info("{} status is {}".format(status[0], status[1]))
-            try:
-                # toggle the ecn status on prio queue
-                if status[1] == "off":
-                    cmd = 'sudo ecnconfig {} -q {} on'.format(asic, prio)
-                else:
-                    cmd = 'sudo ecnconfig {} -q {} off'.format(asic, prio)
-                result = duthost.command(cmd)
-            except Exception as e:
-                logging.info("Error on setting ecn queue : {}".format(e))
-            assert result['rc'] == 0, 'Set wred_profile command failed '
-
-        # revert the changes
-        for prio in test_prio_list:
-            cmd = 'sudo ecnconfig {} -q {}'.format(asic, prio)
-            result = duthost.command(cmd)
+    # Verify ecnconfig status on all queues
+    test_queue_list = all_queues_list
+    for queue in test_queue_list:
+        cmd = 'sudo ecnconfig {} -q {}'.format(asic, queue)
+        result = duthost.command(cmd)
+        assert result['rc'] == 0, f"Missing ecn configuration : {result['stderr']}"
+        if 'queue' in result['stdout_lines'][1]:
             status = result['stdout_lines'][1].split(':')
+            logging.info("{} status is {}".format(status[0], status[1]))
+        try:
+            # toggle the ecn status on queue
             if status[1] == "off":
-                cmd = 'sudo ecnconfig {} -q {} on'.format(asic, prio)
+                cmd = 'sudo ecnconfig {} -q {} on'.format(asic, queue)
             else:
-                cmd = 'sudo ecnconfig {} -q {} off'.format(asic, prio)
+                cmd = 'sudo ecnconfig {} -q {} off'.format(asic, queue)
             result = duthost.command(cmd)
-            assert result['rc'] == 0, 'Set wred_profile command failed '
-    else:
-        logging.info("The DUT has no lossless priorities. Skipping the ecnconfig test.")
+        except Exception as e:
+            logging.info("Error on setting ecn queue : {}".format(e))
+        assert result['rc'] == 0, 'Set wred_profile command failed '
+
+    # revert the changes
+    for queue in test_queue_list:
+        cmd = 'sudo ecnconfig {} -q {}'.format(asic, queue)
+        result = duthost.command(cmd)
+        status = result['stdout_lines'][1].split(':')
+        if status[1] == "off":
+            cmd = 'sudo ecnconfig {} -q {} on'.format(asic, queue)
+        else:
+            cmd = 'sudo ecnconfig {} -q {} off'.format(asic, queue)
+        result = duthost.command(cmd)
+        assert result['rc'] == 0, 'Set wred_profile command failed '
 
     # Verify counterpoll CLI for enabling and disabling ecn statistics
     # WRED_ECN_QUEUE_STAT


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR fixes a test failure in `test_ecn_config::test_ecn_config_utility` that happens on DUTs that have no lossless priorities.

Summary:
Microsoft ADO ID: 38630810
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
Fixed a test failure in `qos/test_ecn_config.py`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: 38630810
Failure type: <!-- day-one issue / regression / other --> day-one issue

### Approach
#### What is the motivation for this PR?
Fixing a test failure in `test_ecn_config::test_ecn_config_utility` that happens on DUTs that have no lossless priorities. This failure happens due to an exception that is raised when `lossless_prio_list` is `None`.

#### How did you do it?
Instead of running the test only on lossless queues, we run the test on all queues.

#### How did you verify/test it?
Ran the test on two DUTs: One that has lossless priorities, and another that does not have any lossless priorities. In both cases, the test passed with the new changes:
```
qos/test_ecn_config.py::test_ecn_config_utility PASSED                                                                        [100%]
```

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A