### PR TITLE
[dhcp_relay] Cover Option 82 reply lifecycle for both agents

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -182,10 +182,6 @@ class DHCPTest(DataplaneBaseTest):
         # 'dual' for dual tor testing
         # 'single' for regular single tor testing
         self.dual_tor = (self.test_params['testing_mode'] == 'dual')
-        self.sonic_reply_uses_option82 = (
-            self.relay_agent == "sonic-relay-agent"
-            and (self.dual_tor or (self.link_selection and self.source_interface))
-        )
         self.vlan_iface_name = self.test_params.get('downlink_vlan_iface_name', None)
 
         # option82 is a byte string created by the relay agent. It contains the circuit_id and remote_id fields.
@@ -194,10 +190,16 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 0: Suboption number, always set to 1
         #  Byte 1: Length of suboption data in bytes
         #  Bytes 2+: Suboption data
-        # Our circuit_id string is of the form "hostname:portname"
-        circuit_id_string = self.hostname + ":" + self.client_iface_alias
-        if self.relay_agent == "sonic-relay-agent":
-            circuit_id_string = circuit_id_string + ":" + self.vlan_iface_name
+        if self.relay_agent == "isc-relay-agent":
+            # ISC identifies the client circuit by hostname and physical port alias.
+            circuit_id_string = self.hostname + ":" + self.client_iface_alias
+        elif self.relay_agent == "sonic-relay-agent":
+            # SONiC also encodes the VLAN used by its reply path to recover the client circuit.
+            circuit_id_string = (
+                self.hostname + ":" + self.client_iface_alias + ":" + self.vlan_iface_name
+            )
+        else:
+            raise ValueError("Unsupported DHCP relay agent: {}".format(self.relay_agent))
         self.option82 = struct.pack('BB', self.CIRCUIT_ID_SUBOPTION, len(circuit_id_string))
         self.option82 += circuit_id_string.encode('utf-8')
 
@@ -273,6 +275,20 @@ class DHCPTest(DataplaneBaseTest):
         self.dest_mac_address = self.test_params['dest_mac_address']
         self.client_udp_src_port = self.test_params['client_udp_src_port']
         self.enable_source_port_ip_in_relay = self.test_params.get('enable_source_port_ip_in_relay', False)
+
+    def add_option82_to_server_reply(self, packet):
+        """Model an Option 82-aware server echoing the relay option verbatim."""
+        options = packet[scapy.DHCP].options
+        options.insert(options.index("end"), (82, self.option82))
+        return packet
+
+    def pad_relayed_reply_after_option82_removal(self, packet):
+        """Model relay padding after it removes Option 82 before client delivery."""
+        bootp_len = len(packet[scapy.BOOTP])
+        pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - bootp_len
+        if pad_bytes > 0:
+            packet /= scapy.PADDING(b"\x00" * pad_bytes)
+        return packet
 
     def tearDown(self):
         DataplaneBaseTest.tearDown(self)
@@ -824,13 +840,7 @@ class DHCPTest(DataplaneBaseTest):
                           dhcp_lease=self.LEASE_TIME,
                           padding_bytes=0,
                           set_broadcast_bit=True)
-        if (self.link_selection and self.source_interface) or self.dual_tor:
-            dhcp_ack_packet[scapy.DHCP].options.insert(
-                dhcp_ack_packet[scapy.DHCP].options.index("end"),
-                (82, self.option82)
-            )
-
-        return dhcp_ack_packet
+        return self.add_option82_to_server_reply(dhcp_ack_packet)
 
     def create_dhcp_ack_relayed_packet(self):
         my_chaddr = binascii.unhexlify(self.client_mac.replace(':', ''))
@@ -878,11 +888,7 @@ class DHCPTest(DataplaneBaseTest):
         # if pad_bytes > 0:
         #    bootp /= scapy.PADDING('\x00' * pad_bytes)
 
-        if self.sonic_reply_uses_option82:
-            pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - len(bootp)
-            if pad_bytes > 0:
-                bootp /= scapy.PADDING('\x00' * pad_bytes)
-
+        bootp = self.pad_relayed_reply_after_option82_removal(bootp)
         pkt = ether / ip / udp / bootp
         return pkt
 
@@ -1103,22 +1109,14 @@ class DHCPTest(DataplaneBaseTest):
         dhcp_unknown = self.create_dhcp_offer_packet()
         logger.info("Server send unknown packet")
         dhcp_unknown[scapy.DHCP] = scapy.DHCP(options=[('message-type', 11), ('end')])
-        if self.sonic_reply_uses_option82:
-            dhcp_unknown[scapy.DHCP].options.insert(
-                    dhcp_unknown[scapy.DHCP].options.index("end"),
-                    (82, self.option82)
-            )
+        dhcp_unknown = self.add_option82_to_server_reply(dhcp_unknown)
         log_dhcp_packet_info(dhcp_unknown)
         testutils.send_packet(self, self.server_port_indices[0], dhcp_unknown)
 
     def verify_relayed_unknown_on_client_side(self):
         dhcp_offer = self.create_dhcp_offer_relayed_packet()
         dhcp_offer[scapy.DHCP] = scapy.DHCP(options=[('message-type', 11), ('end')])
-        if self.sonic_reply_uses_option82:
-            bootp_len = len(dhcp_offer[scapy.BOOTP])
-            pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - bootp_len
-            if pad_bytes > 0:
-                dhcp_offer = dhcp_offer / scapy.PADDING(b"\x00" * pad_bytes)
+        dhcp_offer = self.pad_relayed_reply_after_option82_removal(dhcp_offer)
         masked_offer = Mask(dhcp_offer)
         self.set_common_ignored_mask_fields(masked_offer)
 
@@ -1147,22 +1145,14 @@ class DHCPTest(DataplaneBaseTest):
         # Build the DHCP NAK packet
         packet = self.create_dhcp_ack_packet()
         packet[scapy.DHCP] = scapy.DHCP(options=[('message-type', 'nak'), ('server_id', self.server_ip[0]), ('end')])
-        if self.sonic_reply_uses_option82:
-            packet[scapy.DHCP].options.insert(
-                    packet[scapy.DHCP].options.index("end"),
-                    (82, self.option82)
-            )
+        packet = self.add_option82_to_server_reply(packet)
         log_dhcp_packet_info(packet)
         testutils.send_packet(self, self.server_port_indices[0], packet)
 
     def verify_relayed_nak(self):
         dhcp_nak = self.create_dhcp_ack_relayed_packet()
         dhcp_nak[scapy.DHCP] = scapy.DHCP(options=[('message-type', 'nak'), ('server_id', self.server_ip[0]), ('end')])
-        if self.sonic_reply_uses_option82:
-            bootp_len = len(dhcp_nak[scapy.BOOTP])
-            pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - bootp_len
-            if pad_bytes > 0:
-                dhcp_nak = dhcp_nak / scapy.PADDING(b"\x00" * pad_bytes)
+        dhcp_nak = self.pad_relayed_reply_after_option82_removal(dhcp_nak)
         masked_ack = Mask(dhcp_nak)
         self.set_common_ignored_mask_fields(masked_ack)
         self.check_pkt_on_client_side(masked_ack, dhcp_nak, "Nak")

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -182,6 +182,10 @@ class DHCPTest(DataplaneBaseTest):
         # 'dual' for dual tor testing
         # 'single' for regular single tor testing
         self.dual_tor = (self.test_params['testing_mode'] == 'dual')
+        self.sonic_reply_uses_option82 = (
+            self.relay_agent == "sonic-relay-agent"
+            and (self.dual_tor or (self.link_selection and self.source_interface))
+        )
         self.vlan_iface_name = self.test_params.get('downlink_vlan_iface_name', None)
 
         # option82 is a byte string created by the relay agent. It contains the circuit_id and remote_id fields.
@@ -874,7 +878,7 @@ class DHCPTest(DataplaneBaseTest):
         # if pad_bytes > 0:
         #    bootp /= scapy.PADDING('\x00' * pad_bytes)
 
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - len(bootp)
             if pad_bytes > 0:
                 bootp /= scapy.PADDING('\x00' * pad_bytes)
@@ -1099,7 +1103,7 @@ class DHCPTest(DataplaneBaseTest):
         dhcp_unknown = self.create_dhcp_offer_packet()
         logger.info("Server send unknown packet")
         dhcp_unknown[scapy.DHCP] = scapy.DHCP(options=[('message-type', 11), ('end')])
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             dhcp_unknown[scapy.DHCP].options.insert(
                     dhcp_unknown[scapy.DHCP].options.index("end"),
                     (82, self.option82)
@@ -1110,7 +1114,7 @@ class DHCPTest(DataplaneBaseTest):
     def verify_relayed_unknown_on_client_side(self):
         dhcp_offer = self.create_dhcp_offer_relayed_packet()
         dhcp_offer[scapy.DHCP] = scapy.DHCP(options=[('message-type', 11), ('end')])
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             bootp_len = len(dhcp_offer[scapy.BOOTP])
             pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - bootp_len
             if pad_bytes > 0:
@@ -1143,7 +1147,7 @@ class DHCPTest(DataplaneBaseTest):
         # Build the DHCP NAK packet
         packet = self.create_dhcp_ack_packet()
         packet[scapy.DHCP] = scapy.DHCP(options=[('message-type', 'nak'), ('server_id', self.server_ip[0]), ('end')])
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             packet[scapy.DHCP].options.insert(
                     packet[scapy.DHCP].options.index("end"),
                     (82, self.option82)
@@ -1154,7 +1158,7 @@ class DHCPTest(DataplaneBaseTest):
     def verify_relayed_nak(self):
         dhcp_nak = self.create_dhcp_ack_relayed_packet()
         dhcp_nak[scapy.DHCP] = scapy.DHCP(options=[('message-type', 'nak'), ('server_id', self.server_ip[0]), ('end')])
-        if self.relay_agent == "sonic-relay-agent" and (self.link_selection and self.source_interface):
+        if self.sonic_reply_uses_option82:
             bootp_len = len(dhcp_nak[scapy.BOOTP])
             pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - bootp_len
             if pad_bytes > 0:


### PR DESCRIPTION
### Description of PR

Summary:
Make the DHCP relay PTF model express the Option 82 contract and implementation differences directly:

- ISC Circuit-ID is `hostname:port-alias`.
- SONiC Circuit-ID is `hostname:port-alias:Vlan`.
- An Option 82-aware server echoes the complete option verbatim in replies for both agents.
- Both relays remove Option 82 before forwarding replies to the client.

This closes the ISC ACK/NAK reply coverage gap discovered while resolving ADO 38650789.

Merged prerequisite:

- https://github.com/sonic-net/sonic-mgmt/pull/26285

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: https://msazure.visualstudio.com/One/_workitems/edit/38650789
Failure type: test coverage gap

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: exact restacked head `ee409924d62eefb76f1519cf553bd319756b03ca`; [Azure build 1194551](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1194551) passed every required check. Current PR KVM configuration skips `test_dhcpv4_relay.py`, so this run supplies static/integration coverage rather than fresh DHCPv4 relay functional coverage.
- 202605: exact behavioral head `2b043561989ff5ca9c10061cf6f764a18fb3f53e` was included in the combined `internal-202605` validation stack with PRs #26299, #26108, #26285, and #26311 and relay fixes #120/#121. On physical m0 and dual-ToR testbeds running `SONiC.20260510.06`, `test_dhcp_relay_default` and `test_dhcp_relay_unicast_mac` passed for both ISC and SONiC relay agents. `test_dhcp_relay_default[sonic-relay-agent]` also passed five consecutive runs on each topology. The current restack replayed only this PR's isolated commit after #26285 merged; old and new stable patch ID are both `535031a1f581132635976f7f5ee113ceecceaace`, so the reviewed behavior is unchanged.

### Approach
#### What is the motivation for this PR?

RFC 3046 requires an Option 82-aware DHCP server to echo the complete Relay Agent Information option in its replies, after which the relay removes it before client delivery. The current test models this for OFFER, but ACK and NAK coverage is conditional and does not exercise ISC reply stripping.

PR #26285 fixes the immediate dual-ToR SONiC nightly failure. This follow-up separates the shared protocol contract from the implementation-specific Circuit-ID encoding and applies the echo-and-strip model consistently to both relay agents.

#### How did you do it?

- Made the ISC and SONiC Circuit-ID formats explicit branches in the test setup.
- Added a shared helper for server-side Option 82 echoing.
- Added a shared helper for expected relay padding after Option 82 removal.
- Applied the shared lifecycle to ACK, NAK, and unknown reply coverage for both agents.

#### How did you verify/test it?

Pre-restack head `2b043561989ff5ca9c10061cf6f764a18fb3f53e` was exercised through the default and unicast DHCP relay flows for both agents on physical m0 and dual-ToR 202605 testbeds. After #26285 merged, the child branch was restacked by dropping the old prerequisite commit and replaying only this PR's own commit. The stable patch ID remained unchanged, `git diff --check` passed, and exact-head Azure build 1194551 is fully green.

#### Any platform specific information?

The explicit Circuit-ID values differ by relay implementation. The Option 82 server echo and relay removal lifecycle is shared.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.

##### Work item tracking

- Microsoft ADO **(number only)**: 38650789
