### PR TITLE
[github]: Add tested branch checklist to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -56,6 +56,30 @@ If you request a backport/cherry-pick, provide both:
 Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
 Failure type: <!-- day-one issue / regression / other -->
 
+### Tested branch
+<!--
+Select each branch where the change was tested. If you request a
+backport/cherry-pick, select the base branch and the tested target release
+branch(es).
+-->
+- [ ] master
+- [ ] 202311
+- [ ] 202405
+- [ ] 202411
+- [ ] 202505
+- [ ] 202511
+- [ ] 202512
+- [ ] 202605
+- [ ] N/A
+
+### Test result
+<!--
+Provide the tested image version and test evidence for each selected branch.
+For example:
+- master: 20260716.01 - <test result or link>
+- 202605: 20260531.42 - <test result or link>
+-->
+
 ### Approach
 #### What is the motivation for this PR?
 
@@ -63,8 +87,8 @@ Failure type: <!-- day-one issue / regression / other -->
 
 #### How did you verify/test it?
 <!--
-If you request a backport/cherry-pick, include test evidence from the target
-branch(es), not only from master.
+Summarize the overall validation here. For a backport/cherry-pick request,
+provide branch-specific image versions and evidence in the Test result section.
 -->
 
 #### Any platform specific information?


### PR DESCRIPTION
### Description of PR

Summary:
Add machine-readable tested-branch checkboxes and a separate branch-specific test-result section to the sonic-mgmt PR template. This mirrors sonic-net/sonic-buildimage#28464 and follows @yijingyan2's automation suggestion on sonic-net/sonic-buildimage#28355.

Fixes # (issue): N/A - template-only improvement

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

Template-only change; `git diff --check` passes.

### Approach
#### What is the motivation for this PR?

Structured branch checkboxes allow automation to add `Tested for <branch>` labels and identify backport requests that do not include target-branch test evidence.

#### How did you do it?

Added explicit tested-branch options matching sonic-mgmt's current backport branches, plus `master` and `N/A`. Moved branch-specific image versions and evidence into a separate `Test result` section while keeping the existing overall verification section.

#### How did you verify/test it?

Inspected the rendered Markdown structure and ran `git diff --check`.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
