### PR TITLE
Fix test_iface_namingmode.py Ethernet0 / TestAlias0 in bad state

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -83,13 +83,22 @@ def setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
     up_ports = list(minigraph_facts['minigraph_ports'].keys())
     default_interfaces = list(port_alias_facts['port_name_map'].keys())
     minigraph_portchannels = minigraph_facts['minigraph_portchannels']
-    port_speed_facts = port_alias_facts['port_speed']
-    if not port_speed_facts:
-        all_vars = duthost.host.options['variable_manager'].get_vars()
-        iface_speed = all_vars['hostvars'][duthost.hostname]['iface_speed']
-        iface_speed = str(iface_speed)
-        port_speed_facts = {_: iface_speed for _ in
-                            list(port_alias_facts['port_alias_map'].keys())}
+    # Read the configured speed from CONFIG_DB rather than port_config.ini.
+    # port_alias_facts['port_speed'] reflects the hardware default in
+    # port_config.ini which the minigraph routinely overrides to match
+    # the connected fanout (e.g. 400G). Using the hardware default as
+    # `native_speed` causes test_config_interface_speed to
+    # "restore" the port to a speed the fanout does not support, leaving the
+    # link oper-down for every subsequent test on that port.
+    port_speed_by_intf = {}
+    for intf in default_interfaces:
+        asic = duthost.asic_instance(duthost.get_port_asic_instance(intf).asic_index)
+        speed = duthost.command(
+            'sudo {} CONFIG_DB HGET "PORT|{}" speed'.format(asic.sonic_db_cli, intf)
+        )['stdout'].strip()
+        if speed:
+            port_speed_by_intf[intf] = speed
+    port_speed_fallback = port_alias_facts['port_speed'] or {}
 
     port_alias = list()
     port_name_map = dict()
@@ -105,7 +114,8 @@ def setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
         port_alias.append(port_alias_new)
         port_name_map[item] = port_alias_new
         port_alias_map[port_alias_new] = item
-        port_speed[port_alias_new] = port_speed_facts[port_alias_old]
+        port_speed[port_alias_new] = (port_speed_by_intf.get(item)
+                                      or port_speed_fallback.get(port_alias_old))
 
         # sonic-db-cli command
         db_cmd = 'sudo {} CONFIG_DB HSET "PORT|{}" alias {}'\
@@ -1264,7 +1274,8 @@ class TestConfigInterface():
                       "LLDP neighbor should exist for interface {}".format(test_intf))
 
     def test_config_interface_speed(self, setup_config_mode, sample_intf,
-                                    duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                    duthosts, fanouthosts,
+                                    enum_rand_one_per_hwsku_frontend_hostname,
                                     ignore_host_lane_count_loganalyzer):
         """
         Checks whether 'config interface speed <intf> <speed>' sets
@@ -1286,6 +1297,14 @@ class TestConfigInterface():
         # testbed is configured at a non-platform-default speed.
         if supported_speeds is not None and native_speed in supported_speeds:
             supported_speeds.remove(native_speed)
+            # Skip speeds the connected fanout will not negotiate. A mismatch
+            # leaves the link oper-down past the test, breaking every
+            # subsequent test on this port.
+            fanout, fanout_port = fanout_switch_port_lookup(
+                fanouthosts, duthost.hostname, interface)
+            if fanout is not None:
+                fanout_speeds = fanout.get_supported_speeds(fanout_port) or []
+                supported_speeds = [s for s in supported_speeds if s in fanout_speeds]
         # Set speed to configure
         configure_speed = supported_speeds[0] if supported_speeds else native_speed
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/26245
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

Three iface_namingmode tests fail on NH-4220 testbed with assertions tied to Ethernet0 (alias TestAlias0).

Noticed that during the test run, the DUT's `Ethernet0` speed gets changed to 1600G

```
admin@abcd156:/usr/share/sonic/platform$ show interfaces status Ethernet0
  Interface                   Lanes    Speed    MTU    FEC       Alias    Vlan    Oper    Admin                           Type    Asym PFC
-----------  ----------------------  -------  -----  -----  ----------  ------  ------  -------  -----------------------------  ----------
  Ethernet0  9,10,11,12,13,14,15,16    1600G   9100     rs  TestAlias0  routed    down       up  OSFP 8X Pluggable Transceiver         off
```
while the fanout side remains at 400G
```
admin@abcd412:~$ show interfaces status
  Interface                            Lanes    Speed    MTU    FEC     Alias    Vlan    Oper    Admin                           Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  --------  ------  ------  -------  -----------------------------  ----------
  Ethernet0           9,10,11,12,13,14,15,16     400G   9100     rs     Port1   trunk    down       up  OSFP 8X Pluggable Transceiver         N/A
  Ethernet8                  1,2,3,4,5,6,7,8     400G   9100     rs     Port2   trunk      up       up  OSFP 8X Pluggable Transceiver         N/A
 Ethernet16          25,26,27,28,29,30,31,32     400G   9100     rs     Port3   trunk      up       up  OSFP 8X Pluggable Transceiver         N/A
 Ethernet24          17,18,19,20,21,22,23,24     400G   9100     rs     Port4   trunk      up       up  OSFP 8X Pluggable Transceiver         N/A
 Ethernet32          41,42,43,44,45,46,47,48     400G   9100     rs     Port5   trunk      up       up  OSFP 8X Pluggable Transceiver         N/A
 Ethernet40          33,34,35,36,37,38,39,40     400G   9100     rs     Port6   trunk      up       up  OSFP 8X Pluggable Transceiver         N/A
 Ethernet48          57,58,59,60,61,62,63,64     400G   9100     rs     Port7   trunk      up       up  OSFP 8X Pluggable Transceiver         N/A
 Ethernet56          49,50,51,52,53,54,55,56     400G   9100     rs     Port8   trunk      up       up  OSFP 8X Pluggable Transceiver         N/A
```

The following sequence is the root cause
- `sample_intf['native_speed']` is sourced from `setup['port_speed']`, which reads `port_config.ini` via the
   `port_alias` Ansible module.
- On `NH-4220`, `port_config.ini` lists `Ethernet0` at `1600000` (hardware default). The minigraph configures the port at `400000` to match the fanout. The test never reads `CONFIG_DB`, so `native_speed !=  actual configured speed`.
- The test picks a `configure_speed` from `supported_speeds` excluding native (→ 400000), runs `config interface speed Ethernet0 400000` (no-op, already 400G), then "restores" to native by running `config interface speed Ethernet0 1600000`.
- Test asserts CONFIG_DB equals 1600000 which passes, no link-up check. Port now at 1600G; fanout still 400G → oper-down.

#### How did you do it?

- `setup` fixture sources per-port `native_speed` from CONFIG_DB instead of `port_alias_facts['port_speed']`
- Added fanouthosts parameter to `test_config_interface_speed` and filtered the candidate configure_speed list to only speeds the connected fanout also supports.

#### How did you verify/test it?

Verified the test case passes on multiple Nexthop DUTs

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
