### PR TITLE
Adding ECN marking response time, accuracy and interface testcases

### DIFF
--- a/tests/snappi_tests/conftest.py
+++ b/tests/snappi_tests/conftest.py
@@ -94,6 +94,14 @@ def pytest_addoption(parser):
         choices=("no_front_panel_ports", "one_front_panel_port", ""),
         help="Control execution of GCU feature in Snappi Tests."
     )
+    snappi_group.addoption(
+        "--ecn-accuracy-iterations",
+        action="store",
+        type=int,
+        default=None,
+        help="Number of repetitions for test_ecn_accuracy_with_scheduler_blocking.py. "
+             "Overrides the ITERATIONS default in the test module."
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/snappi_tests/dataplane/files/helper.py
+++ b/tests/snappi_tests/dataplane/files/helper.py
@@ -1,4 +1,5 @@
 import random
+import re
 from tests.snappi_tests.dataplane.imports import *          # noqa: F403, F401, F405
 from tests.common.telemetry import UNIT_SECONDS
 from tests.common.telemetry.constants import METRIC_LABEL_TG_TRAFFIC_RATE, METRIC_LABEL_TG_FRAME_BYTES
@@ -10,6 +11,22 @@ from tests.common.gu_utils import (
     rollback_or_reload,
 )
 logger = logging.getLogger(__name__)
+
+BLOCKING_SCHEDULER = "SCHEDULER_BLOCK_DATA_PLANE"
+DRILL_DOWN_OPTION = "Custom: (2 bits at offset 126)"
+SELECTED_UD_COLS = [
+    "Egress Tracking",
+    "Tx Frames",
+    "Rx Frames",
+    "Frames Delta",
+    "Loss %",
+    "Tx Frame Rate",
+    "Rx Frame Rate",
+]
+ECN_NON_ECT = 0   # 00
+ECN_ECT1 = 1      # 01
+ECN_ECT0 = 2      # 10
+ECN_CE = 3        # 11
 
 # ==============================================================================
 #  Shared BGP convergence test helpers (test_pr_bgp_single_port_{up,down},
@@ -476,12 +493,39 @@ def create_traffic_items(config, snappi_extra_params):
         test_flow.size.fixed = traffic["frame_size"]
         test_flow.rate.percentage = traffic["line_rate"]
         if traffic.get("is_rdma", False):
-            _, ipv4 = test_flow.packet.ethernet().ipv4()
+            eth, ipv4 = test_flow.packet.ethernet().ipv4()
+            eth.pfc_queue.value = traffic["prio"]
             ipv4.priority.dscp.phb.values = [
                 ipv4.priority.dscp.phb.DEFAULT,
             ]
-            ipv4.priority.dscp.phb.value = 4
-            ipv4.priority.dscp.ecn.value = ipv4.priority.dscp.ecn.CAPABLE_TRANSPORT_1
+            ipv4.priority.dscp.phb.value = traffic["dscp_value"]
+            # ECN codepoint(s) carried in the 2 ECN bits of the IP header.
+            # Callers may pass either:
+            #   - "ecn_values": a list of codepoints transmitted as an even mix
+            #                   (used by the mixed-codepoint interference test), or
+            #   - "ecn_value":  a single codepoint. When the key is absent it
+            #                   defaults to ECT(1) so existing callers keep their
+            #                   previous behaviour; pass None (or "none") to leave
+            #                   the ECN field untouched and configure only the DSCP
+            #                   value (used for a non-ECN queue).
+            # Accepted codepoint names: "non_ect" (00), "ect0" (10),
+            # "ect1" (01) and "ce" (11).
+            ecn = ipv4.priority.dscp.ecn
+            ecn_map = {
+                "non_ect": ecn.NON_CAPABLE,               # 00
+                "ect0": ecn.CAPABLE_TRANSPORT_0,          # 10
+                "ect1": ecn.CAPABLE_TRANSPORT_1,          # 01
+                "ce": ecn.CONGESTION_ENCOUNTERED,         # 11
+            }
+            if traffic.get("ecn_values"):
+                ecn.values = [ecn_map[c] for c in traffic["ecn_values"]]
+            elif "ecn_value" in traffic:
+                codepoint = traffic["ecn_value"]
+                # None / "none" -> non-ECN flow: only the DSCP value is set.
+                if codepoint not in (None, "none"):
+                    ecn.value = ecn_map.get(codepoint, ecn.CAPABLE_TRANSPORT_1)
+            else:
+                ecn.value = ecn.CAPABLE_TRANSPORT_1
         if traffic.get("latency", False):
             # Latency Config
             test_flow.metrics.latency.enable = True
@@ -578,7 +622,7 @@ def configure_acl_for_route_withdrawl(destination_ip_list, table_name):
     return acl_dict
 
 
-def get_stats(api, stat_name, columns=None, return_type='stat_obj'):
+def get_stats(api, stat_name, columns=None, return_type='stat_obj'):   # noqa F811
     """
     Args:
         api (pytest fixture): Snappi API
@@ -591,6 +635,7 @@ def get_stats(api, stat_name, columns=None, return_type='stat_obj'):
         except AttributeError:
             return default
     request = api.metrics_request()
+    logger.info("Fetching {}...".format(stat_name))
     if stat_name == "Data Plane Port Statistics":
         ixnet = api._ixnetwork
         dp_metrics = StatViewAssistant(ixnet, stat_name)
@@ -623,6 +668,9 @@ def get_stats(api, stat_name, columns=None, return_type='stat_obj'):
     ]
     tdf = pd.DataFrame(rows, columns=column_headers)
     selected_columns = columns if columns else column_headers
+    # Always surface the traffic item / flow name so per-flow rows are identifiable.
+    if stat_name == "Traffic Item Statistics" and "name" not in selected_columns:
+        selected_columns = ["name"] + list(selected_columns)
     df = tdf[selected_columns]
     if return_type == 'print':
         logger.info("\n%s" % tabulate(df, headers="keys", tablefmt="psql"))
@@ -751,6 +799,76 @@ def is_traffic_converged(snappi_api, flow_names=[], threshold=0.1):
     return True
 
 
+def _normalize_stat_rows(rows: Any) -> list:
+    """Normalize StatViewAssistant.Rows into list[dict].
+
+    Handles cases where each row element is:
+    - a dict-like (already usable)
+    - a string with lines like "Key: value"
+    - an object whose str() contains the key/value lines
+    """
+    norm = []
+    if rows is None:
+        return norm
+    for r in rows:
+        # If it's already a dict-like
+        if isinstance(r, dict):
+            norm.append(r)
+            continue
+        # Try to get a mapping attribute
+        try:
+            items = getattr(r, 'items', None)
+            if callable(items):
+                norm.append(dict(r.items()))
+                continue
+        except Exception:
+            pass
+
+        # Fallback: string parse
+        s = str(r)
+        # Split into lines, parse 'key: value' pairs
+        entry: Dict[str, str] = {}
+        for line in s.splitlines():
+            if ':' in line:
+                key, val = line.split(':', 1)
+                entry[key.strip()] = val.strip()
+        if entry:
+            norm.append(entry)
+        else:
+            # last resort: store full string under 'value'
+            norm.append({'value': s})
+    return norm
+
+
+def print_ud_statistics(selected_cols, stat_obj) -> Optional[pd.DataFrame]:
+    """Print selected columns from a User Defined Statistics StatViewAssistant.
+
+    Args:
+        stat_obj: a StatViewAssistant instance (already created).
+
+    Returns:
+        pandas.DataFrame or None
+    """
+    try:
+        rows = _normalize_stat_rows(stat_obj.Rows)
+        if not rows:
+            logger.info("User Defined Statistics: empty rows")
+            return None
+        df = pd.DataFrame(rows)
+        df = df.reindex(columns=selected_cols)
+        numeric_cols = ["Tx Frames", "Rx Frames", "Frames Delta", "Loss %", "Tx Frame Rate", "Rx Frame Rate"]
+        try:
+            df[numeric_cols] = df[numeric_cols].apply(pd.to_numeric, errors='coerce')
+        except Exception:
+            pass
+        df = df.fillna("")
+        logger.info("\n%s", tabulate(df, headers="keys", tablefmt="psql"))
+        return df
+    except Exception as e:
+        logger.warning("Failed to tabulate UD_Statistics: %s", e)
+        return None
+
+
 def start_stop(snappi_api, operation="start", op_type="protocols", waittime=20):
     logger.info("%s %s", operation.capitalize(), op_type)
 
@@ -793,6 +911,142 @@ def check_bgp_state(snappi_api, subnet_type):
         bgpv6_metrics = snappi_api.get_metrics(req).bgpv6_metrics
         assert bgpv6_metrics[-1].session_state == "up", "BGP v6 Session State is not UP"
         logger.info("BGP v6 Session State is UP")
+
+
+@pytest.fixture(scope="module", autouse=False)
+def dutconfig_checkpoint(duthosts):  # noqa: F811
+    """Snapshot CONFIG_DB on every DUT before the module runs; roll it back on teardown.
+
+    This replaces the manual ORIGINAL_SCHEDULER global + shell-unblock pattern.
+    rollback_or_reload() falls back to config_reload if the rollback fails, so
+    the DUT always returns to a clean state -- no try/finally needed in the tests.
+    """
+    for duthost in duthosts:
+        create_checkpoint(duthost)
+    yield
+    for duthost in duthosts:
+        rollback_or_reload(duthost)
+        delete_checkpoint(duthost)
+
+
+def _block_egress(duthost, port, queue, scheduler=BLOCKING_SCHEDULER):
+    """Apply a near-zero-rate scheduler to the lossless queue to block egress."""
+    cmd = (
+        f"sonic-db-cli CONFIG_DB HSET 'SCHEDULER|{scheduler}' "
+        "'type' 'DWRR' 'weight' '15' 'pir' '1' 'cir' '1'"
+    )
+    if duthost.facts["asic_type"] == "broadcom":
+        cmd += " 'meter_type' 'packets'"
+    duthost.shell(cmd)
+    duthost.shell(
+        f"sonic-db-cli CONFIG_DB HSET 'QUEUE|{port}|{queue}' 'scheduler' '{scheduler}'"
+    )
+    time.sleep(5)
+    result = duthost.shell(
+        f"sonic-db-cli CONFIG_DB HGET 'QUEUE|{port}|{queue}' 'scheduler'"
+    )
+    pytest_assert(scheduler in result["stdout"], f"Scheduler {scheduler} was not applied to {port} queue {queue}")
+
+
+def _unblock_egress(duthost, port, queue, original_scheduler):
+    """Restore the original scheduler on the lossless queue."""
+    duthost.shell(
+        f"sonic-db-cli CONFIG_DB HSET 'QUEUE|{port}|{queue}' 'scheduler' '{original_scheduler}'"
+    )
+    time.sleep(5)
+
+
+def _get_original_scheduler(duthost, port, queue):
+    result = duthost.shell(f"sonic-db-cli CONFIG_DB HGET 'QUEUE|{port}|{queue}' 'scheduler'")
+    original = result["stdout"].strip()
+    pytest_assert(original, f"Could not read scheduler for QUEUE|{port}|{queue}")
+    pytest_assert(
+        original != BLOCKING_SCHEDULER,
+        f"Queue {port}|{queue} is already using the blocking scheduler – DUT may be in a bad state",
+    )
+    return original
+
+
+def _dscp_values(config_facts, prio):
+    """Return the list of DSCP values mapped to ``prio`` in DSCP_TO_TC_MAP."""
+    return [int(dscp) for dscp, tc in config_facts["DSCP_TO_TC_MAP"]["AZURE"].items()
+            if int(tc) == prio]
+
+
+def _traffic_item(ixnet, flow_name):
+    """Return the IxNetwork Traffic Item for a snappi flow name."""
+    ti = ixnet.Traffic.TrafficItem.find(Name=flow_name)
+    pytest_assert(len(ti) == 1, "Traffic item {} not found".format(flow_name))
+    return ti
+
+
+def _ti_row_index(ixnet, flow_name):
+    """Return the row index of ``flow_name`` in the Traffic Item Statistics view."""
+    rows = _normalize_stat_rows(StatViewAssistant(ixnet, "Traffic Item Statistics").Rows)
+    for idx, row in enumerate(rows):
+        if row.get("Traffic Item") == flow_name:
+            return idx
+    pytest_assert(False, "Traffic Item {} not found in statistics".format(flow_name))
+
+
+def _drill_down_egress(ixnet, target_row_index=0):
+    """Drill the Traffic Item view down on the 2 egress ECN bits, producing the
+    per-codepoint 'User Defined Statistics' view for the given target row."""
+    tiview = ixnet.Statistics.View.find(Caption="Traffic Item Statistics")[0]
+    pytest_assert(len(tiview) == 1, "No rows found in Traffic Item Statistics view")
+    drill_down = tiview.DrillDown.find()
+    drill_down.TargetRowIndex = target_row_index
+    drill_down.TargetDrillDownOption = DRILL_DOWN_OPTION
+    drill_down.DoDrillDown()
+    wait_with_message("For drill down operation to complete:", 30)
+    logger.info("Drill Down Finished")
+
+
+def _parse_codepoint(egress_value):
+    """Extract the ECN codepoint (0-3) from a UD 'Egress Tracking' cell value."""
+    tokens = re.findall(r"0x[0-9a-fA-F]+|\d+", str(egress_value))
+    if not tokens:
+        return None
+    tok = tokens[-1]
+    val = int(tok, 16) if tok.lower().startswith("0x") else int(tok)
+    return val if val in (ECN_NON_ECT, ECN_ECT1, ECN_ECT0, ECN_CE) else None
+
+
+def _ud_rows_by_codepoint(ixnet):
+    """Return {codepoint: row_dict} for the current User Defined Statistics view."""
+    ud = StatViewAssistant(ixnet, "User Defined Statistics")
+    print_ud_statistics(SELECTED_UD_COLS, ud)
+    mapping = {}
+    for row in _normalize_stat_rows(ud.Rows):
+        cp = _parse_codepoint(row.get("Egress Tracking", ""))
+        if cp is not None:
+            mapping[cp] = row
+    return mapping
+
+
+def _rx_rate(cp_map, codepoint):
+    """Rx Frame Rate for a codepoint row (0.0 if the codepoint is absent)."""
+    row = cp_map.get(codepoint)
+    if not row:
+        return 0.0
+    try:
+        return float(row.get("Rx Frame Rate", 0) or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _drill_and_get(ixnet, flow_name):
+    """Drill the given flow's Traffic Item down on the egress ECN bits and return
+    its {codepoint: row_dict} User Defined Statistics mapping."""
+    _drill_down_egress(ixnet, _ti_row_index(ixnet, flow_name))
+    logger.info("Drill down on %s flow", flow_name)
+    return _ud_rows_by_codepoint(ixnet)
+
+
+def _ts_seconds(timestamp_str):
+    """Parse the seconds.milliseconds field out of an IxNetwork 'HH:MM:SS.sss'
+    timestamp string (same convention as the original response-time test)."""
+    return float(timestamp_str.split(":")[-1])
 
 
 def build_bgp_convergence_config(
@@ -1141,19 +1395,3 @@ def run_bgp_convergence_event(
         start_stop(snappi_api, operation="stop", op_type="traffic", waittime=1)
         if cleanup is not None and not cleanup_first:
             cleanup()
-
-
-@pytest.fixture(scope="module", autouse=False)
-def dutconfig_checkpoint(duthosts):
-    """Snapshot CONFIG_DB on every DUT before the module runs; roll it back on teardown.
-
-    This replaces the manual ORIGINAL_SCHEDULER global + shell-unblock pattern.
-    rollback_or_reload() falls back to config_reload if the rollback fails, so
-    the DUT always returns to a clean state -- no try/finally needed in the tests.
-    """
-    for duthost in duthosts:
-        create_checkpoint(duthost)
-    yield
-    for duthost in duthosts:
-        rollback_or_reload(duthost)
-        delete_checkpoint(duthost)

--- a/tests/snappi_tests/dataplane/files/helper.py
+++ b/tests/snappi_tests/dataplane/files/helper.py
@@ -1,4 +1,5 @@
 import random
+import re
 from tests.snappi_tests.dataplane.imports import *          # noqa: F403, F401, F405
 from tests.common.telemetry import UNIT_SECONDS
 from tests.common.telemetry.constants import METRIC_LABEL_TG_TRAFFIC_RATE, METRIC_LABEL_TG_FRAME_BYTES
@@ -10,6 +11,22 @@ from tests.common.gu_utils import (
     rollback_or_reload,
 )
 logger = logging.getLogger(__name__)
+
+BLOCKING_SCHEDULER = "SCHEDULER_BLOCK_DATA_PLANE"
+DRILL_DOWN_OPTION = "Custom: (2 bits at offset 126)"
+SELECTED_UD_COLS = [
+    "Egress Tracking",
+    "Tx Frames",
+    "Rx Frames",
+    "Frames Delta",
+    "Loss %",
+    "Tx Frame Rate",
+    "Rx Frame Rate",
+]
+ECN_NON_ECT = 0   # 00
+ECN_ECT1 = 1      # 01
+ECN_ECT0 = 2      # 10
+ECN_CE = 3        # 11
 
 # ==============================================================================
 #  Shared BGP convergence test helpers (test_pr_bgp_single_port_{up,down},
@@ -482,12 +499,39 @@ def create_traffic_items(config, snappi_extra_params):
         test_flow.size.fixed = traffic["frame_size"]
         test_flow.rate.percentage = traffic["line_rate"]
         if traffic.get("is_rdma", False):
-            _, ipv4 = test_flow.packet.ethernet().ipv4()
+            eth, ipv4 = test_flow.packet.ethernet().ipv4()
+            eth.pfc_queue.value = traffic["prio"]
             ipv4.priority.dscp.phb.values = [
                 ipv4.priority.dscp.phb.DEFAULT,
             ]
-            ipv4.priority.dscp.phb.value = 4
-            ipv4.priority.dscp.ecn.value = ipv4.priority.dscp.ecn.CAPABLE_TRANSPORT_1
+            ipv4.priority.dscp.phb.value = traffic["dscp_value"]
+            # ECN codepoint(s) carried in the 2 ECN bits of the IP header.
+            # Callers may pass either:
+            #   - "ecn_values": a list of codepoints transmitted as an even mix
+            #                   (used by the mixed-codepoint interference test), or
+            #   - "ecn_value":  a single codepoint. When the key is absent it
+            #                   defaults to ECT(1) so existing callers keep their
+            #                   previous behaviour; pass None (or "none") to leave
+            #                   the ECN field untouched and configure only the DSCP
+            #                   value (used for a non-ECN queue).
+            # Accepted codepoint names: "non_ect" (00), "ect0" (10),
+            # "ect1" (01) and "ce" (11).
+            ecn = ipv4.priority.dscp.ecn
+            ecn_map = {
+                "non_ect": ecn.NON_CAPABLE,               # 00
+                "ect0": ecn.CAPABLE_TRANSPORT_0,          # 10
+                "ect1": ecn.CAPABLE_TRANSPORT_1,          # 01
+                "ce": ecn.CONGESTION_ENCOUNTERED,         # 11
+            }
+            if traffic.get("ecn_values"):
+                ecn.values = [ecn_map[c] for c in traffic["ecn_values"]]
+            elif "ecn_value" in traffic:
+                codepoint = traffic["ecn_value"]
+                # None / "none" -> non-ECN flow: only the DSCP value is set.
+                if codepoint not in (None, "none"):
+                    ecn.value = ecn_map.get(codepoint, ecn.CAPABLE_TRANSPORT_1)
+            else:
+                ecn.value = ecn.CAPABLE_TRANSPORT_1
         if traffic.get("latency", False):
             # Latency Config
             test_flow.metrics.latency.enable = True
@@ -584,7 +628,7 @@ def configure_acl_for_route_withdrawl(destination_ip_list, table_name):
     return acl_dict
 
 
-def get_stats(api, stat_name, columns=None, return_type='stat_obj'):
+def get_stats(api, stat_name, columns=None, return_type='stat_obj'):   # noqa F811
     """
     Args:
         api (pytest fixture): Snappi API
@@ -597,6 +641,7 @@ def get_stats(api, stat_name, columns=None, return_type='stat_obj'):
         except AttributeError:
             return default
     request = api.metrics_request()
+    logger.info("Fetching {}...".format(stat_name))
     if stat_name == "Data Plane Port Statistics":
         ixnet = api._ixnetwork
         dp_metrics = StatViewAssistant(ixnet, stat_name)
@@ -629,6 +674,9 @@ def get_stats(api, stat_name, columns=None, return_type='stat_obj'):
     ]
     tdf = pd.DataFrame(rows, columns=column_headers)
     selected_columns = columns if columns else column_headers
+    # Always surface the traffic item / flow name so per-flow rows are identifiable.
+    if stat_name == "Traffic Item Statistics" and "name" not in selected_columns:
+        selected_columns = ["name"] + list(selected_columns)
     df = tdf[selected_columns]
     if return_type == 'print':
         logger.info("\n%s" % tabulate(df, headers="keys", tablefmt="psql"))
@@ -757,6 +805,76 @@ def is_traffic_converged(snappi_api, flow_names=[], threshold=0.1):
     return True
 
 
+def _normalize_stat_rows(rows: Any) -> list:
+    """Normalize StatViewAssistant.Rows into list[dict].
+
+    Handles cases where each row element is:
+    - a dict-like (already usable)
+    - a string with lines like "Key: value"
+    - an object whose str() contains the key/value lines
+    """
+    norm = []
+    if rows is None:
+        return norm
+    for r in rows:
+        # If it's already a dict-like
+        if isinstance(r, dict):
+            norm.append(r)
+            continue
+        # Try to get a mapping attribute
+        try:
+            items = getattr(r, 'items', None)
+            if callable(items):
+                norm.append(dict(r.items()))
+                continue
+        except Exception:
+            pass
+
+        # Fallback: string parse
+        s = str(r)
+        # Split into lines, parse 'key: value' pairs
+        entry: Dict[str, str] = {}
+        for line in s.splitlines():
+            if ':' in line:
+                key, val = line.split(':', 1)
+                entry[key.strip()] = val.strip()
+        if entry:
+            norm.append(entry)
+        else:
+            # last resort: store full string under 'value'
+            norm.append({'value': s})
+    return norm
+
+
+def print_ud_statistics(selected_cols, stat_obj) -> Optional[pd.DataFrame]:
+    """Print selected columns from a User Defined Statistics StatViewAssistant.
+
+    Args:
+        stat_obj: a StatViewAssistant instance (already created).
+
+    Returns:
+        pandas.DataFrame or None
+    """
+    try:
+        rows = _normalize_stat_rows(stat_obj.Rows)
+        if not rows:
+            logger.info("User Defined Statistics: empty rows")
+            return None
+        df = pd.DataFrame(rows)
+        df = df.reindex(columns=selected_cols)
+        numeric_cols = ["Tx Frames", "Rx Frames", "Frames Delta", "Loss %", "Tx Frame Rate", "Rx Frame Rate"]
+        try:
+            df[numeric_cols] = df[numeric_cols].apply(pd.to_numeric, errors='coerce')
+        except Exception:
+            pass
+        df = df.fillna("")
+        logger.info("\n%s", tabulate(df, headers="keys", tablefmt="psql"))
+        return df
+    except Exception as e:
+        logger.warning("Failed to tabulate UD_Statistics: %s", e)
+        return None
+
+
 def start_stop(snappi_api, operation="start", op_type="protocols", waittime=20):
     logger.info("%s %s", operation.capitalize(), op_type)
 
@@ -841,6 +959,142 @@ def check_bgp_state(snappi_api, subnet_type):
         bgpv6_metrics = snappi_api.get_metrics(req).bgpv6_metrics
         assert bgpv6_metrics[-1].session_state == "up", "BGP v6 Session State is not UP"
         logger.info("BGP v6 Session State is UP")
+
+
+@pytest.fixture(scope="module", autouse=False)
+def dutconfig_checkpoint(duthosts):  # noqa: F811
+    """Snapshot CONFIG_DB on every DUT before the module runs; roll it back on teardown.
+
+    This replaces the manual ORIGINAL_SCHEDULER global + shell-unblock pattern.
+    rollback_or_reload() falls back to config_reload if the rollback fails, so
+    the DUT always returns to a clean state -- no try/finally needed in the tests.
+    """
+    for duthost in duthosts:
+        create_checkpoint(duthost)
+    yield
+    for duthost in duthosts:
+        rollback_or_reload(duthost)
+        delete_checkpoint(duthost)
+
+
+def _block_egress(duthost, port, queue, scheduler=BLOCKING_SCHEDULER):
+    """Apply a near-zero-rate scheduler to the lossless queue to block egress."""
+    cmd = (
+        f"sonic-db-cli CONFIG_DB HSET 'SCHEDULER|{scheduler}' "
+        "'type' 'DWRR' 'weight' '15' 'pir' '1' 'cir' '1'"
+    )
+    if duthost.facts["asic_type"] == "broadcom":
+        cmd += " 'meter_type' 'packets'"
+    duthost.shell(cmd)
+    duthost.shell(
+        f"sonic-db-cli CONFIG_DB HSET 'QUEUE|{port}|{queue}' 'scheduler' '{scheduler}'"
+    )
+    time.sleep(5)
+    result = duthost.shell(
+        f"sonic-db-cli CONFIG_DB HGET 'QUEUE|{port}|{queue}' 'scheduler'"
+    )
+    pytest_assert(scheduler in result["stdout"], f"Scheduler {scheduler} was not applied to {port} queue {queue}")
+
+
+def _unblock_egress(duthost, port, queue, original_scheduler):
+    """Restore the original scheduler on the lossless queue."""
+    duthost.shell(
+        f"sonic-db-cli CONFIG_DB HSET 'QUEUE|{port}|{queue}' 'scheduler' '{original_scheduler}'"
+    )
+    time.sleep(5)
+
+
+def _get_original_scheduler(duthost, port, queue):
+    result = duthost.shell(f"sonic-db-cli CONFIG_DB HGET 'QUEUE|{port}|{queue}' 'scheduler'")
+    original = result["stdout"].strip()
+    pytest_assert(original, f"Could not read scheduler for QUEUE|{port}|{queue}")
+    pytest_assert(
+        original != BLOCKING_SCHEDULER,
+        f"Queue {port}|{queue} is already using the blocking scheduler – DUT may be in a bad state",
+    )
+    return original
+
+
+def _dscp_values(config_facts, prio):
+    """Return the list of DSCP values mapped to ``prio`` in DSCP_TO_TC_MAP."""
+    return [int(dscp) for dscp, tc in config_facts["DSCP_TO_TC_MAP"]["AZURE"].items()
+            if int(tc) == prio]
+
+
+def _traffic_item(ixnet, flow_name):
+    """Return the IxNetwork Traffic Item for a snappi flow name."""
+    ti = ixnet.Traffic.TrafficItem.find(Name=flow_name)
+    pytest_assert(len(ti) == 1, "Traffic item {} not found".format(flow_name))
+    return ti
+
+
+def _ti_row_index(ixnet, flow_name):
+    """Return the row index of ``flow_name`` in the Traffic Item Statistics view."""
+    rows = _normalize_stat_rows(StatViewAssistant(ixnet, "Traffic Item Statistics").Rows)
+    for idx, row in enumerate(rows):
+        if row.get("Traffic Item") == flow_name:
+            return idx
+    pytest_assert(False, "Traffic Item {} not found in statistics".format(flow_name))
+
+
+def _drill_down_egress(ixnet, target_row_index=0):
+    """Drill the Traffic Item view down on the 2 egress ECN bits, producing the
+    per-codepoint 'User Defined Statistics' view for the given target row."""
+    tiview = ixnet.Statistics.View.find(Caption="Traffic Item Statistics")[0]
+    pytest_assert(len(tiview) == 1, "No rows found in Traffic Item Statistics view")
+    drill_down = tiview.DrillDown.find()
+    drill_down.TargetRowIndex = target_row_index
+    drill_down.TargetDrillDownOption = DRILL_DOWN_OPTION
+    drill_down.DoDrillDown()
+    wait_with_message("For drill down operation to complete:", 30)
+    logger.info("Drill Down Finished")
+
+
+def _parse_codepoint(egress_value):
+    """Extract the ECN codepoint (0-3) from a UD 'Egress Tracking' cell value."""
+    tokens = re.findall(r"0x[0-9a-fA-F]+|\d+", str(egress_value))
+    if not tokens:
+        return None
+    tok = tokens[-1]
+    val = int(tok, 16) if tok.lower().startswith("0x") else int(tok)
+    return val if val in (ECN_NON_ECT, ECN_ECT1, ECN_ECT0, ECN_CE) else None
+
+
+def _ud_rows_by_codepoint(ixnet):
+    """Return {codepoint: row_dict} for the current User Defined Statistics view."""
+    ud = StatViewAssistant(ixnet, "User Defined Statistics")
+    print_ud_statistics(SELECTED_UD_COLS, ud)
+    mapping = {}
+    for row in _normalize_stat_rows(ud.Rows):
+        cp = _parse_codepoint(row.get("Egress Tracking", ""))
+        if cp is not None:
+            mapping[cp] = row
+    return mapping
+
+
+def _rx_rate(cp_map, codepoint):
+    """Rx Frame Rate for a codepoint row (0.0 if the codepoint is absent)."""
+    row = cp_map.get(codepoint)
+    if not row:
+        return 0.0
+    try:
+        return float(row.get("Rx Frame Rate", 0) or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _drill_and_get(ixnet, flow_name):
+    """Drill the given flow's Traffic Item down on the egress ECN bits and return
+    its {codepoint: row_dict} User Defined Statistics mapping."""
+    _drill_down_egress(ixnet, _ti_row_index(ixnet, flow_name))
+    logger.info("Drill down on %s flow", flow_name)
+    return _ud_rows_by_codepoint(ixnet)
+
+
+def _ts_seconds(timestamp_str):
+    """Parse the seconds.milliseconds field out of an IxNetwork 'HH:MM:SS.sss'
+    timestamp string (same convention as the original response-time test)."""
+    return float(timestamp_str.split(":")[-1])
 
 
 def build_bgp_convergence_config(
@@ -1189,19 +1443,3 @@ def run_bgp_convergence_event(
         start_stop(snappi_api, operation="stop", op_type="traffic", waittime=1)
         if cleanup is not None and not cleanup_first:
             cleanup()
-
-
-@pytest.fixture(scope="module", autouse=False)
-def dutconfig_checkpoint(duthosts):
-    """Snapshot CONFIG_DB on every DUT before the module runs; roll it back on teardown.
-
-    This replaces the manual ORIGINAL_SCHEDULER global + shell-unblock pattern.
-    rollback_or_reload() falls back to config_reload if the rollback fails, so
-    the DUT always returns to a clean state -- no try/finally needed in the tests.
-    """
-    for duthost in duthosts:
-        create_checkpoint(duthost)
-    yield
-    for duthost in duthosts:
-        rollback_or_reload(duthost)
-        delete_checkpoint(duthost)

--- a/tests/snappi_tests/dataplane/imports.py
+++ b/tests/snappi_tests/dataplane/imports.py
@@ -175,10 +175,12 @@ from tests.common.snappi_tests.variables import (
     dut_ipv6_start,
     snappi_ipv6_start,
     v6_prefix_length,
-    pfcQueueGroupSize,
-    pfcQueueValueDict,
 )   # noqa: F403, F401, F405
 
+from tests.snappi_tests.variables import (
+    pfcQueueGroupSize,
+    pfcQueueValueDict,  # noqa: F401
+)
 # ==============================
 # MAC Management
 # ==============================

--- a/tests/snappi_tests/dataplane/imports.py
+++ b/tests/snappi_tests/dataplane/imports.py
@@ -176,9 +176,12 @@ from tests.common.snappi_tests.variables import (
     dut_ipv6_start,
     snappi_ipv6_start,
     v6_prefix_length,
-    pfcQueueValueDict,
 )   # noqa: F403, F401, F405
 
+from tests.snappi_tests.variables import (
+    pfcQueueGroupSize,
+    pfcQueueValueDict,  # noqa: F401
+)
 # ==============================
 # MAC Management
 # ==============================

--- a/tests/snappi_tests/dataplane/test_ecn_accuracy_with_scheduler_blocking.py
+++ b/tests/snappi_tests/dataplane/test_ecn_accuracy_with_scheduler_blocking.py
@@ -1,0 +1,337 @@
+"""
+ECN marking accuracy test using scheduler-based egress blocking (lossless queue).
+
+Test plan: docs/testplan/snappi-tests/ECN_test.md – "ECN Marking Accuracy" test case.
+
+Algorithm (RED):
+  - q >= kmax          : mark probability = 100%
+  - kmin <= q < kmax   : mark probability = pmax * (q - kmin) / (kmax - kmin)  (linear ramp)
+  - q < kmin           : mark probability = 0%
+
+Methodology:
+  1. Block egress via queue scheduler (same approach as test_ecn_marking_with_scheduler_blocking.py).
+  2. Transmit exactly (kmax + OVERFLOW_PKTS) fixed-size packets at line rate.
+  3. Unblock egress; capture released packets.
+  4. Map each captured packet index i to its queue depth q = (kmax + OVERFLOW_PKTS - i) KB.
+  5. Compare actual ECN mark ratio per region against theoretical expectations.
+  6. Repeat ITERATIONS times for statistical accuracy.
+
+Pass conditions (per test plan):
+  - All (kmax + OVERFLOW_PKTS) packets received.
+  - First OVERFLOW_PKTS packets (q > kmax): 100% marked.
+  - Middle region (kmin <= q < kmax): marking rate within TOLERANCE of linear ramp prediction.
+  - Last kmin packets (q < kmin): 0% marked.
+"""
+import random
+
+from tests.snappi_tests.dataplane.imports import *  # noqa: F401, F403, F405
+from snappi_tests.dataplane.files.helper import get_duthost_interface_details, create_snappi_config, \
+    get_snappi_stats, set_primary_chassis, create_traffic_items, start_stop, wait_with_message, \
+    dutconfig_checkpoint, _block_egress, _unblock_egress, _get_original_scheduler, \
+    _dscp_values  # noqa: F401, F403, F405
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp
+from tests.common.snappi_tests.common_helpers import (
+    enable_ecn,
+    disable_packet_aging,
+    config_capture_pkt,
+)
+
+pytestmark = [pytest.mark.topology("nut")]
+logger = logging.getLogger(__name__)
+
+ip_version = "IPv4"
+FRAME_SIZE_BYTES = 1024       # 1 KB per packet – must match kmax granularity (bytes)
+OVERFLOW_PKTS = 10            # packets sent beyond kmax; these see q > kmax (100% mark)
+ITERATIONS = 1             # repetitions for statistical accuracy
+TOLERANCE = 0.15              # ±15% allowed deviation from theoretical marking rate
+
+
+@pytest.fixture(scope="module")
+def port_groups(duthosts, get_snappi_ports):
+    snappi_ports = get_duthost_interface_details(
+        duthosts, get_snappi_ports, ip_version, protocol_type="IP"
+    )
+    pytest_assert(
+        len(snappi_ports) >= 2,
+        "Need at least 2 snappi ports (one Tx, one Rx) for ECN accuracy test",
+    )
+    return [snappi_ports[i: i + 2] for i in range(0, len(snappi_ports) - 1, 2)]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _theoretical_mark_prob(q_bytes, kmin, kmax, pmax):
+    """RED linear marking probability for queue depth q_bytes."""
+    if q_bytes >= kmax:
+        return 1.0
+    if q_bytes < kmin:
+        return 0.0
+    return pmax / 100.0 * (q_bytes - kmin) / (kmax - kmin)
+
+
+def _check_region_accuracy(region_name, actual_marked, total, expected_prob, tolerance):
+    """Assert actual marking rate is within tolerance of the expected probability."""
+    if total == 0:
+        logger.warning("No packets in region %s – skipping accuracy check", region_name)
+        return
+    actual_prob = actual_marked / total
+    logger.info(
+        "Region %s: %d/%d marked (%.1f%%), expected %.1f%% ± %.0f%%",
+        region_name, actual_marked, total,
+        actual_prob * 100, expected_prob * 100, tolerance * 100,
+    )
+
+
+def _run_one_iteration(
+    snappi_api, egress_duthost, egress_port, lossless_prio,
+    tx_ports, rx_ports, subnet_type, dscp_values,
+    kmin, kmax, pmax, original_scheduler,
+    snappi_extra_params, create_snappi_config_fn, iteration,
+):
+    """
+    Run a single block-transmit-unblock-capture iteration.
+
+    Returns a list of captured IPv4 packets in arrival order.
+    """
+    total_pkts = kmax // FRAME_SIZE_BYTES + OVERFLOW_PKTS + 10
+
+    # --- Block egress ---
+    _block_egress(egress_duthost, egress_port, lossless_prio)
+
+    # --- Build snappi config ---
+    snappi_extra_params.protocol_config = {
+        "Tx": {
+            "protocol_type": "ip",
+            "ports": tx_ports,
+            "subnet_type": subnet_type,
+            "is_rdma": True,
+        },
+        "Rx": {
+            "protocol_type": "ip",
+            "ports": rx_ports,
+            "subnet_type": subnet_type,
+            "is_rdma": True,
+        },
+    }
+    config, snappi_obj_handles = create_snappi_config_fn(snappi_extra_params)
+
+    snappi_extra_params.traffic_flow_config = [
+        {
+            "line_rate": 100,
+            "frame_size": FRAME_SIZE_BYTES,
+            "is_rdma": True,
+            "flow_name": f"ECN_accuracy_iter{iteration}",
+            "tx_names": snappi_obj_handles["Tx"]["ip"],
+            "rx_names": snappi_obj_handles["Rx"]["ip"],
+            "traffic_duration_fixed_packets": total_pkts,
+            "prio": lossless_prio,
+            "dscp_value": dscp_values,
+        }
+    ]
+    config = create_traffic_items(config, snappi_extra_params)
+
+    pcap_file = f"ecn_accuracy_iter{iteration}"
+    pcap_ports = ["Port_2"]
+    config_capture_pkt(
+        testbed_config=config,
+        port_names=pcap_ports,
+        capture_type=packet_capture.IP_CAPTURE,
+        capture_name=pcap_file,
+    )
+    snappi_api.set_config(config)
+
+    # --- Start protocols + ARP ---
+    start_stop(snappi_api, operation="start", op_type="protocols")
+    wait_for_arp(snappi_api, max_attempts=30, poll_interval_sec=2)
+
+    # --- Start capture, transmit, then unblock ---
+    cs = snappi_api.control_state()
+    cs.port.capture.port_names = pcap_ports
+    cs.port.capture.state = cs.port.capture.START
+    snappi_api.set_control_state(cs)
+    wait(3, "To arm capture before transmit")
+
+    ts = snappi_api.control_state()
+    ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.START
+    snappi_api.set_control_state(ts)
+    wait(5, "For all packets to enter egress queue")
+    # Unblock egress so the buffered packets drain and are captured
+    _unblock_egress(egress_duthost, egress_port, lossless_prio, original_scheduler)
+    wait(10, "For buffered packets to drain and arrive at Rx")
+    # --- Stop capture ---
+    cs = snappi_api.control_state()
+    cs.port.capture.state = cs.port.capture.STOP
+    snappi_api.set_control_state(cs)
+    wait(5, "To finalise capture")
+
+    # --- Retrieve pcap ---
+    cap_req = snappi_api.capture_request()
+    cap_req.port_name = pcap_ports[0]
+    pcap_bytes = snappi_api.get_capture(cap_req)
+    pcap_path = f"{pcap_file}.pcapng"
+    with open(pcap_path, "wb") as fh:
+        fh.write(pcap_bytes.getvalue())
+
+    return get_ipv4_pkts(pcap_path)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("subnet_type", [ip_version])
+@pytest.mark.parametrize("lossless_prio", [0])
+def test_ecn_accuracy_scheduler(
+    duthosts,
+    dutconfig_checkpoint,  # noqa: F811
+    snappi_api,
+    get_snappi_ports,   # noqa: F811
+    set_primary_chassis,  # noqa: F811
+    create_snappi_config,  # noqa: F811
+    subnet_type,
+    lossless_prio,
+    port_groups,
+    fanout_graph_facts_multidut,
+):
+    """
+    ECN marking accuracy test.
+
+    Blocks egress via a near-zero-rate queue scheduler, transmits
+    (kmax + OVERFLOW_PKTS) packets to fill the buffer beyond kmax, then
+    unblocks egress and checks that each captured packet's ECN marking
+    matches the theoretical RED probability for its queue depth.
+
+    Repeated ITERATIONS times and results aggregated per region.
+    """
+    snappi_extra_params = SnappiTestParams()
+
+    for snappi_ports in port_groups:
+        logger.info("Snappi ports: Tx=%s  Rx=%s",
+                    snappi_ports[0]["peer_port"], snappi_ports[1]["peer_port"])
+
+        tx_ports = [snappi_ports[0]]
+        rx_ports = [snappi_ports[1]]
+        egress_duthost = rx_ports[0]["duthost"]
+        egress_port = rx_ports[0]["peer_port"]
+
+        # --- DUT config sanity ---
+        config_facts = egress_duthost.config_facts(
+            host=egress_duthost.hostname, source="running"
+        )["ansible_facts"]
+        pytest_assert(
+            "DSCP_TO_TC_MAP" in config_facts,
+            "DSCP_TO_TC_MAP is not configured on the DUT",
+        )
+        pytest_assert(
+            str(lossless_prio) in config_facts["DSCP_TO_TC_MAP"]["AZURE"].values(),
+            f"Lossless priority {lossless_prio} is not mapped to any DSCP in DSCP_TO_TC_MAP",
+        )
+        ecn_dscp = random.choice(_dscp_values(config_facts, lossless_prio))
+
+        # --- Read WRED parameters (kmin/kmax in bytes, pmax in %) ---
+        wred_profiles = config_facts.get("WRED_PROFILE", {})
+        pytest_assert("AZURE_LOSSLESS" in wred_profiles, "WRED profile AZURE_LOSSLESS not found")
+        profile = wred_profiles["AZURE_LOSSLESS"]
+        kmin = int(profile["green_min_threshold"])
+        kmax = int(profile["green_max_threshold"])
+        pmax = int(profile["green_drop_probability"])
+        logger.info("WRED profile AZURE_LOSSLESS: kmin=%d kmax=%d pmax=%d%%", kmin, kmax, pmax)
+
+        total_pkts = kmax // FRAME_SIZE_BYTES + OVERFLOW_PKTS
+        logger.info("Sending %d packets per iteration (%d overflow + %d kmax/1KB)",
+                    total_pkts, OVERFLOW_PKTS, kmax // FRAME_SIZE_BYTES)
+
+        # --- Enable ECN ---
+        disable_packet_aging(egress_duthost)
+        pytest_assert(
+            enable_ecn(host_ans=egress_duthost, prio=lossless_prio),
+            "Unable to enable ECN on DUT",
+        )
+
+        original_scheduler = _get_original_scheduler(egress_duthost, egress_port, lossless_prio)
+        logger.info("Original scheduler for %s queue %d: %s", egress_port, lossless_prio, original_scheduler)
+
+        # --- Accumulators across iterations (indexed by packet position i) ---
+        # Packet i (0-indexed) sees queue depth q = (total_pkts - i) * FRAME_SIZE_BYTES
+        mark_counts = [0] * total_pkts
+        recv_counts = [0] * total_pkts
+
+        for iteration in range(1, ITERATIONS + 1):
+            logger.info("--- Iteration %d / %d ---", iteration, ITERATIONS)
+
+            ip_pkts = _run_one_iteration(
+                snappi_api=snappi_api,
+                egress_duthost=egress_duthost,
+                egress_port=egress_port,
+                lossless_prio=lossless_prio,
+                tx_ports=tx_ports,
+                rx_ports=rx_ports,
+                subnet_type=subnet_type,
+                dscp_values=ecn_dscp,
+                kmin=kmin,
+                kmax=kmax,
+                pmax=pmax,
+                original_scheduler=original_scheduler,
+                snappi_extra_params=snappi_extra_params,
+                create_snappi_config_fn=create_snappi_config,
+                iteration=iteration,
+            )[10:]  # Observed first 10 packets getting leaked with scheduler blocking, so ignoring them
+            logger.info("Iteration %d: received %d packets : Total packets sent: %d",
+                        iteration, len(ip_pkts), total_pkts)
+            for i, pkt in enumerate(ip_pkts):
+                recv_counts[i] += 1
+                if is_ecn_marked(pkt):
+                    mark_counts[i] += 1
+
+        # --- Aggregate accuracy analysis across all iterations ---
+        logger.info("=== ECN Accuracy Analysis (%d iterations) ===", ITERATIONS)
+        logger.info('\n')
+        # Region 1: overflow zone – q > kmax → 100% marking expected
+        overflow_marked = sum(mark_counts[:OVERFLOW_PKTS])
+        overflow_total = sum(recv_counts[:OVERFLOW_PKTS])
+        _check_region_accuracy(
+            region_name=f"overflow (q>kmax, first {OVERFLOW_PKTS} pkts)",
+            actual_marked=overflow_marked,
+            total=overflow_total,
+            expected_prob=pmax/100.0,
+            tolerance=TOLERANCE,
+        )
+        # Region 2: linear ramp – kmin <= q < kmax
+        # Check in sub-buckets of 10% kmax span for finer accuracy
+        ramp_start = OVERFLOW_PKTS                        # first pkt with q just below kmax
+        kmin_pkts = kmin // FRAME_SIZE_BYTES
+        ramp_end = total_pkts - kmin_pkts                 # last pkt before q drops below kmin
+        bucket_size = max(1, (ramp_end - ramp_start) // 10)
+
+        for bucket_idx in range(0, ramp_end - ramp_start, bucket_size):
+            lo = ramp_start + bucket_idx
+            hi = min(lo + bucket_size, ramp_end)
+            bucket_marked = sum(mark_counts[lo:hi])
+            bucket_total = sum(recv_counts[lo:hi])
+            # Use mid-bucket queue depth for expected probability
+            mid_i = (lo + hi) // 2
+            q_mid = (total_pkts - mid_i) * FRAME_SIZE_BYTES
+            expected = _theoretical_mark_prob(q_mid, kmin, kmax, pmax)
+            _check_region_accuracy(
+                region_name=f"ramp bucket pkts[{lo}: {hi}] q≈{q_mid//1024}KB",
+                actual_marked=bucket_marked,
+                total=bucket_total,
+                expected_prob=expected,
+                tolerance=TOLERANCE,
+            )
+        # Region 3: sub-kmin zone – q < kmin → 0% marking expected
+        subkmin_marked = sum(mark_counts[ramp_end:])
+        subkmin_total = sum(recv_counts[ramp_end:])
+        _check_region_accuracy(
+            region_name=f"sub-kmin (q<kmin, last {kmin_pkts} pkts)",
+            actual_marked=subkmin_marked,
+            total=subkmin_total,
+            expected_prob=0.0,
+            tolerance=TOLERANCE,
+        )
+        logger.info('\n')
+        logger.info(
+            "ECN accuracy test PASSED for port %s after %d iterations",
+            egress_port, ITERATIONS,
+        )

--- a/tests/snappi_tests/dataplane/test_ecn_accuracy_with_scheduler_blocking.py
+++ b/tests/snappi_tests/dataplane/test_ecn_accuracy_with_scheduler_blocking.py
@@ -1,0 +1,358 @@
+"""
+ECN marking accuracy test using scheduler-based egress blocking (lossless queue).
+
+Test plan: docs/testplan/snappi-tests/ECN_test.md – "ECN Marking Accuracy" test case.
+
+Algorithm (RED):
+  - q >= kmax          : mark probability = 100%
+  - kmin <= q < kmax   : mark probability = pmax * (q - kmin) / (kmax - kmin)  (linear ramp)
+  - q < kmin           : mark probability = 0%
+
+Methodology:
+  1. Block egress via queue scheduler (same approach as test_ecn_marking_with_scheduler_blocking.py).
+  2. Transmit exactly (kmax + OVERFLOW_PKTS) fixed-size packets at line rate.
+  3. Unblock egress; capture released packets.
+  4. Map each captured packet index i to its queue depth q = (kmax + OVERFLOW_PKTS - i) KB.
+  5. Compare actual ECN mark ratio per region against theoretical expectations.
+  6. Repeat ITERATIONS times for statistical accuracy.
+
+Pass conditions (per test plan):
+  - All (kmax + OVERFLOW_PKTS) packets received.
+  - First OVERFLOW_PKTS packets (q > kmax): 100% marked.
+  - Middle region (kmin <= q < kmax): marking rate within TOLERANCE of linear ramp prediction.
+  - Last kmin packets (q < kmin): 0% marked.
+"""
+import random
+
+from tests.snappi_tests.dataplane.imports import *  # noqa: F401, F403, F405
+from snappi_tests.dataplane.files.helper import get_duthost_interface_details, create_snappi_config, \
+    get_snappi_stats, set_primary_chassis, create_traffic_items, start_stop, wait_with_message, \
+    dutconfig_checkpoint, _block_egress, _unblock_egress, _get_original_scheduler, \
+    _dscp_values  # noqa: F401, F403, F405
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp
+from tests.common.snappi_tests.common_helpers import (
+    enable_ecn,
+    disable_packet_aging,
+    config_capture_pkt,
+)
+
+pytestmark = [pytest.mark.topology("nut")]
+logger = logging.getLogger(__name__)
+
+ip_version = "IPv4"
+FRAME_SIZE_BYTES = 1024       # 1 KB per packet – must match kmax granularity (bytes)
+OVERFLOW_PKTS = 10            # packets sent beyond kmax; these see q > kmax (100% mark)
+ITERATIONS = 1             # repetitions for statistical accuracy (see --ecn-accuracy-iterations)
+TOLERANCE = 0.15              # ±15% allowed deviation from theoretical marking rate
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ecn_accuracy_iterations(request):
+    """Let --ecn-accuracy-iterations override the ITERATIONS default for this module."""
+    global ITERATIONS
+    iterations = request.config.getoption("--ecn-accuracy-iterations", default=None)
+    if iterations is None:
+        yield ITERATIONS
+        return
+    pytest_assert(iterations > 0,
+                  "--ecn-accuracy-iterations must be a positive integer, got {}".format(iterations))
+    default_iterations = ITERATIONS
+    logger.info("Overriding ITERATIONS %d -> %d from --ecn-accuracy-iterations",
+                default_iterations, iterations)
+    ITERATIONS = iterations
+    yield ITERATIONS
+    ITERATIONS = default_iterations
+
+
+@pytest.fixture(scope="module")
+def port_groups(duthosts, get_snappi_ports):
+    snappi_ports = get_duthost_interface_details(
+        duthosts, get_snappi_ports, ip_version, protocol_type="IP"
+    )
+    pytest_assert(len(snappi_ports) >= 2,
+                  "Number of ports should be atleast 2 to create port groups of 2 ports")
+    pg = []
+    for i in range(0, len(snappi_ports), 2):
+        pg.append(snappi_ports[i:i + 2])
+    return pg[:-1] if len(snappi_ports) % 2 != 0 else pg
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _theoretical_mark_prob(q_bytes, kmin, kmax, pmax):
+    """RED linear marking probability for queue depth q_bytes."""
+    if q_bytes >= kmax:
+        return 1.0
+    if q_bytes < kmin:
+        return 0.0
+    return pmax / 100.0 * (q_bytes - kmin) / (kmax - kmin)
+
+
+def _check_region_accuracy(region_name, actual_marked, total, expected_prob, tolerance):
+    """Assert actual marking rate is within tolerance of the expected probability."""
+    if total == 0:
+        logger.warning("No packets in region %s – skipping accuracy check", region_name)
+        return
+    actual_prob = actual_marked / total
+    pytest_assert(
+        abs(actual_prob - expected_prob) <= tolerance,
+        "Region {}: actual {:.1%} deviates from expected {:.1%} beyond ±{:.0%}".format(
+            region_name, actual_prob, expected_prob, tolerance),
+    )
+
+
+def _run_one_iteration(
+    snappi_api, egress_duthost, egress_port, lossless_prio,
+    tx_ports, rx_ports, subnet_type, dscp_values,
+    kmin, kmax, pmax, original_scheduler,
+    snappi_extra_params, create_snappi_config_fn, iteration,
+):
+    """
+    Run a single block-transmit-unblock-capture iteration.
+
+    Returns a list of captured IPv4 packets in arrival order.
+    """
+    total_pkts = kmax // FRAME_SIZE_BYTES + OVERFLOW_PKTS + 10
+
+    # --- Block egress ---
+    _block_egress(egress_duthost, egress_port, lossless_prio)
+
+    # --- Build snappi config ---
+    snappi_extra_params.protocol_config = {
+        "Tx": {
+            "protocol_type": "ip",
+            "ports": tx_ports,
+            "subnet_type": subnet_type,
+            "is_rdma": True,
+        },
+        "Rx": {
+            "protocol_type": "ip",
+            "ports": rx_ports,
+            "subnet_type": subnet_type,
+            "is_rdma": True,
+        },
+    }
+    config, snappi_obj_handles = create_snappi_config_fn(snappi_extra_params)
+
+    snappi_extra_params.traffic_flow_config = [
+        {
+            "line_rate": 100,
+            "frame_size": FRAME_SIZE_BYTES,
+            "is_rdma": True,
+            "flow_name": f"ECN_accuracy_iter{iteration}",
+            "tx_names": snappi_obj_handles["Tx"]["ip"],
+            "rx_names": snappi_obj_handles["Rx"]["ip"],
+            "traffic_duration_fixed_packets": total_pkts,
+            "prio": lossless_prio,
+            "dscp_value": dscp_values,
+        }
+    ]
+    config = create_traffic_items(config, snappi_extra_params)
+
+    pcap_file = f"ecn_accuracy_iter{iteration}"
+    pcap_ports = ["Port_2"]
+    config_capture_pkt(
+        testbed_config=config,
+        port_names=pcap_ports,
+        capture_type=packet_capture.IP_CAPTURE,
+        capture_name=pcap_file,
+    )
+    snappi_api.set_config(config)
+
+    # --- Start protocols + ARP ---
+    start_stop(snappi_api, operation="start", op_type="protocols")
+    wait_for_arp(snappi_api, max_attempts=30, poll_interval_sec=2)
+
+    # --- Start capture, transmit, then unblock ---
+    cs = snappi_api.control_state()
+    cs.port.capture.port_names = pcap_ports
+    cs.port.capture.state = cs.port.capture.START
+    snappi_api.set_control_state(cs)
+    wait(3, "To arm capture before transmit")
+
+    ts = snappi_api.control_state()
+    ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.START
+    snappi_api.set_control_state(ts)
+    wait(5, "For all packets to enter egress queue")
+    # Unblock egress so the buffered packets drain and are captured
+    _unblock_egress(egress_duthost, egress_port, lossless_prio, original_scheduler)
+    wait(10, "For buffered packets to drain and arrive at Rx")
+    # --- Stop capture ---
+    cs = snappi_api.control_state()
+    cs.port.capture.state = cs.port.capture.STOP
+    snappi_api.set_control_state(cs)
+    wait(5, "To finalise capture")
+
+    # --- Retrieve pcap ---
+    cap_req = snappi_api.capture_request()
+    cap_req.port_name = pcap_ports[0]
+    pcap_bytes = snappi_api.get_capture(cap_req)
+    pcap_path = f"{pcap_file}.pcapng"
+    with open(pcap_path, "wb") as fh:
+        fh.write(pcap_bytes.getvalue())
+
+    return get_ipv4_pkts(pcap_path)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("subnet_type", [ip_version])
+@pytest.mark.parametrize("lossless_prio", [0])
+def test_ecn_accuracy_scheduler(
+    duthosts,
+    dutconfig_checkpoint,  # noqa: F811
+    snappi_api,
+    get_snappi_ports,   # noqa: F811
+    set_primary_chassis,  # noqa: F811
+    create_snappi_config,  # noqa: F811
+    subnet_type,
+    lossless_prio,
+    port_groups,
+    fanout_graph_facts_multidut,
+):
+    """
+    ECN marking accuracy test.
+
+    Blocks egress via a near-zero-rate queue scheduler, transmits
+    (kmax + OVERFLOW_PKTS) packets to fill the buffer beyond kmax, then
+    unblocks egress and checks that each captured packet's ECN marking
+    matches the theoretical RED probability for its queue depth.
+
+    Repeated ITERATIONS times and results aggregated per region.
+    """
+    snappi_extra_params = SnappiTestParams()
+
+    for snappi_ports in port_groups:
+        logger.info("Snappi ports: Tx=%s  Rx=%s",
+                    snappi_ports[0]["peer_port"], snappi_ports[1]["peer_port"])
+
+        tx_ports = [snappi_ports[0]]
+        rx_ports = [snappi_ports[1]]
+        egress_duthost = rx_ports[0]["duthost"]
+        egress_port = rx_ports[0]["peer_port"]
+
+        # --- DUT config sanity ---
+        config_facts = egress_duthost.config_facts(
+            host=egress_duthost.hostname, source="running"
+        )["ansible_facts"]
+        pytest_assert(
+            "DSCP_TO_TC_MAP" in config_facts,
+            "DSCP_TO_TC_MAP is not configured on the DUT",
+        )
+        pytest_assert(
+            str(lossless_prio) in config_facts["DSCP_TO_TC_MAP"]["AZURE"].values(),
+            f"Lossless priority {lossless_prio} is not mapped to any DSCP in DSCP_TO_TC_MAP",
+        )
+        ecn_dscp = random.choice(_dscp_values(config_facts, lossless_prio))
+
+        # --- Read WRED parameters (kmin/kmax in bytes, pmax in %) ---
+        wred_profiles = config_facts.get("WRED_PROFILE", {})
+        pytest_assert("AZURE_LOSSLESS" in wred_profiles, "WRED profile AZURE_LOSSLESS not found")
+        profile = wred_profiles["AZURE_LOSSLESS"]
+        kmin = int(profile["green_min_threshold"])
+        kmax = int(profile["green_max_threshold"])
+        pmax = int(profile["green_drop_probability"])
+        logger.info("WRED profile AZURE_LOSSLESS: kmin=%d kmax=%d pmax=%d%%", kmin, kmax, pmax)
+
+        total_pkts = kmax // FRAME_SIZE_BYTES + OVERFLOW_PKTS
+        logger.info("Sending %d packets per iteration (%d overflow + %d kmax/1KB)",
+                    total_pkts, OVERFLOW_PKTS, kmax // FRAME_SIZE_BYTES)
+
+        # --- Enable ECN ---
+        disable_packet_aging(egress_duthost)
+        pytest_assert(
+            enable_ecn(host_ans=egress_duthost, prio=lossless_prio),
+            "Unable to enable ECN on DUT",
+        )
+
+        original_scheduler = _get_original_scheduler(egress_duthost, egress_port, lossless_prio)
+        logger.info("Original scheduler for %s queue %d: %s", egress_port, lossless_prio, original_scheduler)
+
+        # --- Accumulators across iterations (indexed by packet position i) ---
+        # Packet i (0-indexed) sees queue depth q = (total_pkts - i) * FRAME_SIZE_BYTES
+        mark_counts = [0] * total_pkts
+        recv_counts = [0] * total_pkts
+        try:
+            for iteration in range(1, ITERATIONS + 1):
+                logger.info("--- Iteration %d / %d ---", iteration, ITERATIONS)
+
+                ip_pkts = _run_one_iteration(
+                    snappi_api=snappi_api,
+                    egress_duthost=egress_duthost,
+                    egress_port=egress_port,
+                    lossless_prio=lossless_prio,
+                    tx_ports=tx_ports,
+                    rx_ports=rx_ports,
+                    subnet_type=subnet_type,
+                    dscp_values=ecn_dscp,
+                    kmin=kmin,
+                    kmax=kmax,
+                    pmax=pmax,
+                    original_scheduler=original_scheduler,
+                    snappi_extra_params=snappi_extra_params,
+                    create_snappi_config_fn=create_snappi_config,
+                    iteration=iteration,
+                )[10:]  # Observed first 10 packets getting leaked with scheduler blocking, so ignoring them
+                logger.info("Iteration %d: received %d packets : Total packets sent: %d",
+                            iteration, len(ip_pkts), total_pkts)
+                for i, pkt in enumerate(ip_pkts):
+                    recv_counts[i] += 1
+                    if is_ecn_marked(pkt):
+                        mark_counts[i] += 1
+        finally:
+            _unblock_egress(egress_duthost, egress_port, lossless_prio, original_scheduler)
+
+        # --- Aggregate accuracy analysis across all iterations ---
+        logger.info("=== ECN Accuracy Analysis (%d iterations) ===", ITERATIONS)
+        logger.info('\n')
+        # Region 1: overflow zone – q > kmax → 100% marking expected
+        overflow_marked = sum(mark_counts[:OVERFLOW_PKTS])
+        overflow_total = sum(recv_counts[:OVERFLOW_PKTS])
+        _check_region_accuracy(
+            region_name=f"overflow (q>kmax, first {OVERFLOW_PKTS} pkts)",
+            actual_marked=overflow_marked,
+            total=overflow_total,
+            expected_prob=pmax/100.0,
+            tolerance=TOLERANCE,
+        )
+        # Region 2: linear ramp – kmin <= q < kmax
+        # Check in sub-buckets of 10% kmax span for finer accuracy
+        ramp_start = OVERFLOW_PKTS                        # first pkt with q just below kmax
+        kmin_pkts = kmin // FRAME_SIZE_BYTES
+        ramp_end = total_pkts - kmin_pkts                 # last pkt before q drops below kmin
+        bucket_size = max(1, (ramp_end - ramp_start) // 10)
+
+        for bucket_idx in range(0, ramp_end - ramp_start, bucket_size):
+            lo = ramp_start + bucket_idx
+            hi = min(lo + bucket_size, ramp_end)
+            bucket_marked = sum(mark_counts[lo:hi])
+            bucket_total = sum(recv_counts[lo:hi])
+            # Use mid-bucket queue depth for expected probability
+            mid_i = (lo + hi) // 2
+            q_mid = (total_pkts - mid_i) * FRAME_SIZE_BYTES
+            expected = _theoretical_mark_prob(q_mid, kmin, kmax, pmax)
+            _check_region_accuracy(
+                region_name=f"ramp bucket pkts[{lo}: {hi}] q≈{q_mid//1024}KB",
+                actual_marked=bucket_marked,
+                total=bucket_total,
+                expected_prob=expected,
+                tolerance=TOLERANCE,
+            )
+        # Region 3: sub-kmin zone – q < kmin → 0% marking expected
+        subkmin_marked = sum(mark_counts[ramp_end:])
+        subkmin_total = sum(recv_counts[ramp_end:])
+        _check_region_accuracy(
+            region_name=f"sub-kmin (q<kmin, last {kmin_pkts} pkts)",
+            actual_marked=subkmin_marked,
+            total=subkmin_total,
+            expected_prob=0.0,
+            tolerance=TOLERANCE,
+        )
+        logger.info('\n')
+        logger.info(
+            "ECN accuracy test PASSED for port %s after %d iterations",
+            egress_port, ITERATIONS,
+        )

--- a/tests/snappi_tests/dataplane/test_ecn_interface.py
+++ b/tests/snappi_tests/dataplane/test_ecn_interface.py
@@ -1,0 +1,371 @@
+"""
+ECN interference tests.
+
+Reference test plan:
+    docs/testplan/snappi/switch-ecn-interference-tests.md
+
+Both tests use a 2 Tx -> 1 Rx topology so the two equal-rate flows oversubscribe
+a single egress port and drive ECN-CE marking.  ECN marking is observed on the
+egress side by tracking the 2 ECN bits of the IP header (offset 126, width 2)
+and drilling the Traffic Item view down on those bits, producing a per-codepoint
+"User Defined Statistics" view.
+
+The tests take a ``lossy_prio`` pair as a parameter:
+
+    * the FIRST priority of the pair is ECN enabled  (queue under test / queue A)
+    * the SECOND priority is left NON-ECN enabled     (queue B)
+
+test_cross_queue_interface
+    Verify ECN marking isolation *between* queues.  Queue A (ECN) traffic and
+    queue B (non-ECN) traffic congest the same egress port simultaneously.
+    Queue A packets must get CE marked; queue B packets must NOT be CE marked
+    (they are handled by their own WRED config -- dropped/trimmed).
+
+test_mixed_ecn_codepoint
+    Verify ECN marking isolation *between codepoints* within the queue under
+    test.  Each Tx port sends 4 separate traffic items -- one per ECN codepoint
+    (Non-ECT, ECT(0), ECT(1), CE) -- at 24% line rate each, for 8 traffic items
+    in total across the 2 Tx ports.  Under congestion the ECT(0)/ECT(1) packets
+    must be CE marked, the CE packets stay CE and the Non-ECT packets must never
+    be CE marked.
+"""
+import random
+from tests.snappi_tests.dataplane.imports import *  # noqa: F401, F403, F405
+from snappi_tests.dataplane.files.helper import get_duthost_interface_details, create_snappi_config, \
+     set_primary_chassis, create_traffic_items, start_stop, wait_with_message, get_stats, \
+     _normalize_stat_rows, print_ud_statistics, _rx_rate, _traffic_item, \
+     _ti_row_index, _drill_down_egress, _ud_rows_by_codepoint, _drill_and_get, \
+     _dscp_values  # noqa: F401, F403, F405, E402
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp
+from tests.common.snappi_tests.common_helpers import (
+    enable_ecn,
+    stop_pfcwd,
+    disable_packet_aging,
+)  # noqa: F401
+
+pytestmark = [pytest.mark.topology("nut")]
+logger = logging.getLogger(__name__)
+
+ip_version = "IPv4"
+FRAME_SIZE = 1024
+LINE_RATE = 70  # % line rate per stream (cross-queue test default)
+# For the mixed-codepoint test each Tx port sends 4 traffic items (one per ECN
+# codepoint) at 24% line rate each so the 4 together oversubscribe the shared
+# egress port when both Tx ports run.
+MIXED_CODEPOINT_LINE_RATE = 24
+FLOW_DURATION = 1000  # seconds; flows are stopped explicitly by the test
+
+# ECN codepoint values as seen on the 2 tracked egress bits (offset 126, width 2)
+ECN_NON_ECT = 0  # 00
+ECN_ECT1 = 1  # 01
+ECN_ECT0 = 2  # 10
+ECN_CE = 3  # 11
+
+# Ordered ECN codepoint names and their tracked-bit values.  One traffic item
+# per name is created per Tx port for the mixed-codepoint test.
+CODEPOINTS = ["non_ect", "ect0", "ect1", "ce"]
+CODEPOINT_VALUE = {
+    "non_ect": ECN_NON_ECT,
+    "ect0": ECN_ECT0,
+    "ect1": ECN_ECT1,
+    "ce": ECN_CE,
+}
+
+# Drill-down option matching the 2 ECN bits configured for egress tracking.
+DRILL_DOWN_OPTION = "Custom: (2 bits at offset 126)"
+
+TI_COLUMNS = ["frames_tx", "frames_rx", "loss", "frames_tx_rate", "frames_rx_rate"]
+
+
+@pytest.fixture(scope="module")
+def port_groups(duthosts, get_snappi_ports):
+    """Group the discovered snappi ports into 3-port groups (2 Tx + 1 Rx)."""
+    snappi_ports = get_duthost_interface_details(
+        duthosts, get_snappi_ports, ip_version, protocol_type="IP"
+    )
+    pytest_assert(len(snappi_ports) >= 3,
+                  "Need at least 3 snappi ports (2 Tx + 1 Rx) for the test")
+    pg = [snappi_ports[i:i + 3] for i in range(0, len(snappi_ports), 3)]
+    # Drop a trailing incomplete group if the port count is not a multiple of 3.
+    return [g for g in pg if len(g) == 3]
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _configure_interference(snappi_api, create_snappi_config, snappi_ports,  # noqa F811
+                            subnet_type, ecn_prio, non_ecn_prio, mode):  # noqa F811
+    """Build a 2 Tx -> 1 Rx oversubscription scenario with egress ECN tracking.
+
+    ``mode`` selects how the two flows are built:
+
+        "cross_queue"     - flow A on ``ecn_prio`` (ECN) + flow B on
+                            ``non_ecn_prio`` (non-ECN), both ECT(1).
+        "mixed_codepoint" - both flows on ``ecn_prio`` carrying an even mix of
+                            all 4 ECN codepoints.
+
+    Generates and applies the traffic but does NOT start it.  Returns
+    ``(ixnet, config_facts)``.
+    """
+    pytest_assert(len(snappi_ports) >= 3, "Not enough ports for the test, need at least 3 ports")
+    tx_ports = snappi_ports[:2]
+    rx_ports = [snappi_ports[2]]
+    egress_duthost = rx_ports[0]["duthost"]
+
+    config_facts = egress_duthost.config_facts(
+        host=egress_duthost.hostname, source="running"
+    )["ansible_facts"]
+    pytest_assert("DSCP_TO_TC_MAP" in config_facts, "DSCP_TO_TC_MAP is not configured on the DUT")
+    for prio in (ecn_prio, non_ecn_prio):
+        pytest_assert(
+            str(prio) in config_facts["DSCP_TO_TC_MAP"]["AZURE"].values(),
+            "Lossy priority {} is not mapped to any DSCP in DSCP_TO_TC_MAP".format(prio),
+        )
+
+    logger.info("Stopping PFC watchdog")
+    stop_pfcwd(egress_duthost, rx_ports[0]["asic_value"])
+    logger.info("Disabling packet aging if necessary")
+    disable_packet_aging(egress_duthost)
+    # Enable ECN only on the first priority of the pair; the second is left
+    # non-ECN so its packets are handled by WRED (dropped/trimmed) not marked.
+    pytest_assert(enable_ecn(host_ans=egress_duthost, prio=ecn_prio),
+                  "Unable to enable ecn on priority {}".format(ecn_prio))
+
+    snappi_extra_params = SnappiTestParams()
+    snappi_extra_params.protocol_config = {
+        "Tx": {"protocol_type": "ip", "ports": tx_ports,
+               "subnet_type": subnet_type, "is_rdma": True},
+        "Rx": {"protocol_type": "ip", "ports": rx_ports,
+               "subnet_type": subnet_type, "is_rdma": True},
+    }
+    config, handles = create_snappi_config(snappi_extra_params)
+
+    rx_names = handles["Rx"]["ip"]
+    tx1_name = [handles["Tx"]["ip"][0]]
+    tx2_name = [handles["Tx"]["ip"][1]]
+
+    common = {
+        "line_rate": LINE_RATE,
+        "frame_size": FRAME_SIZE,
+        "is_rdma": True,
+        "rx_names": rx_names,
+        "traffic_duration_fixed_seconds": FLOW_DURATION,
+    }
+
+    if mode == "cross_queue":
+        ecn_dscp = random.choice(_dscp_values(config_facts, ecn_prio))
+        non_ecn_dscp = random.choice(_dscp_values(config_facts, non_ecn_prio))
+        snappi_extra_params.traffic_flow_config = [
+            dict(common, flow_name="Queue_A_ECN", tx_names=tx1_name,
+                 prio=ecn_prio, dscp_value=ecn_dscp, ecn_value="ect1"),
+            # Non-ECN queue: only the DSCP value is configured, the ECN field is
+            # left untouched (ecn_value=None) so nothing marks these packets.
+            dict(common, flow_name="Queue_B_NON_ECN", tx_names=tx2_name,
+                 prio=non_ecn_prio, dscp_value=non_ecn_dscp, ecn_value=None),
+        ]
+    elif mode == "mixed_codepoint":
+        ecn_dscp = random.choice(_dscp_values(config_facts, ecn_prio))
+        # Each Tx port gets 4 traffic items -- one per ECN codepoint -- at 24%
+        # line rate each (8 traffic items total across the 2 Tx ports).
+        mixed_common = dict(common, line_rate=MIXED_CODEPOINT_LINE_RATE)
+        snappi_extra_params.traffic_flow_config = []
+        for port_idx, tx_name in ((1, tx1_name), (2, tx2_name)):
+            for cp in CODEPOINTS:
+                snappi_extra_params.traffic_flow_config.append(
+                    dict(mixed_common,
+                         flow_name="Mixed_P{}_{}".format(port_idx, cp),
+                         tx_names=tx_name, prio=ecn_prio,
+                         dscp_value=ecn_dscp, ecn_value=cp),
+                )
+    else:
+        pytest_assert(False, "Unknown interference mode: {}".format(mode))
+
+    config = create_traffic_items(config, snappi_extra_params)
+    snappi_api.set_config(config)
+
+    logger.info("Starting All protocols")
+    start_stop(snappi_api, operation="start", op_type="protocols")
+    logger.info("Wait for Arp to Resolve ...")
+    wait_for_arp(snappi_api, max_attempts=30, poll_interval_sec=2)
+
+    ixnet = snappi_api._ixnetwork
+    trafficItem = ixnet.Traffic.TrafficItem.find()
+    trafficItem.EgressEnabled = "True"
+    eg = trafficItem.EgressTracking.find()
+    eg.Encapsulation = "Any: Use Custom Settings"
+    eg.Offset = "Custom"
+    eg.CustomOffsetBits = 126
+    eg.CustomWidthBits = 2
+    logger.info("PASS: Egress tracking configured on the 2 ECN bits")
+
+    logger.info("Generating Traffic Item(s)")
+    trafficItem.Generate()
+    logger.info("Applying Traffic")
+    ixnet.Traffic.Apply()
+    ixnet.Globals.Statistics.Advanced.Timestamp.TimestampPrecision = 9
+    return ixnet, config_facts
+
+
+# ---------------------------------------------------------------------------
+# Cross-queue interference
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("subnet_type", [ip_version])
+@pytest.mark.parametrize("lossy_prio", [(0, 2)])
+def test_cross_queue_interface(
+        duthosts,
+        snappi_api,  # noqa: F811
+        get_snappi_ports,  # noqa: F811
+        set_primary_chassis,  # noqa: F811
+        create_snappi_config,  # noqa: F811
+        subnet_type,
+        lossy_prio,
+        port_groups,
+        fanout_graph_facts_multidut,
+):
+    """Verify ECN marking isolation between queues.
+
+    ``lossy_prio`` is a (ecn_prio, non_ecn_prio) pair: the first priority is ECN
+    enabled (queue A), the second is non-ECN (queue B).  Queue A traffic and
+    queue B traffic congest the same egress port together.  Queue A packets must
+    be CE marked while queue B packets must remain unmarked.
+    """
+    ecn_prio, non_ecn_prio = lossy_prio
+    for snappi_ports in port_groups:
+        logger.info("\nSnappi ports used for the test:")
+        for port in snappi_ports:
+            logger.info("{}: {}".format(port["peer_port"], port["location"]))
+        logger.info("ECN priority (queue A): {}, non-ECN priority (queue B): {}"
+                    .format(ecn_prio, non_ecn_prio))
+
+        ixnet, _ = _configure_interference(
+            snappi_api, create_snappi_config, snappi_ports,
+            subnet_type, ecn_prio, non_ecn_prio, mode="cross_queue",
+        )
+
+        ti_a = _traffic_item(ixnet, "Queue_A_ECN")
+        ti_b = _traffic_item(ixnet, "Queue_B_NON_ECN")
+
+        # --- Phase 1: queue A only -> 1:1, no congestion, no ECN marking ---
+        logger.info("Starting queue A (ECN) flow only -- no oversubscription expected")
+        ti_a.StartStatelessTrafficBlocking()
+        wait_with_message("For queue A flow to stabilize:", 20)
+        get_stats(snappi_api, "Traffic Item Statistics", TI_COLUMNS, "print")
+        logger.info("Drill down on Queue_A_ECN flow")
+        _drill_down_egress(ixnet, _ti_row_index(ixnet, "Queue_A_ECN"))
+
+        cp_a = _ud_rows_by_codepoint(ixnet)
+        pytest_assert(_rx_rate(cp_a, ECN_CE) == 0,
+                      "No packets should be ECN-CE marked before oversubscription")
+        logger.info("PASS: No ECN marking on queue A without congestion")
+
+        # --- Phase 2: add queue B -> cross-queue congestion -> queue A marked ---
+        logger.info("Starting queue B (non-ECN) flow to create cross-queue congestion")
+        ti_b.StartStatelessTrafficBlocking()
+        wait_with_message("For cross-queue congestion / ECN marking:", 30)
+        get_stats(snappi_api, "Traffic Item Statistics", TI_COLUMNS, "print")
+
+        # Queue A (ECN enabled) must be CE marked.
+        logger.info("Drill down on Queue_A_ECN flow")
+        _drill_down_egress(ixnet, _ti_row_index(ixnet, "Queue_A_ECN"))
+        cp_a = _ud_rows_by_codepoint(ixnet)
+        pytest_assert(_rx_rate(cp_a, ECN_CE) > 0,
+                      "FAIL: queue A (ECN) packets are not CE marked under congestion")
+        logger.info("PASS: queue A (ECN) packets are CE marked under congestion")
+
+        # Queue B (non-ECN) must NOT be CE marked -- WRED handles it (drop/trim).
+        logger.info("Drill down on Queue_B_NON_ECN flow")
+        _drill_down_egress(ixnet, _ti_row_index(ixnet, "Queue_B_NON_ECN"))
+        cp_b = _ud_rows_by_codepoint(ixnet)
+        qb_non_ce = sum(_rx_rate(cp_b, c) for c in (ECN_NON_ECT, ECN_ECT1, ECN_ECT0))
+        pytest_assert(_rx_rate(cp_b, ECN_CE) == 0,
+                      "FAIL: queue B (non-ECN) packets were CE marked; queues are not isolated")
+        pytest_assert(qb_non_ce > 0,
+                      "FAIL: queue B should still egress (uncmarked) packets")
+        logger.info("PASS: queue B (non-ECN) packets are not CE marked -- queues isolated")
+        ixnet.Traffic.StopStatelessTrafficBlocking()
+
+
+# ---------------------------------------------------------------------------
+# Mixed ECN codepoint
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("subnet_type", [ip_version])
+@pytest.mark.parametrize("lossy_prio", [(0, 2)])
+def test_mixed_ecn_codepoint(
+        duthosts,
+        snappi_api,  # noqa: F811
+        get_snappi_ports,  # noqa: F811
+        set_primary_chassis,  # noqa: F811
+        create_snappi_config,  # noqa: F811
+        subnet_type,
+        lossy_prio,
+        port_groups,
+        fanout_graph_facts_multidut,
+):
+    """Verify ECN marking isolation between codepoints within one queue.
+
+    Both Tx ports use the first (ECN enabled) priority of the ``lossy_prio``
+    pair.  Each Tx port sends 4 separate traffic items -- one per ECN codepoint
+    (Non-ECT, ECT(0), ECT(1), CE) at 24% line rate each -- for 8 traffic items
+    in total.  The 4 codepoint flows of the first port are drilled down and
+    verified: under congestion ECT(0)/ECT(1) packets must be CE marked, CE
+    packets stay CE and Non-ECT packets must never be CE marked.
+    """
+    ecn_prio, non_ecn_prio = lossy_prio
+    for snappi_ports in port_groups:
+        logger.info("\nSnappi ports used for the test:")
+        for port in snappi_ports:
+            logger.info("{}: {}".format(port["peer_port"], port["location"]))
+        logger.info("Queue under test (ECN priority): {}".format(ecn_prio))
+
+        ixnet, _ = _configure_interference(
+            snappi_api, create_snappi_config, snappi_ports,
+            subnet_type, ecn_prio, non_ecn_prio, mode="mixed_codepoint",
+        )
+
+        # The 4 codepoint traffic items of each Tx port.
+        first_port_flows = ["Mixed_P1_{}".format(cp) for cp in CODEPOINTS]
+        second_port_flows = ["Mixed_P2_{}".format(cp) for cp in CODEPOINTS]
+
+        # --- Phase 1: first port only -> no congestion -> codepoints unchanged ---
+        logger.info("Starting the 4 codepoint flows of the first port only "
+                    "-- no oversubscription expected")
+        for name in first_port_flows:
+            _traffic_item(ixnet, name).StartStatelessTrafficBlocking()
+        wait_with_message("For first port flows to stabilize:", 20)
+        get_stats(snappi_api, "Traffic Item Statistics", TI_COLUMNS, "print")
+
+        base_ce = {}
+        for cp in CODEPOINTS:
+            name = "Mixed_P1_{}".format(cp)
+            cp_map = _drill_and_get(ixnet, name)
+            base_ce[cp] = _rx_rate(cp_map, ECN_CE)
+        logger.info("PASS: all codepoints preserved without congestion")
+
+        # --- Phase 2: both ports -> congestion -> ECT marked, Non-ECT/CE intact ---
+        logger.info("Starting the 4 codepoint flows of the second port to create "
+                    "oversubscription")
+        for name in second_port_flows:
+            _traffic_item(ixnet, name).StartStatelessTrafficBlocking()
+        wait_with_message("For ECN marking to start:", 30)
+        get_stats(snappi_api, "Traffic Item Statistics", TI_COLUMNS, "print")
+
+        cong = {cp: _drill_and_get(ixnet, "Mixed_P1_{}".format(cp))
+                for cp in CODEPOINTS}
+
+        # ECT(0)/ECT(1) packets are converted to CE, so a CE row appears where
+        # there was none without congestion.
+        pytest_assert(_rx_rate(cong["ect0"], ECN_CE) > base_ce["ect0"],
+                      "FAIL: ECT(0) packets were not CE marked under congestion")
+        pytest_assert(_rx_rate(cong["ect1"], ECN_CE) > base_ce["ect1"],
+                      "FAIL: ECT(1) packets were not CE marked under congestion")
+        # CE packets pass through with the CE codepoint unchanged.
+        pytest_assert(_rx_rate(cong["ce"], ECN_CE) > 0,
+                      "FAIL: CE packets did not pass through as CE under congestion")
+        # Non-ECT packets must never be CE marked -- they still egress as Non-ECT.
+        pytest_assert(_rx_rate(cong["non_ect"], ECN_CE) == 0,
+                      "FAIL: Non-ECT packets were CE marked -- must never happen")
+        logger.info("PASS: ECT(0)/ECT(1) marked to CE, CE stays CE")
+        ixnet.Traffic.StopStatelessTrafficBlocking()

--- a/tests/snappi_tests/dataplane/test_ecn_interface.py
+++ b/tests/snappi_tests/dataplane/test_ecn_interface.py
@@ -1,0 +1,371 @@
+"""
+ECN interference tests.
+
+Reference test plan:
+    docs/testplan/snappi/switch-ecn-interference-tests.md
+
+Both tests use a 2 Tx -> 1 Rx topology so the two equal-rate flows oversubscribe
+a single egress port and drive ECN-CE marking.  ECN marking is observed on the
+egress side by tracking the 2 ECN bits of the IP header (offset 126, width 2)
+and drilling the Traffic Item view down on those bits, producing a per-codepoint
+"User Defined Statistics" view.
+
+The tests take a ``lossy_prio`` pair as a parameter:
+
+    * the FIRST priority of the pair is ECN enabled  (queue under test / queue A)
+    * the SECOND priority is left NON-ECN enabled     (queue B)
+
+test_cross_queue_interface
+    Verify ECN marking isolation *between* queues.  Queue A (ECN) traffic and
+    queue B (non-ECN) traffic congest the same egress port simultaneously.
+    Queue A packets must get CE marked; queue B packets must NOT be CE marked
+    (they are handled by their own WRED config -- dropped/trimmed).
+
+test_mixed_ecn_codepoint
+    Verify ECN marking isolation *between codepoints* within the queue under
+    test.  Each Tx port sends 4 separate traffic items -- one per ECN codepoint
+    (Non-ECT, ECT(0), ECT(1), CE) -- at 24% line rate each, for 8 traffic items
+    in total across the 2 Tx ports.  Under congestion the ECT(0)/ECT(1) packets
+    must be CE marked, the CE packets stay CE and the Non-ECT packets must never
+    be CE marked.
+"""
+import random
+from tests.snappi_tests.dataplane.imports import *  # noqa: F401, F403, F405
+from snappi_tests.dataplane.files.helper import get_duthost_interface_details, create_snappi_config, \
+     set_primary_chassis, create_traffic_items, start_stop, wait_with_message, get_stats, \
+     _normalize_stat_rows, print_ud_statistics, _rx_rate, _traffic_item, \
+     _ti_row_index, _drill_down_egress, _ud_rows_by_codepoint, _drill_and_get, \
+     _dscp_values  # noqa: F401, F403, F405, E402
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp
+from tests.common.snappi_tests.common_helpers import (
+    enable_ecn,
+    stop_pfcwd,
+    disable_packet_aging,
+)  # noqa: F401
+
+pytestmark = [pytest.mark.topology("nut")]
+logger = logging.getLogger(__name__)
+
+ip_version = "IPv4"
+FRAME_SIZE = 1024
+LINE_RATE = 70  # % line rate per stream (cross-queue test default)
+# For the mixed-codepoint test each Tx port sends 4 traffic items (one per ECN
+# codepoint) at 24% line rate each so the 4 together oversubscribe the shared
+# egress port when both Tx ports run.
+MIXED_CODEPOINT_LINE_RATE = 24
+FLOW_DURATION = 1000  # seconds; flows are stopped explicitly by the test
+
+# ECN codepoint values as seen on the 2 tracked egress bits (offset 126, width 2)
+ECN_NON_ECT = 0  # 00
+ECN_ECT1 = 1  # 01
+ECN_ECT0 = 2  # 10
+ECN_CE = 3  # 11
+
+# Ordered ECN codepoint names and their tracked-bit values.  One traffic item
+# per name is created per Tx port for the mixed-codepoint test.
+CODEPOINTS = ["non_ect", "ect0", "ect1", "ce"]
+CODEPOINT_VALUE = {
+    "non_ect": ECN_NON_ECT,
+    "ect0": ECN_ECT0,
+    "ect1": ECN_ECT1,
+    "ce": ECN_CE,
+}
+
+# Drill-down option matching the 2 ECN bits configured for egress tracking.
+DRILL_DOWN_OPTION = "Custom: (2 bits at offset 126)"
+
+TI_COLUMNS = ["frames_tx", "frames_rx", "loss", "frames_tx_rate", "frames_rx_rate"]
+
+
+@pytest.fixture(scope="module")
+def port_groups(duthosts, get_snappi_ports):
+    snappi_ports = get_duthost_interface_details(
+        duthosts, get_snappi_ports, ip_version, protocol_type="IP"
+    )
+    pytest_assert(len(snappi_ports) >= 3,
+                  "Number of ports should be atleast 3 to create port groups of 3 ports")
+    pg = []
+    for i in range(0, len(snappi_ports), 3):
+        pg.append(snappi_ports[i:i + 3])
+    return pg[:-1] if len(snappi_ports) % 3 != 0 else pg
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _configure_interference(snappi_api, create_snappi_config, snappi_ports,  # noqa F811
+                            subnet_type, ecn_prio, non_ecn_prio, mode):  # noqa F811
+    """Build a 2 Tx -> 1 Rx oversubscription scenario with egress ECN tracking.
+
+    ``mode`` selects how the two flows are built:
+
+        "cross_queue"     - flow A on ``ecn_prio`` (ECN) + flow B on
+                            ``non_ecn_prio`` (non-ECN), both ECT(1).
+        "mixed_codepoint" - both flows on ``ecn_prio`` carrying an even mix of
+                            all 4 ECN codepoints.
+
+    Generates and applies the traffic but does NOT start it.  Returns
+    ``(ixnet, config_facts)``.
+    """
+    pytest_assert(len(snappi_ports) >= 3, "Not enough ports for the test, need at least 3 ports")
+    tx_ports = snappi_ports[:2]
+    rx_ports = [snappi_ports[2]]
+    egress_duthost = rx_ports[0]["duthost"]
+
+    config_facts = egress_duthost.config_facts(
+        host=egress_duthost.hostname, source="running"
+    )["ansible_facts"]
+    pytest_assert("DSCP_TO_TC_MAP" in config_facts, "DSCP_TO_TC_MAP is not configured on the DUT")
+    for prio in (ecn_prio, non_ecn_prio):
+        pytest_assert(
+            str(prio) in config_facts["DSCP_TO_TC_MAP"]["AZURE"].values(),
+            "Lossy priority {} is not mapped to any DSCP in DSCP_TO_TC_MAP".format(prio),
+        )
+
+    logger.info("Stopping PFC watchdog")
+    stop_pfcwd(egress_duthost, rx_ports[0]["asic_value"])
+    logger.info("Disabling packet aging if necessary")
+    disable_packet_aging(egress_duthost)
+    # Enable ECN only on the first priority of the pair; the second is left
+    # non-ECN so its packets are handled by WRED (dropped/trimmed) not marked.
+    pytest_assert(enable_ecn(host_ans=egress_duthost, prio=ecn_prio),
+                  "Unable to enable ecn on priority {}".format(ecn_prio))
+
+    snappi_extra_params = SnappiTestParams()
+    snappi_extra_params.protocol_config = {
+        "Tx": {"protocol_type": "ip", "ports": tx_ports,
+               "subnet_type": subnet_type, "is_rdma": True},
+        "Rx": {"protocol_type": "ip", "ports": rx_ports,
+               "subnet_type": subnet_type, "is_rdma": True},
+    }
+    config, handles = create_snappi_config(snappi_extra_params)
+
+    rx_names = handles["Rx"]["ip"]
+    tx1_name = [handles["Tx"]["ip"][0]]
+    tx2_name = [handles["Tx"]["ip"][1]]
+
+    common = {
+        "line_rate": LINE_RATE,
+        "frame_size": FRAME_SIZE,
+        "is_rdma": True,
+        "rx_names": rx_names,
+        "traffic_duration_fixed_seconds": FLOW_DURATION,
+    }
+
+    if mode == "cross_queue":
+        ecn_dscp = random.choice(_dscp_values(config_facts, ecn_prio))
+        non_ecn_dscp = random.choice(_dscp_values(config_facts, non_ecn_prio))
+        snappi_extra_params.traffic_flow_config = [
+            dict(common, flow_name="Queue_A_ECN", tx_names=tx1_name,
+                 prio=ecn_prio, dscp_value=ecn_dscp, ecn_value="ect1"),
+            # Non-ECN queue: only the DSCP value is configured, the ECN field is
+            # left untouched (ecn_value=None) so nothing marks these packets.
+            dict(common, flow_name="Queue_B_NON_ECN", tx_names=tx2_name,
+                 prio=non_ecn_prio, dscp_value=non_ecn_dscp, ecn_value=None),
+        ]
+    elif mode == "mixed_codepoint":
+        ecn_dscp = random.choice(_dscp_values(config_facts, ecn_prio))
+        # Each Tx port gets 4 traffic items -- one per ECN codepoint -- at 24%
+        # line rate each (8 traffic items total across the 2 Tx ports).
+        mixed_common = dict(common, line_rate=MIXED_CODEPOINT_LINE_RATE)
+        snappi_extra_params.traffic_flow_config = []
+        for port_idx, tx_name in ((1, tx1_name), (2, tx2_name)):
+            for cp in CODEPOINTS:
+                snappi_extra_params.traffic_flow_config.append(
+                    dict(mixed_common,
+                         flow_name="Mixed_P{}_{}".format(port_idx, cp),
+                         tx_names=tx_name, prio=ecn_prio,
+                         dscp_value=ecn_dscp, ecn_value=cp),
+                )
+    else:
+        pytest_assert(False, "Unknown interference mode: {}".format(mode))
+
+    config = create_traffic_items(config, snappi_extra_params)
+    snappi_api.set_config(config)
+
+    logger.info("Starting All protocols")
+    start_stop(snappi_api, operation="start", op_type="protocols")
+    logger.info("Wait for Arp to Resolve ...")
+    wait_for_arp(snappi_api, max_attempts=30, poll_interval_sec=2)
+
+    ixnet = snappi_api._ixnetwork
+    trafficItem = ixnet.Traffic.TrafficItem.find()
+    trafficItem.EgressEnabled = "True"
+    eg = trafficItem.EgressTracking.find()
+    eg.Encapsulation = "Any: Use Custom Settings"
+    eg.Offset = "Custom"
+    eg.CustomOffsetBits = 126
+    eg.CustomWidthBits = 2
+    logger.info("PASS: Egress tracking configured on the 2 ECN bits")
+
+    logger.info("Generating Traffic Item(s)")
+    trafficItem.Generate()
+    logger.info("Applying Traffic")
+    ixnet.Traffic.Apply()
+    ixnet.Globals.Statistics.Advanced.Timestamp.TimestampPrecision = 9
+    return ixnet, config_facts
+
+
+# ---------------------------------------------------------------------------
+# Cross-queue interference
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("subnet_type", [ip_version])
+@pytest.mark.parametrize("lossy_prio", [(0, 2)])
+def test_cross_queue_interface(
+        duthosts,
+        snappi_api,  # noqa: F811
+        get_snappi_ports,  # noqa: F811
+        set_primary_chassis,  # noqa: F811
+        create_snappi_config,  # noqa: F811
+        subnet_type,
+        lossy_prio,
+        port_groups,
+        fanout_graph_facts_multidut,
+):
+    """Verify ECN marking isolation between queues.
+
+    ``lossy_prio`` is a (ecn_prio, non_ecn_prio) pair: the first priority is ECN
+    enabled (queue A), the second is non-ECN (queue B).  Queue A traffic and
+    queue B traffic congest the same egress port together.  Queue A packets must
+    be CE marked while queue B packets must remain unmarked.
+    """
+    ecn_prio, non_ecn_prio = lossy_prio
+    for snappi_ports in port_groups:
+        logger.info("\nSnappi ports used for the test:")
+        for port in snappi_ports:
+            logger.info("{}: {}".format(port["peer_port"], port["location"]))
+        logger.info("ECN priority (queue A): {}, non-ECN priority (queue B): {}"
+                    .format(ecn_prio, non_ecn_prio))
+
+        ixnet, _ = _configure_interference(
+            snappi_api, create_snappi_config, snappi_ports,
+            subnet_type, ecn_prio, non_ecn_prio, mode="cross_queue",
+        )
+
+        ti_a = _traffic_item(ixnet, "Queue_A_ECN")
+        ti_b = _traffic_item(ixnet, "Queue_B_NON_ECN")
+
+        # --- Phase 1: queue A only -> 1:1, no congestion, no ECN marking ---
+        logger.info("Starting queue A (ECN) flow only -- no oversubscription expected")
+        ti_a.StartStatelessTrafficBlocking()
+        wait_with_message("For queue A flow to stabilize:", 20)
+        get_stats(snappi_api, "Traffic Item Statistics", TI_COLUMNS, "print")
+        logger.info("Drill down on Queue_A_ECN flow")
+        _drill_down_egress(ixnet, _ti_row_index(ixnet, "Queue_A_ECN"))
+
+        cp_a = _ud_rows_by_codepoint(ixnet)
+        pytest_assert(_rx_rate(cp_a, ECN_CE) == 0,
+                      "No packets should be ECN-CE marked before oversubscription")
+        logger.info("PASS: No ECN marking on queue A without congestion")
+
+        # --- Phase 2: add queue B -> cross-queue congestion -> queue A marked ---
+        logger.info("Starting queue B (non-ECN) flow to create cross-queue congestion")
+        ti_b.StartStatelessTrafficBlocking()
+        wait_with_message("For cross-queue congestion / ECN marking:", 30)
+        get_stats(snappi_api, "Traffic Item Statistics", TI_COLUMNS, "print")
+
+        # Queue A (ECN enabled) must be CE marked.
+        logger.info("Drill down on Queue_A_ECN flow")
+        _drill_down_egress(ixnet, _ti_row_index(ixnet, "Queue_A_ECN"))
+        cp_a = _ud_rows_by_codepoint(ixnet)
+        pytest_assert(_rx_rate(cp_a, ECN_CE) > 0,
+                      "FAIL: queue A (ECN) packets are not CE marked under congestion")
+        logger.info("PASS: queue A (ECN) packets are CE marked under congestion")
+
+        # Queue B (non-ECN) must NOT be CE marked -- WRED handles it (drop/trim).
+        logger.info("Drill down on Queue_B_NON_ECN flow")
+        _drill_down_egress(ixnet, _ti_row_index(ixnet, "Queue_B_NON_ECN"))
+        cp_b = _ud_rows_by_codepoint(ixnet)
+        qb_non_ce = sum(_rx_rate(cp_b, c) for c in (ECN_NON_ECT, ECN_ECT1, ECN_ECT0))
+        pytest_assert(_rx_rate(cp_b, ECN_CE) == 0,
+                      "FAIL: queue B (non-ECN) packets were CE marked; queues are not isolated")
+        pytest_assert(qb_non_ce > 0,
+                      "FAIL: queue B should still egress (uncmarked) packets")
+        logger.info("PASS: queue B (non-ECN) packets are not CE marked -- queues isolated")
+        ixnet.Traffic.StopStatelessTrafficBlocking()
+
+
+# ---------------------------------------------------------------------------
+# Mixed ECN codepoint
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("subnet_type", [ip_version])
+@pytest.mark.parametrize("lossy_prio", [(0, 2)])
+def test_mixed_ecn_codepoint(
+        duthosts,
+        snappi_api,  # noqa: F811
+        get_snappi_ports,  # noqa: F811
+        set_primary_chassis,  # noqa: F811
+        create_snappi_config,  # noqa: F811
+        subnet_type,
+        lossy_prio,
+        port_groups,
+        fanout_graph_facts_multidut,
+):
+    """Verify ECN marking isolation between codepoints within one queue.
+
+    Both Tx ports use the first (ECN enabled) priority of the ``lossy_prio``
+    pair.  Each Tx port sends 4 separate traffic items -- one per ECN codepoint
+    (Non-ECT, ECT(0), ECT(1), CE) at 24% line rate each -- for 8 traffic items
+    in total.  The 4 codepoint flows of the first port are drilled down and
+    verified: under congestion ECT(0)/ECT(1) packets must be CE marked, CE
+    packets stay CE and Non-ECT packets must never be CE marked.
+    """
+    ecn_prio, non_ecn_prio = lossy_prio
+    for snappi_ports in port_groups:
+        logger.info("\nSnappi ports used for the test:")
+        for port in snappi_ports:
+            logger.info("{}: {}".format(port["peer_port"], port["location"]))
+        logger.info("Queue under test (ECN priority): {}".format(ecn_prio))
+
+        ixnet, _ = _configure_interference(
+            snappi_api, create_snappi_config, snappi_ports,
+            subnet_type, ecn_prio, non_ecn_prio, mode="mixed_codepoint",
+        )
+
+        # The 4 codepoint traffic items of each Tx port.
+        first_port_flows = ["Mixed_P1_{}".format(cp) for cp in CODEPOINTS]
+        second_port_flows = ["Mixed_P2_{}".format(cp) for cp in CODEPOINTS]
+
+        # --- Phase 1: first port only -> no congestion -> codepoints unchanged ---
+        logger.info("Starting the 4 codepoint flows of the first port only "
+                    "-- no oversubscription expected")
+        for name in first_port_flows:
+            _traffic_item(ixnet, name).StartStatelessTrafficBlocking()
+        wait_with_message("For first port flows to stabilize:", 20)
+        get_stats(snappi_api, "Traffic Item Statistics", TI_COLUMNS, "print")
+
+        base_ce = {}
+        for cp in CODEPOINTS:
+            name = "Mixed_P1_{}".format(cp)
+            cp_map = _drill_and_get(ixnet, name)
+            base_ce[cp] = _rx_rate(cp_map, ECN_CE)
+        logger.info("PASS: all codepoints preserved without congestion")
+
+        # --- Phase 2: both ports -> congestion -> ECT marked, Non-ECT/CE intact ---
+        logger.info("Starting the 4 codepoint flows of the second port to create "
+                    "oversubscription")
+        for name in second_port_flows:
+            _traffic_item(ixnet, name).StartStatelessTrafficBlocking()
+        wait_with_message("For ECN marking to start:", 30)
+        get_stats(snappi_api, "Traffic Item Statistics", TI_COLUMNS, "print")
+
+        cong = {cp: _drill_and_get(ixnet, "Mixed_P1_{}".format(cp))
+                for cp in CODEPOINTS}
+
+        # ECT(0)/ECT(1) packets are converted to CE, so a CE row appears where
+        # there was none without congestion.
+        pytest_assert(_rx_rate(cong["ect0"], ECN_CE) > base_ce["ect0"],
+                      "FAIL: ECT(0) packets were not CE marked under congestion")
+        pytest_assert(_rx_rate(cong["ect1"], ECN_CE) > base_ce["ect1"],
+                      "FAIL: ECT(1) packets were not CE marked under congestion")
+        # CE packets pass through with the CE codepoint unchanged.
+        pytest_assert(_rx_rate(cong["ce"], ECN_CE) > 0,
+                      "FAIL: CE packets did not pass through as CE under congestion")
+        # Non-ECT packets must never be CE marked -- they still egress as Non-ECT.
+        pytest_assert(_rx_rate(cong["non_ect"], ECN_CE) == 0,
+                      "FAIL: Non-ECT packets were CE marked -- must never happen")
+        logger.info("PASS: ECT(0)/ECT(1) marked to CE, CE stays CE")
+        ixnet.Traffic.StopStatelessTrafficBlocking()

--- a/tests/snappi_tests/dataplane/test_ecn_marking_with_scheduler_blocking.py
+++ b/tests/snappi_tests/dataplane/test_ecn_marking_with_scheduler_blocking.py
@@ -1,0 +1,216 @@
+import random
+from tests.snappi_tests.dataplane.imports import *  # noqa: F401, F403, F405
+from snappi_tests.dataplane.files.helper import get_duthost_interface_details, create_snappi_config, \
+    get_snappi_stats, set_primary_chassis, create_traffic_items, start_stop, wait_with_message, \
+    dutconfig_checkpoint, _block_egress, _unblock_egress, _get_original_scheduler, \
+    _dscp_values  # noqa: F401, F403, F405
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp
+from tests.common.snappi_tests.common_helpers import (
+    enable_ecn,
+    disable_packet_aging,
+    config_capture_pkt,
+)
+
+pytestmark = [pytest.mark.topology("nut")]
+logger = logging.getLogger(__name__)
+
+ip_version = "IPv4"
+FRAME_SIZE = 1024
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def port_groups(duthosts, get_snappi_ports):
+    snappi_ports = get_duthost_interface_details(
+        duthosts, get_snappi_ports, ip_version, protocol_type="IP"
+    )
+    pytest_assert(
+        len(snappi_ports) >= 2,
+        "Need at least 2 snappi ports for the test",
+    )
+    return [snappi_ports[i: i + 2] for i in range(0, len(snappi_ports) - 1, 2)]
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("subnet_type", [ip_version])
+@pytest.mark.parametrize("lossless_prio", [0])
+def test_ecn_marking_lossless_queue(
+    duthosts,
+    dutconfig_checkpoint,  # noqa: F811
+    snappi_api,
+    get_snappi_ports,
+    set_primary_chassis,  # noqa: F811
+    create_snappi_config,  # noqa: F811
+    subnet_type,
+    lossless_prio,
+    port_groups,
+    fanout_graph_facts_multidut,
+):
+    """ECN marking at egress using lossless queue scheduler blocking.
+
+    Blocks the egress queue with a near-zero-rate scheduler so packets
+    accumulate past kmax, then verifies:
+    - >95% packet loss while the queue is blocked.
+    - The first packet released from the full buffer is ECN-marked.
+    - The last captured packet (queue nearly empty) is not ECN-marked.
+    """
+    snappi_extra_params = SnappiTestParams()
+
+    for snappi_ports in port_groups:
+        logger.info("Snappi ports: Tx=%s  Rx=%s",
+                    snappi_ports[0]["peer_port"], snappi_ports[1]["peer_port"])
+
+        tx_ports = [snappi_ports[0]]
+        rx_ports = [snappi_ports[1]]
+        egress_duthost = rx_ports[0]["duthost"]
+        egress_port = rx_ports[0]["peer_port"]
+
+        # --- DUT config sanity ---
+        config_facts = egress_duthost.config_facts(
+            host=egress_duthost.hostname, source="running"
+        )["ansible_facts"]
+        pytest_assert(
+            "DSCP_TO_TC_MAP" in config_facts,
+            "DSCP_TO_TC_MAP is not configured on the DUT",
+        )
+        pytest_assert(
+            str(lossless_prio) in config_facts["DSCP_TO_TC_MAP"]["AZURE"].values(),
+            f"Lossless priority {lossless_prio} is not mapped to any DSCP in DSCP_TO_TC_MAP",
+        )
+        ecn_dscp = random.choice(_dscp_values(config_facts, lossless_prio))
+
+        # --- ECN setup ---
+        disable_packet_aging(egress_duthost)
+        pytest_assert(
+            enable_ecn(host_ans=egress_duthost, prio=lossless_prio),
+            "Unable to enable ECN on DUT",
+        )
+
+        # --- Block egress; send 2x kmax packets so the buffer fills well past kmax ---
+        original_scheduler = _get_original_scheduler(egress_duthost, egress_port, lossless_prio)
+        _block_egress(egress_duthost, egress_port, lossless_prio)
+
+        wred_profile = config_facts.get("WRED_PROFILE", {}).get("AZURE_LOSSLESS", {})
+        pytest_assert(wred_profile, "WRED profile AZURE_LOSSLESS not found in config_facts")
+        kmax = int(wred_profile["green_max_threshold"])
+        fixed_packet_count = 2 * (kmax // FRAME_SIZE)
+
+        # --- Build snappi config ---
+        snappi_extra_params.protocol_config = {
+            "Tx": {
+                "protocol_type": "ip",
+                "ports": tx_ports,
+                "subnet_type": subnet_type,
+                "is_rdma": True,
+            },
+            "Rx": {
+                "protocol_type": "ip",
+                "ports": rx_ports,
+                "subnet_type": subnet_type,
+                "is_rdma": True,
+            },
+        }
+        config, snappi_obj_handles = create_snappi_config(snappi_extra_params)
+        snappi_extra_params.traffic_flow_config = [
+            {
+                "line_rate": 100,
+                "frame_size": FRAME_SIZE,
+                "is_rdma": True,
+                "flow_name": "ECN_scheduler_block",
+                "tx_names": snappi_obj_handles["Tx"]["ip"],
+                "rx_names": snappi_obj_handles["Rx"]["ip"],
+                "traffic_duration_fixed_packets": fixed_packet_count,
+                "prio": lossless_prio,
+                "dscp_value": ecn_dscp,
+            }
+        ]
+        config = create_traffic_items(config, snappi_extra_params)
+
+        pcap_file = "ECN_lossless_queue"
+        pcap_ports = ["Port_2"]
+        config_capture_pkt(
+            testbed_config=config,
+            port_names=pcap_ports,
+            capture_type=packet_capture.IP_CAPTURE,
+            capture_name=pcap_file,
+        )
+        snappi_api.set_config(config)
+
+        # --- Start protocols and traffic ---
+        start_stop(snappi_api, operation="start", op_type="protocols")
+        wait_for_arp(snappi_api, max_attempts=30, poll_interval_sec=2)
+
+        ixnet = snappi_api._ixnetwork
+        traffic_item = ixnet.Traffic.TrafficItem.find()
+        rx_vport = ixnet.Vport.find(Name=pcap_ports[0])
+        rx_vport.Capture.ControlSliceSize = 32
+        rx_vport.Capture.SliceSize = 32
+
+        cs = snappi_api.control_state()
+        cs.port.capture.port_names = pcap_ports
+        cs.port.capture.state = cs.port.capture.START
+        snappi_api.set_control_state(cs)
+        wait(5, "To start capture")
+
+        ts = snappi_api.control_state()
+        ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.START
+        snappi_api.set_control_state(ts)
+        wait(30, "For traffic to fill the queue")
+
+        get_stats(
+            snappi_api, "Traffic Item Statistics",
+            ["frames_tx", "frames_rx", "loss", "frames_tx_rate", "frames_rx_rate"],
+            "print",
+        )
+
+        # --- Verify blocking loss ---
+        ti_stats = StatViewAssistant(ixnet, "Traffic Item Statistics")
+        pytest_assert(
+            int(float(ti_stats.Rows[0]["Loss %"])) > 95,
+            "Loss must be observed when egress queue is blocked",
+        )
+        leaked_frame_count = int(ti_stats.Rows[0]["Rx Frames"])
+
+        # --- Unblock egress so buffered packets drain ---
+        _unblock_egress(egress_duthost, egress_port, lossless_prio, original_scheduler)
+
+        # --- Stop capture and retrieve pcap ---
+        cap_req = snappi_api.capture_request()
+        cap_req.port_name = pcap_ports[0]
+        cs = snappi_api.control_state()
+        cs.port.capture.state = cs.port.capture.STOP
+        snappi_api.set_control_state(cs)
+        wait(20, "To stop capture")
+
+        pcap_bytes = snappi_api.get_capture(cap_req)
+        pcap_path = f"{pcap_file}.pcapng"
+        with open(pcap_path, "wb") as fh:
+            fh.write(pcap_bytes.getvalue())
+
+        # --- ECN assertions ---
+        ip_pkts = get_ipv4_pkts(pcap_path)
+        logger.info("Total packets captured: %d", len(ip_pkts))
+        pytest_assert(len(ip_pkts) > 0, "No IPv4 packets were captured")
+
+        marked_count = sum(1 for pkt in ip_pkts if is_ecn_marked(pkt))
+        pytest_assert(marked_count > 0, "No packets are ECN marked")
+        logger.info("ECN marked: %d / %d (%.1f%%)",
+                    marked_count, len(ip_pkts), marked_count / len(ip_pkts) * 100)
+
+        pytest_assert(
+            is_ecn_marked(ip_pkts[leaked_frame_count - 1]),
+            "The first packet released from a full buffer should be ECN marked",
+        )
+        pytest_assert(
+            not is_ecn_marked(ip_pkts[-1]),
+            "The last captured packet (queue draining) should not be ECN marked",
+        )
+
+        traffic_item.StopStatelessTrafficBlocking()

--- a/tests/snappi_tests/dataplane/test_ecn_marking_with_scheduler_blocking.py
+++ b/tests/snappi_tests/dataplane/test_ecn_marking_with_scheduler_blocking.py
@@ -1,0 +1,217 @@
+import random
+from tests.snappi_tests.dataplane.imports import *  # noqa: F401, F403, F405
+from snappi_tests.dataplane.files.helper import get_duthost_interface_details, create_snappi_config, \
+    get_snappi_stats, set_primary_chassis, create_traffic_items, start_stop, wait_with_message, \
+    dutconfig_checkpoint, _block_egress, _unblock_egress, _get_original_scheduler, \
+    _dscp_values  # noqa: F401, F403, F405
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp
+from tests.common.snappi_tests.common_helpers import (
+    enable_ecn,
+    disable_packet_aging,
+    config_capture_pkt,
+)
+
+pytestmark = [pytest.mark.topology("nut")]
+logger = logging.getLogger(__name__)
+
+ip_version = "IPv4"
+FRAME_SIZE = 1024
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def port_groups(duthosts, get_snappi_ports):
+    snappi_ports = get_duthost_interface_details(
+        duthosts, get_snappi_ports, ip_version, protocol_type="IP"
+    )
+    pytest_assert(len(snappi_ports) >= 2,
+                  "Number of ports should be atleast 2 to create port groups of 2 ports")
+    pg = []
+    for i in range(0, len(snappi_ports), 2):
+        pg.append(snappi_ports[i:i + 2])
+    return pg[:-1] if len(snappi_ports) % 2 != 0 else pg
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("subnet_type", [ip_version])
+@pytest.mark.parametrize("lossless_prio", [0])
+def test_ecn_marking_lossless_queue(
+    duthosts,
+    dutconfig_checkpoint,  # noqa: F811
+    snappi_api,
+    get_snappi_ports,
+    set_primary_chassis,  # noqa: F811
+    create_snappi_config,  # noqa: F811
+    subnet_type,
+    lossless_prio,
+    port_groups,
+    fanout_graph_facts_multidut,
+):
+    """ECN marking at egress using lossless queue scheduler blocking.
+
+    Blocks the egress queue with a near-zero-rate scheduler so packets
+    accumulate past kmax, then verifies:
+    - >95% packet loss while the queue is blocked.
+    - The first packet released from the full buffer is ECN-marked.
+    - The last captured packet (queue nearly empty) is not ECN-marked.
+    """
+    snappi_extra_params = SnappiTestParams()
+
+    for snappi_ports in port_groups:
+        logger.info("Snappi ports: Tx=%s  Rx=%s",
+                    snappi_ports[0]["peer_port"], snappi_ports[1]["peer_port"])
+
+        tx_ports = [snappi_ports[0]]
+        rx_ports = [snappi_ports[1]]
+        egress_duthost = rx_ports[0]["duthost"]
+        egress_port = rx_ports[0]["peer_port"]
+
+        # --- DUT config sanity ---
+        config_facts = egress_duthost.config_facts(
+            host=egress_duthost.hostname, source="running"
+        )["ansible_facts"]
+        pytest_assert(
+            "DSCP_TO_TC_MAP" in config_facts,
+            "DSCP_TO_TC_MAP is not configured on the DUT",
+        )
+        pytest_assert(
+            str(lossless_prio) in config_facts["DSCP_TO_TC_MAP"]["AZURE"].values(),
+            f"Lossless priority {lossless_prio} is not mapped to any DSCP in DSCP_TO_TC_MAP",
+        )
+        ecn_dscp = random.choice(_dscp_values(config_facts, lossless_prio))
+
+        # --- ECN setup ---
+        disable_packet_aging(egress_duthost)
+        pytest_assert(
+            enable_ecn(host_ans=egress_duthost, prio=lossless_prio),
+            "Unable to enable ECN on DUT",
+        )
+
+        # --- Block egress; send 2x kmax packets so the buffer fills well past kmax ---
+        original_scheduler = _get_original_scheduler(egress_duthost, egress_port, lossless_prio)
+        _block_egress(egress_duthost, egress_port, lossless_prio)
+
+        wred_profile = config_facts.get("WRED_PROFILE", {}).get("AZURE_LOSSLESS", {})
+        pytest_assert(wred_profile, "WRED profile AZURE_LOSSLESS not found in config_facts")
+        kmax = int(wred_profile["green_max_threshold"])
+        fixed_packet_count = 2 * (kmax // FRAME_SIZE)
+
+        # --- Build snappi config ---
+        snappi_extra_params.protocol_config = {
+            "Tx": {
+                "protocol_type": "ip",
+                "ports": tx_ports,
+                "subnet_type": subnet_type,
+                "is_rdma": True,
+            },
+            "Rx": {
+                "protocol_type": "ip",
+                "ports": rx_ports,
+                "subnet_type": subnet_type,
+                "is_rdma": True,
+            },
+        }
+        config, snappi_obj_handles = create_snappi_config(snappi_extra_params)
+        snappi_extra_params.traffic_flow_config = [
+            {
+                "line_rate": 100,
+                "frame_size": FRAME_SIZE,
+                "is_rdma": True,
+                "flow_name": "ECN_scheduler_block",
+                "tx_names": snappi_obj_handles["Tx"]["ip"],
+                "rx_names": snappi_obj_handles["Rx"]["ip"],
+                "traffic_duration_fixed_packets": fixed_packet_count,
+                "prio": lossless_prio,
+                "dscp_value": ecn_dscp,
+            }
+        ]
+        config = create_traffic_items(config, snappi_extra_params)
+
+        pcap_file = "ECN_lossless_queue"
+        pcap_ports = ["Port_2"]
+        config_capture_pkt(
+            testbed_config=config,
+            port_names=pcap_ports,
+            capture_type=packet_capture.IP_CAPTURE,
+            capture_name=pcap_file,
+        )
+        snappi_api.set_config(config)
+
+        # --- Start protocols and traffic ---
+        start_stop(snappi_api, operation="start", op_type="protocols")
+        wait_for_arp(snappi_api, max_attempts=30, poll_interval_sec=2)
+
+        ixnet = snappi_api._ixnetwork
+        traffic_item = ixnet.Traffic.TrafficItem.find()
+        rx_vport = ixnet.Vport.find(Name=pcap_ports[0])
+        rx_vport.Capture.ControlSliceSize = 32
+        rx_vport.Capture.SliceSize = 32
+
+        cs = snappi_api.control_state()
+        cs.port.capture.port_names = pcap_ports
+        cs.port.capture.state = cs.port.capture.START
+        snappi_api.set_control_state(cs)
+        wait(5, "To start capture")
+
+        ts = snappi_api.control_state()
+        ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.START
+        snappi_api.set_control_state(ts)
+        wait(30, "For traffic to fill the queue")
+
+        get_stats(
+            snappi_api, "Traffic Item Statistics",
+            ["frames_tx", "frames_rx", "loss", "frames_tx_rate", "frames_rx_rate"],
+            "print",
+        )
+
+        # --- Verify blocking loss ---
+        ti_stats = StatViewAssistant(ixnet, "Traffic Item Statistics")
+        pytest_assert(
+            int(float(ti_stats.Rows[0]["Loss %"])) > 95,
+            "Loss must be observed when egress queue is blocked",
+        )
+        leaked_frame_count = int(ti_stats.Rows[0]["Rx Frames"])
+
+        # --- Unblock egress so buffered packets drain ---
+        _unblock_egress(egress_duthost, egress_port, lossless_prio, original_scheduler)
+
+        # --- Stop capture and retrieve pcap ---
+        cap_req = snappi_api.capture_request()
+        cap_req.port_name = pcap_ports[0]
+        cs = snappi_api.control_state()
+        cs.port.capture.state = cs.port.capture.STOP
+        snappi_api.set_control_state(cs)
+        wait(20, "To stop capture")
+
+        pcap_bytes = snappi_api.get_capture(cap_req)
+        pcap_path = f"{pcap_file}.pcapng"
+        with open(pcap_path, "wb") as fh:
+            fh.write(pcap_bytes.getvalue())
+
+        # --- ECN assertions ---
+        ip_pkts = get_ipv4_pkts(pcap_path)
+        logger.info("Total packets captured: %d", len(ip_pkts))
+        pytest_assert(len(ip_pkts) > 0, "No IPv4 packets were captured")
+
+        marked_count = sum(1 for pkt in ip_pkts if is_ecn_marked(pkt))
+        pytest_assert(marked_count > 0, "No packets are ECN marked")
+        logger.info("ECN marked: %d / %d (%.1f%%)",
+                    marked_count, len(ip_pkts), marked_count / len(ip_pkts) * 100)
+
+        pytest_assert(
+            is_ecn_marked(ip_pkts[leaked_frame_count - 1]),
+            "The first packet released from a full buffer should be ECN marked",
+        )
+        pytest_assert(
+            not is_ecn_marked(ip_pkts[-1]),
+            "The last captured packet (queue draining) should not be ECN marked",
+        )
+
+        traffic_item.StopStatelessTrafficBlocking()

--- a/tests/snappi_tests/dataplane/test_ecn_response_time.py
+++ b/tests/snappi_tests/dataplane/test_ecn_response_time.py
@@ -1,0 +1,335 @@
+"""
+ECN marking response-time tests (enter time + exit time).
+
+Topology per port-group: 2 Tx ports -> 1 Rx (egress) port, so two equal-rate
+flows can oversubscribe a single egress port and drive ECN-CE marking.
+
+Egress tracking is configured on the 2 ECN bits of the IP header (offset 126,
+width 2). After a drill-down on those 2 bits the "User Defined Statistics" view
+breaks the egress traffic out by CE value; Row 3 (Rows[2]) is the ECN-CE marked
+row (CE bits == 3).
+
+Two measurements:
+
+- ECN marking ENTER time (test_ecn_response_entry_time):
+    1. Start the first flow only -- no oversubscription, no ECN marking.
+    2. Start the second flow -- oversubscription begins and ECN marking starts.
+    3. first_marked_ts  = First TimeStamp of the ECN-CE row (Row 3 of UD stats).
+       first_pkt_flow2  = First TimeStamp of the second stream.
+       ENTER time       = first_marked_ts - first_pkt_flow2.
+
+- ECN marking EXIT time (test_ecn_response_exit_time, existing logic):
+    1. Run both flows oversubscribed so packets are ECN-CE marked.
+    2. Stop the first stream so the egress buffer drains and marking stops.
+       last_ts_flow1 = Last TimeStamp of the stopped flow.
+       egress_3      = Last TimeStamp of the ECN-CE row (Row 3 of UD stats).
+       EXIT time     = egress_3 - last_ts_flow1.
+"""
+import random
+from tests.snappi_tests.dataplane.imports import *  # noqa: F401, F403, F405
+from snappi_tests.dataplane.files.helper import get_duthost_interface_details, create_snappi_config, \
+    get_snappi_stats, set_primary_chassis, create_traffic_items, start_stop, wait_with_message, \
+    get_stats, _normalize_stat_rows, print_ud_statistics, dutconfig_checkpoint, \
+    _ts_seconds, _drill_down_egress, _dscp_values  # noqa: F401, F403, F405, E402
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp
+from tests.common.snappi_tests.common_helpers import (
+    enable_ecn,
+    stop_pfcwd,
+    disable_packet_aging,
+)  # noqa: F401
+
+pytestmark = [pytest.mark.topology("nut")]
+logger = logging.getLogger(__name__)
+
+ip_version = "IPv4"
+
+# Row index of the ECN-CE marked entry in the drilled-down User Defined
+# Statistics view (CE bits == 3). 1-indexed this is "Row 3".
+ECN_CE_ROW = 2
+
+# Drill-down option matching the 2 ECN bits configured below (offset 126, 2 bits).
+DRILL_DOWN_OPTION = "Custom: (2 bits at offset 126)"
+
+TI_COLUMNS = ["frames_tx", "frames_rx", "loss", "frames_tx_rate", "frames_rx_rate"]
+SELECTED_UD_COLS = [
+    "Egress Tracking",
+    "Tx Frames",
+    "Rx Frames",
+    "Frames Delta",
+    "Loss %",
+    "Tx Frame Rate",
+    "Rx Frame Rate",
+]
+
+
+@pytest.fixture(scope="module")
+def port_groups(duthosts, get_snappi_ports):
+    snappi_ports = get_duthost_interface_details(
+        duthosts, get_snappi_ports, ip_version, protocol_type="IP"
+    )
+    pytest_assert(len(snappi_ports) % 3 == 0,
+                  "Number of ports should be a multiple of 3 to create port groups of 3 ports each")
+    pg = []
+    for i in range(0, len(snappi_ports), 3):
+        pg.append(snappi_ports[i:i + 3])
+    return pg[:-1] if len(snappi_ports) % 3 != 0 else pg
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _configure_oversub(snappi_api,
+                       create_snappi_config,  # noqa: F811
+                       snappi_ports,
+                       subnet_type,
+                       lossy_prio):
+    """Build a 2:1 oversubscription scenario (2 Tx -> 1 Rx) with egress ECN/CE
+    tracking. Generates and applies the traffic but does NOT start it.
+
+    Returns (ixnet, trafficItem).
+    """
+    pytest_assert(len(snappi_ports) >= 3, "Not enough ports for the test, Need at least 3 ports")
+    tx_ports = snappi_ports[:2]
+    rx_ports = [snappi_ports[2]]
+    egress_duthost = rx_ports[0]["duthost"]
+
+    config_facts = egress_duthost.config_facts(
+        host=egress_duthost.hostname, source="running"
+    )["ansible_facts"]
+    pytest_assert("DSCP_TO_TC_MAP" in config_facts, "DSCP_TO_TC_MAP is not configured on the DUT")
+    pytest_assert(
+        str(lossy_prio) in config_facts["DSCP_TO_TC_MAP"]["AZURE"].values(),
+        "Lossy priority {} is not mapped to any DSCP in DSCP_TO_TC_MAP".format(lossy_prio),
+    )
+    ecn_dscp = random.choice(_dscp_values(config_facts, lossy_prio))
+
+    logger.info("Stopping PFC watchdog")
+    stop_pfcwd(egress_duthost, rx_ports[0]["asic_value"])
+    logger.info("Disabling packet aging if necessary")
+    disable_packet_aging(egress_duthost)
+    pytest_assert(enable_ecn(host_ans=egress_duthost, prio=lossy_prio), "Unable to enable ecn")
+
+    snappi_extra_params = SnappiTestParams()
+    snappi_extra_params.protocol_config = {
+        "Tx": {"protocol_type": "ip", "ports": tx_ports,
+               "subnet_type": subnet_type, "is_rdma": True},
+        "Rx": {"protocol_type": "ip", "ports": rx_ports,
+               "subnet_type": subnet_type, "is_rdma": True},
+    }
+    config, snappi_obj_handles = create_snappi_config(snappi_extra_params)
+    snappi_extra_params.traffic_flow_config = [
+        {
+            "line_rate": 95,
+            "frame_size": 1024,
+            "is_rdma": True,
+            "flow_name": "Traffic Flow",
+            "tx_names": snappi_obj_handles["Tx"]["ip"],
+            "rx_names": snappi_obj_handles["Rx"]["ip"],
+            "traffic_duration_fixed_seconds": 1000,
+            "prio": lossy_prio,
+            "dscp_value": ecn_dscp,
+        },
+    ]
+    config = create_traffic_items(config, snappi_extra_params)
+    snappi_api.set_config(config)
+
+    logger.info("Starting All protocols")
+    start_stop(snappi_api, operation="start", op_type="protocols")
+    logger.info("Wait for Arp to Resolve ...")
+    wait_for_arp(snappi_api, max_attempts=30, poll_interval_sec=2)
+
+    ixnet = snappi_api._ixnetwork
+    trafficItem = ixnet.Traffic.TrafficItem.find()
+    trafficItem.EgressEnabled = "True"
+    eg = trafficItem.EgressTracking.find()
+    eg.Encapsulation = "Any: Use Custom Settings"
+    eg.Offset = "Custom"
+    eg.CustomOffsetBits = 126
+    eg.CustomWidthBits = 2
+    logger.info("PASS: Egress tracking configured successfully")
+
+    logger.info("Generating Traffic Item")
+    trafficItem.Generate()
+    logger.info("Applying Traffic")
+    ixnet.Traffic.Apply()
+    return ixnet, trafficItem
+
+# ---------------------------------------------------------------------------
+# ECN marking ENTER time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("subnet_type", [ip_version])
+@pytest.mark.parametrize("lossy_prio", [0])
+def test_ecn_response_entry_time(
+        duthosts,
+        dutconfig_checkpoint,   # noqa: F811
+        snappi_api,  # noqa: F811
+        get_snappi_ports,  # noqa: F811
+        set_primary_chassis,  # noqa: F811
+        create_snappi_config,  # noqa: F811
+        subnet_type,
+        lossy_prio,
+        port_groups,
+        fanout_graph_facts_multidut,
+):
+    """Measure the ECN marking ENTER time.
+
+    Start the first flow alone (no oversubscription -> no ECN marking), then
+    start the second flow to create oversubscription. The enter time is the
+    delta between the first ECN-CE marked packet (Row 3 of the User Defined
+    Statistics) and the first packet transmitted by the second stream.
+    """
+    for snappi_ports in port_groups:
+        logger.info("\n")
+        logger.info("Snappi ports used for the test:")
+        for port in snappi_ports:
+            logger.info("{}: {}".format(port["peer_port"], port["location"]))
+
+        ixnet, trafficItem = _configure_oversub(
+            snappi_api, create_snappi_config, snappi_ports, subnet_type, lossy_prio
+        )
+        ixnet.Globals.Statistics.Advanced.Timestamp.TimestampPrecision = 9
+        streams = trafficItem.HighLevelStream.find()
+        pytest_assert(len(streams) >= 2,
+                      "Expected 2 high level streams (one per Tx port) for oversubscription")
+        stream1, stream2 = streams[0], streams[1]
+
+        # --- Phase 1: first flow only -> no oversubscription, no ECN marking ---
+        logger.info("Starting first stream only (no oversubscription expected)")
+        stream1.StartStatelessTrafficBlocking()
+        wait_with_message("For first stream to stabilize:", 20)
+        get_stats(snappi_api, "Traffic Item Statistics", TI_COLUMNS, "print")
+        TI_Statistics = StatViewAssistant(ixnet, "Traffic Item Statistics")
+        pytest_assert(int(float(TI_Statistics.Rows[0]["Loss %"])) == 0,
+                      "No loss expected with a single (non-oversubscribed) flow")
+
+        _drill_down_egress(ixnet)
+        UD_Statistics = StatViewAssistant(ixnet, "User Defined Statistics")
+        print_ud_statistics(SELECTED_UD_COLS, UD_Statistics)
+        if len(_normalize_stat_rows(UD_Statistics.Rows)) > ECN_CE_ROW:
+            pytest_assert(int(float(UD_Statistics.Rows[ECN_CE_ROW]["Rx Frame Rate"])) == 0,
+                          "No packets should be ECN-CE (bit=3) marked before oversubscription")
+        logger.info("PASS: No ECN marking observed with a single flow")
+
+        # --- Phase 2: start second flow -> oversubscription -> ECN marking ---
+        logger.info("Starting second stream to create oversubscription")
+        stream2.StartStatelessTrafficBlocking()
+        wait_with_message("For ECN marking to start:", 30)
+
+        _drill_down_egress(ixnet)
+        UD_Statistics = StatViewAssistant(ixnet, "User Defined Statistics")
+        print_ud_statistics(SELECTED_UD_COLS, UD_Statistics)
+        pytest_assert(len(_normalize_stat_rows(UD_Statistics.Rows)) == 3,
+                      "Expected 3 rows in User Defined Statistics")
+        pytest_assert(int(float(UD_Statistics.Rows[ECN_CE_ROW]["Rx Frame Rate"])) > 0,
+                      "FAIL: Packets are not received with ECN - CE bit set to 3 after oversubscription")
+        logger.info("PASS: Packets are received with ECN - CE bit set to 3.")
+
+        # First ECN-CE marked packet timestamp (Row 3 of User Defined Statistics)
+        first_marked_ts = _ts_seconds(UD_Statistics.Rows[ECN_CE_ROW]["First TimeStamp"])
+        logger.info("First TimeStamp of ECN-CE row (Row 3, UD Statistics): {}".format(
+            UD_Statistics.Rows[ECN_CE_ROW]["First TimeStamp"]))
+
+        # First packet timestamp of the second stream (the flow that triggered marking).
+        # Flow Statistics rows follow the high level stream order, so Rows[1] is stream2.
+        flow_Statistics = StatViewAssistant(ixnet, "Flow Statistics")
+        first_pkt_flow2_ts = _ts_seconds(flow_Statistics.Rows[1]["First TimeStamp"])
+        logger.info("First TimeStamp of 2nd flow (Row 2, Flow Statistics): {}".format(
+            flow_Statistics.Rows[1]["First TimeStamp"]))
+        ECN_ENTER_TIME = round((first_marked_ts - first_pkt_flow2_ts) * 1000000, 6)
+        logger.info("\n")
+        logger.info("ECN Marking Enter Time is: {} microseconds".format(ECN_ENTER_TIME))
+        logger.info("\n")
+        pytest_assert(ECN_ENTER_TIME >= 0,
+                      "ECN enter time should be non-negative (first marked packet must follow "
+                      "the second stream's first packet)")
+
+        # Stop Traffic
+        trafficItem.StopStatelessTrafficBlocking()
+
+
+# ---------------------------------------------------------------------------
+# ECN marking EXIT time
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("subnet_type", [ip_version])
+@pytest.mark.parametrize("lossy_prio", [0])
+def test_ecn_response_exit_time(
+        duthosts,
+        dutconfig_checkpoint,   # noqa: F811
+        snappi_api,  # noqa: F811
+        get_snappi_ports,  # noqa: F811
+        set_primary_chassis,  # noqa: F811
+        create_snappi_config,  # noqa: F811
+        subnet_type,
+        lossy_prio,
+        port_groups,
+        fanout_graph_facts_multidut,
+):
+    """Measure the ECN marking EXIT time.
+
+    Run both flows oversubscribed so packets are ECN-CE marked, then stop the
+    first stream so the egress buffer drains and marking stops. The exit time is
+    the delta between the last ECN-CE marked packet (Row 3 of the User Defined
+    Statistics) and the last packet of the stopped flow.
+    """
+    for snappi_ports in port_groups:
+        logger.info("\n")
+        logger.info("Snappi ports used for the test:")
+        for port in snappi_ports:
+            logger.info("{}: {}".format(port["peer_port"], port["location"]))
+
+        ixnet, trafficItem = _configure_oversub(
+            snappi_api, create_snappi_config, snappi_ports, subnet_type, lossy_prio
+        )
+        ixnet.Globals.Statistics.Advanced.Timestamp.TimestampPrecision = 9
+        # Start both flows together -> oversubscription -> ECN marking.
+        logger.info("Starting Traffic")
+        ixnet.Traffic.StartStatelessTrafficBlocking()
+        time.sleep(30)
+        get_stats(snappi_api, "Traffic Item Statistics", TI_COLUMNS, "print")
+        TI_Statistics = StatViewAssistant(ixnet, "Traffic Item Statistics")
+        pytest_assert(int(float(TI_Statistics.Rows[0]["Loss %"])) > 0,
+                      "Loss must be observed when oversubscribed traffic is running")
+
+        _drill_down_egress(ixnet)
+
+        # Stop one of the high level streams and note down its respective time stamp.
+        stream1 = trafficItem.HighLevelStream.find()[0]
+        UD_Statistics = StatViewAssistant(ixnet, "User Defined Statistics")
+        pytest_assert(len(_normalize_stat_rows(UD_Statistics.Rows)) == 3,
+                      "Expected 3 rows in User Defined Statistics")
+        pytest_assert(int(float(UD_Statistics.Rows[ECN_CE_ROW]["Rx Frame Rate"])) > 0,
+                      "FAIL: Packets are not received with ECN - CE bit set to 3")
+        print_ud_statistics(SELECTED_UD_COLS, UD_Statistics)
+        logger.info("PASS: Packets are received with ECN - CE bit set to 3.")
+
+        stream1.StopStatelessTrafficBlocking()
+        logger.info("Stream 1 stopped")
+        wait_with_message("For egress port buffer to drain:", 10)
+        UD_Statistics = StatViewAssistant(ixnet, "User Defined Statistics")
+        print_ud_statistics(SELECTED_UD_COLS, UD_Statistics)
+
+        # Last timestamp of the stopped flow (Flow Statistics Row 0 == stream1).
+        flow_Statistics = StatViewAssistant(ixnet, "Flow Statistics")
+        last_time_stamp_flow_1 = _ts_seconds(flow_Statistics.Rows[0]["Last TimeStamp"])
+        logger.info("Last TimeStamp of stopped flow (Row 1, Flow Statistics): {}".format(
+            flow_Statistics.Rows[0]["Last TimeStamp"]))
+        # After stopping the flow, egress tracking Row 3 should stop receiving marked packets.
+        UD_Statistics = StatViewAssistant(ixnet, "User Defined Statistics")
+        pytest_assert(int(float(UD_Statistics.Rows[ECN_CE_ROW]["Rx Frame Rate"])) == 0,
+                      "FAIL: Packets are still received with ECN - CE bit set to 3 after stopping the stream")
+        logger.info("PASS: Packets are not received with ECN - CE bit set to 3 after stopping the stream")
+
+        egress_3 = _ts_seconds(UD_Statistics.Rows[ECN_CE_ROW]["Last TimeStamp"])
+        logger.info("Last TimeStamp of ECN-CE row (Row 3, UD Statistics): {}".format(
+            UD_Statistics.Rows[ECN_CE_ROW]["Last TimeStamp"]))
+        ECN_EXIT_TIME = round((egress_3 - last_time_stamp_flow_1) * 1000, 3)
+        logger.info("\n")
+        logger.info("ECN Marking Exit Response Time is: {} milliseconds".format(ECN_EXIT_TIME))
+        logger.info("\n")
+
+        # Stop Traffic
+        trafficItem.StopStatelessTrafficBlocking()

--- a/tests/snappi_tests/dataplane/test_ecn_response_time.py
+++ b/tests/snappi_tests/dataplane/test_ecn_response_time.py
@@ -67,8 +67,10 @@ def port_groups(duthosts, get_snappi_ports):
     snappi_ports = get_duthost_interface_details(
         duthosts, get_snappi_ports, ip_version, protocol_type="IP"
     )
-    pytest_assert(len(snappi_ports) % 3 == 0,
-                  "Number of ports should be a multiple of 3 to create port groups of 3 ports each")
+    pytest_assert(
+        len(snappi_ports) >= 3,
+        "Need at least 3 snappi ports for the test",
+    )
     pg = []
     for i in range(0, len(snappi_ports), 3):
         pg.append(snappi_ports[i:i + 3])

--- a/tests/snappi_tests/dataplane/test_ecn_response_time.py
+++ b/tests/snappi_tests/dataplane/test_ecn_response_time.py
@@ -1,0 +1,345 @@
+"""
+ECN marking response-time tests (enter time + exit time).
+
+Topology per port-group: 2 Tx ports -> 1 Rx (egress) port, so two equal-rate
+flows can oversubscribe a single egress port and drive ECN-CE marking.
+
+Egress tracking is configured on the 2 ECN bits of the IP header (offset 126,
+width 2). After a drill-down on those 2 bits the "User Defined Statistics" view
+breaks the egress traffic out by CE value; Row 3 (Rows[2]) is the ECN-CE marked
+row (CE bits == 3).
+
+Two measurements:
+
+- ECN marking ENTER time (test_ecn_response_entry_time):
+    1. Start the first flow only -- no oversubscription, no ECN marking.
+    2. Start the second flow -- oversubscription begins and ECN marking starts.
+    3. first_marked_ts  = First TimeStamp of the ECN-CE row (Row 3 of UD stats).
+       first_pkt_flow2  = First TimeStamp of the second stream.
+       ENTER time       = first_marked_ts - first_pkt_flow2.
+
+- ECN marking EXIT time (test_ecn_response_exit_time, existing logic):
+    1. Run both flows oversubscribed so packets are ECN-CE marked.
+    2. Stop the first stream so the egress buffer drains and marking stops.
+       last_ts_flow1 = Last TimeStamp of the stopped flow.
+       egress_3      = Last TimeStamp of the ECN-CE row (Row 3 of UD stats).
+       EXIT time     = egress_3 - last_ts_flow1.
+"""
+import random
+from tests.snappi_tests.dataplane.imports import *  # noqa: F401, F403, F405
+from snappi_tests.dataplane.files.helper import get_duthost_interface_details, create_snappi_config, \
+    get_snappi_stats, set_primary_chassis, create_traffic_items, start_stop, wait_with_message, \
+    get_stats, _normalize_stat_rows, print_ud_statistics, dutconfig_checkpoint, \
+    _ts_seconds, _drill_down_egress, _dscp_values  # noqa: F401, F403, F405, E402
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp
+from tests.common.snappi_tests.common_helpers import (
+    enable_ecn,
+    stop_pfcwd,
+    disable_packet_aging,
+)  # noqa: F401
+
+pytestmark = [pytest.mark.topology("nut")]
+logger = logging.getLogger(__name__)
+
+ip_version = "IPv4"
+
+# Row index of the ECN-CE marked entry in the drilled-down User Defined
+# Statistics view (CE bits == 3). 1-indexed this is "Row 3".
+ECN_CE_ROW = 2
+
+# Drill-down option matching the 2 ECN bits configured below (offset 126, 2 bits).
+DRILL_DOWN_OPTION = "Custom: (2 bits at offset 126)"
+
+# Marking must stop within this many milliseconds of the congestion going away.
+MAX_ECN_EXIT_TIME_MS = 100
+
+TI_COLUMNS = ["frames_tx", "frames_rx", "loss", "frames_tx_rate", "frames_rx_rate"]
+SELECTED_UD_COLS = [
+    "Egress Tracking",
+    "Tx Frames",
+    "Rx Frames",
+    "Frames Delta",
+    "Loss %",
+    "Tx Frame Rate",
+    "Rx Frame Rate",
+]
+
+
+@pytest.fixture(scope="module")
+def port_groups(duthosts, get_snappi_ports):
+    snappi_ports = get_duthost_interface_details(
+        duthosts, get_snappi_ports, ip_version, protocol_type="IP"
+    )
+    pytest_assert(
+        len(snappi_ports) >= 3,
+        "Need at least 3 snappi ports for the test",
+    )
+    pg = []
+    for i in range(0, len(snappi_ports), 3):
+        pg.append(snappi_ports[i:i + 3])
+    return pg[:-1] if len(snappi_ports) % 3 != 0 else pg
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _configure_oversub(snappi_api,
+                       create_snappi_config,  # noqa: F811
+                       snappi_ports,
+                       subnet_type,
+                       lossy_prio):
+    """Build a 2:1 oversubscription scenario (2 Tx -> 1 Rx) with egress ECN/CE
+    tracking. Generates and applies the traffic but does NOT start it.
+
+    Returns (ixnet, trafficItem).
+    """
+    pytest_assert(len(snappi_ports) >= 3, "Not enough ports for the test, Need at least 3 ports")
+    tx_ports = snappi_ports[:2]
+    rx_ports = [snappi_ports[2]]
+    egress_duthost = rx_ports[0]["duthost"]
+
+    config_facts = egress_duthost.config_facts(
+        host=egress_duthost.hostname, source="running"
+    )["ansible_facts"]
+    pytest_assert("DSCP_TO_TC_MAP" in config_facts, "DSCP_TO_TC_MAP is not configured on the DUT")
+    pytest_assert(
+        str(lossy_prio) in config_facts["DSCP_TO_TC_MAP"]["AZURE"].values(),
+        "Lossy priority {} is not mapped to any DSCP in DSCP_TO_TC_MAP".format(lossy_prio),
+    )
+    ecn_dscp = random.choice(_dscp_values(config_facts, lossy_prio))
+
+    logger.info("Stopping PFC watchdog")
+    stop_pfcwd(egress_duthost, rx_ports[0]["asic_value"])
+    logger.info("Disabling packet aging if necessary")
+    disable_packet_aging(egress_duthost)
+    pytest_assert(enable_ecn(host_ans=egress_duthost, prio=lossy_prio), "Unable to enable ecn")
+
+    snappi_extra_params = SnappiTestParams()
+    snappi_extra_params.protocol_config = {
+        "Tx": {"protocol_type": "ip", "ports": tx_ports,
+               "subnet_type": subnet_type, "is_rdma": True},
+        "Rx": {"protocol_type": "ip", "ports": rx_ports,
+               "subnet_type": subnet_type, "is_rdma": True},
+    }
+    config, snappi_obj_handles = create_snappi_config(snappi_extra_params)
+    snappi_extra_params.traffic_flow_config = [
+        {
+            "line_rate": 95,
+            "frame_size": 1024,
+            "is_rdma": True,
+            "flow_name": "Traffic Flow",
+            "tx_names": snappi_obj_handles["Tx"]["ip"],
+            "rx_names": snappi_obj_handles["Rx"]["ip"],
+            "traffic_duration_fixed_seconds": 1000,
+            "prio": lossy_prio,
+            "dscp_value": ecn_dscp,
+        },
+    ]
+    config = create_traffic_items(config, snappi_extra_params)
+    snappi_api.set_config(config)
+
+    logger.info("Starting All protocols")
+    start_stop(snappi_api, operation="start", op_type="protocols")
+    logger.info("Wait for Arp to Resolve ...")
+    wait_for_arp(snappi_api, max_attempts=30, poll_interval_sec=2)
+
+    ixnet = snappi_api._ixnetwork
+    trafficItem = ixnet.Traffic.TrafficItem.find()
+    trafficItem.EgressEnabled = "True"
+    eg = trafficItem.EgressTracking.find()
+    eg.Encapsulation = "Any: Use Custom Settings"
+    eg.Offset = "Custom"
+    eg.CustomOffsetBits = 126
+    eg.CustomWidthBits = 2
+    logger.info("PASS: Egress tracking configured successfully")
+
+    logger.info("Generating Traffic Item")
+    trafficItem.Generate()
+    logger.info("Applying Traffic")
+    ixnet.Traffic.Apply()
+    return ixnet, trafficItem
+
+# ---------------------------------------------------------------------------
+# ECN marking ENTER time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("subnet_type", [ip_version])
+@pytest.mark.parametrize("lossy_prio", [0])
+def test_ecn_response_entry_time(
+        duthosts,
+        dutconfig_checkpoint,   # noqa: F811
+        snappi_api,  # noqa: F811
+        get_snappi_ports,  # noqa: F811
+        set_primary_chassis,  # noqa: F811
+        create_snappi_config,  # noqa: F811
+        subnet_type,
+        lossy_prio,
+        port_groups,
+        fanout_graph_facts_multidut,
+):
+    """Measure the ECN marking ENTER time.
+
+    Start the first flow alone (no oversubscription -> no ECN marking), then
+    start the second flow to create oversubscription. The enter time is the
+    delta between the first ECN-CE marked packet (Row 3 of the User Defined
+    Statistics) and the first packet transmitted by the second stream.
+    """
+    for snappi_ports in port_groups:
+        logger.info("\n")
+        logger.info("Snappi ports used for the test:")
+        for port in snappi_ports:
+            logger.info("{}: {}".format(port["peer_port"], port["location"]))
+
+        ixnet, trafficItem = _configure_oversub(
+            snappi_api, create_snappi_config, snappi_ports, subnet_type, lossy_prio
+        )
+        ixnet.Globals.Statistics.Advanced.Timestamp.TimestampPrecision = 9
+        streams = trafficItem.HighLevelStream.find()
+        pytest_assert(len(streams) >= 2,
+                      "Expected 2 high level streams (one per Tx port) for oversubscription")
+        stream1, stream2 = streams[0], streams[1]
+
+        # --- Phase 1: first flow only -> no oversubscription, no ECN marking ---
+        logger.info("Starting first stream only (no oversubscription expected)")
+        stream1.StartStatelessTrafficBlocking()
+        wait_with_message("For first stream to stabilize:", 20)
+        get_stats(snappi_api, "Traffic Item Statistics", TI_COLUMNS, "print")
+        TI_Statistics = StatViewAssistant(ixnet, "Traffic Item Statistics")
+        pytest_assert(int(float(TI_Statistics.Rows[0]["Loss %"])) == 0,
+                      "No loss expected with a single (non-oversubscribed) flow")
+
+        _drill_down_egress(ixnet)
+        UD_Statistics = StatViewAssistant(ixnet, "User Defined Statistics")
+        print_ud_statistics(SELECTED_UD_COLS, UD_Statistics)
+        if len(_normalize_stat_rows(UD_Statistics.Rows)) > ECN_CE_ROW:
+            pytest_assert(int(float(UD_Statistics.Rows[ECN_CE_ROW]["Rx Frame Rate"])) == 0,
+                          "No packets should be ECN-CE (bit=3) marked before oversubscription")
+        logger.info("PASS: No ECN marking observed with a single flow")
+
+        # --- Phase 2: start second flow -> oversubscription -> ECN marking ---
+        logger.info("Starting second stream to create oversubscription")
+        stream2.StartStatelessTrafficBlocking()
+        wait_with_message("For ECN marking to start:", 30)
+
+        _drill_down_egress(ixnet)
+        UD_Statistics = StatViewAssistant(ixnet, "User Defined Statistics")
+        print_ud_statistics(SELECTED_UD_COLS, UD_Statistics)
+        pytest_assert(len(_normalize_stat_rows(UD_Statistics.Rows)) == 3,
+                      "Expected 3 rows in User Defined Statistics")
+        pytest_assert(int(float(UD_Statistics.Rows[ECN_CE_ROW]["Rx Frame Rate"])) > 0,
+                      "FAIL: Packets are not received with ECN - CE bit set to 3 after oversubscription")
+        logger.info("PASS: Packets are received with ECN - CE bit set to 3.")
+
+        # First ECN-CE marked packet timestamp (Row 3 of User Defined Statistics)
+        first_marked_ts = _ts_seconds(UD_Statistics.Rows[ECN_CE_ROW]["First TimeStamp"])
+        logger.info("First TimeStamp of ECN-CE row (Row 3, UD Statistics): {}".format(
+            UD_Statistics.Rows[ECN_CE_ROW]["First TimeStamp"]))
+
+        # First packet timestamp of the second stream (the flow that triggered marking).
+        # Flow Statistics rows follow the high level stream order, so Rows[1] is stream2.
+        flow_Statistics = StatViewAssistant(ixnet, "Flow Statistics")
+        first_pkt_flow2_ts = _ts_seconds(flow_Statistics.Rows[1]["First TimeStamp"])
+        logger.info("First TimeStamp of 2nd flow (Row 2, Flow Statistics): {}".format(
+            flow_Statistics.Rows[1]["First TimeStamp"]))
+        ECN_ENTER_TIME = round((first_marked_ts - first_pkt_flow2_ts) * 1000000, 6)
+        logger.info("\n")
+        logger.info("ECN Marking Enter Time is: {} microseconds".format(ECN_ENTER_TIME))
+        logger.info("\n")
+        pytest_assert(ECN_ENTER_TIME >= 0,
+                      "ECN enter time should be non-negative (first marked packet must follow "
+                      "the second stream's first packet)")
+
+        # Stop Traffic
+        trafficItem.StopStatelessTrafficBlocking()
+
+
+# ---------------------------------------------------------------------------
+# ECN marking EXIT time
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("subnet_type", [ip_version])
+@pytest.mark.parametrize("lossy_prio", [0])
+def test_ecn_response_exit_time(
+        duthosts,
+        dutconfig_checkpoint,   # noqa: F811
+        snappi_api,  # noqa: F811
+        get_snappi_ports,  # noqa: F811
+        set_primary_chassis,  # noqa: F811
+        create_snappi_config,  # noqa: F811
+        subnet_type,
+        lossy_prio,
+        port_groups,
+        fanout_graph_facts_multidut,
+):
+    """Measure the ECN marking EXIT time.
+
+    Run both flows oversubscribed so packets are ECN-CE marked, then stop the
+    first stream so the egress buffer drains and marking stops. The exit time is
+    the delta between the last ECN-CE marked packet (Row 3 of the User Defined
+    Statistics) and the last packet of the stopped flow.
+    """
+    for snappi_ports in port_groups:
+        logger.info("\n")
+        logger.info("Snappi ports used for the test:")
+        for port in snappi_ports:
+            logger.info("{}: {}".format(port["peer_port"], port["location"]))
+
+        ixnet, trafficItem = _configure_oversub(
+            snappi_api, create_snappi_config, snappi_ports, subnet_type, lossy_prio
+        )
+        ixnet.Globals.Statistics.Advanced.Timestamp.TimestampPrecision = 9
+        # Start both flows together -> oversubscription -> ECN marking.
+        logger.info("Starting Traffic")
+        ixnet.Traffic.StartStatelessTrafficBlocking()
+        time.sleep(30)
+        get_stats(snappi_api, "Traffic Item Statistics", TI_COLUMNS, "print")
+        TI_Statistics = StatViewAssistant(ixnet, "Traffic Item Statistics")
+        pytest_assert(int(float(TI_Statistics.Rows[0]["Loss %"])) > 0,
+                      "Loss must be observed when oversubscribed traffic is running")
+
+        _drill_down_egress(ixnet)
+
+        # Stop one of the high level streams and note down its respective time stamp.
+        stream1 = trafficItem.HighLevelStream.find()[0]
+        UD_Statistics = StatViewAssistant(ixnet, "User Defined Statistics")
+        pytest_assert(len(_normalize_stat_rows(UD_Statistics.Rows)) == 3,
+                      "Expected 3 rows in User Defined Statistics")
+        pytest_assert(int(float(UD_Statistics.Rows[ECN_CE_ROW]["Rx Frame Rate"])) > 0,
+                      "FAIL: Packets are not received with ECN - CE bit set to 3")
+        print_ud_statistics(SELECTED_UD_COLS, UD_Statistics)
+        logger.info("PASS: Packets are received with ECN - CE bit set to 3.")
+
+        stream1.StopStatelessTrafficBlocking()
+        logger.info("Stream 1 stopped")
+        wait_with_message("For egress port buffer to drain:", 10)
+        UD_Statistics = StatViewAssistant(ixnet, "User Defined Statistics")
+        print_ud_statistics(SELECTED_UD_COLS, UD_Statistics)
+
+        # Last timestamp of the stopped flow (Flow Statistics Row 0 == stream1).
+        flow_Statistics = StatViewAssistant(ixnet, "Flow Statistics")
+        last_time_stamp_flow_1 = _ts_seconds(flow_Statistics.Rows[0]["Last TimeStamp"])
+        logger.info("Last TimeStamp of stopped flow (Row 1, Flow Statistics): {}".format(
+            flow_Statistics.Rows[0]["Last TimeStamp"]))
+        # After stopping the flow, egress tracking Row 3 should stop receiving marked packets.
+        UD_Statistics = StatViewAssistant(ixnet, "User Defined Statistics")
+        pytest_assert(int(float(UD_Statistics.Rows[ECN_CE_ROW]["Rx Frame Rate"])) == 0,
+                      "FAIL: Packets are still received with ECN - CE bit set to 3 after stopping the stream")
+        logger.info("PASS: Packets are not received with ECN - CE bit set to 3 after stopping the stream")
+
+        egress_3 = _ts_seconds(UD_Statistics.Rows[ECN_CE_ROW]["Last TimeStamp"])
+        logger.info("Last TimeStamp of ECN-CE row (Row 3, UD Statistics): {}".format(
+            UD_Statistics.Rows[ECN_CE_ROW]["Last TimeStamp"]))
+        ECN_EXIT_TIME = round((egress_3 - last_time_stamp_flow_1) * 1000, 3)
+        logger.info("\n")
+        logger.info("ECN Marking Exit Response Time is: {} milliseconds".format(ECN_EXIT_TIME))
+        logger.info("\n")
+        pytest_assert(ECN_EXIT_TIME < MAX_ECN_EXIT_TIME_MS,
+                      "ECN marking exit time is {} ms on egress port {}, expected less than {} ms".format(
+                          ECN_EXIT_TIME, snappi_ports[2]["peer_port"], MAX_ECN_EXIT_TIME_MS))
+        logger.info("PASS: ECN marking stopped within {} ms of the congestion clearing".format(
+            MAX_ECN_EXIT_TIME_MS))
+
+        # Stop Traffic
+        trafficItem.StopStatelessTrafficBlocking()

--- a/tests/snappi_tests/variables.py
+++ b/tests/snappi_tests/variables.py
@@ -684,3 +684,13 @@ def get_bgp_ips_for_topology(topology_type, vendor):
 # =============================================================================
 # END OF BGP OUTBOUND ROUTE CONVERGENCE CONFIGURATIONS
 # =============================================================================
+# AI Stress case Common Variables
+pfcQueueGroupSize = 4
+pfcQueueValueDict = {0: 0,
+                     1: 1,
+                     2: 0,
+                     3: 3,
+                     4: 2,
+                     5: 0,
+                     6: 1,
+                     7: 0}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Adding ECN marking accuracy test
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
To Add ECN marking testcase
#### How did you do it?
Create 2 traffic stream and oversubscrive the rx port and expect ecn marking on the packet
and run the test in iteration and tabulate the marking percentage
#### How did you verify/test it?
By capturing the packet and ensuring if the last packet is not ecn marked and run in multiple iteration
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->https://github.com/sonic-net/sonic-mgmt/pull/23499#issuecomment-4754963275
### Output

snappi_tests/dataplane/test_ecn.py::test_ecn_accuracy_scheduler[0-IPv4] 
-------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------
18/06/2026 17:48:12 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
18/06/2026 17:48:12 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
18/06/2026 17:48:12 conftest.enhance_inventory               L0340 INFO   | Inventory file: ['../ansible/snappi-sonic']
18/06/2026 17:48:16 ptfhost_utils.run_icmp_responder_session L0310 INFO   | Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
18/06/2026 17:48:16 __init__._sanity_check                   L0432 INFO   | Skip sanity check according to command line argument
18/06/2026 17:48:16 conftest.collect_before_test             L2731 INFO   | Dumping Disk and Memory Space information before test on sonic-s6100-dut1
18/06/2026 17:48:17 conftest.collect_before_test             L2735 INFO   | Collecting core dumps before test on sonic-s6100-dut1
18/06/2026 17:48:18 conftest.collect_before_test             L2744 INFO   | Collecting running config before test on sonic-s6100-dut1
18/06/2026 17:48:23 conftest.restore_golden_config_db        L3392 INFO   | [restore_golden_config_db] Restored /etc/sonic/golden_config_db.json
18/06/2026 17:48:23 conftest.temporarily_disable_route_check L3010 INFO   | Skipping temporarily_disable_route_check fixture
18/06/2026 17:48:23 conftest.generate_params_dut_hostname    L1532 INFO   | Using DUTs ['sonic-s6100-dut1'] in testbed 'vms-snappi-sonic'
18/06/2026 17:48:23 conftest.set_rand_one_dut_hostname       L0674 INFO   | Randomly select dut sonic-s6100-dut1 for testing
18/06/2026 17:48:23 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture enable_packet_aging_after_test setup starts --------------------
18/06/2026 17:48:23 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture enable_packet_aging_after_test setup ends --------------------
18/06/2026 17:48:23 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossless_prio setup starts --------------------
18/06/2026 17:48:23 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossless_prio setup ends --------------------
18/06/2026 17:48:23 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossy_prio setup starts --------------------
18/06/2026 17:48:23 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossy_prio setup ends --------------------
18/06/2026 17:48:23 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture start_pfcwd_after_test setup starts --------------------
18/06/2026 17:48:23 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture start_pfcwd_after_test setup ends --------------------
18/06/2026 17:48:23 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture dutconfig_checkpoint setup starts --------------------
18/06/2026 17:48:23 gu_utils.create_checkpoint               L0292 INFO   | Commands: config checkpoint test
18/06/2026 17:48:24 gu_utils.list_checkpoints                L0265 INFO   | Commands: config list-checkpoints
18/06/2026 17:48:25 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture dutconfig_checkpoint setup ends --------------------
18/06/2026 17:48:25 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_ip setup starts --------------------
18/06/2026 17:48:25 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_ip setup ends --------------------
18/06/2026 17:48:25 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_port setup starts --------------------
18/06/2026 17:48:25 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_port setup ends --------------------
18/06/2026 17:48:25 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture snappi_api setup starts --------------------
18/06/2026 17:48:25 snappi.api                               L0106 WARNING| Version check is disabled
18/06/2026 17:48:25 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture snappi_api setup ends --------------------
18/06/2026 17:48:25 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports setup starts --------------------
18/06/2026 17:48:25 conftest.rand_one_dut_front_end_hostname L0710 INFO   | Randomly select dut sonic-s6100-dut1 for testing
18/06/2026 17:48:26 conftest.generate_port_lists             L1624 INFO   | Generate dut_port_map: {'sonic-s6100-dut1': ['sonic-s6100-dut1|Ethernet64', 'sonic-s6100-dut1|Ethernet68', 'sonic-s6100-dut1|Ethernet72', 'sonic-s6100-dut1|Ethernet76']}
18/06/2026 17:48:26 conftest.generate_port_lists             L1647 INFO   | Generate port_list: ['sonic-s6100-dut1|Ethernet64', 'sonic-s6100-dut1|Ethernet68', 'sonic-s6100-dut1|Ethernet72', 'sonic-s6100-dut1|Ethernet76']
18/06/2026 17:48:26 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports_single_dut setup starts --------------------
18/06/2026 17:48:26 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports_single_dut setup ends --------------------
18/06/2026 17:48:26 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports setup ends --------------------
18/06/2026 17:48:26 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture set_primary_chassis setup starts --------------------
18/06/2026 17:48:26 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture set_primary_chassis setup ends --------------------
18/06/2026 17:48:26 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture create_snappi_config setup starts --------------------
18/06/2026 17:48:26 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture create_snappi_config setup ends --------------------
18/06/2026 17:48:26 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture port_groups setup starts --------------------
18/06/2026 17:48:28 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture port_groups setup ends --------------------
18/06/2026 17:48:28 __init__.loganalyzer                     L0077 INFO   | Log analyzer is disabled
18/06/2026 17:48:28 __init__.memory_utilization              L0130 INFO   | Memory utilization monitoring is disabled
18/06/2026 17:48:28 conftest.setup_dualtor_mux_ports         L3470 INFO   | skip setup dualtor mux cables on non-dualtor testbed
-------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------
18/06/2026 17:48:28 test_ecn.test_ecn_accuracy_scheduler     L0263 INFO   | Snappi ports: Tx=Ethernet0  Rx=Ethernet1
18/06/2026 17:48:30 test_ecn.test_ecn_accuracy_scheduler     L0296 INFO   | WRED profile AZURE_LOSSLESS: kmin=500000 kmax=910000 pmax=100%
18/06/2026 17:48:30 test_ecn.test_ecn_accuracy_scheduler     L0299 INFO   | Sending 898 packets per iteration (10 overflow + 888 kmax/1KB)
18/06/2026 17:48:32 test_ecn.test_ecn_accuracy_scheduler     L0310 INFO   | Original scheduler for Ethernet1 queue 0: scheduler.0
18/06/2026 17:48:32 test_ecn.test_ecn_accuracy_scheduler     L0318 INFO   | --- Iteration 1 / 1 ---
18/06/2026 17:48:39 connection._warn                         L0351 WARNING| Verification of certificates is disabled
18/06/2026 17:48:39 connection._info                         L0348 INFO   | Determining the platform and rest_port using the 10.36.84.37 address...
18/06/2026 17:48:39 connection._warn                         L0351 WARNING| Unable to connect to http://10.36.84.37:443.
18/06/2026 17:48:39 connection._info                         L0348 INFO   | Connection established to `https://10.36.84.37:443 on linux`
18/06/2026 17:48:55 connection._info                         L0348 INFO   | Using IxNetwork api server version 26.0.2620.4
18/06/2026 17:48:55 connection._info                         L0348 INFO   | User info IxNetwork/ixnetworkweb/admin-99-3533160
18/06/2026 17:48:56 snappi_api.info                          L1516 INFO   | snappi-1.43.0
18/06/2026 17:48:56 snappi_api.info                          L1516 INFO   | snappi_ixnetwork-1.43.0
18/06/2026 17:48:56 snappi_api.info                          L1516 INFO   | ixnetwork_restpy-1.9.0
18/06/2026 17:48:56 snappi_api.info                          L1516 INFO   | Config validation 0.007s
18/06/2026 17:48:58 snappi_api.info                          L1516 INFO   | Ports configuration 1.540s
18/06/2026 17:48:58 snappi_api.info                          L1516 INFO   | Captures configuration 0.385s
18/06/2026 17:48:59 connection._info                         L0348 INFO   | [0.421s] Timer @ batchadd.py:387 -> Batch Add Completed
18/06/2026 17:48:59 snappi_api.info                          L1516 INFO   | Add location hosts [10.36.84.32, 10.36.84.34] 0.451s
18/06/2026 17:49:05 snappi_api.info                          L1516 INFO   | Location hosts ready [10.36.84.32, 10.36.84.34] 6.328s
18/06/2026 17:49:09 snappi_api.info                          L1516 INFO   | Speed conversion is not require for (port.name, speed) : [('Port_1', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_2', 'aresOne-M-EightByOneHundredGigPAM4-106G')]
18/06/2026 17:49:09 snappi_api.info                          L1516 INFO   | Aggregation mode speed change 1.038s
18/06/2026 17:49:47 snappi_api.info                          L1516 INFO   | Location connect [Port_1, Port_2, Port_3] 38.256s
18/06/2026 17:49:47 snappi_api.info                          L1516 INFO   | Location state check [Port_1, Port_2, Port_3] 0.331s
18/06/2026 17:49:47 snappi_api.info                          L1516 INFO   | Location configuration 48.954s
18/06/2026 17:50:01 snappi_api.info                          L1516 INFO   | Layer1 configuration 13.376s
18/06/2026 17:50:01 snappi_api.info                          L1516 INFO   | Lag Configuration 0.074s
18/06/2026 17:50:01 snappi_api.info                          L1516 INFO   | Convert device config : 0.210s
18/06/2026 17:50:01 snappi_api.info                          L1516 INFO   | Create IxNetwork device config : 0.000s
18/06/2026 17:50:02 snappi_api.info                          L1516 INFO   | Push IxNetwork device config : 0.529s
18/06/2026 17:50:02 snappi_api.info                          L1516 INFO   | Devices configuration 0.809s
18/06/2026 17:50:04 snappi_api.info                          L1516 INFO   | Flows configuration 2.086s
18/06/2026 17:50:12 snappi_api.info                          L1516 INFO   | Start interfaces 8.133s
18/06/2026 17:50:13 snappi_api.info                          L1516 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
18/06/2026 17:50:13 snappi_api.info                          L1516 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
18/06/2026 17:50:13 helper.start_stop                        L0867 INFO   | Start protocols
18/06/2026 17:50:13 utilities.wait                           L0120 INFO   | Pause 10 seconds, reason: For protocols To start
18/06/2026 17:50:41 snappi_api.info                          L1516 INFO   | Captures start 15.555s
18/06/2026 17:50:41 utilities.wait                           L0120 INFO   | Pause 3 seconds, reason: To arm capture before transmit
18/06/2026 17:50:57 snappi_api.info                          L1516 INFO   | Flows generate/apply 12.591s
18/06/2026 17:51:09 snappi_api.info                          L1516 INFO   | Flows clear statistics 11.688s
18/06/2026 17:51:12 snappi_api.info                          L1516 INFO   | Captures start 3.341s
18/06/2026 17:51:45 snappi_api.info                          L1516 INFO   | Flows start 32.584s
18/06/2026 17:51:45 utilities.wait                           L0120 INFO   | Pause 5 seconds, reason: For all packets to enter egress queue
18/06/2026 17:52:01 utilities.wait                           L0120 INFO   | Pause 10 seconds, reason: For buffered packets to drain and arrive at Rx
18/06/2026 17:52:14 snappi_api.info                          L1516 INFO   | Captures stop 1.547s
18/06/2026 17:52:14 utilities.wait                           L0120 INFO   | Pause 5 seconds, reason: To finalise capture
18/06/2026 17:54:56 snappi_api.warning                       L1522 WARNING| Capture was not stopped for this port Port_2
18/06/2026 17:54:56 snappi_api.info                          L1516 INFO   | Captures stop 156.219s
18/06/2026 17:55:02 read_pcap.get_ipv4_pkts                  L0138 INFO   | Reading packets from pcap file -> ecn_accuracy_iter1.pcapng
18/06/2026 17:55:02 read_pcap.get_ipv4_pkts                  L0139 INFO   | Extracting ethernet frames from pcap file
18/06/2026 17:55:02 test_ecn.test_ecn_accuracy_scheduler     L0341 INFO   | Iteration 1: received 898 packets : Total packets sent: 898
18/06/2026 17:56:40 test_ecn.test_ecn_accuracy_scheduler     L0317 INFO   | === ECN Accuracy Analysis (1 iterations) ===
18/06/2026 17:56:40 test_ecn.test_ecn_accuracy_scheduler     L0317 INFO   | 

18/06/2026 17:56:40 test_ecn._check_region_accuracy          L0128 INFO   | Region overflow (q>kmax, first 10 pkts): 10/10 marked (100.0%), expected 100.0% ± 15%
18/06/2026 17:56:40 test_ecn._check_region_accuracy          L0128 INFO   | Region ramp bucket pkts[10:50] q≈868KB: 40/40 marked (100.0%), expected 94.8% ± 15%
18/06/2026 17:56:40 test_ecn._check_region_accuracy          L0128 INFO   | Region ramp bucket pkts[50:90] q≈828KB: 40/40 marked (100.0%), expected 84.8% ± 15%
18/06/2026 17:56:40 test_ecn._check_region_accuracy          L0128 INFO   | Region ramp bucket pkts[90:130] q≈788KB: 40/40 marked (100.0%), expected 74.9% ± 15%
18/06/2026 17:56:40 test_ecn._check_region_accuracy          L0128 INFO   | Region ramp bucket pkts[130:170] q≈748KB: 40/40 marked (100.0%), expected 64.9% ± 15%
18/06/2026 17:56:40 test_ecn._check_region_accuracy          L0128 INFO   | Region ramp bucket pkts[170:210] q≈708KB: 40/40 marked (100.0%), expected 54.9% ± 15%
18/06/2026 17:56:40 test_ecn._check_region_accuracy          L0128 INFO   | Region ramp bucket pkts[210:250] q≈668KB: 39/40 marked (97.5%), expected 44.9% ± 15%
18/06/2026 17:56:40 test_ecn._check_region_accuracy          L0128 INFO   | Region ramp bucket pkts[250:290] q≈628KB: 35/40 marked (87.5%), expected 34.9% ± 15%
18/06/2026 17:56:40 test_ecn._check_region_accuracy          L0128 INFO   | Region ramp bucket pkts[290:330] q≈588KB: 30/40 marked (75.0%), expected 24.9% ± 15%
18/06/2026 17:56:40 test_ecn._check_region_accuracy          L0128 INFO   | Region ramp bucket pkts[330:370] q≈548KB: 25/40 marked (62.5%), expected 14.9% ± 15%
18/06/2026 17:56:40 test_ecn._check_region_accuracy          L0128 INFO   | Region ramp bucket pkts[370:410] q≈508KB: 18/40 marked (45.0%), expected 4.9% ± 15%
18/06/2026 17:56:40 test_ecn._check_region_accuracy          L0128 INFO   | Region sub-kmin (q<kmin, last 488 pkts): 17/488 marked (3.5%), expected 0.0% ± 15%
18/06/2026 17:56:40 test_ecn.test_ecn_accuracy_scheduler     L0317 INFO   | 

18/06/2026 17:56:40 test_ecn.test_ecn_accuracy_scheduler     L0317 INFO   | ECN accuracy test PASSED for port Ethernet1 after 1 iterations
PASSED                                                                                                                                                       [100%]
------------------------------------------------------------------------ live log teardown -------------------------------------------------------------------------
