### PR TITLE
[ha]: Restore DPU after power-down test failure

### DIFF
--- a/tests/ha/ha_dpu_utils.py
+++ b/tests/ha/ha_dpu_utils.py
@@ -5,6 +5,7 @@ from tests.common.utilities import wait_until
 # (tests/smartswitch/common/device_utils_dpu.py: DPU_MAX_ONLINE_TIMEOUT / DPU_TIME_INT).
 CHECK_DPU_STATE_TIMEOUT = 360
 CHECK_DPU_STATE_TIME_INT = 30
+DPU_TRANSITION_SETTLE_TIMEOUT = 120
 DPU_STARTUP_ATTEMPTS = 2
 
 logger = logging.getLogger(__name__)
@@ -17,7 +18,7 @@ def dpu_power_on_for_index(duthost, dpu_index):    # noqa F811
     """
     for attempt in range(1, DPU_STARTUP_ATTEMPTS + 1):
         startup_accepted = wait_until(
-            CHECK_DPU_STATE_TIMEOUT, CHECK_DPU_STATE_TIME_INT, 0,
+            DPU_TRANSITION_SETTLE_TIMEOUT, CHECK_DPU_STATE_TIME_INT, 0,
             _startup_dpu_when_transition_settled, duthost, dpu_index
         )
         if not startup_accepted:

--- a/tests/ha/ha_dpu_utils.py
+++ b/tests/ha/ha_dpu_utils.py
@@ -5,6 +5,7 @@ from tests.common.utilities import wait_until
 # (tests/smartswitch/common/device_utils_dpu.py: DPU_MAX_ONLINE_TIMEOUT / DPU_TIME_INT).
 CHECK_DPU_STATE_TIMEOUT = 360
 CHECK_DPU_STATE_TIME_INT = 30
+DPU_STARTUP_ATTEMPTS = 2
 
 logger = logging.getLogger(__name__)
 
@@ -14,15 +15,49 @@ def dpu_power_on_for_index(duthost, dpu_index):    # noqa F811
     """
     Executes power on for a specific DPU
     """
-    try:
-        duthost.shell(f"sudo config chassis module startup DPU{dpu_index}")
-    except Exception as e:
-        logger.error(f"Error powering on dpu{dpu_index}: {e}")
-        return False
+    for attempt in range(1, DPU_STARTUP_ATTEMPTS + 1):
+        startup_accepted = wait_until(
+            CHECK_DPU_STATE_TIMEOUT, CHECK_DPU_STATE_TIME_INT, 0,
+            _startup_dpu_when_transition_settled, duthost, dpu_index
+        )
+        if not startup_accepted:
+            return False
 
-    status = wait_until(CHECK_DPU_STATE_TIMEOUT, CHECK_DPU_STATE_TIME_INT, 0,
-                        check_dpu_up_state, duthost, dpu_index)
-    return status
+        if wait_until(CHECK_DPU_STATE_TIMEOUT, CHECK_DPU_STATE_TIME_INT, 0,
+                      check_dpu_up_state, duthost, dpu_index):
+            return True
+
+        logger.warning(
+            "DPU%d did not become Online/up after startup attempt %d on %s",
+            dpu_index, attempt, duthost.hostname
+        )
+
+    return False
+
+
+def _startup_dpu_when_transition_settled(duthost, dpu_index):
+    """Request startup after any prior chassis state transition has settled."""
+    if check_dpu_up_state(duthost, dpu_index):
+        return True
+
+    result = duthost.shell(
+        f"sudo config chassis module startup DPU{dpu_index}",
+        module_ignore_errors=True
+    )
+    output = f"{result.get('stdout', '')}\n{result.get('stderr', '')}"
+    if "state transition is already in progress" in output.lower():
+        logger.info(
+            "DPU%d startup is blocked by a state transition on %s",
+            dpu_index, duthost.hostname
+        )
+        return False
+    if result.get("rc", 1) != 0:
+        logger.error(
+            "Failed to request startup for DPU%d on %s: %s",
+            dpu_index, duthost.hostname, output.strip()
+        )
+        return False
+    return True
 
 
 def dpu_power_off_for_index(duthost, dpu_index):    # noqa F811
@@ -44,9 +79,7 @@ def check_dpu_up_state(duthost, dpu_index):
     """
     Checks if DPU is up.
 
-    Mirrors check_dpu_module_status(..., "on", ...) from the smartswitch reload
-    test (tests/smartswitch/common/device_utils_dpu.py): a DPU is UP when it is
-    not "offline" in "show chassis module status".
+    A DPU is UP when chassis status reports Online/up.
     Args:
         duthost : Host handle
         dpu_index: Index of the DPU
@@ -86,19 +119,20 @@ def check_dpu_module_status(duthost, power_status, dpu_name):
     Returns:
         Returns True or False based on status of the given DPU module
     """
-    output_dpu_status = duthost.shell(
-        'show chassis module status | grep %s' % (dpu_name), module_ignore_errors=True)
-    stdout = output_dpu_status.get("stdout", "").lower()
-
-    if "offline" in stdout:
-        logger.info(f"'{dpu_name}' is offline on {duthost.hostname}")
-        return power_status == "off"
-    elif "online" in stdout:
-        logger.info(f"'{dpu_name}' is online on {duthost.hostname}")
-        return power_status == "on"
-    else:
-        logger.warning(
-            f"{dpu_name} status on {duthost.hostname} is neither online nor "
-            f"offline. stdout={stdout!r}"
-        )
+    entries = duthost.show_and_parse("show chassis module status")
+    entry = next(
+        (item for item in entries if item.get("name") == dpu_name),
+        None
+    )
+    if entry is None:
+        logger.warning("'%s' is missing from chassis module status on %s",
+                       dpu_name, duthost.hostname)
         return False
+
+    oper_status = entry.get("oper-status", "").lower()
+    admin_status = entry.get("admin-status", "").lower()
+    logger.info("'%s' is oper=%s admin=%s on %s",
+                dpu_name, oper_status, admin_status, duthost.hostname)
+    if power_status == "off":
+        return oper_status == "offline"
+    return oper_status == "online" and admin_status == "up"

--- a/tests/ha/test_ha_dpu_power_down.py
+++ b/tests/ha/test_ha_dpu_power_down.py
@@ -193,15 +193,22 @@ def test_ha_dpu_failure(
         dut, scope_key, expected_state="down",
         timeout=60, interval=5,
     )
-    pytest_assert(
-        down_ok,
-        f"{dut.hostname}: DASH_HA_SCOPE_STATE PMON fields did not reach "
-        f"'down' for {scope_key} while {dpu_name} was powered off. "
-        f"Observed: {down_state}"
-    )
 
-    logger.info(f"Startup {dpu_name} on {dut.hostname}")
-    pytest_assert(dpu_power_on_for_index(dut, dpu_id), f"Failed to bring up {dpu_name} on {dut.hostname}")
+    # Restore the DPU before fixture teardown even when state validation fails.
+    try:
+        pytest_assert(
+            down_ok,
+            f"{dut.hostname}: DASH_HA_SCOPE_STATE PMON fields did not reach "
+            f"'down' for {scope_key} while {dpu_name} was powered off. "
+            f"Observed: {down_state}"
+        )
+    finally:
+        logger.info(f"Startup {dpu_name} on {dut.hostname}")
+        power_on_ok = dpu_power_on_for_index(dut, dpu_id)
+        if not power_on_ok:
+            logger.error(f"Failed to bring up {dpu_name} on {dut.hostname}")
+
+    pytest_assert(power_on_ok, f"Failed to bring up {dpu_name} on {dut.hostname}")
 
     # Verify HA scope PMON state returns to "up" after powering the DPU back on.
     logger.info(


### PR DESCRIPTION
### Description of PR

Summary:
Prevent an HA power-down assertion failure from leaving a DPU shut down before fixture teardown and causing cascading test failures.

Fixes # N/A

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: other

### Approach
#### What is the motivation for this PR?

When the DPU power-down state assertion fails, the test raises before restarting the DPU. Function teardown then runs a forced configuration reload against the unavailable DPU, which can leave the testbed unhealthy and cause subsequent HA modules to fail during setup.

#### How did you do it?

The test now restores the DPU in a `finally` block before propagating the state assertion. DPU startup waits for an in-progress chassis transition to settle, retries a bounded number of times, and requires a strict `Online/up` state.

#### How did you verify/test it?

- Python compilation and pytest collection
- Repository pre-commit checks, including flake8
- Isolated execution of `test_ha_dpu_failure[Standby DPU Fail-Standby Traffic]` on a SmartSwitch HA testbed
- The existing PMON state assertion exercised the failure path; the DPU recovered automatically to `Online/up`, teardown configuration reload completed, and no unreachable-host cascade occurred

#### Any platform specific information?

SmartSwitch platforms with chassis-managed DPUs.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
