### PR TITLE
Avoid CACL restore failure without golden config

### DIFF
--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -49,8 +49,9 @@ def get_iptable_rules(duthost, ip_netns_namespace_prefix):
 @pytest.fixture(scope="module", autouse=True)
 def restore_test_env(duthosts, rand_one_dut_front_end_hostname):
     duthost = duthosts[rand_one_dut_front_end_hostname]
+    golden_config_exists = duthost.stat(path="/etc/sonic/golden_config_db.json")["stat"]["exists"]
     config_reload(duthost, config_source="minigraph", safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True,
-                  override_config=True)
+                  override_config=golden_config_exists)
     yield
 
 


### PR DESCRIPTION
### Description of PR
Fix `generic_config_updater/test_cacl.py` setup on DUTs that do not have `/etc/sonic/golden_config_db.json`.

The `restore_test_env` fixture currently always passes `override_config=True` to minigraph reload. That makes `config load_minigraph` try to load `/etc/sonic/golden_config_db.json` and fail before tests start on non-golden-config testbeds. This PR keeps the override behavior when the golden config exists, and falls back to normal minigraph reload otherwise.

Fixes ADO PBI 38839539.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?
Nightly `generic_config_updater.test_cacl::test_cacl_tc3_acl_all` fails during fixture setup with `Cannot find '/etc/sonic/golden_config_db.json'!` after PR #23811 made override config unconditional.

#### How did you do it?
Check whether `/etc/sonic/golden_config_db.json` exists on the DUT and pass `override_config=True` only when it is available.

#### How did you verify/test it?
Ran `python -m py_compile tests/generic_config_updater/test_cacl.py`.

#### Any platform specific information?
Applies to non-golden-config testbeds across platforms.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A