### PR TITLE
[202511] Generate golden_config_db for UT2 (#24157)

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -78,6 +78,54 @@ class GenerateGoldenConfigDBModule(object):
         self.dut_loopbacks = self.module.params['dut_loopbacks']
         self.console_ports = self.module.params['console_ports']
 
+    def _update_config_db_in_ns(self, config, table, value, namespaces_to_update='asic'):
+        """Update a table entry across all ASIC namespaces for multi-ASIC platforms.
+
+        Args:
+            config: Dict with the original config db content to update.
+            table: The config table path to update, using '/' to denote nested levels.
+                   e.g. "DEVICE_METADATA/localhost" navigates to asicN -> DEVICE_METADATA -> localhost.
+            value: A dict of field-value pairs to merge at the resolved path.
+            namespaces_to_update: Specifies which namespaces to update. can be "asic" or "localhost" or "all"
+
+        Returns:
+            Updated config as a JSON string.
+        """
+
+        if namespaces_to_update == "localhost":
+            ns_to_update = ["localhost"]
+        elif namespaces_to_update == "all":
+            ns_to_update = ["localhost"] + ["asic{}".format(asic) for asic in range(self.num_asics)]
+        else:
+            ns_to_update = ["asic{}".format(asic) for asic in range(self.num_asics)]
+        path_parts = table.split("/")
+        for ns in ns_to_update:
+            ns_cfg = config.get(ns)
+            if ns_cfg is None:
+                continue
+            target = ns_cfg
+            for part in path_parts:
+                target = target.setdefault(part, {})
+            target.update(value)
+        return config
+
+    def _render_macsec_config(self):
+        if not self.macsec_profile:
+            return {}
+
+        with open(MACSEC_PROFILE_PATH) as f:
+            macsec_profiles = json.load(f)
+
+        profile = macsec_profiles.get(self.macsec_profile)
+        if not profile:
+            return {}
+
+        profile['macsec_profile'] = self.macsec_profile
+        profile['asic_cnt'] = self.num_asics
+
+        with open(GOLDEN_CONFIG_TEMPLATE_PATH) as template_file:
+            return Template(template_file.read()).render(profile)
+
     def generate_mgfx_golden_config_db(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
         if rc != 0:
@@ -163,6 +211,34 @@ class GenerateGoldenConfigDBModule(object):
             return False
         repos = [line.strip().lower() for line in out.splitlines() if line.strip()]
         return "docker-sonic-otel" in repos
+
+    def get_port_config_path(self, asic_id):
+        platform = device_info.get_platform()
+        hwsku = device_info.get_hwsku()
+
+        return "/usr/share/sonic/device/{}/{}/{}/port_config.ini".format(
+                platform, hwsku, asic_id)
+
+    def get_config_from_minigraph_multiasic(self):
+        full_config = {}
+        cmd = "sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data"
+        # get the config for the host
+        rc, out, err = self.module.run_command(cmd)
+        if rc != 0:
+            self.module.fail_json(
+                msg="Failed to get config from minigraph for namespace {}: {}".format("localhost", err))
+        full_config["localhost"] = json.loads(out)
+
+        # get the config for asic namespaces
+        for asic_id in range(self.num_asics):
+            ns = "asic{}".format(asic_id)
+            port_config_path = self.get_port_config_path(asic_id)
+            asic_cmd = f"{cmd} -n {ns} -p {port_config_path}"
+            rc, out, err = self.module.run_command(asic_cmd)
+            if rc != 0:
+                self.module.fail_json(msg="Failed to get config from minigraph for namespace {}: {}".format(ns, err))
+            full_config[ns] = json.loads(out)
+        return full_config
 
     def get_config_from_minigraph(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
@@ -670,6 +746,38 @@ class GenerateGoldenConfigDBModule(object):
 
         return ha_config
 
+    def generate_ut2_golden_config_db(self):
+        full_config = {}
+        if self.num_asics > 1:
+            full_config = self.get_config_from_minigraph_multiasic()
+        else:
+            full_config = json.loads(self.get_config_from_minigraph())
+
+        macsec_config = self._render_macsec_config()
+
+        if self.num_asics > 1:
+            for asic in range(self.num_asics):
+                asic_name = f"asic{asic}"
+                if macsec_config:
+                    full_config[asic_name].update(macsec_config[asic_name])
+
+                if self.bgp_confd_asn and self.bgp_confd_peers:
+                    bgp_device_global = full_config[asic_name].setdefault("BGP_DEVICE_GLOBAL", {})
+                    bgp_device_global["CONFED"] = {
+                        "asn": str(self.bgp_confd_asn),
+                        "peers": str(self.bgp_confd_peers).replace(' ', ';')
+                    }
+        else:
+            full_config.update(macsec_config)
+            if self.bgp_confd_asn and self.bgp_confd_peers:
+                bgp_device_global = full_config.setdefault("BGP_DEVICE_GLOBAL", {})
+                bgp_device_global["CONFED"] = {
+                    "asn": str(self.bgp_confd_asn),
+                    "peers": str(self.bgp_confd_peers).replace(' ', ';')
+                }
+
+        return json.dumps(full_config, indent=4)
+
     def generate_t2_golden_config_db(self):
         with open(MACSEC_PROFILE_PATH) as f:
             macsec_profiles = json.load(f)
@@ -757,18 +865,23 @@ class GenerateGoldenConfigDBModule(object):
             self.module.fail_json(
                 msg="Invalid zebra_nexthop value '{}': must be 'enabled' or 'disabled'".format(zebra_nexthop))
         ori_config_db = json.loads(config)
-        if "DEVICE_METADATA" not in ori_config_db or \
-                "localhost" not in ori_config_db["DEVICE_METADATA"]:
-            # When DEVICE_METADATA is absent from the golden config (e.g. T0/T1
-            # topologies), do not inject a minigraph-derived entry here.
-            # config_reload.py already restores zebra_nexthop via an additive
-            # hset after every minigraph-based config reload, so no golden-config
-            # override is needed.  Injecting a full minigraph entry here would
-            # cause config override-config-table (which uses set_entry / REPLACE
-            # semantics) to wipe fields such as default_pfcwd_status that are
-            # present in the running config_db but absent from minigraph output.
-            return config
-        ori_config_db["DEVICE_METADATA"]["localhost"]["zebra_nexthop"] = zebra_nexthop
+        if self.num_asics > 1:
+            ori_config_db = self._update_config_db_in_ns(
+                ori_config_db, "DEVICE_METADATA/localhost",
+                {"zebra_nexthop": zebra_nexthop})
+        else:
+            if "DEVICE_METADATA" not in ori_config_db or \
+                    "localhost" not in ori_config_db["DEVICE_METADATA"]:
+                # When DEVICE_METADATA is absent from the golden config (e.g. T0/T1
+                # topologies), do not inject a minigraph-derived entry here.
+                # config_reload.py already restores zebra_nexthop via an additive
+                # hset after every minigraph-based config reload, so no golden-config
+                # override is needed.  Injecting a full minigraph entry here would
+                # cause config override-config-table (which uses set_entry / REPLACE
+                # semantics) to wipe fields such as default_pfcwd_status that are
+                # present in the running config_db but absent from minigraph output.
+                return config
+            ori_config_db["DEVICE_METADATA"]["localhost"]["zebra_nexthop"] = zebra_nexthop
         return json.dumps(ori_config_db, indent=4)
 
     def generate_lt2_ft2_golden_config_db(self):


### PR DESCRIPTION
### Description of PR

Manual backport of #24157 to the `202511` branch. The automated cherry-pick could not be applied because `ansible/library/generate_golden_config_db.py` has diverged between `master` and `202511`, so this PR carries the conflicts resolved by hand.

This adds golden_config_db generation for the UT2 (single-node T2) topology by introducing the UT2-specific helpers — `generate_ut2_golden_config_db`, `_render_macsec_config`, `_update_config_db_in_ns`, `get_config_from_minigraph_multiasic`, and `get_port_config_path` — and by adding multi-ASIC awareness to `update_zebra_nexthop_config`.

**Conflict resolution notes (for reviewers):**
- The cherry-pick surfaced `update_zmq_config` and `generate_default_init_config_db` as incoming context; those methods are **not** part of #24157 (they come from other master-only PRs not present on `202511`), so they were intentionally **not** imported here to keep this backport scoped to #24157.
- For `update_zebra_nexthop_config`, `202511` already had a refined single-ASIC guard (protecting `default_pfcwd_status` during override-config). This was preserved as the single-ASIC `else` branch, with #24157's `num_asics > 1` multi-ASIC branch added on top.
- The new `generate_ut2_golden_config_db` is defined but not yet dispatched here — the `t2_single_node` dispatch wiring lands in the follow-up backport of #24415 (stacked on this PR), matching the original master sequence.

Summary:
Backport of #24157 to `202511`. Depends on nothing; follow-up #24415 backport stacks on top.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: <!-- add the GitHub issue / ADO work item that requested the 202511 backport -->
Failure type: other (feature enablement for UT2 single-node T2 testbeds on 202511)

### Approach
#### What is the motivation for this PR?

UT2 (single-node T2) testbeds running the `202511` image need golden_config_db generation support, including multi-ASIC handling for `zebra_nexthop`. This capability exists on `master` (via #24157/#24415) but was never backported to `202511`.

#### How did you do it?

Cherry-picked #24157 (`8137897e94`) onto `202511` and resolved the two conflicts as described above: kept the backport scoped to UT2 (excluded unrelated `update_zmq_config`/`generate_default_init_config_db`), and merged the multi-ASIC `zebra_nexthop` branch with `202511`'s existing refined single-ASIC guard.

#### How did you verify/test it?

- Confirmed the resolved file passes a Python syntax/parse check (`ast.parse`).
- Verified `generate_ut2_golden_config_db` only depends on methods present after this change (`get_config_from_minigraph_multiasic`, `get_config_from_minigraph`, `_render_macsec_config`), keeping the backport self-consistent.
- Confirmed the resolution mirrors the master intent: methods added here, dispatch wired in the stacked #24415 backport.

#### Any platform specific information?

Targets UT2 single-node T2 topologies (e.g. NH-5010 multi-ASIC VoQ). Multi-ASIC paths use `_update_config_db_in_ns`.

#### Supported testbed topology if it's a new test case?

N/A (framework/testbed change; applies to `t2_single_node` topologies).

### Documentation

N/A — no new user-facing feature or wiki changes.
