### PR TITLE
Add ISSU skip check and adapt IPv6 to warm reboot tests

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -23,6 +23,7 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG, UPSTREAM_NEIGHBOR_MAP
 from tests.common import config_reload
 from tests.common.reboot import reboot
+from tests.common.mellanox_data import is_mellanox_device, is_issu_enabled
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 import ptf.testutils as testutils
 import ptf.mask as mask
@@ -602,13 +603,16 @@ def test_static_route_warmboot(localhost, rand_selected_dut, rand_unselected_dut
     Addresses issue: https://github.com/sonic-net/sonic-buildimage/issues/21423
     """
     duthost = rand_selected_dut
+    if is_mellanox_device(duthost) and not is_issu_enabled(duthost):
+        pytest.skip("ISSU is not enabled on this HWSKU, warm reboot is not supported")
     unselected_duthost = rand_unselected_dut
-    prefix = "3.3.3.0/24"
+    ipv6 = is_ipv6_only_topology(tbinfo)
+    prefix = "2000:3::/64" if ipv6 else "3.3.3.0/24"
 
     with static_route_context(duthost, unselected_duthost, ptfadapter, ptfhost, tbinfo,
                               prefix, nexthop_count=1,
                               is_route_flow_counter_supported_flag=is_route_flow_counter_supported,
-                              ipv6=False):
+                              ipv6=ipv6):
         # Save config and perform warmboot
         duthost.shell('config save -y')
         reboot(duthost, localhost, reboot_type='warm', wait_warmboot_finalizer=True, safe_reboot=True)
@@ -627,13 +631,16 @@ def test_static_route_ecmp_warmboot(localhost, rand_selected_dut, rand_unselecte
     4. Traffic continues to be forwarded across all paths after warmboot
     """
     duthost = rand_selected_dut
+    if is_mellanox_device(duthost) and not is_issu_enabled(duthost):
+        pytest.skip("ISSU is not enabled on this HWSKU, warm reboot is not supported")
     unselected_duthost = rand_unselected_dut
-    prefix = "4.4.4.0/24"
+    ipv6 = is_ipv6_only_topology(tbinfo)
+    prefix = "2000:4::/64" if ipv6 else "4.4.4.0/24"
 
     with static_route_context(duthost, unselected_duthost, ptfadapter, ptfhost, tbinfo,
                               prefix, nexthop_count=3,
                               is_route_flow_counter_supported_flag=is_route_flow_counter_supported,
-                              ipv6=False):
+                              ipv6=ipv6):
         # Save config and perform warmboot
         duthost.shell('config save -y')
         reboot(duthost, localhost, reboot_type='warm', wait_warmboot_finalizer=True, safe_reboot=True)
@@ -652,6 +659,8 @@ def test_static_route_ipv6_warmboot(localhost, rand_selected_dut, rand_unselecte
     3. Continue to forward traffic correctly after warmboot completes
     """
     duthost = rand_selected_dut
+    if is_mellanox_device(duthost) and not is_issu_enabled(duthost):
+        pytest.skip("ISSU is not enabled on this HWSKU, warm reboot is not supported")
     unselected_duthost = rand_unselected_dut
     prefix = "2000:3::/64"
 
@@ -679,12 +688,13 @@ def test_static_route_config_reload_with_traffic(rand_selected_dut, rand_unselec
     duthost = rand_selected_dut
     unselected_duthost = rand_unselected_dut
     is_dual_tor = 'dualtor' in tbinfo['topo']['name'] and unselected_duthost is not None
-    prefix = "5.5.5.0/24"
+    ipv6 = is_ipv6_only_topology(tbinfo)
+    prefix = "2000:5::/64" if ipv6 else "5.5.5.0/24"
 
     with static_route_context(duthost, unselected_duthost, ptfadapter, ptfhost, tbinfo,
                               prefix, nexthop_count=2,
                               is_route_flow_counter_supported_flag=is_route_flow_counter_supported,
-                              ipv6=False):
+                              ipv6=ipv6):
         # Perform config reload
         duthost.shell('config save -y')
         if duthost.facts["platform"] == "x86_64-cel_e1031-r0":


### PR DESCRIPTION

### Description of PR
Summary:
Fixes # (issue)
Add ISSU (In-Service Software Upgrade) skip check for Mellanox devices in warm reboot
static route tests, and adapt IPv4-only tests to support IPv6-only topologies.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: pass
- 202605: pass

### Approach
#### What is the motivation for this PR?
1. **ISSU skip check**: On Mellanox platforms, warm reboot requires ISSU to be enabled.
   If ISSU is not enabled on the HWSKU, the warm reboot tests will fail. These tests
   should be skipped rather than failing when ISSU is not supported.
2. **IPv6 topology support**: Several static route warm reboot and config reload tests
   were hardcoded to use IPv4 prefixes (e.g., `3.3.3.0/24`, `4.4.4.0/24`, `5.5.5.0/24`)
   and passed `ipv6=False` to `static_route_context()`. This causes failures on
   IPv6-only topologies where IPv4 is not available.

#### How did you do it?
1. Added `is_issu_enabled()` check at the beginning of three warm reboot test functions:
   - `test_static_route_warmboot`
   - `test_static_route_ecmp_warmboot`
   - `test_static_route_ipv6_warmboot`
   If the device is Mellanox and ISSU is not enabled, the test is skipped with a clear message.
2. Updated four test functions to dynamically select IPv4 or IPv6 prefixes based on topology:
   - `test_static_route_warmboot`: `3.3.3.0/24` → `2000:3::/64` when IPv6-only
   - `test_static_route_ecmp_warmboot`: `4.4.4.0/24` → `2000:4::/64` when IPv6-only
   - `test_static_route_ipv6_warmboot`: already uses IPv6 prefix, only added ISSU check
   - `test_static_route_config_reload_with_traffic`: `5.5.5.0/24` → `2000:5::/64` when IPv6-only

#### How did you verify/test it?
Verified on Mellanox platform with both IPv4 and IPv6-only topologies.

#### Any platform specific information?
Any
#### Supported testbed topology if it's a new test case?
t0, m0, mx

### Documentation
N/A
