### PR TITLE
fix bgp update timer wrong ipv6 prefix filter

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -65,7 +65,7 @@ WAIT_TIMEOUT = 120
 
 def _apply_outbound_route_filter(duthost, dut_asn, neighbor_ips, is_v6, namespace=DEFAULT_NAMESPACE):
     """Apply an outbound route-map to ExaBGP neighbors so the DUT only
-    advertises the test prefixes (10.10.100.0/24 or fc00:10::/44) instead
+    advertises the test prefixes (10.10.100.0/24 or fc00:10::/28) instead
     of the full routing table.  Without this, ExaBGP sessions flap on
     topologies where the test neighbors share routed interfaces with real
     BGP peers (e.g. M0 L3 scenario).
@@ -73,8 +73,8 @@ def _apply_outbound_route_filter(duthost, dut_asn, neighbor_ips, is_v6, namespac
     See: https://github.com/sonic-net/sonic-mgmt/issues/22391
     """
     if is_v6:
-        # Cover fc00:10::/64 through fc00:14::/64 (and the whole fc00:10::/44 block)
-        prefix_match = "fc00:10::/44 le 64"
+        # Cover fc00:10::/64 through fc00:14::/64 (and the whole fc00:10::/28 block)
+        prefix_match = "fc00:10::/28 le 64"
     else:
         prefix_match = "10.10.100.0/24 le 32"
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)

This fix is for PR https://github.com/sonic-net/sonic-mgmt/pull/22924.

Which added this ipv6 prefix match in tests/bgp/test_bgp_update_timer.py → _apply_outbound_route_filter():
    if is_v6:
        # Cover fc00:10::/64 through fc00:14::/64 (and the whole fc00:10::/44 block)
        prefix_match = "fc00:10::/44 le 64" <- BUG
    else:

Below is how the bug happened:
- The test announces fc00:10::/64 … fc00:14::/64, which differ in the 2nd hextet
- A /44 boundary lands inside the 3rd hextet, so it fixes the whole 2nd hextet to 0x0010 → the prefix-list matches only fc00:10::/64. The fix is to apply the correct aggregate /28, which cover fc00:001
- fc00:11–14:: don't match → route-map deny 20 drops them → the DUT correctly withholds them from the ExaBGP neighbor → test fails (no bgp update announce … fc00:11::/64).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
fix a bug
#### How did you do it?
update with the right prefix in ipv6 scenario
#### How did you verify/test it?
after the fix, the test can pass on ipv6 only topo
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation