### PR TITLE
Porting PR:25867 to 202511: Adding fixes for qos-sai for issues found during 202511 runs

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -17,6 +17,7 @@ class QosParamCisco(object):
                                                             "Cisco-8101C01-V64",
                                                             "Cisco-8101C01-C28S4",
                                                             "Cisco-8101C01-C32"],
+                              "x86_64-88_lc0_36fh-r0": ["Cisco-88-LC0-36FH-O36"],
                               "x86_64-8102_64h_o-r0": ["Cisco-8102-C64"]}
     VOQ_ASICS = ["gb", "gr"]
 

--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -270,6 +270,7 @@ qos_params:
                 pkts_num_fill_egr_min: 0
                 cell_size: 384
                 packet_size: 1350
+                pkts_num_margin: 6
             wrr:
                 ecn: 1
                 q0_num_of_pkts: 70
@@ -417,6 +418,7 @@ qos_params:
                     pkts_num_trig_pfc: 3415
                     cell_size: 384
                     packet_size: 1350
+                    pkts_num_margin: 6
             400000_300m:
                 pkts_num_leak_out: 0
                 pkts_num_egr_mem: 6884
@@ -543,6 +545,7 @@ qos_params:
                     pkts_num_trig_pfc: 3038
                     cell_size: 384
                     packet_size: 1350
+                    pkts_num_margin: 6
             100000_120000m:
                 pkts_num_leak_out: 0
                 pkts_num_egr_mem: 1256
@@ -612,6 +615,7 @@ qos_params:
                     pkts_num_trig_pfc: 642
                     cell_size: 8192
                     packet_size: 6144
+                    pkts_num_margin: 6
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1346,7 +1346,8 @@ class QosSaiBase(QosBase):
                     get_src_dst_asic_and_duts['dst_asic']:
                 dutTopo = dutTopo + "any"
             else:
-                dutTopo = dutTopo + topo
+                # Any t2 variant for gb asic has to use the gb/t2 qos params only.
+                dutTopo = dutTopo + "t2"
         elif dutTopo + topo in qosConfigs['qos_params'].get(dutAsic, {}):
             dutTopo = dutTopo + topo
         else:
@@ -1451,6 +1452,9 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
+        if get_src_dst_asic_and_duts['src_dut'].facts['asic_type'] == "cisco-8000":
+            yield
+            return
         all_asics = get_src_dst_asic_and_duts['all_asics']
 
         ipVersions = [{"ip_version": "ipv4"}, {"ip_version": "ipv6"}]
@@ -3699,6 +3703,9 @@ def clear_pg_watermark(interface):
         By default WRED_ECN_QUEUE and WRED_ECN_PORT are disabled for polling.
         Enable flexcounter groups WRED_ECN_QUEUE and WRED_ECN_PORT using counterpoll CLI
         """
+        if get_src_dst_asic_and_duts['all_duts'][0].facts["asic_type"] == 'cisco-8000':
+            yield
+            return
         for duthost in get_src_dst_asic_and_duts['all_duts']:
             for dut_asic in duthost.asics:
                 ConterpollHelper.enable_counterpoll(dut_asic, ['wredqueue', 'wredport'])

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -567,7 +567,7 @@ class TestQosSai(QosSaiBase):
             "pkts_num_trig_pfc": qosConfig[xoffProfile]["pkts_num_trig_pfc"],
             "pkts_num_trig_ingr_drp": qosConfig[xoffProfile]["pkts_num_trig_ingr_drp"],
             "hwsku": dutTestParams['hwsku'],
-            "src_dst_asic_diff": (dutConfig['dutAsic'] != dutConfig['dstDutAsic'])
+            "src_dst_asic_diff": get_src_dst_asic_and_duts['src_asic'] != get_src_dst_asic_and_duts['dst_asic']
         })
 
         if "platform_asic" in dutTestParams["basicParams"]:
@@ -856,7 +856,7 @@ class TestQosSai(QosSaiBase):
             "pkts_num_leak_out": dutQosConfig["param"][portSpeedCableLength]["pkts_num_leak_out"],
             "hwsku": dutTestParams['hwsku'],
             "pkts_num_egr_mem": qosConfig[xonProfile].get('pkts_num_egr_mem', None),
-            "src_dst_asic_diff": (dutConfig['dutAsic'] != dutConfig['dstDutAsic']),
+            "src_dst_asic_diff": get_src_dst_asic_and_duts['src_asic'] != get_src_dst_asic_and_duts['dst_asic'],
             "dut_asic": dutConfig["dutAsic"]
         })
 
@@ -1296,7 +1296,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiBufferPoolWatermark(
         self, request, get_src_dst_asic_and_duts, bufPool, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         ingressLosslessProfile, egressLossyProfile, resetWatermark,
-        skip_src_dst_different_asic
+        skip_src_dst_different_asic, permit_only_test_traffic_on_fanout
     ):
         """
             Test QoS SAI Queue buffer pool watermark for lossless/lossy traffic
@@ -1453,7 +1453,8 @@ class TestQosSai(QosSaiBase):
     def testQosSaiLossyQueueVoq(
         self, LossyVoq, ptfhost, dutTestParams, dutConfig, dutQosConfig,
             ingressLossyProfile, duthost, localhost, get_src_dst_asic_and_duts,
-            skip_src_dst_different_asic, dut_qos_maps    # noqa:  F811
+            skip_src_dst_different_asic, dut_qos_maps,       # noqa:  F811
+            permit_only_test_traffic_on_fanout       # noqa:  F811
     ):
         # NOTE: cisco 8800 will skip this test, this test only for single asic with long link
         """
@@ -1557,7 +1558,8 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiDscpQueueMapping(
         self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dut_qos_maps,  # noqa: F811
-        tc_to_dscp_count, change_lag_lacp_timer
+        tc_to_dscp_count, change_lag_lacp_timer,
+        permit_only_test_traffic_on_fanout
     ):
         """
             Test QoS SAI DSCP to queue mapping
@@ -2129,7 +2131,8 @@ class TestQosSai(QosSaiBase):
     def testQosSaiDscpToPgMapping(
         self, get_src_dst_asic_and_duts, duthost,
         request, ptfhost, dutTestParams, dutConfig, dut_qos_maps,  # noqa: F811
-        change_lag_lacp_timer, dutQosConfig
+        change_lag_lacp_timer, dutQosConfig,
+        permit_only_test_traffic_on_fanout
     ):
         """
             Test QoS SAI DSCP to PG mapping ptf test


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Summary:
Issues seen:
1. There are some minor code fixes - related to checking if the dest and src asics are different.
2. In 202511 PR, there will be adding the margin for BufferPoolWM tests. This is already present in master.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Approach
#### What is the motivation for this PR?
Failures in qos-sai runs in 202511.

#### How did you do it?
I have added multiple fixes in qos-sai.
#### How did you verify/test it?
Ran it in my T2 testbed.

#### Any platform specific information?
Specific to cisco-8000.