### PR TITLE
fix ntp ipv6 sync with ntpsec on trixie ptf

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -33,6 +33,12 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
         # exhaustion
         ptfhost.lineinfile(path=ntp_conf_path, line="interface ignore wildcard")
         ptfhost.lineinfile(path=ntp_conf_path, line="interface listen mgmt")
+        # ntpsec (Debian trixie+ ptf) resolves the "mgmt" interface name to its
+        # IPv4 address only, so it never binds the mgmt IPv6 address. Add an
+        # explicit listen directive for the IPv6 case so the DUT can sync over
+        # IPv6. Classic ntpd bound both families via the interface name.
+        if ptf_use_ipv6 and ptfhost.mgmt_ipv6:
+            ptfhost.lineinfile(path=ntp_conf_path, line="interface listen %s" % ptfhost.mgmt_ipv6)
 
     ptfhost.lineinfile(path=ntp_conf_path, line="server 127.127.1.0 prefer")
 
@@ -103,6 +109,8 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
     if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP):
         ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.ignore.wildcard")
         ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.listen.mgmt")
+        if ptf_use_ipv6 and ptfhost.mgmt_ipv6:
+            ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface listen %s" % ptfhost.mgmt_ipv6)
 
     # reset ntp client configuration
     duthost.command("config ntp del %s" % (ptfhost.mgmt_ipv6 if ptf_use_ipv6 else ptfhost.mgmt_ip))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix NTP IPv6 synchronization in the `ntp/test_ntp` helper when the PTF container runs `ntpsec` (Debian trixie docker-ptf). ntpsec resolves the `mgmt` interface name to its IPv4 address only, so it never binds the mgmt IPv6 address, causing the `ipv6_only` variants of `test_ntp` to fail with the DUT chronyd reporting "No suitable source for synchronisation".

This is the sonic-mgmt companion to sonic-buildimage PR #27889, which upgrades docker-ptf from bookworm to trixie (classic `ntp`/`ntpd` was removed in trixie, so the ptf now uses `ntpsec`).
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?
The docker-ptf needs to be upgraded from Debian bookworm to trixie. Trixie dropped the classic `ntp`/`ntpd` package, so the ptf now installs `ntpsec`. With ntpsec, `test_ntp`'s `ipv6_only` variants fail because the NTP server on the ptf never binds its mgmt IPv6 address, so the DUT cannot sync over IPv6. The IPv4 variants pass. Classic ntpd bound both IPv4 and IPv6 of the mgmt interface via the interface name, which masked this behavior.
#### How did you do it?
In `setup_ntp_context` (tests/common/helpers/ntp_helper.py), the helper writes `interface ignore wildcard` + `interface listen mgmt` to keep the NTP server bound only to the mgmt interface (to avoid socket-allocation exhaustion across the ptf's many injected interfaces). ntpsec resolves the `mgmt` name to IPv4 only. For the IPv6 case, add an explicit `interface listen <ptf mgmt_ipv6>` directive so ntpsec also binds the mgmt IPv6 address. The teardown mirrors the removal. The change is a no-op for the IPv4 case and for the old classic-ntpd (bookworm) ptf, so it is safe to merge ahead of the buildimage PR.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
