### PR TITLE
[transceiver][cdb_fw] Enforce exactly 3 firmware binaries (2 latest + gold) in firmware selection API

### DIFF
--- a/tests/transceiver/cdb_firmware_upgrade/conftest.py
+++ b/tests/transceiver/cdb_firmware_upgrade/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from tests.transceiver.attribute_parser.paths import get_repo_root
 from tests.transceiver.cdb_firmware_upgrade.parser import TransceiverFirmwareInfoParser
 from tests.transceiver.cdb_firmware_upgrade.utils.firmware_utils import (
-    get_latest_two_firmware_metadata_for_all_transceivers,
+    get_required_firmware_metadata_for_all_transceivers,
     get_dut_firmware_base_url,
     prepare_firmware_base_directory_on_dut,
     download_and_validate_firmware_binaries,
@@ -33,15 +33,14 @@ def transceiver_firmware_info_parser():
 
 
 @pytest.fixture(scope="session")
-def get_gold_firmware_and_latest_two_firmware_metadata_for_all_transceivers(
+def required_firmware_metadata_for_all_transceivers(
     get_dev_transceiver_details,
     transceiver_firmware_info_parser,
     get_transceiver_common_attributes
 ):
-    return get_latest_two_firmware_metadata_for_all_transceivers(
+    return get_required_firmware_metadata_for_all_transceivers(
         get_dev_transceiver_details,
         transceiver_firmware_info_parser.transceiver_firmware_info,
-        include_gold_firmware=True,
         transceiver_common_attributes=get_transceiver_common_attributes
     )
 
@@ -51,7 +50,7 @@ def download_latest_firmware_binaries_on_dut(
     duthosts,
     enum_rand_one_per_hwsku_frontend_hostname,
     transceiver_firmware_info_parser,
-    get_gold_firmware_and_latest_two_firmware_metadata_for_all_transceivers
+    required_firmware_metadata_for_all_transceivers
 ):
     logger.info("Downloading latest CMIS CDB firmware binaries on DUT")
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
@@ -60,14 +59,14 @@ def download_latest_firmware_binaries_on_dut(
         duthost, transceiver_firmware_info_parser.firmware_base_url_dict
     )
 
-    if not get_gold_firmware_and_latest_two_firmware_metadata_for_all_transceivers:
+    if not required_firmware_metadata_for_all_transceivers:
         pytest.skip("No transceiver firmware information found, skipping test.")
 
     prepare_firmware_base_directory_on_dut(duthost, CMIS_CDB_FIRMWARE_BASE_PATH_ON_DUT)
     download_and_validate_firmware_binaries(
         duthost,
         dut_firmware_base_url,
-        get_gold_firmware_and_latest_two_firmware_metadata_for_all_transceivers,
+        required_firmware_metadata_for_all_transceivers,
         CMIS_CDB_FIRMWARE_BASE_PATH_ON_DUT
     )
     logger.info("All latest firmware downloaded to {}".format(CMIS_CDB_FIRMWARE_BASE_PATH_ON_DUT))

--- a/tests/transceiver/cdb_firmware_upgrade/utils/firmware_utils.py
+++ b/tests/transceiver/cdb_firmware_upgrade/utils/firmware_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
-NUM_LATEST_FIRMWARE_VERSIONS = 2  # Number of latest firmware versions to retrieve
+NUM_LATEST_FIRMWARE_VERSIONS = 2  # Number of latest firmware versions to retrieve (gold firmware is added on top)
 
 
 def get_transceiver_gold_firmware_version(normalized_vendor_pn, transceiver_common_attributes):
@@ -105,32 +105,30 @@ def get_firmware_metadata_list_by_transceiver_type(
     return firmware_metadata_list
 
 
-def get_latest_two_firmware_metadata_for_all_transceivers(
+def get_required_firmware_metadata_for_all_transceivers(
     get_dev_transceiver_details,
     transceiver_firmware_info,
-    include_gold_firmware=False,
-    transceiver_common_attributes=None,
+    transceiver_common_attributes,
 ):
     """
-    Finds all types of transceivers installed on the DUT and returns
-    the most recent two firmware versions for each type of transceiver.
+    Finds all types of transceivers installed on the DUT and returns the
+    required firmware versions (the latest NUM_LATEST_FIRMWARE_VERSIONS plus the
+    gold firmware) for each type of transceiver.
 
     @param get_dev_transceiver_details: Dictionary of port transceiver details
     @param transceiver_firmware_info: Dictionary containing transceiver firmware information
-    @param include_gold_firmware: Whether to include gold firmware metadata
     @param transceiver_common_attributes: Dictionary containing common attributes of transceivers
-                                          (required if include_gold_firmware is True)
     @return: Dictionary of transceiver types with (normalized vendor name, part number) as keys,
-             and a list of the most recent firmware metadata as values.
+             and a list of the required firmware metadata as values.
     @raises: pytest.skip if no transceiver details or firmware versions found
-    @raises: pytest.fail if gold firmware is requested but transceiver_common_attributes not provided or
-                if not enough firmware versions are available for a transceiver type.
+    @raises: pytest.fail if transceiver_common_attributes not provided or if the required
+                number of firmware versions is not available for a transceiver type.
     """
     if not get_dev_transceiver_details:
         pytest.skip("No transceiver details available, skipping test.")
 
-    if include_gold_firmware and not transceiver_common_attributes:
-        pytest.fail("Transceiver common attributes are required to include gold firmware.")
+    if not transceiver_common_attributes:
+        pytest.fail("Transceiver common attributes are required to determine the mandatory gold firmware.")
 
     firmware_metadata_by_transceiver_type = {}
 
@@ -186,32 +184,35 @@ def get_latest_two_firmware_metadata_for_all_transceivers(
         else:
             selected_firmware = sorted_firmware[:NUM_LATEST_FIRMWARE_VERSIONS]
 
-        # Add gold firmware if requested
-        if include_gold_firmware:
-            gold_firmware_metadata = get_transceiver_gold_firmware_metadata(
-                normalized_vendor_name,
-                normalized_vendor_pn,
-                transceiver_firmware_info,
-                transceiver_common_attributes
+        # Add gold firmware
+        gold_firmware_metadata = get_transceiver_gold_firmware_metadata(
+            normalized_vendor_name,
+            normalized_vendor_pn,
+            transceiver_firmware_info,
+            transceiver_common_attributes
+        )
+        if gold_firmware_metadata:
+            # Add gold firmware and remove duplicates while preserving order
+            all_firmware = selected_firmware + [gold_firmware_metadata]
+            seen_versions = set()
+            unique_firmware = []
+            for firmware in all_firmware:
+                version = firmware.get('version')
+                if version and version not in seen_versions:
+                    seen_versions.add(version)
+                    unique_firmware.append(firmware)
+            selected_firmware = unique_firmware
+        else:
+            logger.error(f"No gold firmware metadata found for transceiver type {transceiver_key}")
+
+        num_required_firmware = NUM_LATEST_FIRMWARE_VERSIONS + 1  # latest versions + gold
+        if len(selected_firmware) != num_required_firmware:
+            pytest.fail(
+                f"Expected exactly {num_required_firmware} firmware versions "
+                f"({NUM_LATEST_FIRMWARE_VERSIONS} latest + gold) for transceiver type {transceiver_key}, "
+                f"found {len(selected_firmware)}: "
+                f"{[fw.get('version') for fw in selected_firmware]}"
             )
-            if gold_firmware_metadata:
-                # Add gold firmware and remove duplicates while preserving order
-                all_firmware = selected_firmware + [gold_firmware_metadata]
-                seen_versions = set()
-                unique_firmware = []
-                for firmware in all_firmware:
-                    version = firmware.get('version')
-                    if version and version not in seen_versions:
-                        seen_versions.add(version)
-                        unique_firmware.append(firmware)
-                selected_firmware = unique_firmware
-                if len(selected_firmware) < NUM_LATEST_FIRMWARE_VERSIONS + 1:
-                    pytest.fail(
-                        f"Not enough unique firmware versions found for transceiver type {transceiver_key}. "
-                        f"Expected at least {NUM_LATEST_FIRMWARE_VERSIONS + 1}, found {len(selected_firmware)}."
-                    )
-            else:
-                logger.error(f"No gold firmware metadata found for transceiver type {transceiver_key}")
 
         firmware_metadata_by_transceiver_type[transceiver_key] = selected_firmware
 

--- a/tests/transceiver/cdb_firmware_upgrade/utils/firmware_utils.py
+++ b/tests/transceiver/cdb_firmware_upgrade/utils/firmware_utils.py
@@ -184,6 +184,8 @@ def get_required_firmware_metadata_for_all_transceivers(
         else:
             selected_firmware = sorted_firmware[:NUM_LATEST_FIRMWARE_VERSIONS]
 
+        num_required_firmware = NUM_LATEST_FIRMWARE_VERSIONS + 1  # latest versions + gold
+
         # Add gold firmware
         gold_firmware_metadata = get_transceiver_gold_firmware_metadata(
             normalized_vendor_name,
@@ -202,10 +204,18 @@ def get_required_firmware_metadata_for_all_transceivers(
                     seen_versions.add(version)
                     unique_firmware.append(firmware)
             selected_firmware = unique_firmware
+
+            if len(selected_firmware) < num_required_firmware:
+                for firmware in sorted_firmware[NUM_LATEST_FIRMWARE_VERSIONS:]:
+                    version = firmware.get('version')
+                    if version and version not in seen_versions:
+                        seen_versions.add(version)
+                        selected_firmware.append(firmware)
+                        if len(selected_firmware) >= num_required_firmware:
+                            break
         else:
             logger.error(f"No gold firmware metadata found for transceiver type {transceiver_key}")
 
-        num_required_firmware = NUM_LATEST_FIRMWARE_VERSIONS + 1  # latest versions + gold
         if len(selected_firmware) != num_required_firmware:
             pytest.fail(
                 f"Expected exactly {num_required_firmware} firmware versions "


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Follow-up to PR [sonic-net/sonic-mgmt#25702](https://github.com/sonic-net/sonic-mgmt/pull/25702).
Reference: review comment [API comment](https://github.com/sonic-net/sonic-mgmt/pull/25702#discussion_r3560326798).

Summary:

Per the updated CDB firmware upgrade HLD, each transceiver's firmware_versions must contain exactly 3 firmware binaries including the gold image. The current implementation returns "latest two + optional gold" via `get_latest_two_firmware_metadata_for_all_transceivers()`, which no longer matches the HLD.

Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
The CDB firmware upgrade test previously downloaded only the latest two firmware versions per transceiver type. Per the new HLD, the test must exercise exactly three firmware binaries for each transceiver type, so that gold-firmware download and revert paths are always validated. This PR makes the gold firmware mandatory and enforces the exact count.

#### How did you do it?

#### How did you verify/test it?
Ran `transceiver/cdb_firmware_upgrade/test_firmware_upgrade.py` and verified the test selected the expected 3 versions (2 latest + gold), downloaded them, and passed md5 checksum verification. Test passes. Verified the guard fails as intended when the firmware binaries are not exactly 3.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

MSFT ADO - 38761000