### PR TITLE
[test/gcu]: Add MOR add-cluster scaling test (apply-patch capacity vs N)

### DIFF
--- a/tests/generic_config_updater/add_cluster/conftest.py
+++ b/tests/generic_config_updater/add_cluster/conftest.py
@@ -1,9 +1,23 @@
 import logging
+import os
 import pytest
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 from tests.common.gu_utils import restore_backup_test_config, save_backup_test_config
 
 logger = logging.getLogger(__name__)
+
+
+def pytest_configure(config):
+    """Register custom markers used by the Add-MOR scaling tests."""
+    config.addinivalue_line(
+        "markers",
+        "gcu_scaling_nightly: Add-MOR scaling — runs in nightly pipeline")
+    config.addinivalue_line(
+        "markers",
+        "gcu_scaling_weekly: Add-MOR scaling — runs weekly / on-demand")
+    config.addinivalue_line(
+        "markers",
+        "gcu_scaling_sanity: Add-MOR scaling — one-time test-validation only")
 
 
 # -----------------------------
@@ -12,6 +26,18 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope="module")
 def enum_rand_one_asic_namespace(enum_rand_one_frontend_asic_index):
+    # Optional deterministic override for scaling runs on testbeds where
+    # only one asic has enough external PortChannels for the requested N.
+    # Set GCU_FORCE_ASIC="asic1" (or "asic0", or "host" for None) in the
+    # test environment to skip the random pick.  Nightly on production
+    # testbeds should leave this unset.
+    forced = os.environ.get("GCU_FORCE_ASIC")
+    if forced:
+        if forced.lower() == "host":
+            logger.info("GCU_FORCE_ASIC=host -> using None (localhost)")
+            return None
+        logger.info("GCU_FORCE_ASIC=%s -> overriding random asic pick", forced)
+        return forced
     return None if enum_rand_one_frontend_asic_index is None else 'asic{}'.format(enum_rand_one_frontend_asic_index)
 
 

--- a/tests/generic_config_updater/add_cluster/conftest.py
+++ b/tests/generic_config_updater/add_cluster/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import pytest
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 from tests.common.gu_utils import restore_backup_test_config, save_backup_test_config
@@ -30,12 +31,19 @@ def enum_rand_one_asic_namespace(enum_rand_one_frontend_asic_index):
     # only one asic has enough external PortChannels for the requested N.
     # Set GCU_FORCE_ASIC="asic1" (or "asic0", or "host" for None) in the
     # test environment to skip the random pick.  Nightly on production
-    # testbeds should leave this unset.
-    forced = os.environ.get("GCU_FORCE_ASIC")
-    if forced:
-        if forced.lower() == "host":
+    # testbeds should leave this unset.  The value is normalised (stripped
+    # and lower-cased) and validated up front so a typo fails immediately
+    # rather than silently targeting a namespace that does not exist.
+    raw_forced = os.environ.get("GCU_FORCE_ASIC")
+    if raw_forced:
+        forced = raw_forced.strip().lower()
+        if forced == "host":
             logger.info("GCU_FORCE_ASIC=host -> using None (localhost)")
             return None
+        if not re.match(r"^asic\d+$", forced):
+            pytest.fail(
+                "GCU_FORCE_ASIC must be 'host' or 'asic<N>' (e.g. 'asic0'), "
+                "got {!r}".format(raw_forced))
         logger.info("GCU_FORCE_ASIC=%s -> overriding random asic pick", forced)
         return forced
     return None if enum_rand_one_frontend_asic_index is None else 'asic{}'.format(enum_rand_one_frontend_asic_index)

--- a/tests/generic_config_updater/add_cluster/test_add_cluster.py
+++ b/tests/generic_config_updater/add_cluster/test_add_cluster.py
@@ -1,12 +1,21 @@
 import logging
+import os
+import time
 import pytest
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 from tests.common.config_reload import config_reload
-from tests.common.gu_utils import delete_tmpfile, expect_op_success, generate_tmpfile
-from tests.common.gu_utils import apply_patch
+from tests.common.gu_utils import (
+    apply_patch,
+    create_checkpoint,
+    delete_checkpoint,
+    delete_tmpfile,
+    expect_op_success,
+    generate_tmpfile,
+    rollback_or_reload,
+)
 from tests.generic_config_updater.add_cluster.helpers import add_static_route, \
     clear_static_route, get_active_interfaces, get_cfg_info_from_dut, \
     get_exabgp_port_for_neighbor, remove_dataacl_table_single_dut, remove_static_route, \
@@ -1004,13 +1013,16 @@ def apply_patch_add_cluster(config_facts,
                             config_facts_localhost,
                             mg_facts,
                             duthost,
-                            enum_rand_one_asic_namespace):
+                            enum_rand_one_asic_namespace,
+                            include_acl_table=True):
     """
     Apply patch to add cluster information for a given ASIC namespace.
 
     Changes are perfomed to below tables:
 
-    ACL_TABLE
+    ACL_TABLE (skipped when include_acl_table=False — used by the N-MOR
+    scaling test which manages ACL_TABLE ports separately as a
+    localhost-only replace op)
     BGP_NEIGHBOR
     DEVICE_NEIGHBOR
     DEVICE_NEIGHBOR_METADATA
@@ -1134,22 +1146,25 @@ def apply_patch_add_cluster(config_facts,
             "value": f"{highest}m"
         })
 
-    # table ACL_TABLE changes
-    json_patch_asic.append({
-        "op": "add",
-        "path": f"{json_namespace}/ACL_TABLE/DATAACL",
-        "value": config_facts["ACL_TABLE"]["DATAACL"]
-    })
-    json_patch_asic.append({
-        "op": "add",
-        "path": f"{json_namespace}/ACL_TABLE/EVERFLOW",
-        "value": config_facts["ACL_TABLE"]["EVERFLOW"]
-    })
-    json_patch_asic.append({
-        "op": "add",
-        "path": f"{json_namespace}/ACL_TABLE/EVERFLOWV6",
-        "value": config_facts["ACL_TABLE"]["EVERFLOWV6"]
-    })
+    # table ACL_TABLE changes (skip when caller opts out — the N-MOR
+    # scaling test does this so it can manage ACL_TABLE ports via a
+    # separate localhost-only replace op)
+    if include_acl_table:
+        json_patch_asic.append({
+            "op": "add",
+            "path": f"{json_namespace}/ACL_TABLE/DATAACL",
+            "value": config_facts["ACL_TABLE"]["DATAACL"]
+        })
+        json_patch_asic.append({
+            "op": "add",
+            "path": f"{json_namespace}/ACL_TABLE/EVERFLOW",
+            "value": config_facts["ACL_TABLE"]["EVERFLOW"]
+        })
+        json_patch_asic.append({
+            "op": "add",
+            "path": f"{json_namespace}/ACL_TABLE/EVERFLOWV6",
+            "value": config_facts["ACL_TABLE"]["EVERFLOWV6"]
+        })
 
     ######################
     # LOCALHOST NAMESPACE
@@ -1223,21 +1238,22 @@ def apply_patch_add_cluster(config_facts,
             "value": value
         })
 
-    json_patch_localhost.append({
-        "op": "add",
-        "path": "/localhost/ACL_TABLE/DATAACL/ports",
-        "value": config_facts_localhost["ACL_TABLE"]["DATAACL"]["ports"]
-    })
-    json_patch_localhost.append({
-        "op": "add",
-        "path": "/localhost/ACL_TABLE/EVERFLOW/ports",
-        "value": config_facts_localhost["ACL_TABLE"]["EVERFLOW"]["ports"]
-    })
-    json_patch_localhost.append({
-        "op": "add",
-        "path": "/localhost/ACL_TABLE/EVERFLOWV6/ports",
-        "value": config_facts_localhost["ACL_TABLE"]["EVERFLOWV6"]["ports"]
-    })
+    if include_acl_table:
+        json_patch_localhost.append({
+            "op": "add",
+            "path": "/localhost/ACL_TABLE/DATAACL/ports",
+            "value": config_facts_localhost["ACL_TABLE"]["DATAACL"]["ports"]
+        })
+        json_patch_localhost.append({
+            "op": "add",
+            "path": "/localhost/ACL_TABLE/EVERFLOW/ports",
+            "value": config_facts_localhost["ACL_TABLE"]["EVERFLOW"]["ports"]
+        })
+        json_patch_localhost.append({
+            "op": "add",
+            "path": "/localhost/ACL_TABLE/EVERFLOWV6/ports",
+            "value": config_facts_localhost["ACL_TABLE"]["EVERFLOWV6"]["ports"]
+        })
 
     #####################################
     # combine localhost and ASIC patch data
@@ -1256,7 +1272,8 @@ def apply_patch_add_cluster_chassis_packet(config_facts,
                                            config_facts_localhost,
                                            mg_facts,
                                            duthost,
-                                           enum_rand_one_asic_namespace):
+                                           enum_rand_one_asic_namespace,
+                                           include_acl_table=True):
     """
     Apply patch to add cluster information for chassis-packet switches.
 
@@ -1473,13 +1490,14 @@ def apply_patch_add_cluster_chassis_packet(config_facts,
         })
 
     # STEP 12: Add/Replace ACL_TABLE changes
-    for acl_table_name in ["DATAACL", "EVERFLOW", "EVERFLOWV6"]:
-        if acl_table_name in config_facts.get("ACL_TABLE", {}):
-            json_patch_asic_rest.append({
-                "op": "add",
-                "path": f"{json_namespace}/ACL_TABLE/{acl_table_name}/ports",
-                "value": config_facts["ACL_TABLE"][acl_table_name]["ports"]
-            })
+    if include_acl_table:
+        for acl_table_name in ["DATAACL", "EVERFLOW", "EVERFLOWV6"]:
+            if acl_table_name in config_facts.get("ACL_TABLE", {}):
+                json_patch_asic_rest.append({
+                    "op": "add",
+                    "path": f"{json_namespace}/ACL_TABLE/{acl_table_name}/ports",
+                    "value": config_facts["ACL_TABLE"][acl_table_name]["ports"]
+                })
 
     #####################################
     # Apply patches in correct order
@@ -1879,3 +1897,921 @@ def test_add_cluster(tbinfo,
                                   else acl_counter["packets count"] == '0',
                                   "Acl rule {} statistics are not as expected. Found value {}"
                                   .format(acl_counter["rule name"], acl_counter["packets count"]))
+
+
+# ===========================================================================
+# GCU Add-MOR SCALING TEST
+# ===========================================================================
+#
+# Purpose
+# -------
+# Measure how ``config apply-patch`` elapsed time scales with the number of
+# MORs (T1 neighbors) added in a single patch.  Baseline instrument for
+# comparing stock 202405 GCU vs. GCU-container (with master #3831 backported)
+# and for validating removal of ``skip-sort_table`` on 202412 .61 images.
+#
+# Design
+# ------
+# 1. Full cluster is present at test entry.
+# 2. Pick N external PortChannels (= N MORs).
+# 3. Build a targeted REMOVE patch for those N MORs (setup, untimed).
+# 4. Filter ``config_facts`` down to just those N MORs.
+# 5. Call the existing ``apply_patch_add_cluster*()`` with the filtered dict
+#    and ``include_acl_table=False`` — TIMED.  ACL_TABLE port lists are
+#    handled separately via a small localhost replace op.
+# 6. Verify BGP peers on those N MORs come back up.
+# 7. record_property() the metric so CI / Kusto ingest can graph it.
+# 8. Teardown: rollback_or_reload restores full state.
+#
+# Reuses ``apply_patch_add_cluster()`` / ``apply_patch_add_cluster_chassis_packet()``
+# for the ADD path so there is no duplicate patch-builder logic.  Only the
+# subset REMOVE path is custom (existing remove functions operate on whole
+# tables and cannot be filtered without a much larger refactor).
+# ===========================================================================
+
+# Tiered N values (see meeting notes 2026-07-14):
+#   - Nightly: fast regression + one near-production data point.
+#   - Weekly:  full-scale capacity ("how many MORs in 1 hour" number).
+#   - Sanity:  validates the test itself; opt-in only.
+# Selected with -m markers; each pytest run instantiates one (n_mors, tier).
+NIGHTLY_MOR_COUNTS = [5, 20]
+WEEKLY_MOR_COUNTS = [24, 30]
+SANITY_MOR_COUNTS = [1]
+
+# Vaibhav's stated operational target (Meeting 1, 2026-07-01): 1 hour end-to-end.
+# Override with env GCU_TIME_BUDGET_S for local experimentation.
+DEFAULT_TIME_BUDGET_S = 3600
+
+SCALING_CHECKPOINT = "gcu_scaling"
+_SCALING_ACL_TABLES = ("DATAACL", "EVERFLOW", "EVERFLOWV6")
+
+
+def _is_internal_port_scaling(port_name):
+    """Backplane/internal ports never make up a MOR."""
+    return (port_name.startswith("Ethernet-BP") or
+            port_name.startswith("Ethernet-IB") or
+            port_name.startswith("Ethernet-Rec"))
+
+
+def _select_n_mors(config_facts, n):
+    """Pick N external PortChannels from config_facts.
+
+    Returns a dict:
+        {
+          "portchannels": [pc_name, ...],
+          "member_ports": [ethernet_name, ...],
+          "bgp_neigh_ips": [ip_addr, ...],
+          "device_neigh_names": [neighbor_name, ...],
+        }
+
+    Deterministic (alphabetical) selection so runs are comparable across GCU
+    versions.  Raises ValueError if the ASIC has fewer than N external PCs.
+    """
+    pc_members = config_facts.get("PORTCHANNEL_MEMBER", {})
+    device_neighbors = config_facts.get("DEVICE_NEIGHBOR", {})
+    bgp_neighbors = config_facts.get("BGP_NEIGHBOR", {})
+
+    external_pcs = [
+        pc for pc, members in pc_members.items()
+        if all(not _is_internal_port_scaling(p) for p in members.keys())
+    ]
+    if len(external_pcs) < n:
+        raise ValueError(
+            "ASIC has only {} external PortChannels; requested {}".format(
+                len(external_pcs), n))
+
+    selected_pcs = sorted(external_pcs)[:n]
+    member_ports = []
+    for pc in selected_pcs:
+        member_ports.extend(pc_members[pc].keys())
+
+    # Dedupe: multiple member ports on the same PortChannel share one peer
+    # (e.g., Ethernet0+Ethernet8 -> ARISTA01T1). Emitting the same remove op
+    # twice trips GCU YANG validation ("can't remove a non-existent object").
+    seen = set()
+    device_neigh_names = []
+    for p in member_ports:
+        if p not in device_neighbors:
+            continue
+        name = device_neighbors[p].get("name")
+        if name and name not in seen:
+            seen.add(name)
+            device_neigh_names.append(name)
+    bgp_neigh_ips = [
+        ip for ip, cfg in bgp_neighbors.items()
+        if cfg.get("name") in device_neigh_names
+    ]
+    return {
+        "portchannels": selected_pcs,
+        "member_ports": member_ports,
+        "bgp_neigh_ips": bgp_neigh_ips,
+        "device_neigh_names": device_neigh_names,
+    }
+
+
+def _build_scaling_acl_reattach_patch(config_facts_localhost, selection,
+                                      mg_facts):
+    """Build the localhost-only ACL_TABLE ports re-attach patch.
+
+    Used by the scaling test AFTER the (filtered) add_cluster call, since we
+    passed include_acl_table=False and stripped ACL_TABLE ports for the N
+    MORs in the setup step.
+    """
+    del mg_facts  # kept for signature symmetry; not needed here
+    acl_local = config_facts_localhost.get("ACL_TABLE", {})
+    patch = []
+    for tname in _SCALING_ACL_TABLES:
+        entry = acl_local.get(tname)
+        if not entry or "ports" not in entry:
+            continue
+        # Restore the full ports list (which includes our N MORs since the
+        # module-scoped config_facts_localhost was captured pre-modification).
+        patch.append({
+            "op": "replace",
+            "path": f"/localhost/ACL_TABLE/{tname}/ports",
+            "value": list(entry["ports"]),
+        })
+    _ = selection  # unused; kept for future per-MOR ACL granularity
+    return patch
+
+
+class _TimedApplyResult(object):
+    """Container for one timed apply_patch call."""
+
+    def __init__(self):
+        self.elapsed_s = 0.0
+        self.success = False
+        self.hwproxy_timeout = False
+        self.stdout = ""
+
+
+def _timed_apply_patch(duthost, patch_list):
+    """Run apply_patch, record wall-clock, detect HWProxy-style timeouts.
+
+    Uses the shared apply_patch/generate_tmpfile/delete_tmpfile helpers so
+    behaviour matches every other GCU test (including the async wrapper
+    that raises TimeoutError on the internal wait_until fuse).
+    """
+    result = _TimedApplyResult()
+    if not patch_list:
+        result.success = True
+        return result
+    tmpfile = generate_tmpfile(duthost)
+    start = time.time()
+    try:
+        output = apply_patch(duthost, json_data=patch_list, dest_file=tmpfile)
+        result.elapsed_s = time.time() - start
+        result.stdout = output.get("stdout", "")
+        result.success = (
+            output.get("rc") == 0 and
+            "Patch applied successfully" in result.stdout
+        )
+        if not result.success:
+            lowered = (result.stdout + output.get("stderr", "")).lower()
+            if ("hardwareproxy" in lowered or "hardware proxy" in lowered or
+                    "connectiondroppedbydevice" in lowered or
+                    "waitforregex" in lowered):
+                result.hwproxy_timeout = True
+    except TimeoutError:
+        # apply_patch's internal wait_until fuse fired
+        result.elapsed_s = time.time() - start
+        result.hwproxy_timeout = True
+    finally:
+        try:
+            delete_tmpfile(duthost, tmpfile)
+        except Exception:
+            pass
+    return result
+
+
+def _verify_bgp_up_scaling(duthost, bgp_neigh_ips, timeout=180):
+    """Poll ``show ip bgp summary -d all`` for all peers reaching Established.
+
+    Same command used elsewhere in this file (line ~1687).  Returns True on
+    success; caller decides whether to fail or just log a warning.
+    """
+    def _all_established():
+        out = duthost.shell("show ip bgp summary -d all",
+                            module_ignore_errors=True)["stdout"]
+        count = 0
+        for ip in bgp_neigh_ips:
+            for line in out.splitlines():
+                if ip in line and "Estab" in line:
+                    count += 1
+                    break
+        return count == len(bgp_neigh_ips)
+
+    return wait_until(timeout, 10, 0, _all_established)
+
+
+@pytest.fixture(scope="function")
+def scaling_checkpoint(duthosts, enum_downstream_dut_hostname):
+    """Per-test checkpoint + rollback so each parametrization starts clean."""
+    duthost = duthosts[enum_downstream_dut_hostname]
+    create_checkpoint(duthost, cp=SCALING_CHECKPOINT)
+    yield SCALING_CHECKPOINT
+    try:
+        rollback_or_reload(duthost, cp=SCALING_CHECKPOINT)
+    finally:
+        delete_checkpoint(duthost, cp=SCALING_CHECKPOINT)
+
+
+def _record_platform_metadata(duthost, config_facts, selection, record_property):
+    """Emit per-run metadata to enable Kusto slicing across platforms."""
+    facts = duthost.facts or {}
+    record_property("gcu_sonic_version",
+                    facts.get("asic_type", "") + "/" + str(facts.get("num_asic", "")))
+    try:
+        img = duthost.shell("sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version",
+                            module_ignore_errors=True)["stdout"].strip()
+        record_property("gcu_sonic_image", img)
+    except Exception:
+        pass
+    record_property("gcu_hwsku", facts.get("hwsku", ""))
+    record_property("gcu_switch_type", facts.get("switch_type", ""))
+    record_property("gcu_platform", facts.get("platform", ""))
+    # PC composition: how many are single-port vs multi-port among selected.
+    pc_members = config_facts.get("PORTCHANNEL_MEMBER", {})
+    single = sum(1 for pc in selection["portchannels"]
+                 if len(pc_members.get(pc, {})) == 1)
+    multi = len(selection["portchannels"]) - single
+    record_property("gcu_pc_single_port", single)
+    record_property("gcu_pc_multi_port", multi)
+
+
+def _cli_remove_selected_mors(duthost, selection, namespace):
+    """Surgically delete ONLY the N selected MORs from CONFIG_DB via
+    ``sonic-db-cli del`` (no wildcards, no YANG-cascade risk, no reliance
+    on existing helpers).
+
+    Order matters: children (BGP_NEIGHBOR, DEVICE_NEIGHBOR) before parent
+    (DEVICE_NEIGHBOR_METADATA); PORTCHANNEL_INTERFACE and PORTCHANNEL_MEMBER
+    before PORTCHANNEL.  Both asic-namespace and localhost tables are cleaned.
+    ``module_ignore_errors=True`` because some entries may exist on only one
+    side (asic vs localhost) or may have been auto-removed by prior ops.
+
+    Safe by construction: our fixture takes a checkpoint before this runs
+    and calls ``config rollback`` in teardown, so any intermediate state
+    (including a partially-removed MOR if a command errors) is undone.
+    """
+    ns_flag = "" if namespace is None else "-n {}".format(namespace)
+
+    def run(where, cmd, desc):
+        logger.info("[%s] %s: %s", where, desc, cmd)
+        duthost.shell(cmd, module_ignore_errors=True)
+
+    for ip in selection["bgp_neigh_ips"]:
+        run("asic", "sudo sonic-db-cli {} CONFIG_DB del 'BGP_NEIGHBOR|{}'"
+            .format(ns_flag, ip), "del BGP_NEIGHBOR " + ip)
+        run("localhost", "sudo sonic-db-cli CONFIG_DB del 'BGP_NEIGHBOR|{}'"
+            .format(ip), "del localhost BGP_NEIGHBOR " + ip)
+
+    for port in selection["member_ports"]:
+        run("asic", "sudo sonic-db-cli {} CONFIG_DB del 'DEVICE_NEIGHBOR|{}'"
+            .format(ns_flag, port), "del DEVICE_NEIGHBOR " + port)
+        run("localhost", "sudo sonic-db-cli CONFIG_DB del 'DEVICE_NEIGHBOR|{}'"
+            .format(port), "del localhost DEVICE_NEIGHBOR " + port)
+
+    for name in selection["device_neigh_names"]:
+        run("asic",
+            "sudo sonic-db-cli {} CONFIG_DB del 'DEVICE_NEIGHBOR_METADATA|{}'"
+            .format(ns_flag, name),
+            "del DEVICE_NEIGHBOR_METADATA " + name)
+        run("localhost",
+            "sudo sonic-db-cli CONFIG_DB del 'DEVICE_NEIGHBOR_METADATA|{}'"
+            .format(name),
+            "del localhost DEVICE_NEIGHBOR_METADATA " + name)
+
+    for pc in selection["portchannels"]:
+        # PORTCHANNEL_INTERFACE: both bare PC key and PC|ip compound keys.
+        run("asic",
+            "sudo sonic-db-cli {ns} CONFIG_DB keys 'PORTCHANNEL_INTERFACE|{pc}*' "
+            "| xargs -r -n1 sudo sonic-db-cli {ns} CONFIG_DB del"
+            .format(ns=ns_flag, pc=pc),
+            "del PORTCHANNEL_INTERFACE " + pc + "*")
+        run("localhost",
+            "sudo sonic-db-cli CONFIG_DB keys 'PORTCHANNEL_INTERFACE|{pc}*' "
+            "| xargs -r -n1 sudo sonic-db-cli CONFIG_DB del".format(pc=pc),
+            "del localhost PORTCHANNEL_INTERFACE " + pc + "*")
+
+        # PORTCHANNEL_MEMBER: PC|Ethernet* keys.
+        run("asic",
+            "sudo sonic-db-cli {ns} CONFIG_DB keys 'PORTCHANNEL_MEMBER|{pc}|*' "
+            "| xargs -r -n1 sudo sonic-db-cli {ns} CONFIG_DB del"
+            .format(ns=ns_flag, pc=pc),
+            "del PORTCHANNEL_MEMBER " + pc + "|*")
+        run("localhost",
+            "sudo sonic-db-cli CONFIG_DB keys 'PORTCHANNEL_MEMBER|{pc}|*' "
+            "| xargs -r -n1 sudo sonic-db-cli CONFIG_DB del".format(pc=pc),
+            "del localhost PORTCHANNEL_MEMBER " + pc + "|*")
+
+        # PORTCHANNEL parent last.
+        run("asic",
+            "sudo sonic-db-cli {} CONFIG_DB del 'PORTCHANNEL|{}'"
+            .format(ns_flag, pc), "del PORTCHANNEL " + pc)
+        run("localhost",
+            "sudo sonic-db-cli CONFIG_DB del 'PORTCHANNEL|{}'".format(pc),
+            "del localhost PORTCHANNEL " + pc)
+
+    # Per-port scalars (safe if absent). PORT stays — we do NOT delete PORT
+    # entries; admin_status flipped to down instead so add-back can re-enable.
+    for port in selection["member_ports"]:
+        run("asic",
+            "sudo sonic-db-cli {} CONFIG_DB del 'PORT_QOS_MAP|{}'"
+            .format(ns_flag, port), "del PORT_QOS_MAP " + port)
+        run("asic",
+            "sudo sonic-db-cli {} CONFIG_DB hdel 'CABLE_LENGTH|AZURE' {}"
+            .format(ns_flag, port), "hdel CABLE_LENGTH " + port)
+        run("asic",
+            "sudo sonic-db-cli {ns} CONFIG_DB keys 'BUFFER_PG|{p}|*' "
+            "| xargs -r -n1 sudo sonic-db-cli {ns} CONFIG_DB del"
+            .format(ns=ns_flag, p=port), "del BUFFER_PG " + port + "|*")
+        run("asic",
+            "sudo sonic-db-cli {} CONFIG_DB hset 'PORT|{}' admin_status down"
+            .format(ns_flag, port), "admin_status down " + port)
+
+
+def _probe_parent_tables_present(duthost, namespace):
+    """After ``_cli_remove_selected_mors`` runs, probe the DUT to see
+    whether the parent hashes we restore in ``_build_scaling_add_patch``
+    still exist on the asic namespace.
+
+    Redis auto-deletes a hash key when its last field is removed, so if
+    our per-port ``hdel``/``del`` cleared out every entry, the parent
+    key is gone.  ``jsonpatch`` (RFC 6902) refuses to path into a
+    missing intermediate — ``add /CABLE_LENGTH/AZURE/EthernetX`` on an
+    empty/missing ``CABLE_LENGTH`` raises ``member 'AZURE' not found
+    in {}``.  We use this snapshot to prepend defensive ``add
+    /parent = {}`` ops only when the parent is actually gone.
+
+    Returns a dict:
+        {"cable_azure": bool,  # CABLE_LENGTH|AZURE key exists
+         "port_qos_map": bool, # any PORT_QOS_MAP|* keys exist
+         "buffer_pg":    bool} # any BUFFER_PG|* keys exist
+    """
+    if namespace is None:
+        ns_flag = ""
+    else:
+        ns_flag = "-n " + namespace
+
+    def _exists(pattern):
+        cmd = ("sudo sonic-db-cli {} CONFIG_DB keys '{}' | head -n1"
+               .format(ns_flag, pattern))
+        out = duthost.shell(cmd, module_ignore_errors=True)["stdout"].strip()
+        return bool(out)
+
+    return {
+        "cable_azure":  _exists("CABLE_LENGTH|AZURE"),
+        "port_qos_map": _exists("PORT_QOS_MAP|*"),
+        "buffer_pg":    _exists("BUFFER_PG|*"),
+    }
+
+
+def _scan_pc_references(config_facts, config_facts_localhost, pcs):
+    """Scan config for tables whose entries carry a ``ports`` leaf-list
+    that references one or more of our selected PortChannels.
+
+    Real-world referrers: ACL_TABLE.ports (localhost, and sometimes
+    per-asic), PBH_TABLE.ports, MIRROR_SESSION.ports, etc.  YANG treats
+    those as leafrefs to PORTCHANNEL_LIST/PORT_LIST, so any entry that
+    still references a PC we've removed becomes dangling and blocks the
+    re-add patch with ``Invalid value "PortChannelXXX" in "ports"
+    element``.
+
+    Returns a list of dicts:
+        {"scope": "asic"|"localhost",
+         "table": "<TABLE_NAME>",
+         "key":   "<row_key>",
+         "orig":  [<full port list>],
+         "trimmed": [<same list minus our PCs>],
+         "removed": [<our PCs that were present>]}
+    """
+    pc_set = set(pcs)
+    refs = []
+    for scope, cf in (("asic", config_facts), ("localhost", config_facts_localhost)):
+        if not isinstance(cf, dict):
+            continue
+        for table, entries in cf.items():
+            if not isinstance(entries, dict):
+                continue
+            for key, val in entries.items():
+                if not isinstance(val, dict):
+                    continue
+                port_list = val.get("ports")
+                if not isinstance(port_list, list):
+                    continue
+                hit = [p for p in port_list if p in pc_set]
+                if not hit:
+                    continue
+                refs.append({
+                    "scope": scope,
+                    "table": table,
+                    "key": key,
+                    "orig": list(port_list),
+                    "trimmed": [p for p in port_list if p not in pc_set],
+                    "removed": hit,
+                })
+    return refs
+
+
+def _cli_remove_pc_references(duthost, refs, namespace):
+    """Strip our selected PCs from every ``ports@`` list captured by
+    ``_scan_pc_references``.  Uses ``sonic-db-cli hset`` with the redis
+    leaf-list encoding (``ports@`` = comma-joined values).
+
+    Untimed setup step; ``module_ignore_errors=True`` because the
+    checkpoint-based rollback in teardown covers any partial state.
+    """
+    ns_flag = "" if namespace is None else "-n {}".format(namespace)
+    for ref in refs:
+        scope_flag = ns_flag if ref["scope"] == "asic" else ""
+        joined = ",".join(ref["trimmed"])
+        redis_key = "{table}|{key}".format(table=ref["table"], key=ref["key"])
+        # Write the trimmed leaf-list back.  If trimmed is empty we still
+        # write empty string — YANG will accept an empty ports list on the
+        # referrer as long as its own presence constraints allow it.
+        cmd = ("sudo sonic-db-cli {scope} CONFIG_DB hset '{k}' 'ports@' '{v}'"
+               .format(scope=scope_flag, k=redis_key, v=joined))
+        logger.info("[%s] strip PC refs from %s|%s: removed=%s",
+                    ref["scope"], ref["table"], ref["key"], ref["removed"])
+        duthost.shell(cmd, module_ignore_errors=True)
+
+
+def _build_scaling_add_patch(config_facts, config_facts_localhost, mg_facts,
+                             selection, namespace, pc_refs=None,
+                             parents_present=None):
+    """Build an INCREMENTAL add patch that re-inserts our N selected MORs.
+
+    Uses per-key paths (``add /asic0/PORTCHANNEL/PortChannel121 {..}``)
+    rather than bulk table-level replace (``add /asic0/PORTCHANNEL {..}``)
+    so we don't accidentally clobber the other 20+ PortChannels already
+    in the ASIC config.  That bulk-replace pattern is what
+    ``apply_patch_add_cluster()`` does (it was designed for add-from-empty
+    in the reverse of test_add_cluster's teardown), and it triggered
+    leafref-validation failures on our incremental scenario.
+
+    Ordering: parents before children within each table family, and
+    tables ordered so leafref targets exist before referencing entries:
+        PORTCHANNEL -> PORTCHANNEL_MEMBER -> PORTCHANNEL_INTERFACE
+        port scalars restore (CABLE_LENGTH, PORT_QOS_MAP, BUFFER_PG,
+                              admin_status)
+        DEVICE_NEIGHBOR_METADATA -> DEVICE_NEIGHBOR -> BGP_NEIGHBOR
+    """
+    ns = "" if namespace is None else "/" + namespace
+    port_alias = mg_facts.get("minigraph_port_name_to_alias_map", {})
+
+    pcs = selection["portchannels"]
+    ports = selection["member_ports"]
+    bgp_ips = selection["bgp_neigh_ips"]
+    dev_names = selection["device_neigh_names"]
+
+    pc_table = config_facts.get("PORTCHANNEL", {})
+    pc_intf = config_facts.get("PORTCHANNEL_INTERFACE", {})
+    pc_members = config_facts.get("PORTCHANNEL_MEMBER", {})
+    dev_neigh = config_facts.get("DEVICE_NEIGHBOR", {})
+    dev_meta = config_facts.get("DEVICE_NEIGHBOR_METADATA", {})
+    bgp_neigh = config_facts.get("BGP_NEIGHBOR", {})
+    cable = config_facts.get("CABLE_LENGTH", {}).get("AZURE", {})
+    qos = config_facts.get("PORT_QOS_MAP", {})
+    buf_pg = config_facts.get("BUFFER_PG", {})
+
+    dev_meta_local = config_facts_localhost.get("DEVICE_NEIGHBOR_METADATA", {})
+    dev_neigh_local = config_facts_localhost.get("DEVICE_NEIGHBOR", {})
+    bgp_local = config_facts_localhost.get("BGP_NEIGHBOR", {})
+    pc_intf_local = config_facts_localhost.get("PORTCHANNEL_INTERFACE", {})
+
+    patch = []
+
+    # PORTCHANNEL (parent) per-key add
+    for pc in pcs:
+        val = pc_table.get(pc, {})
+        # PORTCHANNEL entries in config_facts include a "members" list we
+        # don't want on the wire (real config has it as a separate table).
+        clean = {k: v for k, v in val.items() if k != "members"}
+        patch.append({"op": "add",
+                      "path": f"{ns}/PORTCHANNEL/{pc}", "value": clean})
+        patch.append({"op": "add",
+                      "path": f"/localhost/PORTCHANNEL/{pc}", "value": clean})
+
+    # PORTCHANNEL_MEMBER (references PORTCHANNEL parent)
+    for pc in pcs:
+        for member, mval in pc_members.get(pc, {}).items():
+            alias = port_alias.get(member, member).replace("/", "~1")
+            patch.append({
+                "op": "add",
+                "path": f"{ns}/PORTCHANNEL_MEMBER/{pc}|{member}",
+                "value": mval if isinstance(mval, dict) else {},
+            })
+            patch.append({
+                "op": "add",
+                "path": f"/localhost/PORTCHANNEL_MEMBER/{pc}|{alias}",
+                "value": mval if isinstance(mval, dict) else {},
+            })
+
+    # PORTCHANNEL_INTERFACE (bare key first, then IP subkeys)
+    for pc in pcs:
+        entry = pc_intf.get(pc, {})
+        # bare key with empty value (or entry-level fields if any non-IP keys)
+        patch.append({"op": "add",
+                      "path": f"{ns}/PORTCHANNEL_INTERFACE/{pc}", "value": {}})
+        if pc in pc_intf_local or pc_intf.get(pc):
+            patch.append({"op": "add",
+                          "path": f"/localhost/PORTCHANNEL_INTERFACE/{pc}",
+                          "value": {}})
+        if isinstance(entry, dict):
+            for ip_key, ip_val in entry.items():
+                escaped = ip_key.replace("/", "~1")
+                patch.append({
+                    "op": "add",
+                    "path": f"{ns}/PORTCHANNEL_INTERFACE/{pc}|{escaped}",
+                    "value": ip_val if isinstance(ip_val, dict) else {},
+                })
+                patch.append({
+                    "op": "add",
+                    "path": f"/localhost/PORTCHANNEL_INTERFACE/{pc}|{escaped}",
+                    "value": ip_val if isinstance(ip_val, dict) else {},
+                })
+
+    # Restore per-port scalars removed by _cli_remove_selected_mors.
+    # These use "replace" (they may or may not currently exist depending
+    # on whether the surgical remove actually deleted them, which is
+    # namespace-dependent).  Use "add" — replaces if present.
+    #
+    # Bug 7 guard: our per-port ``hdel``/``del`` in _cli_remove_selected_mors
+    # can empty the parent hash entirely (CABLE_LENGTH|AZURE, PORT_QOS_MAP|*,
+    # BUFFER_PG|*), in which case Redis auto-deletes the key and the parent
+    # path disappears from ``show runningconfiguration all``.  jsonpatch
+    # (RFC 6902) then refuses ``add /CABLE_LENGTH/AZURE/EthernetX`` with
+    # ``member 'AZURE' not found in {}``.  When ``parents_present`` tells
+    # us the parent is gone, prepend a defensive ``add /parent = {}`` op.
+    # We only emit these when actually missing — an ``add`` on an existing
+    # object member REPLACES it, which would clobber unrelated entries.
+    if parents_present is not None:
+        if not parents_present.get("cable_azure", True):
+            patch.append({"op": "add",
+                          "path": f"{ns}/CABLE_LENGTH",
+                          "value": {"AZURE": {}}})
+        if not parents_present.get("port_qos_map", True):
+            patch.append({"op": "add",
+                          "path": f"{ns}/PORT_QOS_MAP",
+                          "value": {}})
+        if not parents_present.get("buffer_pg", True):
+            patch.append({"op": "add",
+                          "path": f"{ns}/BUFFER_PG",
+                          "value": {}})
+
+    for port in ports:
+        if port in cable:
+            patch.append({
+                "op": "add",
+                "path": f"{ns}/CABLE_LENGTH/AZURE/{port}",
+                "value": cable[port],
+            })
+        if port in qos:
+            patch.append({
+                "op": "add",
+                "path": f"{ns}/PORT_QOS_MAP/{port}",
+                "value": qos[port],
+            })
+        for pg_range, pg_val in buf_pg.get(port, {}).items():
+            patch.append({
+                "op": "add",
+                "path": f"{ns}/BUFFER_PG/{port}|{pg_range}",
+                "value": pg_val if isinstance(pg_val, dict) else {},
+            })
+        # Flip admin_status back to up.
+        patch.append({"op": "replace",
+                      "path": f"{ns}/PORT/{port}/admin_status",
+                      "value": "up"})
+
+    # DEVICE_NEIGHBOR_METADATA (parent) - both asic and localhost.
+    for name in dev_names:
+        if name in dev_meta:
+            patch.append({
+                "op": "add",
+                "path": f"{ns}/DEVICE_NEIGHBOR_METADATA/{name}",
+                "value": dev_meta[name],
+            })
+        if name in dev_meta_local:
+            patch.append({
+                "op": "add",
+                "path": f"/localhost/DEVICE_NEIGHBOR_METADATA/{name}",
+                "value": dev_meta_local[name],
+            })
+
+    # DEVICE_NEIGHBOR (child references METADATA)
+    for port in ports:
+        if port in dev_neigh:
+            patch.append({
+                "op": "add",
+                "path": f"{ns}/DEVICE_NEIGHBOR/{port}",
+                "value": dev_neigh[port],
+            })
+        if port in dev_neigh_local:
+            patch.append({
+                "op": "add",
+                "path": f"/localhost/DEVICE_NEIGHBOR/{port}",
+                "value": dev_neigh_local[port],
+            })
+
+    # BGP_NEIGHBOR (child references METADATA)
+    for ip in bgp_ips:
+        if ip in bgp_neigh:
+            patch.append({"op": "add",
+                          "path": f"{ns}/BGP_NEIGHBOR/{ip}",
+                          "value": bgp_neigh[ip]})
+        if ip in bgp_local:
+            patch.append({"op": "add",
+                          "path": f"/localhost/BGP_NEIGHBOR/{ip}",
+                          "value": bgp_local[ip]})
+
+    # Restore referrer ``ports`` leaf-lists.  These were stripped in
+    # ``_cli_remove_pc_references`` during untimed setup so the surgical
+    # PORTCHANNEL remove wouldn't leave dangling leafrefs.  We now put
+    # our PCs back into every referring row so its ``ports`` list matches
+    # the pre-test state.  ``replace`` (not ``add``) because the row
+    # itself already exists.
+    for ref in (pc_refs or []):
+        scope_prefix = ns if ref["scope"] == "asic" else "/localhost"
+        patch.append({
+            "op": "replace",
+            "path": f"{scope_prefix}/{ref['table']}/{ref['key']}/ports",
+            "value": ref["orig"],
+        })
+
+    return patch
+
+
+def _run_scaling_measurement(duthost, tbinfo, config_facts, config_facts_localhost,
+                             mg_facts, enum_rand_one_asic_namespace, n_mors,
+                             record_property):
+    """Core measurement: remove N MORs, time the add-back, verify, cleanup.
+
+    Returns dict with keys:
+        selection, apply_elapsed_s, e2e_elapsed_s, success, hwproxy_to,
+        bgp_up, ns_label
+    Raises pytest.skip for unsupported topologies / insufficient PCs.
+    """
+    if not duthost.get_facts().get("modular_chassis"):
+        pytest.skip("Scaling test only runs on modular chassis")
+    if tbinfo["topo"]["type"] not in ("t2", "lt2"):
+        pytest.skip("Scaling test only runs on t2 / lt2 topology")
+    switch_type = duthost.facts.get("switch_type")
+    if switch_type not in ("voq", "chassis-packet"):
+        pytest.skip("Unsupported switch_type={}".format(switch_type))
+
+    try:
+        selection = _select_n_mors(config_facts, n_mors)
+    except ValueError as exc:
+        pytest.skip(str(exc))
+
+    ns_label = enum_rand_one_asic_namespace or "host"
+    logger.info("Scaling: n=%d ns=%s pcs=%s",
+                n_mors, ns_label, selection["portchannels"])
+
+    _record_platform_metadata(duthost, config_facts, selection, record_property)
+
+    # ---- Setup: targeted remove of N MORs (untimed) ----
+    # Surgical CLI-based removal: only touches our N selected MORs, no
+    # wildcards on whole tables. GCU/JSON-patch remove was tried first but
+    # hit YANG cascade-delete edge cases ("can't remove a non-existent
+    # object"); the existing remove_cluster_via_sonic_db_cli helper was
+    # rejected because it wildcard-deletes the whole ASIC.  Our fixture
+    # rolls back via `config rollback` regardless of intermediate state.
+    _cli_remove_selected_mors(duthost, selection, enum_rand_one_asic_namespace)
+
+    # Also strip our PCs from any referrer's ``ports`` leaf-list (ACL_TABLE,
+    # PBH_TABLE, MIRROR_SESSION, etc.) so the incremental ADD patch below
+    # doesn't hit ``Invalid value "PortChannelXXX" in "ports" element``.
+    pc_refs = _scan_pc_references(config_facts, config_facts_localhost,
+                                  selection["portchannels"])
+    if pc_refs:
+        logger.info("Found %d ports-referrer rows to strip: %s",
+                    len(pc_refs),
+                    [(r["scope"], r["table"], r["key"]) for r in pc_refs])
+        _cli_remove_pc_references(duthost, pc_refs, enum_rand_one_asic_namespace)
+
+    # Bug 7 guard: snapshot which parent hashes survived the CLI removal.
+    # If a parent (CABLE_LENGTH|AZURE, PORT_QOS_MAP|*, BUFFER_PG|*) is
+    # empty post-removal, Redis has auto-deleted it and RFC-6902 add
+    # into its child path will fail.  _build_scaling_add_patch uses this
+    # to prepend defensive parent-add ops only when needed.
+    parents_present = _probe_parent_tables_present(
+        duthost, enum_rand_one_asic_namespace)
+    logger.info("Scaling parent-table probe: %s", parents_present)
+
+    # ---- Timed: incremental add-patch built from selection ----
+    add_patch = _build_scaling_add_patch(config_facts, config_facts_localhost,
+                                         mg_facts, selection,
+                                         enum_rand_one_asic_namespace,
+                                         pc_refs=pc_refs,
+                                         parents_present=parents_present)
+    logger.info("Scaling add patch: %d ops for n=%d",
+                len(add_patch), len(selection["portchannels"]))
+
+    tmpfile = generate_tmpfile(duthost)
+    apply_start = time.time()
+    success = False
+    hwproxy_to = False
+    try:
+        output = apply_patch(duthost, json_data=add_patch, dest_file=tmpfile)
+        expect_op_success(duthost, output)
+        success = True
+    except TimeoutError:
+        hwproxy_to = True
+        logger.warning("apply_patch fuse fired — treating as HWProxy timeout")
+    except Exception as exc:
+        lowered = repr(exc).lower()
+        if "hardware" in lowered or "connectiondroppedbydevice" in lowered:
+            hwproxy_to = True
+        logger.error("add_cluster failed: %r", exc)
+    finally:
+        delete_tmpfile(duthost, tmpfile)
+    apply_elapsed_s = time.time() - apply_start
+
+    # ---- BGP convergence check counts toward e2e wall clock ----
+    bgp_up = False
+    if success and selection["bgp_neigh_ips"]:
+        bgp_up = _verify_bgp_up_scaling(duthost, selection["bgp_neigh_ips"])
+    e2e_elapsed_s = time.time() - apply_start
+
+    # ---- ACL re-attach: not needed with CLI-based removal above
+    # (we never detached ACL_TABLE ports in the setup step). If a future
+    # variant of the setup does detach ACL, uncomment the block below.
+    #
+    # if success:
+    #     acl_patch = _build_scaling_acl_reattach_patch(
+    #         config_facts_localhost, selection, mg_facts)
+    #     if acl_patch:
+    #         tmp = generate_tmpfile(duthost)
+    #         try:
+    #             out = apply_patch(duthost, json_data=acl_patch, dest_file=tmp)
+    #             expect_op_success(duthost, out)
+    #         finally:
+    #             delete_tmpfile(duthost, tmp)
+
+    return {
+        "selection": selection,
+        "ns_label": ns_label,
+        "apply_elapsed_s": apply_elapsed_s,
+        "e2e_elapsed_s": e2e_elapsed_s,
+        "success": success,
+        "hwproxy_to": hwproxy_to,
+        "bgp_up": bgp_up,
+    }
+
+
+@pytest.mark.gcu_scaling_nightly
+@pytest.mark.parametrize("n_mors", NIGHTLY_MOR_COUNTS)
+def test_add_mor_scaling_nightly(
+    tbinfo, duthosts, enum_downstream_dut_hostname,
+    enum_rand_one_asic_namespace, config_facts, config_facts_localhost,
+    mg_facts, scaling_checkpoint, record_property, n_mors,
+):
+    """Nightly Add-MOR scaling measurement. See NIGHTLY_MOR_COUNTS."""
+    duthost = duthosts[enum_downstream_dut_hostname]
+    _run_and_publish(duthost, tbinfo, config_facts, config_facts_localhost,
+                     mg_facts, enum_rand_one_asic_namespace, n_mors,
+                     "nightly", record_property)
+
+
+@pytest.mark.gcu_scaling_weekly
+@pytest.mark.parametrize("n_mors", WEEKLY_MOR_COUNTS)
+def test_add_mor_scaling_weekly(
+    tbinfo, duthosts, enum_downstream_dut_hostname,
+    enum_rand_one_asic_namespace, config_facts, config_facts_localhost,
+    mg_facts, scaling_checkpoint, record_property, n_mors,
+):
+    """Weekly full-scale Add-MOR capacity measurement. See WEEKLY_MOR_COUNTS."""
+    duthost = duthosts[enum_downstream_dut_hostname]
+    _run_and_publish(duthost, tbinfo, config_facts, config_facts_localhost,
+                     mg_facts, enum_rand_one_asic_namespace, n_mors,
+                     "weekly", record_property)
+
+
+@pytest.mark.gcu_scaling_sanity
+@pytest.mark.parametrize("n_mors", SANITY_MOR_COUNTS)
+def test_add_mor_scaling_sanity(
+    tbinfo, duthosts, enum_downstream_dut_hostname,
+    enum_rand_one_asic_namespace, config_facts, config_facts_localhost,
+    mg_facts, scaling_checkpoint, record_property, n_mors,
+):
+    """One-time sanity: validate the scaling test itself. Not for nightly."""
+    duthost = duthosts[enum_downstream_dut_hostname]
+    _run_and_publish(duthost, tbinfo, config_facts, config_facts_localhost,
+                     mg_facts, enum_rand_one_asic_namespace, n_mors,
+                     "sanity", record_property)
+
+
+def _run_and_publish(duthost, tbinfo, config_facts, config_facts_localhost,
+                     mg_facts, namespace, n_mors, tier, record_property):
+    """Shared runner: measure, publish metrics, apply pass/fail policy.
+
+    Policy:
+      - HWProxy timeout is recorded but does NOT fail the test.
+        Vaibhav owns the SSH-chatty fix separately; treating it as failure
+        would block nightly signal on an issue we're not measuring here.
+      - Real GCU failures DO fail the test.
+      - Elapsed exceeding the time budget fails the test (that IS the metric).
+      - BGP check is soft — logged only.
+    """
+    result = _run_scaling_measurement(
+        duthost, tbinfo, config_facts, config_facts_localhost,
+        mg_facts, namespace, n_mors, record_property)
+
+    budget = int(os.environ.get("GCU_TIME_BUDGET_S", DEFAULT_TIME_BUDGET_S))
+
+    record_property("gcu_tier", tier)
+    record_property("gcu_n_mors", n_mors)
+    record_property("gcu_apply_elapsed_s", round(result["apply_elapsed_s"], 3))
+    record_property("gcu_e2e_elapsed_s", round(result["e2e_elapsed_s"], 3))
+    record_property("gcu_success", result["success"])
+    record_property("gcu_hwproxy_to", result["hwproxy_to"])
+    record_property("gcu_ns", result["ns_label"])
+    record_property("gcu_pcs", ",".join(result["selection"]["portchannels"]))
+    record_property("gcu_bgp_up", result["bgp_up"])
+    record_property("gcu_time_budget_s", budget)
+
+    logger.info(
+        "SCALING RESULT tier=%s n=%d ns=%s apply=%.2fs e2e=%.2fs "
+        "success=%s hwproxy_to=%s bgp_up=%s budget=%ds",
+        tier, n_mors, result["ns_label"],
+        result["apply_elapsed_s"], result["e2e_elapsed_s"],
+        result["success"], result["hwproxy_to"], result["bgp_up"], budget)
+
+    if result["hwproxy_to"] and not result["success"]:
+        logger.warning(
+            "HWProxy-style timeout observed (N=%d). Recording data point; "
+            "not failing (ANP SSH-chatty rollout owns this).", n_mors)
+        # Skip the elapsed-budget check when we hit the timeout — the number
+        # would be meaningless.
+        return
+
+    pytest_assert(
+        result["success"],
+        "apply-patch failed during Add-MOR scaling (N={})".format(n_mors))
+    pytest_assert(
+        result["e2e_elapsed_s"] <= budget,
+        "Add-MOR N={} exceeded time budget: {:.1f}s > {}s".format(
+            n_mors, result["e2e_elapsed_s"], budget))
+
+    if not result["bgp_up"] and result["selection"]["bgp_neigh_ips"]:
+        logger.warning(
+            "BGP peers did not all reach Established: %s",
+            result["selection"]["bgp_neigh_ips"])
+
+
+@pytest.mark.gcu_scaling_weekly
+def test_max_mors_under_budget(
+    tbinfo, duthosts, enum_downstream_dut_hostname,
+    enum_rand_one_asic_namespace, config_facts, config_facts_localhost,
+    mg_facts, scaling_checkpoint, record_property,
+):
+    """Answer Vaibhav's question directly: how many MORs fit in 1 hour?
+
+    Sweeps N ascending, stops at the first N that fails or exceeds budget.
+    Records ``gcu_max_n_under_budget`` = the largest N that succeeded
+    within the time budget on this testbed.
+    """
+    duthost = duthosts[enum_downstream_dut_hostname]
+    budget = int(os.environ.get("GCU_TIME_BUDGET_S", DEFAULT_TIME_BUDGET_S))
+    sweep = [1, 5, 10, 20, 24, 30, 33]
+    max_n = 0
+    max_ports = 0
+    last_elapsed = 0.0
+
+    for n in sweep:
+        try:
+            result = _run_scaling_measurement(
+                duthost, tbinfo, config_facts, config_facts_localhost,
+                mg_facts, enum_rand_one_asic_namespace, n, record_property)
+        except pytest.skip.Exception as exc:
+            logger.info("Skip at N=%d: %s", n, exc)
+            break
+        # Best-effort rollback between iterations so the next iteration
+        # starts from the same pre-state (module-scoped config_facts is
+        # the reference; rollback restores CONFIG_DB to it).
+        try:
+            rollback_or_reload(duthost, cp=SCALING_CHECKPOINT)
+        except Exception:
+            logger.warning("rollback between N iterations failed at N=%d", n)
+            break
+
+        logger.info("[max-N sweep] N=%d elapsed=%.1fs success=%s",
+                    n, result["e2e_elapsed_s"], result["success"])
+        if not result["success"] or result["e2e_elapsed_s"] > budget:
+            break
+        max_n = n
+        max_ports = len(result["selection"]["member_ports"])
+        last_elapsed = result["e2e_elapsed_s"]
+
+    record_property("gcu_max_mors_under_budget", max_n)
+    record_property("gcu_max_ports_under_budget", max_ports)
+    record_property("gcu_max_n_last_elapsed_s", round(last_elapsed, 3))
+    record_property("gcu_time_budget_s", budget)
+    logger.info(
+        "MAX MORs under %ds budget: %d MORs (=%d ports, last elapsed=%.1fs)",
+        budget, max_n, max_ports, last_elapsed)
+    pytest_assert(
+        max_n > 0,
+        "Could not add even N=1 MOR within budget {}s".format(budget))

--- a/tests/generic_config_updater/add_cluster/test_add_cluster.py
+++ b/tests/generic_config_updater/add_cluster/test_add_cluster.py
@@ -1938,9 +1938,34 @@ NIGHTLY_MOR_COUNTS = [5, 20]
 WEEKLY_MOR_COUNTS = [24, 30]
 SANITY_MOR_COUNTS = [1]
 
-# Vaibhav's stated operational target (Meeting 1, 2026-07-01): 1 hour end-to-end.
-# Override with env GCU_TIME_BUDGET_S for local experimentation.
+# test_max_mors_under_budget sweeps to find the largest N that fits under a
+# FIXED absolute ceiling — the operational 1-hour target.
 DEFAULT_TIME_BUDGET_S = 3600
+
+# nightly/weekly/sanity use a per-N budget: catches per-MOR perf regressions
+# instead of only flagging when total elapsed exceeds the 1-hour target.
+# Data on ``str3-7800-lc4-1`` (SONiC.internal-202601.170538176, 202405-
+# equivalent sonic-utilities): elapsed/N observed ~1.47 s/change * ~34
+# changes/MOR ~= 50 s/MOR.  60 s/MOR gives ~20% headroom over the current
+# baseline; small-N runs are covered by BUDGET_FLOOR_S which pays for the
+# fixed apply-patch overhead visible even at N=1 (~50s measured).
+# GCU_TIME_BUDGET_S env var overrides to an absolute budget (useful for
+# local debugging / capacity experiments).
+PER_MOR_BUDGET_S = 60
+BUDGET_FLOOR_S = 300
+
+
+def _time_budget_for(n_mors):
+    """Per-N time budget for the scaling assertion.
+
+    Returns max(BUDGET_FLOOR_S, PER_MOR_BUDGET_S * n_mors) unless
+    GCU_TIME_BUDGET_S is set, in which case that absolute value wins.
+    """
+    override = os.environ.get("GCU_TIME_BUDGET_S")
+    if override is not None:
+        return int(override)
+    return max(BUDGET_FLOOR_S, PER_MOR_BUDGET_S * int(n_mors))
+
 
 SCALING_CHECKPOINT = "gcu_scaling"
 _SCALING_ACL_TABLES = ("DATAACL", "EVERFLOW", "EVERFLOWV6")
@@ -2009,81 +2034,6 @@ def _select_n_mors(config_facts, n):
     }
 
 
-def _build_scaling_acl_reattach_patch(config_facts_localhost, selection,
-                                      mg_facts):
-    """Build the localhost-only ACL_TABLE ports re-attach patch.
-
-    Used by the scaling test AFTER the (filtered) add_cluster call, since we
-    passed include_acl_table=False and stripped ACL_TABLE ports for the N
-    MORs in the setup step.
-    """
-    del mg_facts  # kept for signature symmetry; not needed here
-    acl_local = config_facts_localhost.get("ACL_TABLE", {})
-    patch = []
-    for tname in _SCALING_ACL_TABLES:
-        entry = acl_local.get(tname)
-        if not entry or "ports" not in entry:
-            continue
-        # Restore the full ports list (which includes our N MORs since the
-        # module-scoped config_facts_localhost was captured pre-modification).
-        patch.append({
-            "op": "replace",
-            "path": f"/localhost/ACL_TABLE/{tname}/ports",
-            "value": list(entry["ports"]),
-        })
-    _ = selection  # unused; kept for future per-MOR ACL granularity
-    return patch
-
-
-class _TimedApplyResult(object):
-    """Container for one timed apply_patch call."""
-
-    def __init__(self):
-        self.elapsed_s = 0.0
-        self.success = False
-        self.hwproxy_timeout = False
-        self.stdout = ""
-
-
-def _timed_apply_patch(duthost, patch_list):
-    """Run apply_patch, record wall-clock, detect HWProxy-style timeouts.
-
-    Uses the shared apply_patch/generate_tmpfile/delete_tmpfile helpers so
-    behaviour matches every other GCU test (including the async wrapper
-    that raises TimeoutError on the internal wait_until fuse).
-    """
-    result = _TimedApplyResult()
-    if not patch_list:
-        result.success = True
-        return result
-    tmpfile = generate_tmpfile(duthost)
-    start = time.time()
-    try:
-        output = apply_patch(duthost, json_data=patch_list, dest_file=tmpfile)
-        result.elapsed_s = time.time() - start
-        result.stdout = output.get("stdout", "")
-        result.success = (
-            output.get("rc") == 0 and
-            "Patch applied successfully" in result.stdout
-        )
-        if not result.success:
-            lowered = (result.stdout + output.get("stderr", "")).lower()
-            if ("hardwareproxy" in lowered or "hardware proxy" in lowered or
-                    "connectiondroppedbydevice" in lowered or
-                    "waitforregex" in lowered):
-                result.hwproxy_timeout = True
-    except TimeoutError:
-        # apply_patch's internal wait_until fuse fired
-        result.elapsed_s = time.time() - start
-        result.hwproxy_timeout = True
-    finally:
-        try:
-            delete_tmpfile(duthost, tmpfile)
-        except Exception:
-            pass
-    return result
-
-
 def _verify_bgp_up_scaling(duthost, bgp_neigh_ips, timeout=180):
     """Poll ``show ip bgp summary -d all`` for all peers reaching Established.
 
@@ -2149,6 +2099,17 @@ def _cli_remove_selected_mors(duthost, selection, namespace):
     before PORTCHANNEL.  Both asic-namespace and localhost tables are cleaned.
     ``module_ignore_errors=True`` because some entries may exist on only one
     side (asic vs localhost) or may have been auto-removed by prior ops.
+
+    Scope note (INTERFACE table): this test targets ``PORTCHANNEL``-based
+    MORs on T2/lt2 topologies, where port members are grouped under
+    ``PORTCHANNEL_INTERFACE`` — not ``INTERFACE`` (which is used for
+    L3-on-port designs).  We therefore deliberately do not strip
+    ``INTERFACE|{port}`` entries.  The rollback fixture undoes any stray
+    state at teardown regardless.
+
+    Persistence note: we intentionally do NOT ``config save`` after the
+    CLI removals.  Persisting would defeat the ``config rollback`` in
+    ``scaling_checkpoint`` teardown, which is the primary cleanup path.
 
     Safe by construction: our fixture takes a checkpoint before this runs
     and calls ``config rollback`` in teardown, so any intermediate state
@@ -2635,21 +2596,6 @@ def _run_scaling_measurement(duthost, tbinfo, config_facts, config_facts_localho
         bgp_up = _verify_bgp_up_scaling(duthost, selection["bgp_neigh_ips"])
     e2e_elapsed_s = time.time() - apply_start
 
-    # ---- ACL re-attach: not needed with CLI-based removal above
-    # (we never detached ACL_TABLE ports in the setup step). If a future
-    # variant of the setup does detach ACL, uncomment the block below.
-    #
-    # if success:
-    #     acl_patch = _build_scaling_acl_reattach_patch(
-    #         config_facts_localhost, selection, mg_facts)
-    #     if acl_patch:
-    #         tmp = generate_tmpfile(duthost)
-    #         try:
-    #             out = apply_patch(duthost, json_data=acl_patch, dest_file=tmp)
-    #             expect_op_success(duthost, out)
-    #         finally:
-    #             delete_tmpfile(duthost, tmp)
-
     return {
         "selection": selection,
         "ns_label": ns_label,
@@ -2719,7 +2665,7 @@ def _run_and_publish(duthost, tbinfo, config_facts, config_facts_localhost,
         duthost, tbinfo, config_facts, config_facts_localhost,
         mg_facts, namespace, n_mors, record_property)
 
-    budget = int(os.environ.get("GCU_TIME_BUDGET_S", DEFAULT_TIME_BUDGET_S))
+    budget = _time_budget_for(n_mors)
 
     record_property("gcu_tier", tier)
     record_property("gcu_n_mors", n_mors)

--- a/tests/generic_config_updater/add_cluster/test_add_cluster.py
+++ b/tests/generic_config_updater/add_cluster/test_add_cluster.py
@@ -1968,7 +1968,6 @@ def _time_budget_for(n_mors):
 
 
 SCALING_CHECKPOINT = "gcu_scaling"
-_SCALING_ACL_TABLES = ("DATAACL", "EVERFLOW", "EVERFLOWV6")
 
 
 def _is_internal_port_scaling(port_name):
@@ -2076,6 +2075,8 @@ def _record_platform_metadata(duthost, config_facts, selection, record_property)
                             module_ignore_errors=True)["stdout"].strip()
         record_property("gcu_sonic_image", img)
     except Exception:
+        # Best-effort metadata capture; a missing sonic_version.yml or
+        # shell error shouldn't fail the scaling measurement itself.
         pass
     record_property("gcu_hwsku", facts.get("hwsku", ""))
     record_property("gcu_switch_type", facts.get("switch_type", ""))
@@ -2521,6 +2522,7 @@ def _run_scaling_measurement(duthost, tbinfo, config_facts, config_facts_localho
     if switch_type not in ("voq", "chassis-packet"):
         pytest.skip("Unsupported switch_type={}".format(switch_type))
 
+    selection = None
     try:
         selection = _select_n_mors(config_facts, n_mors)
     except ValueError as exc:

--- a/tests/generic_config_updater/add_cluster/test_add_cluster.py
+++ b/tests/generic_config_updater/add_cluster/test_add_cluster.py
@@ -1013,16 +1013,13 @@ def apply_patch_add_cluster(config_facts,
                             config_facts_localhost,
                             mg_facts,
                             duthost,
-                            enum_rand_one_asic_namespace,
-                            include_acl_table=True):
+                            enum_rand_one_asic_namespace):
     """
     Apply patch to add cluster information for a given ASIC namespace.
 
     Changes are perfomed to below tables:
 
-    ACL_TABLE (skipped when include_acl_table=False — used by the N-MOR
-    scaling test which manages ACL_TABLE ports separately as a
-    localhost-only replace op)
+    ACL_TABLE
     BGP_NEIGHBOR
     DEVICE_NEIGHBOR
     DEVICE_NEIGHBOR_METADATA
@@ -1146,25 +1143,22 @@ def apply_patch_add_cluster(config_facts,
             "value": f"{highest}m"
         })
 
-    # table ACL_TABLE changes (skip when caller opts out — the N-MOR
-    # scaling test does this so it can manage ACL_TABLE ports via a
-    # separate localhost-only replace op)
-    if include_acl_table:
-        json_patch_asic.append({
-            "op": "add",
-            "path": f"{json_namespace}/ACL_TABLE/DATAACL",
-            "value": config_facts["ACL_TABLE"]["DATAACL"]
-        })
-        json_patch_asic.append({
-            "op": "add",
-            "path": f"{json_namespace}/ACL_TABLE/EVERFLOW",
-            "value": config_facts["ACL_TABLE"]["EVERFLOW"]
-        })
-        json_patch_asic.append({
-            "op": "add",
-            "path": f"{json_namespace}/ACL_TABLE/EVERFLOWV6",
-            "value": config_facts["ACL_TABLE"]["EVERFLOWV6"]
-        })
+    # table ACL_TABLE changes
+    json_patch_asic.append({
+        "op": "add",
+        "path": f"{json_namespace}/ACL_TABLE/DATAACL",
+        "value": config_facts["ACL_TABLE"]["DATAACL"]
+    })
+    json_patch_asic.append({
+        "op": "add",
+        "path": f"{json_namespace}/ACL_TABLE/EVERFLOW",
+        "value": config_facts["ACL_TABLE"]["EVERFLOW"]
+    })
+    json_patch_asic.append({
+        "op": "add",
+        "path": f"{json_namespace}/ACL_TABLE/EVERFLOWV6",
+        "value": config_facts["ACL_TABLE"]["EVERFLOWV6"]
+    })
 
     ######################
     # LOCALHOST NAMESPACE
@@ -1238,22 +1232,21 @@ def apply_patch_add_cluster(config_facts,
             "value": value
         })
 
-    if include_acl_table:
-        json_patch_localhost.append({
-            "op": "add",
-            "path": "/localhost/ACL_TABLE/DATAACL/ports",
-            "value": config_facts_localhost["ACL_TABLE"]["DATAACL"]["ports"]
-        })
-        json_patch_localhost.append({
-            "op": "add",
-            "path": "/localhost/ACL_TABLE/EVERFLOW/ports",
-            "value": config_facts_localhost["ACL_TABLE"]["EVERFLOW"]["ports"]
-        })
-        json_patch_localhost.append({
-            "op": "add",
-            "path": "/localhost/ACL_TABLE/EVERFLOWV6/ports",
-            "value": config_facts_localhost["ACL_TABLE"]["EVERFLOWV6"]["ports"]
-        })
+    json_patch_localhost.append({
+        "op": "add",
+        "path": "/localhost/ACL_TABLE/DATAACL/ports",
+        "value": config_facts_localhost["ACL_TABLE"]["DATAACL"]["ports"]
+    })
+    json_patch_localhost.append({
+        "op": "add",
+        "path": "/localhost/ACL_TABLE/EVERFLOW/ports",
+        "value": config_facts_localhost["ACL_TABLE"]["EVERFLOW"]["ports"]
+    })
+    json_patch_localhost.append({
+        "op": "add",
+        "path": "/localhost/ACL_TABLE/EVERFLOWV6/ports",
+        "value": config_facts_localhost["ACL_TABLE"]["EVERFLOWV6"]["ports"]
+    })
 
     #####################################
     # combine localhost and ASIC patch data
@@ -1272,8 +1265,7 @@ def apply_patch_add_cluster_chassis_packet(config_facts,
                                            config_facts_localhost,
                                            mg_facts,
                                            duthost,
-                                           enum_rand_one_asic_namespace,
-                                           include_acl_table=True):
+                                           enum_rand_one_asic_namespace):
     """
     Apply patch to add cluster information for chassis-packet switches.
 
@@ -1490,14 +1482,13 @@ def apply_patch_add_cluster_chassis_packet(config_facts,
         })
 
     # STEP 12: Add/Replace ACL_TABLE changes
-    if include_acl_table:
-        for acl_table_name in ["DATAACL", "EVERFLOW", "EVERFLOWV6"]:
-            if acl_table_name in config_facts.get("ACL_TABLE", {}):
-                json_patch_asic_rest.append({
-                    "op": "add",
-                    "path": f"{json_namespace}/ACL_TABLE/{acl_table_name}/ports",
-                    "value": config_facts["ACL_TABLE"][acl_table_name]["ports"]
-                })
+    for acl_table_name in ["DATAACL", "EVERFLOW", "EVERFLOWV6"]:
+        if acl_table_name in config_facts.get("ACL_TABLE", {}):
+            json_patch_asic_rest.append({
+                "op": "add",
+                "path": f"{json_namespace}/ACL_TABLE/{acl_table_name}/ports",
+                "value": config_facts["ACL_TABLE"][acl_table_name]["ports"]
+            })
 
     #####################################
     # Apply patches in correct order
@@ -1906,30 +1897,37 @@ def test_add_cluster(tbinfo,
 # Purpose
 # -------
 # Measure how ``config apply-patch`` elapsed time scales with the number of
-# MORs (T1 neighbors) added in a single patch.  Baseline instrument for
-# comparing stock 202405 GCU vs. GCU-container (with master #3831 backported)
-# and for validating removal of ``skip-sort_table`` on 202412 .61 images.
+# MORs (T1 neighbors) re-added in a single patch.  The GCU patch sorter's
+# cost grows super-linearly with the number of moves in a patch, so this is
+# a baseline instrument for catching sorter regressions that a fixed-size
+# patch would miss.
 #
 # Design
 # ------
 # 1. Full cluster is present at test entry.
-# 2. Pick N external PortChannels (= N MORs).
-# 3. Build a targeted REMOVE patch for those N MORs (setup, untimed).
-# 4. Filter ``config_facts`` down to just those N MORs.
-# 5. Call the existing ``apply_patch_add_cluster*()`` with the filtered dict
-#    and ``include_acl_table=False`` — TIMED.  ACL_TABLE port lists are
-#    handled separately via a small localhost replace op.
+# 2. Pick N external PortChannels (= N MORs) via ``_select_n_mors()``.
+# 3. Remove just those N MORs with targeted ``sonic-db-cli`` deletes in
+#    ``_cli_remove_selected_mors()`` (setup, untimed).  A GCU/JSON-patch
+#    remove was tried first but hit YANG cascade-delete edge cases, and the
+#    existing ``remove_cluster_via_sonic_db_cli()`` helper wildcard-deletes
+#    the whole ASIC, which is too coarse for a per-N measurement.
+# 4. Strip those PortChannels from any referring ``ports`` leaf-list via
+#    ``_scan_pc_references()`` / ``_cli_remove_pc_references()`` so the
+#    add-back patch does not trip leafref validation.
+# 5. Build one incremental JSON patch that re-adds exactly those N MORs
+#    (``_build_scaling_add_patch()``) and apply it in a single
+#    ``apply_patch()`` call — TIMED.
 # 6. Verify BGP peers on those N MORs come back up.
-# 7. record_property() the metric so CI / Kusto ingest can graph it.
-# 8. Teardown: rollback_or_reload restores full state.
+# 7. record_property() the metric so CI can graph it.
+# 8. Teardown: ``config rollback`` restores full state.
 #
-# Reuses ``apply_patch_add_cluster()`` / ``apply_patch_add_cluster_chassis_packet()``
-# for the ADD path so there is no duplicate patch-builder logic.  Only the
-# subset REMOVE path is custom (existing remove functions operate on whole
-# tables and cannot be filtered without a much larger refactor).
+# The ADD path deliberately builds its own patch instead of reusing
+# ``apply_patch_add_cluster*()``: those helpers rebuild the *entire* cluster
+# from ``config_facts``, so the measured time would not vary with N.  A
+# scaling measurement needs a patch whose size is a function of N alone.
 # ===========================================================================
 
-# Tiered N values (see meeting notes 2026-07-14):
+# Tiered N values:
 #   - Nightly: fast regression + one near-production data point.
 #   - Weekly:  full-scale capacity ("how many MORs in 1 hour" number).
 #   - Sanity:  validates the test itself; opt-in only.
@@ -1944,11 +1942,11 @@ DEFAULT_TIME_BUDGET_S = 3600
 
 # nightly/weekly/sanity use a per-N budget: catches per-MOR perf regressions
 # instead of only flagging when total elapsed exceeds the 1-hour target.
-# Data on ``str3-7800-lc4-1`` (SONiC.internal-202601.170538176, 202405-
-# equivalent sonic-utilities): elapsed/N observed ~1.47 s/change * ~34
-# changes/MOR ~= 50 s/MOR.  60 s/MOR gives ~20% headroom over the current
-# baseline; small-N runs are covered by BUDGET_FLOOR_S which pays for the
-# fixed apply-patch overhead visible even at N=1 (~50s measured).
+# Measured on a modular-chassis line card: elapsed/N was ~1.47 s per
+# change at ~34 changes/MOR, i.e. ~50 s/MOR.  60 s/MOR gives ~20% headroom
+# over that baseline; small-N runs are covered by BUDGET_FLOOR_S, which
+# pays for the fixed apply-patch overhead that is visible even at N=1
+# (~50 s measured).
 # GCU_TIME_BUDGET_S env var overrides to an absolute budget (useful for
 # local debugging / capacity experiments).
 PER_MOR_BUDGET_S = 60
@@ -2077,7 +2075,7 @@ def scaling_checkpoint(duthosts, enum_downstream_dut_hostname):
 
 
 def _record_platform_metadata(duthost, config_facts, selection, record_property):
-    """Emit per-run metadata to enable Kusto slicing across platforms."""
+    """Emit per-run metadata so results can be sliced across platforms."""
     facts = duthost.facts or {}
     record_property("gcu_sonic_version",
                     facts.get("asic_type", "") + "/" + str(facts.get("num_asic", "")))
@@ -2406,14 +2404,16 @@ def _build_scaling_add_patch(config_facts, config_facts_localhost, mg_facts,
                 })
 
     # Restore per-port scalars removed by _cli_remove_selected_mors.
-    # These use "replace" (they may or may not currently exist depending
-    # on whether the surgical remove actually deleted them, which is
-    # namespace-dependent).  Use "add" — replaces if present.
+    # These use "add" rather than "replace": the keys may or may not still
+    # exist, depending on whether the surgical remove actually deleted them
+    # (which is namespace-dependent).  RFC 6902 "replace" requires the
+    # target to already exist, whereas "add" overwrites it if present.
     #
-    # Bug 7 guard: our per-port ``hdel``/``del`` in _cli_remove_selected_mors
-    # can empty the parent hash entirely (CABLE_LENGTH|AZURE, PORT_QOS_MAP|*,
-    # BUFFER_PG|*), in which case Redis auto-deletes the key and the parent
-    # path disappears from ``show runningconfiguration all``.  jsonpatch
+    # Empty-parent guard: our per-port ``hdel``/``del`` in
+    # _cli_remove_selected_mors can empty the parent hash entirely
+    # (CABLE_LENGTH|AZURE, PORT_QOS_MAP|*, BUFFER_PG|*), in which case Redis
+    # auto-deletes the key and the parent path disappears from
+    # ``show runningconfiguration all``.  jsonpatch
     # (RFC 6902) then refuses ``add /CABLE_LENGTH/AZURE/EthernetX`` with
     # ``member 'AZURE' not found in {}``.  When ``parents_present`` tells
     # us the parent is gone, prepend a defensive ``add /parent = {}`` op.
@@ -2565,11 +2565,11 @@ def _run_scaling_measurement(duthost, tbinfo, config_facts, config_facts_localho
                     [(r["scope"], r["table"], r["key"]) for r in pc_refs])
         _cli_remove_pc_references(duthost, pc_refs, enum_rand_one_asic_namespace)
 
-    # Bug 7 guard: snapshot which parent hashes survived the CLI removal.
-    # If a parent (CABLE_LENGTH|AZURE, PORT_QOS_MAP|*, BUFFER_PG|*) is
-    # empty post-removal, Redis has auto-deleted it and RFC-6902 add
-    # into its child path will fail.  _build_scaling_add_patch uses this
-    # to prepend defensive parent-add ops only when needed.
+    # Empty-parent guard: snapshot which parent hashes survived the CLI
+    # removal.  If a parent (CABLE_LENGTH|AZURE, PORT_QOS_MAP|*,
+    # BUFFER_PG|*) is empty post-removal, Redis has auto-deleted it and an
+    # RFC-6902 add into its child path will fail.  _build_scaling_add_patch
+    # uses this to prepend defensive parent-add ops only when needed.
     parents_present = _probe_parent_tables_present(
         duthost, enum_rand_one_asic_namespace)
     logger.info("Scaling parent-table probe: %s", parents_present)
@@ -2600,8 +2600,10 @@ def _run_scaling_measurement(duthost, tbinfo, config_facts, config_facts_localho
             hwproxy_to = True
         logger.error("add_cluster failed: %r", exc)
     finally:
+        # Stop the clock before cleanup: removing the temp file is a separate
+        # SSH round-trip and is not part of what apply-patch costs.
+        apply_elapsed_s = time.time() - apply_start
         delete_tmpfile(duthost, tmpfile)
-    apply_elapsed_s = time.time() - apply_start
 
     # ---- BGP convergence check counts toward e2e wall clock ----
     bgp_up = False
@@ -2667,9 +2669,9 @@ def _run_and_publish(duthost, tbinfo, config_facts, config_facts_localhost,
     """Shared runner: measure, publish metrics, apply pass/fail policy.
 
     Policy:
-      - HWProxy timeout is recorded but does NOT fail the test.
-        Vaibhav owns the SSH-chatty fix separately; treating it as failure
-        would block nightly signal on an issue we're not measuring here.
+      - HWProxy timeout is recorded but does NOT fail the test.  The
+        underlying SSH chattiness is a separate issue; failing on it would
+        block nightly signal on something this test does not measure.
       - Real GCU failures DO fail the test.
       - Elapsed exceeding the time budget fails the test (that IS the metric).
       - BGP check is soft — logged only.
@@ -2726,10 +2728,10 @@ def test_max_mors_under_budget(
     enum_rand_one_asic_namespace, config_facts, config_facts_localhost,
     mg_facts, scaling_checkpoint, record_property,
 ):
-    """Answer Vaibhav's question directly: how many MORs fit in 1 hour?
+    """Find how many MORs fit inside the 1-hour operational budget.
 
     Sweeps N ascending, stops at the first N that fails or exceeds budget.
-    Records ``gcu_max_n_under_budget`` = the largest N that succeeded
+    Records ``gcu_max_mors_under_budget`` = the largest N that succeeded
     within the time budget on this testbed.
     """
     duthost = duthosts[enum_downstream_dut_hostname]
@@ -2746,6 +2748,13 @@ def test_max_mors_under_budget(
                 mg_facts, enum_rand_one_asic_namespace, n, record_property)
         except pytest.skip.Exception as exc:
             logger.info("Skip at N=%d: %s", n, exc)
+            if max_n == 0:
+                # Nothing measured yet, so the skip is about the platform or
+                # testbed rather than the sweep running out of headroom.
+                # Propagate it instead of falling through to the assertion,
+                # which would report this as a failure.  Matches how the
+                # tiered scaling tests behave.
+                pytest.skip(str(exc))
             break
         # Best-effort rollback between iterations so the next iteration
         # starts from the same pre-state (module-scoped config_facts is

--- a/tests/generic_config_updater/add_cluster/test_add_cluster.py
+++ b/tests/generic_config_updater/add_cluster/test_add_cluster.py
@@ -2034,21 +2034,32 @@ def _select_n_mors(config_facts, n):
 
 
 def _verify_bgp_up_scaling(duthost, bgp_neigh_ips, timeout=180):
-    """Poll ``show ip bgp summary -d all`` for all peers reaching Established.
+    """Poll ``show ip bgp summary`` until every peer in *bgp_neigh_ips* is Established.
 
-    Same command used elsewhere in this file (line ~1687).  Returns True on
-    success; caller decides whether to fail or just log a warning.
+    SONiC reports an Established session by printing the received-prefix count in
+    the ``State/PfxRcd`` column -- the literal word "Established" is never shown
+    (it only prints state strings such as ``Idle (Admin)``, ``Active`` or
+    ``Connect`` for sessions that are *not* up).  A substring match on "Estab"
+    therefore never succeeds and the poll always burns its full timeout while
+    reporting the peers as down.  Test whether ``State/PfxRcd`` is numeric
+    instead.  Returns True on success; caller decides whether to fail or just
+    log a warning.
     """
+    wanted = set(bgp_neigh_ips)
+
     def _all_established():
-        out = duthost.shell("show ip bgp summary -d all",
+        out = duthost.shell("show ip bgp summary",
                             module_ignore_errors=True)["stdout"]
-        count = 0
-        for ip in bgp_neigh_ips:
-            for line in out.splitlines():
-                if ip in line and "Estab" in line:
-                    count += 1
-                    break
-        return count == len(bgp_neigh_ips)
+        established = set()
+        for line in out.splitlines():
+            fields = line.split()
+            # <neighbor> <V> <AS> <MsgRcvd> <MsgSent> <TblVer> <InQ> <OutQ>
+            #     <Up/Down> <State/PfxRcd> <NeighborName>
+            if len(fields) < 10 or fields[0] not in wanted:
+                continue
+            if fields[-2].isdigit():
+                established.add(fields[0])
+        return established == wanted
 
     return wait_until(timeout, 10, 0, _all_established)
 


### PR DESCRIPTION
### Description of PR

Summary:
Adds a GCU **add-cluster scaling** test suite (`tests/generic_config_updater/add_cluster/test_add_cluster.py`) that measures how many MORs — external PortChannels re-added in a single `config apply-patch` — can be pushed through the GCU add-cluster path within an operational time budget, on real T2 chassis hardware.

There is no scaling test for this path today; every capacity claim so far has been anecdotal.

Fixes # (issue)
<!-- No linked GitHub issue or ADO work item: this is a new test case, not a fix for a reported failure, and no backport is requested. -->

**Use case being modeled.** Operators re-add N PortChannels' worth of config (PC + members + neighbor + BGP peer + QoS + buffer + cable + ACL binding) as one atomic JSON patch. The question this test answers: *for a given line card, what is the largest N that stays under the budget, and how does apply time grow with N?*

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

<!-- No backport requested. -->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A — no backport requested.
Failure type: N/A — new test case.

### Tested branch

- [x] master
- [ ] N/A

### Test result

- **master: `internal_26_08_26`** — Arista 7800R3 T2 chassis line card (`x86_64-arista_7800r3ak_36dm2_lc`), topology `t2`, namespace `asic0`: **3 passed, 1 skipped** in 519.6 s. See *How did you verify/test it?* below for the per-test table.
- **master: `SONiC.20240532.59`** — same platform, used for the baseline-vs-optimized A/B sweeps (4 full `test_max_mors_under_budget` sweeps across asic0/asic1 and two `sonic-utilities` stacks, N = 1 -> 14), plus 3 repeatability runs and 2 BGP-state control runs. All sweeps passed.

### Approach

#### What is the motivation for this PR?

GCU add-cluster capacity on a T2 line card has never been measured. Without a test, there is no way to state a supported N, no way to detect a scaling regression, and no way to quantify the uplift from GCU performance work. This test makes all three possible, and publishes machine-readable metrics so nightly can trend them.

#### How did you do it?

1. Deterministically select N external PCs on the target ASIC (alphabetical, reproducible).
2. Tear those N clusters down with targeted `sonic-db-cli` deletes (untimed setup), and **verify** every selected key is gone before timing starts. A JSON-patch remove was tried first but hit YANG cascade-delete edge cases, and the existing `remove_cluster_via_sonic_db_cli` helper wildcard-deletes the whole ASIC.
3. Build an incremental ADD patch covering all tables the removed clusters touched.
4. Time a **single** `config apply-patch` call for the ADD. That is the metric.
5. `record_property()` emits `gcu_apply_elapsed_s`, `gcu_apply_wall_elapsed_s`, `gcu_timing_source`, `gcu_sorter_changes`, `gcu_sorter_changes_by_ns`, `gcu_e2e_elapsed_s`, `gcu_time_budget_s`, `gcu_success`, `gcu_n_mors`, `gcu_patch_ops`, `gcu_bgp_up`, `gcu_stop_reason`, `gcu_complete`, plus platform metadata (`gcu_hwsku`, `gcu_switch_type`, `gcu_platform`).

Four entry points for distinct questions:
- `nightly` — regression, N tuned per testbed.
- `weekly` — capacity at N=24 and N=30 (skips on testbeds with fewer externals).
- `sanity` — opt-in N=1 smoke.
- `max_mors_under_budget` — ascending sweep (`1, 5, 10, 20, 24, 30, 33`) that stops at the first N which fails or exceeds the budget, publishing the largest N that fit **together with an explicit `stop_reason` and a `complete` flag** — an incomplete sweep is never reported as a platform maximum.

#### How did you verify/test it?

**Suite run — `internal_26_08_26`, `str2-7804-lc3-1`, `asic0`: 3 passed, 1 skipped (519.6 s).**

| test | result | apply | patch ops | sorter changes | budget |
|---|---|---:|---:|---:|---:|
| `scaling_sanity` N=1 | PASS | 32.85 s | 36 | 23 | 68 s |
| `scaling_nightly` N=5 | PASS | 34.81 s | 156 | 23 | 95 s |
| `scaling_nightly` N=20 | SKIP | — | — | — | — |
| `max_mors_under_budget` | PASS | — | — | — | 780 s |

`gcu_bgp_up=True` on both measured runs (10 IPv4 + 10 IPv6 peers Established). The skip is genuine and graceful: *ASIC has only 8 external PortChannels; requested 20*.

**Fault injection.** Each failure path was injected and confirmed to fail *for the right reason*, not merely to fail: GCU fuse (timeout) trip, GCU apply rejection, forced-`host` namespace on a multi-ASIC DUT, unresolved namespace, and budget exceeded. Two of these previously produced a false green or lost all telemetry — see *Correctness fixes in this PR* below.

**No regression to existing `test_add_cluster`.** It is not modified by this PR. It was run before and after on the same testbed from a pristine worktree of the base commit: it errors identically either way, on a static route this testbed does not provide.

**Static checks.** `flake8 --max-line-length=120` clean, `py_compile` clean, and the CI collect-only gate (`veos_vtb` / `vms-kvm-t0`) exits 0.

**Not covered.** The `rollback_failed` and `sweep_exhausted` stop_reasons are unexercised — both need a DUT that genuinely fails rollback, which is not safe to induce on a shared testbed. Both fail closed (red); neither can silent-pass.

#### Any platform specific information?

T2 chassis, tested on Arista 7800R3. No vendor-specific hooks. The test skips gracefully on testbeds with fewer external PortChannels than the requested N, and skips rather than fails when the requested N is infeasible under the platform's GCU timeout fuse.

Note for reviewers: on platforms whose GCU fuse is 900 s, N >= 14 now **skips** instead of silently passing. That is a deliberate consequence of the fuse fix described below.

#### Supported testbed topology if it's a new test case?

`t2`. Topology marker `t2`; runs against a single line card via `--host-pattern <lc>`. Unlike the existing functional `test_add_cluster`, the scaling tests do not require both an upstream (T3-facing) and a downstream DUT in `duthosts`.

### Documentation

No wiki/doc change required — this is a self-contained test addition. Metric names and their meaning are documented in the module docstring and in the `record_property()` block described above.

---

## Results

### Baseline capacity — measured with this test

> **Measurement-method note.** The table immediately below was produced with the original **wall-clock** timing, before this PR corrected it. `gu_utils.apply_patch` polls `wait_until(timeout, 10, …)`, so wall-clock measurements around it quantise to that 10 s interval. These numbers remain directionally correct at large N, but **sub-10 s differences in them are not meaningful** — the N=1 row in particular. Timing is now taken from the Ansible result's own `delta`; see *Correctness fixes* below.

| N  | ASIC  | Changes | Apply (wall-clock) | s/change |
|---:|:-----:|--------:|-------------------:|---------:|
| 1  | asic0 | 34      | 50.3 s             | 1.48     |
| 5  | asic0 | 170     | 232.0 s            | 1.36     |
| 10 | asic0 | 312     | 456.8 s            | 1.46     |
| 14 | asic1 | 381     | 558.8 s            | 1.47     |

- Per-change cost is essentially **flat at ~1.47 s/change** across N = 1 -> 14. No exponential blowup.
- Scaling is **sub-linear in N** at the outer level (fixed overhead does not grow with N).
- On this LC, N=14 uses ~15.5 % of the 1-hour budget.

**Independent reproduction.** The table was re-measured on a second line card of the same testbed (asic0, pristine 8-LAG topology) on a different image line — `SONiC.20240532.59` instead of `internal-202601`:

| N | Published changes / apply | Re-measured changes / apply |
|--:|--------------------------:|----------------------------:|
| 1 | 34 / 50.3 s               | 34 / 50.19 s                |
| 5 | 170 / 232.0 s             | 170 / 217.35 s              |

Change counts match exactly and wall-clock lands within 6 %, across two images and two line cards.

### Uplift measured with this test

Both sides below were run by this test, unmodified, on the **same LC, same image (`SONiC.20240532.59`), same topology, back to back** — the only variable is the `sonic-utilities` / `sonic-yang-mgmt` stack:

- **Baseline** — stock GCU on that image.
- **Optimized** — a candidate GCU stack under evaluation: bulk leaf-list move generator, YANG schema-dependency caching, and a libyang `must_size` binding that lets the sorter skip must-expression re-evaluation.

**asic1 — 14 single-member MORs (widest measured range):**

| N  | Input ops | Baseline changes | Baseline apply | Optimized changes | Optimized apply | Change ratio | Speedup |
|---:|----------:|-----------------:|---------------:|------------------:|----------------:|-------------:|--------:|
| 1  | 25        | 24               | 38.85 s        | 20                | 31.88 s         | 1.20x        | 1.22x   |
| 5  | 113       | 120              | 161.54 s       | 20                | 33.25 s         | 6.00x        | 4.86x   |
| 8  | 179       | 192              | 249.27 s       | 20                | 32.41 s         | 9.60x        | 7.69x   |
| 10 | 223       | 240              | 309.60 s       | 20                | 32.95 s         | 12.00x       | 9.40x   |
| 14 | 317       | 339              | 530.33 s       | 26                | 43.40 s         | 13.04x       | **12.22x** |

**asic0 — 10 MORs (mixed 2-member and 1-member):**

| N  | Input ops | Baseline changes | Baseline apply | Optimized changes | Optimized apply | Speedup |
|---:|----------:|-----------------:|---------------:|------------------:|----------------:|--------:|
| 1  | 36        | 34               | 51.51 s        | 23                | 35.35 s         | 1.46x   |
| 5  | 156       | 170              | 222.79 s       | 23                | 36.24 s         | 6.15x   |
| 8  | 238       | 265              | 341.62 s       | 23                | 37.18 s         | 9.19x   |
| 10 | 301       | 315              | 472.39 s       | 32                | 50.94 s         | 9.27x   |

What the test surfaced:

- **Marginal cost per additional MOR** drops from 37.8 s to 0.89 s on asic1 — a **42x slope reduction**. On asic0, 46.8 s to 1.73 s (27x).
- **Per-change cost is unchanged** between the two stacks (baseline 1.28-1.48 s/change, optimized 1.52-1.58 s/change). The entire win is change-count collapse, not a faster per-change path — exactly what the `s/change` column in this test was added to distinguish.
- Because the optimized stack keeps change count roughly flat in N, the `s/change` metric alone would have looked *worse*; only the combination of `ops`, `changes` and `apply` that this test records tells the real story.
- Extrapolating each slope to the 1800 s budget used for these runs: baseline ~47 MORs, optimized ~1990 MORs.
- Whole-run wall clock, asic1 sweep: 51 m 39 s -> 32 m 51 s.

These A/B numbers are large-N and far outside the 10 s quantisation window, so the measurement-method note above does not affect them. The current `internal_26_08_26` image already sits in the optimized regime: 23 sorter changes at both N=1 (36 ops) and N=5 (156 ops), 0.61 s marginal cost per MOR.

---

## Correctness fixes in this PR

### Addressing review feedback

**Dual-stack BGP verification.** `_verify_bgp_up_scaling()` now splits the wanted peers by address family and queries the matching summary per family through the asic instance for the namespace, so IPv6 peers can reach `established`. A second, latent half of the same bug is also fixed: `bgp_facts` lower-cases IPv6 neighbour keys while CONFIG_DB preserves the minigraph's spelling, so a testbed whose minigraph writes `FC00::…` would still never match. Both sides are now lower-cased, matching what `sonic_asic.py` / `multi_asic.py` already do internally.

**Budget gated on the quantity it is calibrated from.** The time budget is now checked against **apply** time (`gcu_apply_elapsed_s`), not e2e; `e2e` is still published but is informational. The budget is no longer a hardcoded 60 s/MOR — it is derived from a `loadData()` cost measured on the platform, and clamped below the platform fuse so "exceeded budget" stays reachable rather than being masked by the timeout.

**Removals verified before the timer starts.** Required ASIC-side deletes are return-code checked instead of being swallowed by `module_ignore_errors=True`, and `_verify_selected_mors_removed()` asserts every selected key is absent from the ASIC CONFIG_DB before timing begins. Only genuinely optional localhost entries tolerate absence.

**A truncated sweep can no longer be published as capacity.** The sweep emits an explicit `stop_reason` and a `complete` flag, and a rollback failure is propagated after restoration rather than being treated as a capacity boundary.

### Found while validating the above

**The test could PASS when GCU blew its timeout.** `apply_patch`'s `TimeoutError` — the single condition this test exists to detect — was caught and downgraded to a soft, non-failing "transport drop". Proven by fault injection: before the fix an injected fuse trip PASSES; after it, FAILS.

**All failure telemetry was silently discarded.** `expect_op_success` and `rollback_or_reload` signal via `pytest.fail`, whose exception derives from `BaseException`, not `Exception`, so `except Exception` never caught the most common real failure. Proven by injecting a GCU rejection: without the fix, zero `gcu_*` properties are recorded; with it, the full set.

**The headline metric was quantised.** Nine consecutive measurements all read ~41.4 s regardless of N, because wall clock snapped to `wait_until`'s 10 s poll. Measured slope was 0.022 s/MOR against a true **0.608 s/MOR — a 27x understatement**. Timing now comes from the Ansible result's `delta` (verified ~5 ms accurate); wall clock is retained as `gcu_apply_wall_elapsed_s` and `gcu_timing_source` records which was used. A hardware-independent companion metric, `gcu_sorter_changes`, is published alongside it.

**Namespace selection could silently run unscoped.** Upstream `generate_param_asic_index()` falls back to `DEFAULT_ASIC_ID = None` when it cannot read `frontend_asics` for a host, producing unscoped patch paths against the wrong database — surfacing only after the apply as a misleading `apply-patch failed`. It now fails during fixture setup with an actionable message, before any config is touched.

**Historical: `_verify_bgp_up_scaling` could never return True.** The helper originally matched the substring `"Estab"` in `show ip bgp summary -d all`. FRR signals an Established session by printing the received-prefix count, never the word; and under `-d all` the per-namespace tables do not repeat peer IPs in a matchable form. `wait_until(180, …)` therefore always ran to full timeout. Three back-to-back runs — two with peers `Idle (Admin)`, one with 24/24 IPv4 + 24/24 IPv6 Established — produced e2e figures within 0.8 s of each other, confirming the 180 s was pure timeout, not convergence. Superseded by the per-family rewrite above.

---

## Known limitations / follow-ups

- **MOR selection is LAG-only.** `_select_n_mors` enumerates candidates from `PORTCHANNEL_MEMBER`, so routed (non-LAG) L3 MORs are not covered and N is hard-capped at the LC's external-LAG count. On the 7800R3 LC used here that ceiling is 18 on asic0 (only if every 2-member LAG is split) and 14 on asic1.
- **Some tier N-counts are unreachable on this platform.** `NIGHTLY_MOR_COUNTS = [5, 20]` and `WEEKLY_MOR_COUNTS = [24, 30]` exceed the ceiling above, so those N can only skip on a 7800R3 LC. They remain valid on higher-density platforms; the skip path is graceful, but the tiers are worth revisiting per-platform.
- **On a 900 s-fuse platform, N >= 14 skips** rather than running, because the infeasibility gate now refuses to start a run that cannot complete under the fuse.
- **`DEVICE_METADATA|localhost:default_bgp_status` is a silent precondition.** When it is `down`, every peer comes up `Idle (Admin)` and stays there. `config bgp startup all` alone does not survive the `scaling_checkpoint` teardown's `config reload`; the knob has to be set and `config save -y` run.
- **Topology changes need `config save -y`** for the same reason.
- **`rollback_failed` / `sweep_exhausted` stop_reasons are unexercised** — both require a DUT that genuinely fails rollback. Both fail closed.
- **`GCUTIMEOUT_MAP` has no entry for the T2 LC platforms tested**, so they fall back to the 900 s default. That is an upstream gap, tracked separately, not changed here.

## Implementation notes

- Does **not** modify the existing `apply_patch_add_cluster{,_chassis_packet}` helpers. The scaling tests build their own incremental, per-key add patch (`_build_scaling_add_patch`), so both helpers remain byte-identical to master and existing `test_add_cluster` behaviour is unchanged.
- Includes two fixes needed for reliability on real T2 hardware:
  - Dynamic `ACL_TABLE` ports-leaf-list referrer scanning, so the test does not hit `Invalid value "PortChannelXXX" in "ports" element` when the LC has ACL-bound downstream PCs.
  - Conditional parent-table prepend (`CABLE_LENGTH|AZURE` / `PORT_QOS_MAP` / `BUFFER_PG`) **only** when Redis has auto-deleted the empty parent hash after last-child removal — avoids RFC 6902 add-replace clobbering of unrelated port entries.
- `conftest.py`: 3 pytest markers (`gcu_scaling_nightly` / `weekly` / `sanity`) + a `GCU_FORCE_ASIC` env override on `enum_rand_one_asic_namespace` for deterministic ASIC pinning on asymmetric testbeds, now with a guard that refuses any unscoped namespace on a multi-ASIC DUT.
