### PR TITLE
[dhcp_relay] Fix dual-ToR expectations in test_dhcp_relay_default

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -205,7 +205,8 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 0: Suboption number, always set to 2
         #  Byte 1: Length of suboption data in bytes
         #  Bytes 2+: Suboption data
-        # Our remote_id string simply consists of the MAC address of the port that received the request
+        # remote_id (suboption 2) is the switch base MAC. On dual-ToR the VLAN carries a virtual MAC,
+        # so the relay stamps the base MAC (uplink_mac); on single-ToR relay_iface_mac already equals it.
         remote_id_string = self.uplink_mac if self.dual_tor else self.relay_iface_mac
         self.option82 += struct.pack('BB', self.REMOTE_ID_SUBOPTION, len(remote_id_string))
         self.option82 += remote_id_string.encode('utf-8')

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -218,8 +218,14 @@ class DHCPTest(DataplaneBaseTest):
             #  Byte 0: Suboption number, always set to 5
             #  Byte 1: Length of suboption data (4 bytes for IPv4)
             #  Bytes 2–5: The link selection IP address (in byte format)
-            if (self.link_selection and self.source_interface) or self.server_vrf:
-                link_selection_ip = bytes(list(map(int, self.link_selection_ip.split('.'))))
+            # The relay (sonic-dhcp-relay dhcp4relay.cpp) encodes link-selection (SubOption 5)
+            # when is_dualTor OR link-selection is enabled, BEFORE SubOption 11 (server-override),
+            # with value = link_address & netmask (the VLAN subnet network address). Match that here
+            # so dual-tor (incl. server_id_override) runs no longer byte-mismatch on order/value.
+            if self.dual_tor or (self.link_selection and self.source_interface) or self.server_vrf:
+                ip_octets = list(map(int, self.relay_iface_ip.split('.')))
+                mask_octets = list(map(int, self.test_params['relay_iface_netmask'].split('.')))
+                link_selection_ip = bytes([ip_octets[i] & mask_octets[i] for i in range(4)])
                 self.option82 += struct.pack('BB', self.LINK_SELECTION_SUBOPTION, 4)
                 self.option82 += link_selection_ip
                 link_selection_added = True
@@ -250,8 +256,9 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 0: Suboption number, always set to 5
         #  Byte 1: Length of suboption data in bytes, always set to 4 (ipv4 addr has 4 bytes)
         #  Bytes 2+: vlan ip addr
-        # Relay emits link-selection (SubOption 5) once; skip this legacy dual-tor
-        # copy if the block above already added it (see commit msg).
+        # Legacy dual-tor SubOption 5, now only for the non-sonic-relay-agent (isc) path:
+        # the sonic-relay-agent block above already adds SubOption 5 for dual-tor (setting
+        # link_selection_added), so this only runs when that gate was not entered (isc).
         if self.dual_tor and not link_selection_added:
             link_selection = bytes(
                 list(map(int, self.relay_iface_ip.split('.'))))

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -176,9 +176,6 @@ class DHCPTest(DataplaneBaseTest):
         self.max_hop_count = self.test_params.get('max_hop_count', None)
         self.client_vrf = self.test_params.get('client_vrf', None)
         self.dhcpv4_disable_flag = self.test_params.get('dhcpv4_disable_flag', None)
-        if self.relay_agent == "sonic-relay-agent":
-            if (self.link_selection and self.source_interface) or self.server_vrf:
-                self.link_selection_ip = self.test_params['link_selection_ip']
 
         self.uplink_mac = self.test_params['uplink_mac']
 

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -182,6 +182,10 @@ class DHCPTest(DataplaneBaseTest):
         # 'dual' for dual tor testing
         # 'single' for regular single tor testing
         self.dual_tor = (self.test_params['testing_mode'] == 'dual')
+        self.sonic_reply_uses_option82 = (
+            self.relay_agent == "sonic-relay-agent"
+            and (self.dual_tor or (self.link_selection and self.source_interface))
+        )
         self.vlan_iface_name = self.test_params.get('downlink_vlan_iface_name', None)
 
         # option82 is a byte string created by the relay agent. It contains the circuit_id and remote_id fields.
@@ -822,7 +826,7 @@ class DHCPTest(DataplaneBaseTest):
                           dhcp_lease=self.LEASE_TIME,
                           padding_bytes=0,
                           set_broadcast_bit=True)
-        if (self.link_selection and self.source_interface):
+        if (self.link_selection and self.source_interface) or self.sonic_reply_uses_option82:
             dhcp_ack_packet[scapy.DHCP].options.insert(
                 dhcp_ack_packet[scapy.DHCP].options.index("end"),
                 (82, self.option82)
@@ -876,7 +880,7 @@ class DHCPTest(DataplaneBaseTest):
         # if pad_bytes > 0:
         #    bootp /= scapy.PADDING('\x00' * pad_bytes)
 
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - len(bootp)
             if pad_bytes > 0:
                 bootp /= scapy.PADDING('\x00' * pad_bytes)
@@ -1104,7 +1108,7 @@ class DHCPTest(DataplaneBaseTest):
         dhcp_unknown = self.create_dhcp_offer_packet()
         logger.info("Server send unknown packet")
         dhcp_unknown[scapy.DHCP] = scapy.DHCP(options=[('message-type', 11), ('end')])
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             dhcp_unknown[scapy.DHCP].options.insert(
                     dhcp_unknown[scapy.DHCP].options.index("end"),
                     (82, self.option82)
@@ -1115,7 +1119,7 @@ class DHCPTest(DataplaneBaseTest):
     def verify_relayed_unknown_on_client_side(self):
         dhcp_offer = self.create_dhcp_offer_relayed_packet()
         dhcp_offer[scapy.DHCP] = scapy.DHCP(options=[('message-type', 11), ('end')])
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             bootp_len = len(dhcp_offer[scapy.BOOTP])
             pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - bootp_len
             if pad_bytes > 0:
@@ -1148,7 +1152,7 @@ class DHCPTest(DataplaneBaseTest):
         # Build the DHCP NAK packet
         packet = self.create_dhcp_ack_packet()
         packet[scapy.DHCP] = scapy.DHCP(options=[('message-type', 'nak'), ('server_id', self.server_ip[0]), ('end')])
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             packet[scapy.DHCP].options.insert(
                     packet[scapy.DHCP].options.index("end"),
                     (82, self.option82)
@@ -1159,7 +1163,7 @@ class DHCPTest(DataplaneBaseTest):
     def verify_relayed_nak(self):
         dhcp_nak = self.create_dhcp_ack_relayed_packet()
         dhcp_nak[scapy.DHCP] = scapy.DHCP(options=[('message-type', 'nak'), ('server_id', self.server_ip[0]), ('end')])
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             bootp_len = len(dhcp_nak[scapy.BOOTP])
             pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - bootp_len
             if pad_bytes > 0:

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -202,9 +202,10 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 0: Suboption number, always set to 2
         #  Byte 1: Length of suboption data in bytes
         #  Bytes 2+: Suboption data
-        # remote_id (suboption 2) is the switch base MAC. On dual-ToR the VLAN carries a virtual MAC,
-        # so the relay stamps the base MAC (uplink_mac); on single-ToR relay_iface_mac already equals it.
-        remote_id_string = self.uplink_mac if self.dual_tor else self.relay_iface_mac
+        # sonic-relay-agent stamps the switch base MAC on dual-ToR, where the VLAN has a virtual MAC.
+        # ISC stamps the receiving VLAN interface MAC.
+        use_switch_mac = self.dual_tor and self.relay_agent == "sonic-relay-agent"
+        remote_id_string = self.uplink_mac if use_switch_mac else self.relay_iface_mac
         self.option82 += struct.pack('BB', self.REMOTE_ID_SUBOPTION, len(remote_id_string))
         self.option82 += remote_id_string.encode('utf-8')
 

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -1050,7 +1050,10 @@ class DHCPTest(DataplaneBaseTest):
         else:
             source_ip = self.portchannels_ip_list[0]
 
-        if ((self.link_selection and self.source_interface) or self.server_vrf or self.dual_tor):
+        # ISC sets BOOTP giaddr to the incoming VLAN interface address, including on dual-ToR.
+        if self.relay_agent == "isc-relay-agent":
+            giaddr = self.relay_iface_ip
+        elif ((self.link_selection and self.source_interface) or self.server_vrf or self.dual_tor):
             giaddr = self.switch_loopback_ip
         elif self.server_id_override or not self.dual_tor:
             giaddr = self.relay_iface_ip

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -211,6 +211,8 @@ class DHCPTest(DataplaneBaseTest):
         self.option82 += struct.pack('BB', self.REMOTE_ID_SUBOPTION, len(remote_id_string))
         self.option82 += remote_id_string.encode('utf-8')
 
+        link_selection_added = False  # set below; dual-tor block skips SubOption 5 if set
+
         if self.relay_agent == "sonic-relay-agent":
             # Structure:
             #  Byte 0: Suboption number, always set to 5
@@ -220,6 +222,7 @@ class DHCPTest(DataplaneBaseTest):
                 link_selection_ip = bytes(list(map(int, self.link_selection_ip.split('.'))))
                 self.option82 += struct.pack('BB', self.LINK_SELECTION_SUBOPTION, 4)
                 self.option82 += link_selection_ip
+                link_selection_added = True
 
             # The structure is as follows:
             #  Byte 0: Suboption number, always set to 11
@@ -247,11 +250,14 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 0: Suboption number, always set to 5
         #  Byte 1: Length of suboption data in bytes, always set to 4 (ipv4 addr has 4 bytes)
         #  Bytes 2+: vlan ip addr
-        if self.dual_tor:
+        # Relay emits link-selection (SubOption 5) once; skip this legacy dual-tor
+        # copy if the block above already added it (see commit msg).
+        if self.dual_tor and not link_selection_added:
             link_selection = bytes(
                 list(map(int, self.relay_iface_ip.split('.'))))
             self.option82 += struct.pack('BB', self.LINK_SELECTION_SUBOPTION, 4)
             self.option82 += link_selection
+            link_selection_added = True
 
         # We'll assign our client the IP address 1 greater than our relay interface (i.e., gateway) IP
         self.client_ip = incrementIpAddress(self.relay_iface_ip, 1)

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -206,7 +206,7 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 1: Length of suboption data in bytes
         #  Bytes 2+: Suboption data
         # Our remote_id string simply consists of the MAC address of the port that received the request
-        remote_id_string = self.relay_iface_mac
+        remote_id_string = self.uplink_mac if self.dual_tor else self.relay_iface_mac
         self.option82 += struct.pack('BB', self.REMOTE_ID_SUBOPTION, len(remote_id_string))
         self.option82 += remote_id_string.encode('utf-8')
 


### PR DESCRIPTION
### Description of PR

Summary:
Fix dual-ToR PTF packet expectations exercised by
`dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default`.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38538173

The test was failing for both relay implementations on the 202605 nightly:

- ISC BOOTP relays use the incoming VLAN address as `giaddr`; the PTF expected
  the dual-ToR Loopback address.
- SONiC relay packets use the switch base MAC for Option 82 Remote-ID, emit one
  correctly ordered Link-Selection suboption, and echo Option 82 in replies;
  the PTF modeled different bytes.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
https://msazure.visualstudio.com/One/_workitems/edit/38538173

Failure type: regression

### Approach
#### What is the motivation for this PR?

The shared PTF DHCP packet model did not match either relay implementation on
dual-ToR. The resulting byte mismatches appeared as missing relayed packets even
though the DUT forwarded them.

#### How did you do it?

- Preserve ISC's VLAN-based BOOTP `giaddr` expectation.
- Use the switch base MAC for SONiC relay Option 82 Remote-ID on dual-ToR.
- Build one Link-Selection suboption with the relay's value and ordering.
- Scope the base-MAC expectation to the SONiC relay implementation.
- Expect SONiC dual-ToR replies to echo Option 82.

#### How did you verify/test it?

Ran the exact test through `run_tests.sh` on
`testbed-bjw3-can-dual-t0-7260-2`, with both DUTs running
`SONiC-OS-20260510.05`:

- `test_dhcp_relay_default[isc-relay-agent]`: passed
- `test_dhcp_relay_default[sonic-relay-agent]`: passed
- Overall: 2 passed, exit 0

#### Any platform specific information?

The corrected expectations are specific to dual-ToR behavior.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.
