### PR TITLE
[SmartSwitch HA] Correct ha skip file paths and move them to the ha section

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3111,6 +3111,66 @@ ha/:
       - "hwsku not in ['Cisco-8102-28FH-DPU-O-T1', 'Mellanox-SN4280-O8C40', 'Mellanox-SN4280-O28', 'Cisco-8102-28FH-DPU-O']"
       - "topo_name not in 't1-smartswitch-ha'"
 
+ha/test_ha_bfd_pin.py:
+  xfail:
+    reason: "BFD pin test is expected to fail on Cisco 8102 SmartSwitch with SONiC 202511"
+    conditions:
+      - "is_smartswitch == True and platform in ['x86_64-8102_28fh_dpu_o-r0'] and branch in ['202511', 'internal-202511']"
+
+ha/test_ha_bfd_pin.py::test_ha_bfd_pin[Primary Traffic-Both Sides Pinned]:
+  xfail:
+    reason: "Test scenario does not apply to NVIDIA SmartSwitch"
+    conditions:
+      - "hwsku in ['Mellanox-SN4280-O28', 'Mellanox-SN4280-O8C40']"
+
+ha/test_ha_bfd_pin.py::test_ha_bfd_pin[Standby Traffic-Both Sides Pinned]:
+  xfail:
+    reason: "Test scenario does not apply to NVIDIA SmartSwitch"
+    conditions:
+      - "hwsku in ['Mellanox-SN4280-O28', 'Mellanox-SN4280-O8C40']"
+
+ha/test_ha_eni_out_of_order.py:
+  skip:
+    reason: "Test scenario does not apply to NPU-driven NVIDIA SmartSwitch"
+    conditions:
+      - "hwsku in ['Mellanox-SN4280-O28', 'Mellanox-SN4280-O8C40']"
+
+ha/test_ha_npu_process_crash.py::TestNpuProcessCrash::test_crash_active_npu_traffic_on_active[bgp]:
+  skip:
+    reason: "BGP process crash is only tested when HA owner is 'dpu'; skip on switch-owner SmartSwitch"
+    conditions:
+      - "hwsku in ['Mellanox-SN4280-O28', 'Mellanox-SN4280-O8C40']"
+
+ha/test_ha_npu_process_crash.py::TestNpuProcessCrash::test_crash_active_npu_traffic_on_standby[bgp]:
+  skip:
+    reason: "BGP process crash is only tested when HA owner is 'dpu'; skip on switch-owner SmartSwitch"
+    conditions:
+      - "hwsku in ['Mellanox-SN4280-O28', 'Mellanox-SN4280-O8C40']"
+
+ha/test_ha_npu_process_crash.py::TestNpuProcessCrash::test_crash_standby_npu_traffic_on_active[bgp]:
+  skip:
+    reason: "BGP process crash is only tested when HA owner is 'dpu'; skip on switch-owner SmartSwitch"
+    conditions:
+      - "hwsku in ['Mellanox-SN4280-O28', 'Mellanox-SN4280-O8C40']"
+
+ha/test_ha_npu_process_crash.py::TestNpuProcessCrash::test_crash_standby_npu_traffic_on_standby[bgp]:
+  skip:
+    reason: "BGP process crash is only tested when HA owner is 'dpu'; skip on switch-owner SmartSwitch"
+    conditions:
+      - "hwsku in ['Mellanox-SN4280-O28', 'Mellanox-SN4280-O8C40']"
+
+ha/test_ha_repairing_dpu.py:
+  xfail:
+    reason: "HA repairing DPU test is expected to fail on Cisco 8102 SmartSwitch with SONiC 202511"
+    conditions:
+      - "is_smartswitch == True and platform in ['x86_64-8102_28fh_dpu_o-r0'] and branch in ['202511', 'internal-202511']"
+
+ha/test_ha_split_brain.py:
+  skip:
+    reason: "Test scenario does not apply to NPU-driven NVIDIA SmartSwitch"
+    conditions:
+      - "hwsku in ['Mellanox-SN4280-O28', 'Mellanox-SN4280-O8C40']"
+
 #######################################
 #####           hash              #####
 #######################################
@@ -5724,66 +5784,6 @@ test_vs_chassis_setup.py:
     conditions:
       - "asic_type not in ['vs']"
       - *lossyTopos
-
-tests/ha/test_ha_bfd_pin.py:
-  xfail:
-    reason: "BFD pin test is expected to fail on Cisco 8102 SmartSwitch with SONiC 202511"
-    conditions:
-      - "is_smartswitch == True and platform in ['x86_64-8102_28fh_dpu_o-r0'] and branch in ['202511', 'internal-202511']"
-
-tests/ha/test_ha_bfd_pin.py::test_ha_bfd_pin[Primary Traffic-Both Sides Pinned]:
-  xfail:
-    reason: "Test scenario does not apply to NVIDIA SmartSwitch"
-    conditions:
-      - "hwsku in ['Mellanox-SN4280-O28', 'Mellanox-SN4280-O8C40']"
-
-tests/ha/test_ha_bfd_pin.py::test_ha_bfd_pin[Standby Traffic-Both Sides Pinned]:
-  xfail:
-    reason: "Test scenario does not apply to NVIDIA SmartSwitch"
-    conditions:
-      - "hwsku in ['Mellanox-SN4280-O28', 'Mellanox-SN4280-O8C40']"
-
-tests/ha/test_ha_eni_out_of_order.py:
-  skip:
-    reason: "Test scenario does not apply to NPU-driven NVIDIA SmartSwitch"
-    conditions:
-      - "hwsku in ['Mellanox-SN4280-O28', 'Mellanox-SN4280-O8C40']"
-
-tests/ha/test_ha_npu_process_crash.py::TestNpuProcessCrash::test_crash_active_npu_traffic_on_active[bgp]:
-  skip:
-    reason: "BGP process crash is only tested when HA owner is 'dpu'; skip on switch-owner SmartSwitch"
-    conditions:
-      - "hwsku in ['Mellanox-SN4280-O28']"
-
-tests/ha/test_ha_npu_process_crash.py::TestNpuProcessCrash::test_crash_active_npu_traffic_on_standby[bgp]:
-  skip:
-    reason: "BGP process crash is only tested when HA owner is 'dpu'; skip on switch-owner SmartSwitch"
-    conditions:
-      - "hwsku in ['Mellanox-SN4280-O28']"
-
-tests/ha/test_ha_npu_process_crash.py::TestNpuProcessCrash::test_crash_standby_npu_traffic_on_active[bgp]:
-  skip:
-    reason: "BGP process crash is only tested when HA owner is 'dpu'; skip on switch-owner SmartSwitch"
-    conditions:
-      - "hwsku in ['Mellanox-SN4280-O28']"
-
-tests/ha/test_ha_npu_process_crash.py::TestNpuProcessCrash::test_crash_standby_npu_traffic_on_standby[bgp]:
-  skip:
-    reason: "BGP process crash is only tested when HA owner is 'dpu'; skip on switch-owner SmartSwitch"
-    conditions:
-      - "hwsku in ['Mellanox-SN4280-O28']"
-
-tests/ha/test_ha_repairing_dpu.py:
-  xfail:
-    reason: "HA repairing DPU test is expected to fail on Cisco 8102 SmartSwitch with SONiC 202511"
-    conditions:
-      - "is_smartswitch == True and platform in ['x86_64-8102_28fh_dpu_o-r0'] and branch in ['202511', 'internal-202511']"
-
-tests/ha/test_ha_split_brain.py:
-  skip:
-    reason: "Test scenario does not apply to NPU-driven NVIDIA SmartSwitch"
-    conditions:
-      - "hwsku in ['Mellanox-SN4280-O28', 'Mellanox-SN4280-O8C40']"
 
 #######################################
 #####         upgrade_path        #####


### PR DESCRIPTION
### Description of PR

Summary:
1. Some of the recently added skip conditions for the smartswitch HA tests are not in the correct section, move them to the correct section.
2. Remove the "tests/" prefix, this is wrong actually and would not work in the past, but a recent PR relaxed it: https://github.com/sonic-net/sonic-mgmt/pull/25930. Even though, we still need remove it to align with other entries and pass the alphabetic order check.
3. Add Mellanox-SN4280-O8C40 to some of the confitions.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
Tests are correctly skipped on SN4280 HA tetsbed:
<img width="963" height="813" alt="image" src="https://github.com/user-attachments/assets/2b894dca-b811-4bba-b7ba-344068d53763" />


### Approach
#### What is the motivation for this PR?
Fix issues in the HA test skip conditions.
#### How did you do it?
1. Move the entries to the correct section.
2. Remove the "tests/" prefix.
3. Add Mellanox-SN4280-O8C40 to some of the confitions.
#### How did you verify/test it?
Run the full HA test suite on SN4280 HA testbed.

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
