### PR TITLE
[cacl] Expect FRR loopback ACL rules (ports 2601/2620); temp-skip pending image fix

### DIFF
--- a/.azure-pipelines/impacted_area_testing/constant.py
+++ b/.azure-pipelines/impacted_area_testing/constant.py
@@ -13,7 +13,10 @@ PR_TOPOLOGY_TYPE = ["t0_checker", "t0-2vlans_checker", "t0-sonic_checker", "t1_c
 
 EXCLUDE_TEST_SCRIPTS = [
     "test_posttest.py",
-    "test_pretest.py"
+    "test_pretest.py",
+    # Temporary: skip until sonic-buildimage#28061 (caclmgrd FRR loopback ACL rules
+    # submodule bump for sonic-host-services#389) is merged.
+    "cacl/test_cacl_application.py"
 ]
 
 # The mapping of topology type in PR test and topology recorded in kusto and the name of PR test.

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -73,6 +73,9 @@ t0:
   - snmp/test_snmp_phy_entity.py
   # Remove from PR test in https://github.com/sonic-net/sonic-mgmt/pull/6073
   - cacl/test_ebtables_application.py
+  # Temporary: skip until sonic-buildimage#28061 (caclmgrd FRR loopback ACL rules
+  # submodule bump for sonic-host-services#389) is merged.
+  - cacl/test_cacl_application.py
   # There is no table SYSTEM_HEALTH_INFO in STATE_DB on kvm testbed
   # The tests in this script are all related to the above table
   - system_health/test_system_health.py
@@ -133,6 +136,9 @@ t1-lag:
   - snmp/test_snmp_phy_entity.py
   # Remove from PR test in https://github.com/sonic-net/sonic-mgmt/pull/6073
   - cacl/test_ebtables_application.py
+  # Temporary: skip until sonic-buildimage#28061 (caclmgrd FRR loopback ACL rules
+  # submodule bump for sonic-host-services#389) is merged.
+  - cacl/test_cacl_application.py
   # There is no table SYSTEM_HEALTH_INFO in STATE_DB on kvm testbed
   # The tests in this script are all related to the above table
   - system_health/test_system_health.py
@@ -187,6 +193,9 @@ t2:
   - snmp/test_snmp_phy_entity.py
   # Remove from PR test in https://github.com/sonic-net/sonic-mgmt/pull/6073
   - cacl/test_ebtables_application.py
+  # Temporary: skip until sonic-buildimage#28061 (caclmgrd FRR loopback ACL rules
+  # submodule bump for sonic-host-services#389) is merged.
+  - cacl/test_cacl_application.py
   # There is no table SYSTEM_HEALTH_INFO in STATE_DB on kvm testbed
   # The tests in this script are all related to the above table
   - system_health/test_system_health.py

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -794,6 +794,15 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
             iptables_rules.append("-A FORWARD -j DROP")
             ip6tables_rules.append("-A FORWARD -j DROP")
 
+    # Restrict access to FRR daemon TCP ports (zebra VTY 2601, fpmsyncd<->zebra 2620) on the
+    # loopback interface to the frr user (uid 300) only. caclmgrd applies this OUTPUT-chain
+    # ACCEPT(uid-owner)+DROP pair per port in every managed namespace (see
+    # sonic-net/sonic-host-services#389), so it is expected regardless of asic_index.
+    iptables_rules.append("-A OUTPUT -o lo -p tcp -m tcp --dport 2620 -m owner --uid-owner 300 -j ACCEPT")
+    iptables_rules.append("-A OUTPUT -o lo -p tcp -m tcp --dport 2601 -m owner --uid-owner 300 -j ACCEPT")
+    iptables_rules.append("-A OUTPUT -o lo -p tcp -m tcp --dport 2620 -j DROP")
+    iptables_rules.append("-A OUTPUT -o lo -p tcp -m tcp --dport 2601 -j DROP")
+
     # IP Table rule to allow eth1-midplane traffic for chassis
     if asic_index is None:
         append_midplane_traffic_rules(duthost, iptables_rules)


### PR DESCRIPTION
## What is the motivation for this PR?

Port the OUTPUT-chain rule expectations from an internal (ADO `sonic-mgmt-int`, PR 8937) test change now that the corresponding caclmgrd change has landed publicly in [sonic-net/sonic-host-services#389](https://github.com/sonic-net/sonic-host-services/pull/389).

caclmgrd restricts access to FRR daemon TCP ports on the loopback interface -- zebra VTY (`2601`) and fpmsyncd&lt;-&gt;zebra (`2620`) -- to the `frr` user (uid 300) only, via an OUTPUT-chain `ACCEPT (uid-owner)` + `DROP` rule pair per port. Per sonic-host-services#389, this is applied in **every managed namespace**, including per-ASIC namespaces on multi-asic platforms.

## What is changed?

`generate_expected_rules()` in `tests/cacl/test_cacl_application.py` now appends these 4 expected OUTPUT-chain rules unconditionally, regardless of `asic_index`:

```
-A OUTPUT -o lo -p tcp -m tcp --dport 2620 -m owner --uid-owner 300 -j ACCEPT
-A OUTPUT -o lo -p tcp -m tcp --dport 2601 -m owner --uid-owner 300 -j ACCEPT
-A OUTPUT -o lo -p tcp -m tcp --dport 2620 -j DROP
-A OUTPUT -o lo -p tcp -m tcp --dport 2601 -j DROP
```

Note: the original internal PR gated this behind `if "master" not in duthost.os_version:`, because at the time public master had not yet picked up the caclmgrd fix. This port intentionally **omits** that exclusion, since the fix is now public and expected on all currently-tested branches going forward.

**Temporary skip**: The sonic-buildimage submodule bump that actually pulls sonic-host-services#389 into built images ([sonic-net/sonic-buildimage#28061](https://github.com/sonic-net/sonic-buildimage/pull/28061)) has not yet merged. Until it does, PR-checker images won't have this fix, so `cacl/test_cacl_application.py` is temporarily added to the `t0`/`t1-lag`/`t2` skip lists in `.azure-pipelines/pr_test_skip_scripts.yaml` (matching the existing `cacl/test_ebtables_application.py` skip pattern already in this file). **This skip should be removed once #28061 merges.**

## How did you verify it?

- `python3 -m py_compile tests/cacl/test_cacl_application.py`
- `flake8 --max-line-length=120 tests/cacl/test_cacl_application.py` -- clean, no new issues.
- Validated `.azure-pipelines/pr_test_skip_scripts.yaml` with `yaml.safe_load()` after the edits.

## Related

- sonic-host-services PR (merged): https://github.com/sonic-net/sonic-host-services/pull/389
- sonic-buildimage submodule bump (pending): https://github.com/sonic-net/sonic-buildimage/pull/28061
