### PR TITLE
[202605][bgp]: Skip test_bgp_suppress_fib module on 202605 (suppress-fib dynamic-toggle race)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -602,11 +602,20 @@ bgp/test_bgp_stress_link_flap.py::test_bgp_stress_link_flap[all]:
 
 bgp/test_bgp_suppress_fib.py:
   skip:
-    reason: "Not supported before release 202411."
+    reason: "(1) Not supported before release 202411.
+             (2) suppress-fib dynamic-toggle offload/propagation race: the module toggles
+             suppress-fib-pending dynamically at runtime, causing an orchagent/fpmsyncd/FRR race
+             where routes are intermittently not offloaded in FRR / not propagated to the upstream VM.
+             The product fix that makes suppress-fib static (sonic-swss#4333 + sonic-mgmt#22916) is
+             merging to master only and is not backported. Therefore master auto-lifts once the fix
+             lands and the tracking issue is closed, while the release branches 202505/202511/202605
+             never receive the fix and stay skipped for the life of the branch.
+             Tracked by https://github.com/sonic-net/sonic-mgmt/issues/26175"
     conditions_logical_operator: or
     conditions:
-      - "release in ['201811', '201911', '202012', '202205', '202211', '202305', '202311', '202405', 'master']"
-      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/14449"
+      - "release in ['201811', '201911', '202012', '202205', '202211', '202305', '202311', '202405']"
+      - "release in ['202505', '202511', '202605']"
+      - "release in ['master'] and https://github.com/sonic-net/sonic-mgmt/issues/26175"
   xfail:
     reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20756 or Mellanox platform due to https://github.com/sonic-net/sonic-buildimage/issues/24679"
     conditions_logical_operator: or


### PR DESCRIPTION
### Description of PR

**202605 backport** of [sonic-mgmt #26176](https://github.com/sonic-net/sonic-mgmt/pull/26176).

Summary:
Skip the whole `bgp/test_bgp_suppress_fib.py` module on the **202605** release branch. The module
toggles `suppress-fib-pending` dynamically at runtime, causing an orchagent/fpmsyncd/FRR race where
routes are intermittently **not offloaded in FRR / not propagated to the upstream VM**. The product
fix that makes `suppress-fib-pending` static (config-reload only) is **master-only and is not
backported to 202605**, so the module is skipped for the life of the branch.
Tracked by [sonic-mgmt issue #26175](https://github.com/sonic-net/sonic-mgmt/issues/26175).

> **Holistic context — two master PRs touched this block, neither is on 202605:**
> - [#25598](https://github.com/sonic-net/sonic-mgmt/pull/25598) — un-skipped select VS control-plane
>   cases (refactored the whole-file VS skip into per-case skips).
> - [#26176](https://github.com/sonic-net/sonic-mgmt/pull/26176) — then skipped the *whole module*
>   for the dynamic-toggle race (auto-lifts on master once the product fix lands + [issue #26175](https://github.com/sonic-net/sonic-mgmt/issues/26175) closes).
>
> On 202605 the product fix will **not** land. Per review feedback, this PR sets the
> `bgp/test_bgp_suppress_fib.py:` skip block **byte-identical to master** (the [#26176](https://github.com/sonic-net/sonic-mgmt/pull/26176) form)
> so the file stays consistent across branches and future edits cherry-pick cleanly. We still do
> **not** backport [#25598](https://github.com/sonic-net/sonic-mgmt/pull/25598)'s VS re-scope — the whole-module skip makes its per-case VS key inert on 202605.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

(This **is** the 202605 backport PR — base branch `202605`.)

### Approach

#### What is the motivation for this PR?

Each release branch's nightly runs its own `sonic-mgmt` checkout. Without this skip,
`test_bgp_suppress_fib` is a persistent nightly-noise source on 202605 (the dynamic-toggle race with
no product fix on this branch).

#### How did you do it?

A literal `git cherry-pick` of `c859f53` (master [#26176](https://github.com/sonic-net/sonic-mgmt/pull/26176)) does **not** apply cleanly,
because [#26176](https://github.com/sonic-net/sonic-mgmt/pull/26176) is stacked on
[#25598](https://github.com/sonic-net/sonic-mgmt/pull/25598) (which reshaped this block on master) and #25598 was never
backported to 202605. So [#26176](https://github.com/sonic-net/sonic-mgmt/pull/26176)'s content is applied by hand: the
`bgp/test_bgp_suppress_fib.py:` skip block is set **identical to master**:

```yaml
bgp/test_bgp_suppress_fib.py:
  skip:
    reason: "(1) Not supported before release 202411.
             (2) suppress-fib dynamic-toggle offload/propagation race: the module toggles
             suppress-fib-pending dynamically at runtime, causing an orchagent/fpmsyncd/FRR race
             where routes are intermittently not offloaded in FRR / not propagated to the upstream VM.
             The product fix that makes suppress-fib static (sonic-swss#4333 + sonic-mgmt#22916) is
             merging to master only and is not backported. Therefore master auto-lifts once the fix
             lands and the tracking issue is closed, while the release branches 202505/202511/202605
             never receive the fix and stay skipped for the life of the branch.
             Tracked by https://github.com/sonic-net/sonic-mgmt/issues/26175"
    conditions_logical_operator: or
    conditions:
      - "release in ['201811', '201911', '202012', '202205', '202211', '202305', '202311', '202405']"
      - "release in ['202505', '202511', '202605']"
      - "release in ['master'] and https://github.com/sonic-net/sonic-mgmt/issues/26175"
```

On a 202605 checkout the `release in ['202505', '202511', '202605']` condition matches, so the whole
module is skipped on all ASICs/topologies; the `'master'` + [#26175](https://github.com/sonic-net/sonic-mgmt/issues/26175)-gated
auto-lift line is inert here (never lifts on 202605, which is the intent). Keeping the block identical
to master addresses the review concern about cross-branch consistency / future cherry-pick conflicts.

> Note: [#25598](https://github.com/sonic-net/sonic-mgmt/pull/25598)'s VS re-scope (a separate
> `bgp/test_bgp_suppress_fib.py::test_bgp_route_with_suppress:` per-case key) is intentionally **not**
> backported — it would be inert under the whole-module skip on 202605. As a result this region is not
> 100% byte-identical to master (master carries that extra per-case key), so an edit touching that exact
> boundary could still need a manual resolution; the skip **conditions** themselves now match master.

#### How did you verify/test it?

- `tests_mark_conditions.yaml` parses cleanly (`yaml.safe_load`) and the `bgp/test_bgp_suppress_fib.py:`
  block is verified **byte-identical** to master.
- The skip condition `release in ['202505', '202511', '202605']` evaluates **True** on a 202605
  checkout → whole module skipped on all ASICs/topologies.

#### Any platform specific information?

None — the whole-module skip is keyed on `release` only (all ASICs/topologies).

#### Supported testbed topology if it's a new test case?

N/A — not a new test case; whole-module skip only.

### Documentation

N/A
