### PR TITLE
[dhcp_relay]: Restore relay-specific Remote-ID expectation

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -205,20 +205,8 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 0: Suboption number, always set to 2
         #  Byte 1: Length of suboption data in bytes
         #  Bytes 2+: Suboption data
-        if self.relay_agent == "isc-relay-agent" and not self.dual_tor:
-            # Single-ToR ISC uses the receiving VLAN MAC, which is the base MAC.
-            remote_id_string = self.relay_iface_mac
-        elif self.relay_agent == "sonic-relay-agent" and not self.dual_tor:
-            # Single-ToR SONiC uses the base MAC, which is also the VLAN MAC.
-            remote_id_string = self.relay_iface_mac
-        elif self.relay_agent == "isc-relay-agent" and self.dual_tor:
-            # Dual-ToR ISC uses the receiving VLAN's virtual MAC.
-            remote_id_string = self.relay_iface_mac
-        elif self.relay_agent == "sonic-relay-agent" and self.dual_tor:
-            # Dual-ToR SONiC uses the switch base MAC, not the virtual VLAN MAC.
-            remote_id_string = self.uplink_mac
-        else:
-            raise ValueError("Unsupported DHCP relay agent: {}".format(self.relay_agent))
+        # Our remote_id string simply consists of the MAC address of the port that received the request
+        remote_id_string = self.uplink_mac if self.dual_tor and self.relay_agent == "sonic-relay-agent" else self.relay_iface_mac
         self.option82 += struct.pack('BB', self.REMOTE_ID_SUBOPTION, len(remote_id_string))
         self.option82 += remote_id_string.encode('utf-8')
 

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -205,13 +205,20 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 0: Suboption number, always set to 2
         #  Byte 1: Length of suboption data in bytes
         #  Bytes 2+: Suboption data
-        # Single-ToR ISC: relay_iface_mac (base MAC).
-        # Single-ToR SONiC: relay_iface_mac (base MAC).
-        # Dual-ToR ISC: relay_iface_mac (virtual VLAN MAC).
-        # Dual-ToR SONiC: uplink_mac (base MAC).
-        remote_id_string = self.relay_iface_mac
-        if self.relay_agent == "sonic-relay-agent" and self.dual_tor:
+        if self.relay_agent == "isc-relay-agent" and not self.dual_tor:
+            # Single-ToR ISC uses the receiving VLAN MAC, which is the base MAC.
+            remote_id_string = self.relay_iface_mac
+        elif self.relay_agent == "sonic-relay-agent" and not self.dual_tor:
+            # Single-ToR SONiC uses the base MAC, which is also the VLAN MAC.
+            remote_id_string = self.relay_iface_mac
+        elif self.relay_agent == "isc-relay-agent" and self.dual_tor:
+            # Dual-ToR ISC uses the receiving VLAN's virtual MAC.
+            remote_id_string = self.relay_iface_mac
+        elif self.relay_agent == "sonic-relay-agent" and self.dual_tor:
+            # Dual-ToR SONiC uses the switch base MAC, not the virtual VLAN MAC.
             remote_id_string = self.uplink_mac
+        else:
+            raise ValueError("Unsupported DHCP relay agent: {}".format(self.relay_agent))
         self.option82 += struct.pack('BB', self.REMOTE_ID_SUBOPTION, len(remote_id_string))
         self.option82 += remote_id_string.encode('utf-8')
 

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -205,7 +205,7 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 0: Suboption number, always set to 2
         #  Byte 1: Length of suboption data in bytes
         #  Bytes 2+: Suboption data
-        # Our remote_id string simply consists of the MAC address of the port that received the request
+        # SONiC dual-ToR uses the switch base MAC; other paths use the receiving VLAN interface MAC.
         remote_id_string = (
             self.uplink_mac
             if self.dual_tor and self.relay_agent == "sonic-relay-agent"

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -206,7 +206,11 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 1: Length of suboption data in bytes
         #  Bytes 2+: Suboption data
         # Our remote_id string simply consists of the MAC address of the port that received the request
-        remote_id_string = self.uplink_mac if self.dual_tor and self.relay_agent == "sonic-relay-agent" else self.relay_iface_mac
+        remote_id_string = (
+            self.uplink_mac
+            if self.dual_tor and self.relay_agent == "sonic-relay-agent"
+            else self.relay_iface_mac
+        )
         self.option82 += struct.pack('BB', self.REMOTE_ID_SUBOPTION, len(remote_id_string))
         self.option82 += remote_id_string.encode('utf-8')
 

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -205,9 +205,13 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 0: Suboption number, always set to 2
         #  Byte 1: Length of suboption data in bytes
         #  Bytes 2+: Suboption data
-        # remote_id (suboption 2) is the switch base MAC. On dual-ToR the VLAN carries a virtual MAC,
-        # so the relay stamps the base MAC (uplink_mac); on single-ToR relay_iface_mac already equals it.
-        remote_id_string = self.uplink_mac if self.dual_tor else self.relay_iface_mac
+        # Single-ToR ISC: relay_iface_mac (base MAC).
+        # Single-ToR SONiC: relay_iface_mac (base MAC).
+        # Dual-ToR ISC: relay_iface_mac (virtual VLAN MAC).
+        # Dual-ToR SONiC: uplink_mac (base MAC).
+        remote_id_string = self.relay_iface_mac
+        if self.relay_agent == "sonic-relay-agent" and self.dual_tor:
+            remote_id_string = self.uplink_mac
         self.option82 += struct.pack('BB', self.REMOTE_ID_SUBOPTION, len(remote_id_string))
         self.option82 += remote_id_string.encode('utf-8')
 


### PR DESCRIPTION
### Description of PR

Summary:
Restore relay-specific Option 82 Remote-ID expectations after #26055 applied the SONiC dual-ToR value to ISC relay tests.

Regression from #26055.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: https://msazure.visualstudio.com/One/_workitems/edit/38757669
Failure type: regression

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: all 26 current PR checks passed.
- 202605: exact PR head `ad3068964569b2c158ce5a10ddb7cdc5848b6b73` was included in the combined `internal-202605` validation stack on physical m0 and dual-ToR testbeds running `SONiC.20260510.06`. `test_dhcp_relay_default` and `test_dhcp_relay_unicast_mac` passed for both ISC and SONiC relay agents on both topologies. `test_dhcp_relay_default[sonic-relay-agent]` also passed five consecutive runs on each topology.

### Approach
#### What is the motivation for this PR?

#26055 fixed the SONiC relay expectation on dual-ToR by using the switch base MAC, but selected the value only by topology. ISC relay continues to use the receiving VLAN interface MAC, so the change caused the original ISC test path to expect the wrong Remote-ID.

#### How did you do it?

Keep `relay_iface_mac` for ISC relay in both topologies. Use `uplink_mac` only for SONiC relay on dual-ToR, where the VLAN interface carries a virtual MAC.

#### How did you verify/test it?

The combined 202605 hardware validation exercised the corrected ISC and SONiC Remote-ID expectations through the full default and unicast relay flows on m0 and dual-ToR.

#### Any platform specific information?

The regression affects dual-ToR, where ISC and SONiC relay intentionally encode different Remote-ID MACs.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.

##### Work item tracking

- Microsoft ADO **(number only)**: 38757669
