### PR TITLE
Add 2 cli (shutdown and startup) into cli helper for system-link_behavior test case

### DIFF
--- a/tests/transceiver/common/cli_helpers.py
+++ b/tests/transceiver/common/cli_helpers.py
@@ -64,6 +64,10 @@ SFPUTIL_SHOW_FWVERSION = "sfputil show fwversion"
 SFPUTIL_SHOW_PRESENCE = "sfputil show presence"
 SHOW_TRANSCEIVER_INFO = "show interfaces transceiver info"
 SHOW_TRANSCEIVER_PRESENCE = "show interfaces transceiver presence"
+# Unlike sfputil, "config interface" needs root; matches the pre-existing
+# "sudo config interface ..." convention in tests/common/devices/multi_asic.py
+# and tests/common/devices/sonic_asic.py.
+CONFIG_INTERFACE = "sudo config interface"
 
 # Max characters of stdout/stderr echoed into a failure message.  Some sfputil
 # errors dump the full 500+ port list, which would bury the failure summary in
@@ -90,6 +94,12 @@ CLI_ERROR_DETAIL_MAX_CHARS = 200
 # hardware from the port name alone, so no ASIC scoping is needed.  (Note
 # ``sfputil read-eeprom``/``eeprom-hexdump`` do use ``-n``, but it is the
 # ``--page`` option, unrelated to namespaces.)
+#
+# ``config interface`` places its ``-n <namespace>`` BEFORE the startup/shutdown
+# subcommand (``config interface -n asic0 shutdown Ethernet0``), unlike the
+# ``show``/``sfputil`` families above which append ``-n`` at the end — hence the
+# separate flag placement in ``config_interface_shutdown_cmd``/``_startup_cmd``
+# below rather than reuse of ``_ns_flag``.
 # ──────────────────────────────────────────────────────────────────────
 
 
@@ -179,9 +189,41 @@ def show_interfaces_transceiver_presence_cmd(port=None, namespace=None):
     return cmd
 
 
+def config_interface_shutdown_cmd(port, namespace=None):
+    """Return ``sudo config interface [-n <namespace>] shutdown <port>``."""
+    ns = f" -n {namespace}" if namespace else ""
+    return f"{CONFIG_INTERFACE}{ns} shutdown {port}"
+
+
+def config_interface_startup_cmd(port, namespace=None):
+    """Return ``sudo config interface [-n <namespace>] startup <port>``."""
+    ns = f" -n {namespace}" if namespace else ""
+    return f"{CONFIG_INTERFACE}{ns} startup {port}"
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Parsed wrappers (run + rc check + empty check + parse → (parsed, err))
 # ──────────────────────────────────────────────────────────────────────
+
+
+def _cli_failure_detail(cmd, result):
+    """Format a short single-line failure string for a non-zero-rc CLI result.
+
+    sfputil writes its error text to STDOUT (not stderr) on a non-zero exit —
+    verified on hardware: ``Error: invalid port ...`` and ``Root privileges are
+    required`` both land on stdout with an empty stderr.  The message therefore
+    surfaces stdout (and stderr too, for any command that does use it); both
+    are truncated because some sfputil errors dump the full 500+ port list.
+    """
+    stdout = " ".join(result.get("stdout_lines") or []).strip()
+    stderr = (result.get("stderr") or "").strip()
+    parts = []
+    if stdout:
+        parts.append(f"stdout: {stdout[:CLI_ERROR_DETAIL_MAX_CHARS]}")
+    if stderr:
+        parts.append(f"stderr: {stderr[:CLI_ERROR_DETAIL_MAX_CHARS]}")
+    detail = "; ".join(parts) if parts else "no stdout/stderr"
+    return f"{cmd} failed with rc={result.get('rc')} ({detail})"
 
 
 def _run_and_parse(duthost, cmd, parser=None):
@@ -196,41 +238,40 @@ def _run_and_parse(duthost, cmd, parser=None):
     ``cmd`` is echoed verbatim into the error message, so it doubles as the
     human-readable label (e.g. ``sfputil show eeprom -p Ethernet0``).
 
-    sfputil writes its error text to STDOUT (not stderr) on a non-zero exit —
-    verified on hardware: ``Error: invalid port ...`` and ``Root privileges are
-    required`` both land on stdout with an empty stderr.  The failure message
-    therefore surfaces stdout (and stderr too, for any command that does use
-    it); both are truncated because some sfputil errors dump the full 500+ port
-    list.
-
     Contract note: on rc 0 this intentionally does NOT gate on the parser
     recognizing any rows — non-zero rc and empty stdout are the only failure
-    signals here.  A command that exits 0 while printing an unparseable error
+    signals here. A command that exits 0 while printing an unparseable error
     banner returns ``(parser(stdout_lines), None)`` (typically an empty / rowless
     result); catching that is the caller's responsibility via the suite-wide
     per-port aggregation — the per-port tests treat a missing ``parsed[port]`` /
     field as a failure, and TC8 (``test_error_handling.py``) compares the parsed
     status against the exact ``"Not present"`` / ``"SFP EEPROM not detected"``
-    tokens.  Keeping the "recognized row" check in the callers lets this pipeline
+    tokens. Keeping the "recognized row" check in the callers lets this pipeline
     stay generic across the CLIs' differing output shapes.
     """
     result = duthost.command(cmd, module_ignore_errors=True)
     if result.get("rc", RC_FAILURE) != 0:
-        stdout = " ".join(result.get("stdout_lines") or []).strip()
-        stderr = (result.get("stderr") or "").strip()
-        parts = []
-        if stdout:
-            parts.append(f"stdout: {stdout[:CLI_ERROR_DETAIL_MAX_CHARS]}")
-        if stderr:
-            parts.append(f"stderr: {stderr[:CLI_ERROR_DETAIL_MAX_CHARS]}")
-        detail = "; ".join(parts) if parts else "no stdout/stderr"
-        return None, f"{cmd} failed with rc={result.get('rc')} ({detail})"
+        return None, _cli_failure_detail(cmd, result)
     stdout_lines = result.get("stdout_lines", [])
     if not stdout_lines:
         return None, f"{cmd} returned empty output"
     if parser is None:
         return stdout_lines, None
     return parser(stdout_lines), None
+
+
+def _run_config_cmd(duthost, cmd):
+    """Run a ``config`` CLI command that produces no stdout on success.
+
+    Returns ``None`` on rc 0, else a short single-line failure string (see
+    ``_cli_failure_detail``). Unlike ``_run_and_parse``, empty stdout is NOT
+    treated as a failure here: a successful ``config interface shutdown`` /
+    ``startup`` intentionally produces no output.
+    """
+    result = duthost.command(cmd, module_ignore_errors=True)
+    if result.get("rc", RC_FAILURE) != 0:
+        return _cli_failure_detail(cmd, result)
+    return None
 
 
 def sfputil_show_eeprom(duthost, port=None):
@@ -285,3 +326,24 @@ def show_interfaces_transceiver_info(duthost, port=None, namespace=None):
     """Run ``show interfaces transceiver info [-n <ns>] [<port>]`` → ``({port: {field: value}}, err)``."""
     cmd = show_interfaces_transceiver_info_cmd(port, namespace=namespace)
     return _run_and_parse(duthost, cmd, parse_eeprom)
+
+
+def config_interface_shutdown(duthost, port, namespace=None):
+    """Run ``sudo config interface [-n <namespace>] shutdown <port>`` → ``err``.
+
+    Returns ``None`` on success, else a short single-line failure string —
+    matching the per-port aggregation pattern used across the transceiver
+    test suite (e.g. ``err = config_interface_shutdown(...); if err: ...``).
+    """
+    cmd = config_interface_shutdown_cmd(port, namespace=namespace)
+    return _run_config_cmd(duthost, cmd)
+
+
+def config_interface_startup(duthost, port, namespace=None):
+    """Run ``sudo config interface [-n <namespace>] startup <port>`` → ``err``.
+
+    Returns ``None`` on success, else a short single-line failure string; see
+    ``config_interface_shutdown`` for the return-shape rationale.
+    """
+    cmd = config_interface_startup_cmd(port, namespace=namespace)
+    return _run_config_cmd(duthost, cmd)

--- a/tests/transceiver/common/cli_helpers.py
+++ b/tests/transceiver/common/cli_helpers.py
@@ -64,10 +64,10 @@ SFPUTIL_SHOW_FWVERSION = "sfputil show fwversion"
 SFPUTIL_SHOW_PRESENCE = "sfputil show presence"
 SHOW_TRANSCEIVER_INFO = "show interfaces transceiver info"
 SHOW_TRANSCEIVER_PRESENCE = "show interfaces transceiver presence"
-# Unlike sfputil, "config interface" needs root; matches the pre-existing
-# "sudo config interface ..." convention in tests/common/devices/multi_asic.py
-# and tests/common/devices/sonic_asic.py.
-CONFIG_INTERFACE = "sudo config interface"
+# No "sudo" prefix: the transceiver suite's pytest session already runs as
+# root on the DUT, unlike tests/common/devices/multi_asic.py / sonic_asic.py
+# (which run under a non-root ansible user and so need it).
+CONFIG_INTERFACE = "config interface"
 
 # Max characters of stdout/stderr echoed into a failure message.  Some sfputil
 # errors dump the full 500+ port list, which would bury the failure summary in
@@ -190,13 +190,13 @@ def show_interfaces_transceiver_presence_cmd(port=None, namespace=None):
 
 
 def config_interface_shutdown_cmd(port, namespace=None):
-    """Return ``sudo config interface [-n <namespace>] shutdown <port>``."""
+    """Return ``config interface [-n <namespace>] shutdown <port>``."""
     ns = f" -n {namespace}" if namespace else ""
     return f"{CONFIG_INTERFACE}{ns} shutdown {port}"
 
 
 def config_interface_startup_cmd(port, namespace=None):
-    """Return ``sudo config interface [-n <namespace>] startup <port>``."""
+    """Return ``config interface [-n <namespace>] startup <port>``."""
     ns = f" -n {namespace}" if namespace else ""
     return f"{CONFIG_INTERFACE}{ns} startup {port}"
 
@@ -329,7 +329,7 @@ def show_interfaces_transceiver_info(duthost, port=None, namespace=None):
 
 
 def config_interface_shutdown(duthost, port, namespace=None):
-    """Run ``sudo config interface [-n <namespace>] shutdown <port>`` → ``err``.
+    """Run ``config interface [-n <namespace>] shutdown <port>`` → ``err``.
 
     Returns ``None`` on success, else a short single-line failure string —
     matching the per-port aggregation pattern used across the transceiver
@@ -340,7 +340,7 @@ def config_interface_shutdown(duthost, port, namespace=None):
 
 
 def config_interface_startup(duthost, port, namespace=None):
-    """Run ``sudo config interface [-n <namespace>] startup <port>`` → ``err``.
+    """Run ``config interface [-n <namespace>] startup <port>`` → ``err``.
 
     Returns ``None`` on success, else a short single-line failure string; see
     ``config_interface_shutdown`` for the return-shape rationale.

--- a/tests/transceiver/common/cli_helpers.py
+++ b/tests/transceiver/common/cli_helpers.py
@@ -64,9 +64,7 @@ SFPUTIL_SHOW_FWVERSION = "sfputil show fwversion"
 SFPUTIL_SHOW_PRESENCE = "sfputil show presence"
 SHOW_TRANSCEIVER_INFO = "show interfaces transceiver info"
 SHOW_TRANSCEIVER_PRESENCE = "show interfaces transceiver presence"
-# No "sudo" prefix: the transceiver suite's pytest session already runs as
-# root on the DUT, unlike tests/common/devices/multi_asic.py / sonic_asic.py
-# (which run under a non-root ansible user and so need it).
+# No explicit "sudo" prefix: duthost.command() runs with Ansible become=True (root) on the DUT.
 CONFIG_INTERFACE = "config interface"
 
 # Max characters of stdout/stderr echoed into a failure message.  Some sfputil
@@ -97,9 +95,9 @@ CLI_ERROR_DETAIL_MAX_CHARS = 200
 #
 # ``config interface`` places its ``-n <namespace>`` BEFORE the startup/shutdown
 # subcommand (``config interface -n asic0 shutdown Ethernet0``), unlike the
-# ``show``/``sfputil`` families above which append ``-n`` at the end — hence the
-# separate flag placement in ``config_interface_shutdown_cmd``/``_startup_cmd``
-# below rather than reuse of ``_ns_flag``.
+# ``show``/``sfputil`` families above which append ``-n`` at the end — so callers
+# must insert the namespace flag in the correct position (but can still reuse
+# ``_ns_flag`` for the string itself).
 # ──────────────────────────────────────────────────────────────────────
 
 
@@ -191,14 +189,12 @@ def show_interfaces_transceiver_presence_cmd(port=None, namespace=None):
 
 def config_interface_shutdown_cmd(port, namespace=None):
     """Return ``config interface [-n <namespace>] shutdown <port>``."""
-    ns = f" -n {namespace}" if namespace else ""
-    return f"{CONFIG_INTERFACE}{ns} shutdown {port}"
+    return f"{CONFIG_INTERFACE}{_ns_flag(namespace)} shutdown {port}"
 
 
 def config_interface_startup_cmd(port, namespace=None):
     """Return ``config interface [-n <namespace>] startup <port>``."""
-    ns = f" -n {namespace}" if namespace else ""
-    return f"{CONFIG_INTERFACE}{ns} startup {port}"
+    return f"{CONFIG_INTERFACE}{_ns_flag(namespace)} startup {port}"
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -216,7 +212,7 @@ def _cli_failure_detail(cmd, result):
     are truncated because some sfputil errors dump the full 500+ port list.
     """
     stdout = " ".join(result.get("stdout_lines") or []).strip()
-    stderr = (result.get("stderr") or "").strip()
+    stderr = " ".join((result.get("stderr") or "").splitlines()).strip()
     parts = []
     if stdout:
         parts.append(f"stdout: {stdout[:CLI_ERROR_DETAIL_MAX_CHARS]}")


### PR DESCRIPTION
Added config_interface_shutdown and config_interface_startup to cli_helpers.py

This is 1 of 4 PR for  \sonic-mgmt\tests\transceiver\system\link_behavior