### PR TITLE
chore: enable pc VPP tests p2

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -482,14 +482,6 @@ override_config_table/test_override_config_table.py::test_load_minigraph_with_go
 #######################################
 #####          PC                 #####
 #######################################
-pc/test_lag_member_forwarding.py::test_lag_member_forwarding_packets:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
 pc/test_po_cleanup.py::test_po_cleanup_after_reload:
   disable_memory_utilization:
     reason: >

--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -268,7 +268,7 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
         )
         logger.info("All LAG members of %s confirmed disabled in ASIC_DB", portchannel_name)
 
-        if duthost.facts['asic_type'] == "vs":
+        if duthost.facts['asic_type'].lower() in ["vs", "vpp"]:
             # VS SAI populates ASIC_DB but the Linux kernel teamdev doesn't
             # enforce LAG member disable in the dataplane, so packets still flow.
             # Skip traffic and BGP verification on VS.

--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -268,7 +268,7 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
         )
         logger.info("All LAG members of %s confirmed disabled in ASIC_DB", portchannel_name)
 
-        if duthost.facts['asic_type'].lower() in ["vs", "vpp"]:
+        if duthost.facts['asic_type'] == "vs":
             # VS SAI populates ASIC_DB but the Linux kernel teamdev doesn't
             # enforce LAG member disable in the dataplane, so packets still flow.
             # Skip traffic and BGP verification on VS.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Part 2 of enabling PortChannel (PC) tests on VPP testbeds.

This PR enables the `pc/test_lag_member_forwarding.py` test on VPP, which depends on https://github.com/sonic-net/sonic-sairedis/pull/1928

Fixes # (issue): https://github.com/sonic-net/sonic-buildimage/issues/25771

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

