### PR TITLE
Deflake syslog_rate_limit by waiting for full forwarded log count

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -16,7 +16,9 @@ logger = logging.getLogger(__name__)
 
 RATE_LIMIT_BURST = 100
 RATE_LIMIT_INTERVAL = 10
-SYSLOG_FORWARD_TIMEOUT = 60
+# Container -> host syslog forwarding is asynchronous and, on loaded/virtual testbeds,
+# can lag well beyond a minute. 
+SYSLOG_FORWARD_TIMEOUT = 120
 SYSLOG_FORWARD_INTERVAL = 2
 # Generate 101 packets in tests/syslog/log_generator.py, so that 1 log message will be dropped by rsyslogd
 LOG_MESSAGE_GENERATE_COUNT = 101
@@ -281,7 +283,7 @@ def verify_config_rate_limit_fail(duthost, service_name):
     pytest_assert('Error' in output, 'Error: config syslog rate limit for {}: {}'.format(service_name, output))
 
 
-def _wait_expected_logs_forwarded(duthost, start_marker, expect_log_regex, additional_files):
+def _wait_expected_logs_forwarded(duthost, start_marker, expect_log_regex, expect_log_matches, additional_files):
     """Wait until every expected message has been forwarded into the host log files for
     this LogAnalyzer window before the window is closed.
 
@@ -291,6 +293,12 @@ def _wait_expected_logs_forwarded(duthost, start_marker, expect_log_regex, addit
     test fails intermittently. Poll the host log files, scoped to this window's unique
     start marker (the test reuses a marker prefix across config_reload, so an earlier
     window's identical logs must not be matched), until the expected messages appear.
+
+    Wait for the full expected count rather than mere presence: forwarding delivers the
+    burst incrementally, so a presence-only check (>=1 match) lets the window close while
+    the tail of the burst is still in flight, dropping the last message(s) out of the
+    window.  When ``expect_log_matches`` is 0 the count is non-deterministic (e.g. logs
+    routed to an additional file), so fall back to a presence check.
 
     The scoping pattern is the bare marker (``<prefix>.<timestamp>``) rather than the full
     ``start-LogAnalyzer-<marker>`` line: this shell command is itself echoed into syslog,
@@ -305,7 +313,13 @@ def _wait_expected_logs_forwarded(duthost, start_marker, expect_log_regex, addit
         for log_file in log_files:
             captured += duthost.shell("sudo awk '/{}/,0' {}".format(escaped_marker, log_file),
                                       module_ignore_errors=True)['stdout']
-        return all(re.search(regex, captured) for regex in expect_log_regex)
+        for regex in expect_log_regex:
+            if expect_log_matches:
+                if len(re.findall(regex, captured)) < expect_log_matches:
+                    return False
+            elif not re.search(regex, captured):
+                return False
+        return True
 
     return wait_until(SYSLOG_FORWARD_TIMEOUT, SYSLOG_FORWARD_INTERVAL, 0, _all_expected_present)
 
@@ -354,7 +368,8 @@ def verify_rate_limit_with_log_generator(duthost, service_name, log_marker, expe
         # forwarded (scoped to this window's unique start marker) before LogAnalyzer closes
         # and verifies the window, instead of racing that forwarding with a fixed sleep.
         # LogAnalyzer itself asserts the messages on exit, so this is only a wait.
-        _wait_expected_logs_forwarded(duthost, loganalyzer._markers[-1], expect_log_regex, additional_files)
+        _wait_expected_logs_forwarded(duthost, loganalyzer._markers[-1], expect_log_regex,
+                                      expect_log_matches, additional_files)
 
     if presence_log_regex:
         presence_analyzer.analyze(presence_marker)

--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 RATE_LIMIT_BURST = 100
 RATE_LIMIT_INTERVAL = 10
 # Container -> host syslog forwarding is asynchronous and, on loaded/virtual testbeds,
-# can lag well beyond a minute. 
+# can lag well beyond a minute.
 SYSLOG_FORWARD_TIMEOUT = 120
 SYSLOG_FORWARD_INTERVAL = 2
 # Generate 101 packets in tests/syslog/log_generator.py, so that 1 log message will be dropped by rsyslogd


### PR DESCRIPTION
### Description of PR

Summary:
Deflakes `syslog.test_syslog_rate_limit::test_syslog_rate_limit`, (61 distinct PRs failing on it in a 14-day window, one continuous episode). ~148/155 of the observed failures share the same signature: `LogAnalyzerError ... expected_missing_match` on the `.*database#rate-limit-test: This is a test log:.*` count (e.g. `expected_match: 100, match: 99`).

Root cause (test-side timing race, no product bug):
Each SONiC container runs its own `rsyslogd` that forwards its logs to the host `rsyslogd` over loopback RELP (`127.0.0.1:2514`); the host writes `/var/log/syslog`. The test fires 101 messages via `log_generator.py` inside a container and a `LogAnalyzer` window asserts exactly 100 forwarded lines (1 dropped by the burst limiter). Forwarding is asynchronous and incremental, but the wait helper `_wait_expected_logs_forwarded` was presence-only: it returned the instant the first forwarded line appeared (60s cap). On loaded/virtual testbeds the window closed while lines 2-100 were still in flight, so `LogAnalyzer` counted fewer than 100 and failed on teardown.

Fix (minimal, one file, 19 insertions / 4 deletions):
- Make the forwarding wait count-aware: hold the `LogAnalyzer` window open until every expected line has actually landed (`len(re.findall(regex, captured)) >= expect_log_matches`), with a presence-only fallback when the expected count is non-deterministic (`expect_log_matches == 0`).
- Bump `SYSLOG_FORWARD_TIMEOUT` 60 -> 120 so slow forwarding still completes inside the wait.

Failure type: day-one issue in the forwarding-wait helper (it has been presence-only since it was introduced).

Tracking issue/work item: <!-- TODO: link the GitHub issue / ADO work item before requesting a backport -->

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: <!-- TODO: link issue/ADO -->
Failure type: day-one issue (presence-only forwarding wait races the async container->host RELP burst)

### Approach
#### What is the motivation for this PR?
`test_syslog_rate_limit` is a top flaky PR test: 61 distinct PRs failed on it within a 14-day window as one continuous episode, across master/internal and release branches (202511, 202605, 202607, 202608). The dominant signature is `LogAnalyzerError ... expected_missing_match` on the forwarded `database#rate-limit-test: This is a test log:` count. It is a false failure: all 100 messages are eventually forwarded, but the `LogAnalyzer` window closed before the async burst finished arriving.

#### How did you do it?
Replaced the presence-only forwarding wait with a count-aware wait that keeps the `LogAnalyzer` window open until all expected lines are present in the host log (falling back to presence when the expected count is 0), and raised the forwarding timeout 60 -> 120s. No structural/flow change; the healthy fast path is unaffected.

#### How did you verify/test it?
Reproduced deterministically on a dev-VM (SONiC VS KVM `vlab-01`, `sonic-mgmt` container). The async container->host RELP forward was throttled with `tc netem` scoped to `lo dport 2514` only, so the forwarded burst trickles in while the host-local `LogAnalyzer` start/end markers (written via imuxsock) are unaffected -- a faithful reproduction of the production race. A harness exercised the exact wait logic (presence vs count) against that real throttled forward.

Before fix (presence-only, 60s) vs after fix (count-aware, 120s), same throttled forward:

    === VARIANT: presence (timeout=60s, before-fix / master) ===
    wait returned=True after 0.6s; lines_in_LA_window=1/100 -> FAIL
    (LogAnalyzerError: expected_match 100, match 1, missing 99)
    (post-drain total forwarded for this marker: 100)

    === VARIANT: count (timeout=120s, after-fix / patched) ===
    wait returned=True after 38.2s; lines_in_LA_window=100/100 -> PASS
    (post-drain total forwarded for this marker: 100)

Healthy path (no throttle) -- both variants unchanged and fast:

    healthy presence(before-fix)   returned 0.2s  window=100/100 -> PASS
    healthy count(after-fix)       returned 0.3s  window=100/100 -> PASS

The `post-drain total forwarded: 100` in both throttled variants confirms no message is ever lost -- it is purely a wait-timing race. The before-fix row reproduces the exact production `LogAnalyzerError` signature; the after-fix row closes it; the healthy path is unchanged.

Truth table:

    | Scenario                       | Before fix (presence, 60s)      | After fix (count, 120s)     |
    | ------------------------------ | ------------------------------- | --------------------------- |
    | DB burst throttled (lo:2514)   | wait 0.6s, window 1/100 -> FAIL | wait 38.2s, 100/100 -> PASS |
    | Healthy (no throttle)          | 0.2s, 100/100 -> PASS           | 0.3s, 100/100 -> PASS       |

#### Any platform specific information?
The race manifests on loaded/virtual (KVM) testbeds where container->host forwarding lags. The change is strictly more tolerant: fast testbeds already reach the full count in well under a second and are unaffected.

#### Supported testbed topology if it's a new test case?
N/A -- not a new test case (t0, t1-lag).

### Documentation
N/A -- test-only change.
