### PR TITLE
[topo] Announce routes for t1-d96u4 backend neighbors

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -83,6 +83,14 @@ BGP_SCALE_T1S = [
     't1-isolated-d254u2', 't1-isolated-d254u2s1', 't1-isolated-d254u2s2',
     't1-isolated-d510u2', 't1-isolated-d510u2s2'
 ]
+T1_ROUTER_TYPE_BY_PROPERTY = {
+    'spine': 'spine',
+    'leaf': 'leaf',
+    'tor': 'tor',
+    'bt0': 'tor',
+    'bt1': 'leaf',
+    'bt2': 'spine',
+}
 ROUTES_BATCH_SIZE = 200
 
 # Describe default number of COLOs
@@ -619,6 +627,14 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
             current_routes_offset += last_suffix
 
 
+def get_t1_router_type(properties):
+    """Map topology property groups to the T1 synthetic route model."""
+    for property_name in properties:
+        if property_name in T1_ROUTER_TYPE_BY_PROPERTY:
+            return T1_ROUTER_TYPE_BY_PROPERTY[property_name]
+    return None
+
+
 def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce", tor_default_route=False,
                downstream_neighbor_groups=0, topo_routes={}):
     common_config = topo['configuration_properties'].get('common', {})
@@ -725,13 +741,14 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
         aggregate_routes_v6 = get_ipv6_routes(aggregate_routes)
         if k not in topo_routes:
             topo_routes[k] = {}
-        router_type = None
-        if 'spine' in v['properties']:
-            router_type = 'spine'
-        elif 'tor' in v['properties']:
-            router_type = 'tor'
+        router_type = get_t1_router_type(v['properties'])
         tornum = v.get('tornum', None)
         tor_index = tornum - 1 if tornum is not None else None
+        if 'bt0' in v['properties'] and tor_index is not None:
+            # The backend topology can have more BT0 peers than logical ToRs in
+            # the synthetic route space. Reuse indices so every peer announces
+            # routes instead of dropping peers whose index exceeds tor_number.
+            tor_index %= tor_number
         if router_type:
             if enable_ipv4_routes_generation:
                 routes_v4, _ = generate_routes("v4", podset_number, tor_number, tor_subnet_number,

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -627,7 +627,7 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
             current_routes_offset += last_suffix
 
 
-def get_t1_router_type(properties):
+def get_router_type(properties):
     """Map topology property groups to the T1 synthetic route model."""
     for property_name in properties:
         if property_name in T1_ROUTER_TYPE_BY_PROPERTY:
@@ -647,6 +647,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
     tor_subnet_size = common_config.get("tor_subnet_size", TOR_SUBNET_SIZE)
     nhipv4 = common_config.get("nhipv4", NHIPV4)
     nhipv6 = common_config.get("nhipv6", NHIPV6)
+    spine_asn = common_config.get("spine_asn", SPINE_ASN)
     leaf_asn_start = common_config.get("leaf_asn_start", LEAF_ASN_START)
     tor_asn_start = common_config.get("tor_asn_start", TOR_ASN_START)
     ipv6_address_pattern = common_config.get("ipv6_address_pattern", IPV6_ADDRESS_PATTERN_DEFAULT_VALUE)
@@ -741,7 +742,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
         aggregate_routes_v6 = get_ipv6_routes(aggregate_routes)
         if k not in topo_routes:
             topo_routes[k] = {}
-        router_type = get_t1_router_type(v['properties'])
+        router_type = get_router_type(v['properties'])
         tornum = v.get('tornum', None)
         tor_index = tornum - 1 if tornum is not None else None
         if 'bt0' in v['properties'] and tor_index is not None:
@@ -752,7 +753,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
         if router_type:
             if enable_ipv4_routes_generation:
                 routes_v4, _ = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
-                                               None, leaf_asn_start, tor_asn_start,
+                                               spine_asn, leaf_asn_start, tor_asn_start,
                                                nhipv4, nhipv6, tor_subnet_size, max_tor_subnet_number, "t1",
                                                router_type=router_type, tor_index=tor_index,
                                                no_default_route=curr_no_default_route,
@@ -764,7 +765,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
                 routes_to_change[port] += routes_v4
             if enable_ipv6_routes_generation:
                 routes_v6, _ = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
-                                               None, leaf_asn_start, tor_asn_start,
+                                               spine_asn, leaf_asn_start, tor_asn_start,
                                                nhipv4, nhipv6, tor_subnet_size, max_tor_subnet_number, "t1",
                                                router_type=router_type, tor_index=tor_index,
                                                no_default_route=curr_no_default_route,


### PR DESCRIPTION
## Summary

Follow up to #25903 and [this post-merge review finding](https://github.com/sonic-net/sonic-mgmt/pull/25903#issuecomment-4998191393).

`fib_t1_lag()` only recognized the literal `tor` and `spine` property groups. The new topology uses `bt0`, `bt1`, and `bt2`, so `add-topo` started ExaBGP sessions but generated no synthetic routes for any of the 96 backend neighbors.

## Changes

- Map `bt0` to the existing `tor` route model.
- Map `bt1` to the existing `leaf` route model.
- Map `bt2` to the existing `spine` route model.
- Reuse the 16 logical ToR indices across 60 BT0 peers so every backend ToR session announces routes instead of dropping peers whose `tornum` exceeds `tor_number`.
- Preserve existing `tor` and `spine` behavior for other T1 topologies.

## Validation

- `python -m py_compile ansible/library/announce_routes.py`
- Full `t1-d96u4` dry-run route generation:
  - BT0: 60/60 neighbors, 2 IPv4 + 2 IPv6 routes each
  - BT1: 32/32 neighbors, 6,399 IPv4 + 6,399 IPv6 routes each
  - BT2: 4/4 neighbors, 6,369 IPv4 + 6,369 IPv6 routes each
  - T2: unchanged at 6,369 IPv4 + 6,369 IPv6 routes each
- Representative KVM deployment: `testbed_announce_routes.yml` completed with `failed=0`.
- DUT BGP received-prefix counts after live injection, for both IPv4 and IPv6:
  - BT0: 3 (2 synthetic + neighbor loopback)
  - BT1: 6,400
  - BT2: 6,370
  - T2: 6,370

<img width="1090" height="711" alt="image" src="https://github.com/user-attachments/assets/bb40a047-826e-4f82-a2ae-4cd7e28e1aa4" />


Signed-off-by: r12f <r12f.code@gmail.com>
