### PR TITLE
[qos/sai]: Fix fill_leakout_plus_one no-op on single-ASIC

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -900,12 +900,12 @@ def fill_leakout_plus_one(
         pkts_num_egr_mem=None):
     # Attempts to queue 1 packet while compensating for a varying packet leakout.
     # Returns whether 1 packet was successfully enqueued.
-    if pkts_num_egr_mem is not None:
-        if test_case.clients['dst'] != test_case.clients['src']:
-            fill_egress_plus_one(
-                test_case, src_port_id, pkt, queue,
-                asic_type, int(pkts_num_egr_mem))
-        return
+
+    if test_case.clients['dst'] != test_case.clients['src'] and pkts_num_egr_mem is not None:
+        fill_egress_plus_one(
+            test_case, src_port_id, pkt, queue,
+            asic_type, int(pkts_num_egr_mem))
+        return True
 
     if asic_type in ['cisco-8000']:
         queue_counters_base = sai_thrift_read_queue_occupancy(


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue internal to Cisco)

`fill_leakout_plus_one()` is a no-op on single-ASIC setups when a
`pkts_num_egr_mem` value is supplied. The function guards its egress-fill with
`if pkts_num_egr_mem is not None:` and then only does work when `dst != src`
(multi-ASIC); on single-ASIC (`dst == src`) it returns early without priming the
egress leakout at all.

On platforms with a deep egress pipeline (observed on Cisco cisco-8000 / G200X),
watermark tests that rely on this priming - notably `PGSharedWatermarkTest` -
therefore undershoot the expected watermark at high fill and fail.

This is a small, general fix to `fill_leakout_plus_one()`: single-ASIC now
falls through to the normal cisco-8000 queue-occupancy fill and primes the
leakout correctly. The multi-ASIC path is unchanged, and the fix is not gated
on any specific ASIC.

Background: the early-return path was introduced in #9780 (porting the
202205 sai-qos-tests changes to master) and stayed latent until a later change
began passing a non-None `pkts_num_egr_mem` into the single-ASIC PG-shared path,
which turned the guard true and exposed the no-op.

Reviewer starting point:
- `tests/saitests/py3/sai_qos_tests.py` - `fill_leakout_plus_one()`

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511
- [X] 202512
- [X] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type:  Regression, exposed by [this merge](https://github.com/sonic-net/sonic-mgmt/pull/24668)

### Approach
#### What is the motivation for this PR?

`fill_leakout_plus_one()` returns early without priming the egress leakout on
single-ASIC (`dst == src`) whenever `pkts_num_egr_mem` is not None. On a deep
egress pipeline (cisco-8000 / G200X) the missing priming makes the ingress PG
shared watermark read short at high fill, so
`testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossy]` fails.

#### How did you do it?

Restructured the early-return condition so the egress-fill branch is taken only
when `dst != src` **and** `pkts_num_egr_mem is not None`. Single-ASIC now falls
through to the existing cisco-8000 queue-occupancy fill, which primes the
leakout correctly. The change is confined to `fill_leakout_plus_one()`; no test
parameters or per-ASIC gating were added.

#### How did you verify/test it?

Ran the PG shared watermark test on a single-ASIC cisco-8000 (Cisco-8122X) t0
testbed:

- `testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossy]` - PASS

The multi-ASIC (`dst != src`) egress-fill branch is preserved, so multi-ASIC
cisco-8000 and non-cisco-8000 platforms are unaffected.

#### Any platform specific information?

The failure was observed on Cisco cisco-8000 (G200X / Cisco-8122X) because of
its deep egress pipeline, but the change is general single-ASIC behavior in
`fill_leakout_plus_one()` and is not gated on any specific ASIC. Shallower
pipelines were already unaffected, so this cannot introduce a regression there.

#### Supported testbed topology if it's a new test case?

Not a new test case - a bug fix to shared test helper logic. Exercised on
single-ASIC t0.

### Documentation

N/A - no functional/user-facing change; test-infrastructure fix only.
