### PR TITLE
[202605] Backport get_routes_not_announced_to_bgpmon poll fix (#25389)

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -914,9 +914,9 @@ def check_fib_route(duthost, route_list, ip_ver=IP_VER):
 
     for route in route_list:
         if route in out:
-            logging.debug(f"Route:{route} installed into fib")
+            logging.debug("Route:{} installed into fib".format(route))
         else:
-            logging.info(f"Route:{route} not found in fib")
+            logging.info("Route:{} not found in fib".format(route))
             assert False
     logging.info(f"{route_list} are installed into fib successfully")
 

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -195,19 +195,29 @@ def parse_rib(host, ip_ver, asic_namespace=None):
     return routes
 
 
-def get_routes_not_announced_to_bgpmon(duthost, ptfhost, asic_namespace=None):
+def get_routes_not_announced_to_bgpmon(duthost, ptfhost, asic_namespace=None, expected_routes=None):
     """
     Get the routes that are not announced to bgpmon by checking dump of bgpmon on PTF.
     """
     def _dump_fie_exists(host):
         return host.stat(path=DUMP_FILE).get('stat', {}).get('exists', False)
-    pytest_assert(wait_until(120, 10, 0, _dump_fie_exists, ptfhost))
-    time.sleep(20)  # Wait until all routes announced to bgpmon
+    pytest_assert(wait_until(120, 10, 0, _dump_fie_exists, ptfhost),
+                  "bgpmon dump file is not found: {}".format(DUMP_FILE))
+
+    if expected_routes is None:
+        rib_v4 = parse_rib(duthost, 4, asic_namespace=asic_namespace)
+        rib_v6 = parse_rib(duthost, 6, asic_namespace=asic_namespace)
+        routes_to_check = list(dict(list(rib_v4.items()) + list(rib_v6.items())).keys())
+    else:
+        routes_to_check = expected_routes
+
+    def _all_routes_announced():
+        bgpmon_routes = parse_exabgp_dump(ptfhost)
+        return all(route in bgpmon_routes for route in routes_to_check)
+
+    wait_until(WAIT_TIMEOUT, 10, 0, _all_routes_announced)
     bgpmon_routes = parse_exabgp_dump(ptfhost)
-    rib_v4 = parse_rib(duthost, 4, asic_namespace=asic_namespace)
-    rib_v6 = parse_rib(duthost, 6, asic_namespace=asic_namespace)
-    routes_dut = dict(list(rib_v4.items()) + list(rib_v6.items()))
-    return [route for route in list(routes_dut.keys()) if route not in bgpmon_routes]
+    return [route for route in routes_to_check if route not in bgpmon_routes]
 
 
 def remove_bgp_neighbors(duthost, asic_index):
@@ -594,8 +604,10 @@ def check_routes_on_neighbors(nbrhosts, setup, permit=True):
     check_results(results)
 
 
-def checkout_bgp_mon_routes(duthost, ptfhost):
-    routes_not_announced = get_routes_not_announced_to_bgpmon(duthost, ptfhost)
+def checkout_bgp_mon_routes(duthost, ptfhost, asic_namespace=None, expected_routes=None):
+    routes_not_announced = get_routes_not_announced_to_bgpmon(
+        duthost, ptfhost, asic_namespace=asic_namespace, expected_routes=expected_routes
+    )
     pytest_assert(routes_not_announced == [], "Not all routes are announced to bgpmon: {}".format(routes_not_announced))
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #26290
Backport of the `tests/bgp/bgp_helpers.py` portion of #25389 to the `202605` branch.

`get_routes_not_announced_to_bgpmon` used a fixed `time.sleep(20)` before comparing the DUT RIB against the routes received by bgpmon, with no retry. On slower platforms (e.g. Cisco-8101-O8C48) BGP re-advertisement to the bgpmon iBGP session after a traffic shift can take longer than 20s, causing intermittent `Not all routes are announced to bgpmon` failures in `bgp/test_traffic_shift.py` (`test_TSA`, `test_TSB`, `test_TSA_TSB_with_config_reload`, `test_load_minigraph_with_traffic_shift_away`).

This backports the already-merged master fix (#25389): replace the fixed sleep with a `wait_until(WAIT_TIMEOUT, 10, 0, _all_routes_announced)` poll that returns as soon as every route is announced (or after the timeout), and add the optional `expected_routes` parameter (with `checkout_bgp_mon_routes` updated to pass it through).

A full cherry-pick of #25389 does not apply cleanly on `202605` due to an unrelated conflict in `tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml` (part of the bgp_allow_list changes), so only the `bgp_helpers.py` change is backported here.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Intermittent `Not all routes are announced to bgpmon` failures in `bgp/test_traffic_shift.py` on the `202605` branch on slower platforms (Cisco-8101-O8C48). master already fixed this in #25389; `202605` still had the old fixed-sleep version.

#### How did you do it?
Backported the `bgp_helpers.py` change from #25389: `get_routes_not_announced_to_bgpmon` now polls with `wait_until(WAIT_TIMEOUT, 10, 0, _all_routes_announced)` instead of a fixed `time.sleep(20)`, and gains an optional `expected_routes` parameter.

#### How did you verify/test it?
- flake8 (`--max-line-length=120`) and `py_compile` pass on `tests/bgp/bgp_helpers.py`.
- The change is identical to the corresponding portion of the already-merged and validated master PR #25389.
- All existing callers (`checkout_bgp_mon_routes`, `bgp/test_traffic_shift.py`) use the backward-compatible signature.

#### Any platform specific information?
Benefits slower platforms such as Cisco-8101-O8C48 where BGP convergence to bgpmon exceeds the previous 20s fixed wait.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case.

### Documentation
N/A
