### PR TITLE
[dhcp_relay] Echo Option 82 in dual-ToR SONiC replies

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -182,6 +182,10 @@ class DHCPTest(DataplaneBaseTest):
         # 'dual' for dual tor testing
         # 'single' for regular single tor testing
         self.dual_tor = (self.test_params['testing_mode'] == 'dual')
+        self.sonic_reply_uses_option82 = (
+            self.relay_agent == "sonic-relay-agent"
+            and (self.dual_tor or (self.link_selection and self.source_interface))
+        )
         self.vlan_iface_name = self.test_params.get('downlink_vlan_iface_name', None)
 
         # option82 is a byte string created by the relay agent. It contains the circuit_id and remote_id fields.
@@ -874,7 +878,7 @@ class DHCPTest(DataplaneBaseTest):
         # if pad_bytes > 0:
         #    bootp /= scapy.PADDING('\x00' * pad_bytes)
 
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - len(bootp)
             if pad_bytes > 0:
                 bootp /= scapy.PADDING('\x00' * pad_bytes)
@@ -1099,7 +1103,7 @@ class DHCPTest(DataplaneBaseTest):
         dhcp_unknown = self.create_dhcp_offer_packet()
         logger.info("Server send unknown packet")
         dhcp_unknown[scapy.DHCP] = scapy.DHCP(options=[('message-type', 11), ('end')])
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             dhcp_unknown[scapy.DHCP].options.insert(
                     dhcp_unknown[scapy.DHCP].options.index("end"),
                     (82, self.option82)
@@ -1110,7 +1114,7 @@ class DHCPTest(DataplaneBaseTest):
     def verify_relayed_unknown_on_client_side(self):
         dhcp_offer = self.create_dhcp_offer_relayed_packet()
         dhcp_offer[scapy.DHCP] = scapy.DHCP(options=[('message-type', 11), ('end')])
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             bootp_len = len(dhcp_offer[scapy.BOOTP])
             pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - bootp_len
             if pad_bytes > 0:
@@ -1143,7 +1147,7 @@ class DHCPTest(DataplaneBaseTest):
         # Build the DHCP NAK packet
         packet = self.create_dhcp_ack_packet()
         packet[scapy.DHCP] = scapy.DHCP(options=[('message-type', 'nak'), ('server_id', self.server_ip[0]), ('end')])
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             packet[scapy.DHCP].options.insert(
                     packet[scapy.DHCP].options.index("end"),
                     (82, self.option82)
@@ -1154,7 +1158,7 @@ class DHCPTest(DataplaneBaseTest):
     def verify_relayed_nak(self):
         dhcp_nak = self.create_dhcp_ack_relayed_packet()
         dhcp_nak[scapy.DHCP] = scapy.DHCP(options=[('message-type', 'nak'), ('server_id', self.server_ip[0]), ('end')])
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             bootp_len = len(dhcp_nak[scapy.BOOTP])
             pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - bootp_len
             if pad_bytes > 0:


### PR DESCRIPTION
### Description of PR

Summary:
`test_dhcp_relay_unicast_mac[sonic-relay-agent]` fails on dual-ToR because the PTF server reply does not echo Option 82. SONiC relay uses Loopback0 as `giaddr` and the echoed Circuit-ID to recover the client VLAN before stripping Option 82 from the reply.

This PR updates the PTF packet model to:
- include Option 82 in dual-ToR SONiC ACK, NAK, and unknown server replies;
- reuse the same behavior for explicit link-selection/source-interface cases; and
- account for the bytes removed when the relay strips Option 82 before forwarding the reply to the client.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38650789

**Prerequisite (merged):** https://github.com/sonic-net/sonic-mgmt/pull/26108

PR #26108 corrected the request-side Option 82 model for dual-ToR SONiC relay. It places Link Selection (Suboption 5) before Server-ID Override (Suboption 11), uses the receiving VLAN address as its value, and prevents the generic dual-ToR block from adding a duplicate. This matches the behavior introduced by the companion product fix https://github.com/sonic-net/sonic-dhcp-relay/pull/121.

This prerequisite is required because PR #26285 builds ACK, NAK, and unknown server replies by echoing the request’s Option 82 bytes. Without #26108, the test expects the wrong Link Selection value/order and rejects the relayed DISCOVER before reaching the reply path, so #26285 cannot validly test the reply lifecycle.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: https://msazure.visualstudio.com/One/_workitems/edit/38650789
Failure type: day-one test expectation gap for dual-ToR SONiC relay replies

### Approach
#### What is the motivation for this PR?

For dual-ToR SONiC relay, the server reply must echo Option 82 so the relay can use Circuit-ID to select the client VLAN. The previous PTF packet model omitted Option 82 unless explicit link-selection and source-interface options were enabled, so valid relay behavior was tested with an invalid server reply and produced a `0 != 48` packet-count failure.

#### How did you do it?

Added a shared `sonic_reply_uses_option82` condition and applied it consistently to ACK, NAK, and unknown server replies. Client-side expected packets retain the existing stripped-Option-82 behavior and now calculate padding for the dual-ToR path as well.

#### How did you verify/test it?

- `python3 -m py_compile ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py`
- Target-branch validation on `internal-202605`, image `20260510.05`, physical BJW dual-ToR hardware.
- Exact case: `test_dhcp_relay_unicast_mac[sonic-relay-agent]`.
- Five consecutive runs passed, all exit code 0:
  - 1 passed in 998.17s
  - 1 passed in 999.10s
  - 1 passed in 1003.91s
  - 1 passed in 999.10s
  - 1 passed in 995.74s

#### Any platform specific information?

Dual-ToR SONiC relay behavior.

#### Supported testbed topology if it's a new test case?

N/A; this fixes an existing test.

### Documentation

N/A

##### Work item tracking
- Microsoft ADO **(number only)**: 38650789

### Tested branch

- Base: `internal-202605`
- Local validation branch: `dev/xichenlin/validate-38650789-sonic-reply`
- Tested head: `34d82d9d6e`
- Stack: merged #26033 and #26055, plus #26108 and #26285
- Image: `20260510.05`
- Testbed: `testbed-bjw3-can-dual-t0-7260-2`

### Test result

Exact case: `test_dhcp_relay_unicast_mac[sonic-relay-agent]`

Five consecutive physical runs passed, all exit code 0:
- 1 passed in 998.17s
- 1 passed in 999.10s
- 1 passed in 1003.91s
- 1 passed in 999.10s
- 1 passed in 995.74s