### PR TITLE
[route][dualtor] Backport #25579: skip test_static_route warm reboot cases on dualtor (202605)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4870,11 +4870,29 @@ route/test_static_route.py::test_static_route_ecmp_ipv6:
       - "release in ['201811', '201911']"
       - "'standalone' in topo_name"
 
+route/test_static_route.py::test_static_route_ecmp_warmboot:
+  skip:
+    reason: "Warm reboot is not supported on dualtor topology"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+
 route/test_static_route.py::test_static_route_ipv6:
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
+
+route/test_static_route.py::test_static_route_ipv6_warmboot:
+  skip:
+    reason: "Warm reboot is not supported on dualtor topology"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+
+route/test_static_route.py::test_static_route_warmboot:
+  skip:
+    reason: "Warm reboot is not supported on dualtor topology"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
 
 #######################################
 #####           sai_qualify       #####


### PR DESCRIPTION
### Description of PR
Backport of #25579 to the `202605` branch.

### Summary
Warm reboot is not supported on dualtor topology. On `202605`, `route/test_static_route.py::test_static_route_warmboot`, `test_static_route_ecmp_warmboot` and `test_static_route_ipv6_warmboot` are missing their conditional_mark skip, so they run on **Cisco 8101C01-C32 dualtor** nightly and fail with:

```
AssertionError: Did not receive expected packet on any of ports [11] for device 0
```

Master already skips these on dualtor for all platforms via #25579, which:
- removed the `asic_type in ['mellanox', 'nvidia']` restriction originally added by #23612 (mellanox-only), and
- added the bare `test_static_route_warmboot` key.

This backport brings the same three skip entries to `202605` so the cases are correctly skipped on Cisco dualtor as well.

### Type of change
- [x] Test case (new/improvement)

### Approach
Cherry-pick of the conditional_mark changes from #25579 (`route/test_static_route.py` warmboot cases), applied to `202605`.

Related nightly PBI: 38791679 (Cisco 8101C01-C32 dualtor, 20260510).