### PR TITLE
[transceiver/eeprom]: Add dynamic DataPath field verification (TC#4 step-4 + scenario S1)

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -14,7 +14,6 @@ from natsort import natsorted
 from .transceiver_utils import all_transceivers_detected
 import ast
 from tests.common.mellanox_data import is_mellanox_device
-from tests.common.utilities import wait_until
 
 
 def parse_intf_status(lines):
@@ -108,6 +107,10 @@ def wait_ports_oper_status(duthost, ports, status, wait_sec, poll_interval_sec=2
     as a failure (rather than raising) so a missing/renamed port aggregates like
     any other laggard.
     """
+    # Imported lazily to avoid a module-load import cycle
+    # (tests.common.utilities <-> tests.common.platform.interface_utils).
+    from tests.common.utilities import wait_until
+
     def _ports_not_at_status():
         snapshot = get_dut_interfaces_status(duthost)
         return [port for port in ports

--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -14,6 +14,7 @@ from natsort import natsorted
 from .transceiver_utils import all_transceivers_detected
 import ast
 from tests.common.mellanox_data import is_mellanox_device
+from tests.common.utilities import wait_until
 
 
 def parse_intf_status(lines):
@@ -92,6 +93,32 @@ def expect_interface_status(dut, interface_name, expected_op_status):
     if status is None:
         raise Exception(f'interface name {interface_name} does not exist')
     return status['oper'] == expected_op_status
+
+
+def wait_ports_oper_status(duthost, ports, status, wait_sec, poll_interval_sec=2):
+    """Poll until every port in ``ports`` reaches oper-``status``; return failures.
+
+    Issues a single ``show interface description`` per poll (one full-table dump,
+    parsed once) and checks every port against that snapshot, rather than one CLI
+    call per port -- the latter is O(N) redundant dumps per poll and does not
+    scale to hundreds of ports.
+
+    Returns a list with one string per port still not at oper-``status`` after
+    ``wait_sec``; empty once all reach it. A port absent from the dump is reported
+    as a failure (rather than raising) so a missing/renamed port aggregates like
+    any other laggard.
+    """
+    def _ports_not_at_status():
+        snapshot = get_dut_interfaces_status(duthost)
+        return [port for port in ports
+                if (snapshot.get(port) or {}).get("oper") != status]
+
+    if wait_until(wait_sec, poll_interval_sec, 0, lambda: not _ports_not_at_status()):
+        return []
+    return [
+        "port {} did not reach oper-{} within {}s".format(port, status, wait_sec)
+        for port in _ports_not_at_status()
+    ]
 
 
 def check_interface_status(dut, asic_index, interfaces, xcvr_skip_list):

--- a/tests/transceiver/common/eeprom_decode.py
+++ b/tests/transceiver/common/eeprom_decode.py
@@ -93,6 +93,19 @@ def is_dac(eeprom_attrs):
     return isinstance(cable_type, str) and cable_type.strip().upper() == "DAC"
 
 
+def is_cmis_active_optical(eeprom_attrs):
+    """True if the module is CMIS **active optical** (``cmis_active_optical`` true).
+
+    CMIS active-optical modules publish the dynamic DataPath fields
+    (``active_apsel_hostlane*`` and lane counts) that passive-copper / flat-memory
+    and non-CMIS modules do not, so several tests scope to these ports. The
+    ``cmis_revision``-based :func:`classify` gate ensures a stray
+    ``cmis_active_optical`` on a non-CMIS entry does not qualify.
+    """
+    return (classify(eeprom_attrs) is ModuleFamily.CMIS
+            and bool(eeprom_attrs.get("cmis_active_optical")))
+
+
 def extract_ascii_field(page_data, start_addr, length):
     """Extract a fixed-width ASCII string from a hexdump page byte map.
 

--- a/tests/transceiver/common/scenario_ops.py
+++ b/tests/transceiver/common/scenario_ops.py
@@ -1,0 +1,82 @@
+"""Reusable, feature-agnostic scenario *operation* helpers for transceiver tests.
+
+Shared half of the scenario-coverage model
+(``docs/testplan/transceiver/scenario_test_template.md``): a scenario pairs a
+``perform_<op>`` from here with a feature-owned ``verify_<feature>_*`` verifier,
+so EEPROM/DOM/VDM/PM reuse the same disruptive operations. The operations act on
+a *list* of ports (one bulk config + a single settle wait) and return the
+suite-wide list of per-port failure strings for aggregation into one
+``pytest.fail``.
+"""
+
+import logging
+
+from tests.common.platform.interface_utils import wait_ports_oper_status
+
+logger = logging.getLogger(__name__)
+
+# Base port count for scaling a *per-port* settle wait up to a *bulk*
+# (all-at-once) operation, matching ``tests/common/port_toggle.BASE_PORT_COUNT``
+# (the default t0 topology's ~28 toggled ports).
+BASE_PORT_COUNT = 28.0
+
+
+def scale_bulk_wait(per_port_wait_sec, num_ports):
+    """Scale a per-port settle wait to a bulk (all-at-once) operation budget.
+
+    A bulk shut/startup of ``num_ports`` ports settles slower than a single port,
+    so the per-port attribute (``port_startup_wait_sec`` /
+    ``port_shutdown_wait_sec``) is multiplied by
+    ``max(1, num_ports / BASE_PORT_COUNT)`` — the same port-count scaling
+    ``tests/common/port_toggle.default_port_toggle_wait_time`` uses. Because
+    ``wait_until`` polls and returns the instant every port settles, this only
+    raises the give-up ceiling; it never lengthens a fast run, so over-estimating
+    on a large fabric (e.g. 512 ports) is free.
+    """
+    factor = max(1.0, num_ports / BASE_PORT_COUNT)
+    return int(per_port_wait_sec * factor)
+
+
+def perform_ports_shutdown(duthost, ports, wait_sec):
+    """Admin-down all ``ports`` (one bulk config) then wait until each is oper-down.
+
+    Uses the canonical ``SonicHost.shutdown_multiple`` (single ``config interface
+    shutdown <p1>,<p2>,...``). Returns a list of per-port failure strings, one per
+    port that did not reach oper-down within ``wait_sec``; empty when all did.
+    """
+    if not ports:
+        logger.debug("perform_ports_shutdown called with no ports; nothing to do")
+        return []
+    duthost.shutdown_multiple(ports)
+    logger.info("Admin-down issued for %d port(s); waiting up to %ss for oper-down",
+                len(ports), wait_sec)
+    failures = wait_ports_oper_status(duthost, ports, "down", wait_sec)
+    if failures:
+        for failure in failures:
+            logger.warning("%s", failure)
+    else:
+        logger.info("All %d port(s) reached oper-down", len(ports))
+    return failures
+
+
+def perform_ports_startup(duthost, ports, wait_sec):
+    """Admin-up all ``ports`` (one bulk config) then wait until each is oper-up.
+
+    Uses the canonical ``SonicHost.no_shutdown_multiple`` (single ``config
+    interface startup <p1>,<p2>,...``). Returns a list of per-port failure
+    strings, one per port that did not reach oper-up within ``wait_sec``; empty
+    when all did.
+    """
+    if not ports:
+        logger.debug("perform_ports_startup called with no ports; nothing to do")
+        return []
+    duthost.no_shutdown_multiple(ports)
+    logger.info("Admin-up issued for %d port(s); waiting up to %ss for oper-up",
+                len(ports), wait_sec)
+    failures = wait_ports_oper_status(duthost, ports, "up", wait_sec)
+    if failures:
+        for failure in failures:
+            logger.warning("%s", failure)
+    else:
+        logger.info("All %d port(s) reached oper-up", len(ports))
+    return failures

--- a/tests/transceiver/eeprom/datapath.py
+++ b/tests/transceiver/eeprom/datapath.py
@@ -97,11 +97,16 @@ def _iter_targets(port_attributes_dict, ports):
     """Yield ``(port, attrs)`` for each CMIS active-optical port under test.
 
     ``ports`` (if not None) restricts to that subset; non-CMIS / non-active-optical
-    ports are skipped (DataPath fields do not apply to them).
+    ports are skipped (DataPath fields do not apply to them). When ``ports`` is
+    given we iterate it directly (O(len(ports)) dict look-ups) rather than
+    scanning every port and doing a membership test, so polling stays cheap on
+    large fabrics.
     """
-    for port, attrs in port_attributes_dict.items():
-        if ports is not None and port not in ports:
-            continue
+    if ports is None:
+        candidates = port_attributes_dict.items()
+    else:
+        candidates = ((port, port_attributes_dict.get(port)) for port in ports)
+    for port, attrs in candidates:
         if not attrs or not is_cmis_active_optical(attrs.get(EEPROM_ATTRIBUTES_KEY, {})):
             continue
         yield port, attrs

--- a/tests/transceiver/eeprom/datapath.py
+++ b/tests/transceiver/eeprom/datapath.py
@@ -1,0 +1,325 @@
+"""EEPROM dynamic DataPath-field helpers (absolute, attribute-derived checks).
+
+Feature-owned half of the scenario-coverage model for the EEPROM category's
+dynamic DataPath fields, read from ``show interfaces transceiver info``
+(``host_lane_count`` / ``media_lane_count`` and the per-host-lane
+``active_apsel_hostlane<n>`` codes; the CLI is a view over STATE_DB
+``TRANSCEIVER_INFO``).
+
+These are **absolute** checks against the inventory (EEPROM plan Generic TC 4
+step-4, reused by scenario S1 — see
+``docs/testplan/transceiver/eeprom_test_plan.md``). Expectations by module class:
+
+  * **non-CMIS** (``cmis_revision`` undefined) — skipped by the caller.
+  * **CMIS active optical** (``cmis_active_optical`` true) — each active host
+    lane (bit set in ``host_lane_mask``) equals the ``active_apsel_hostlane``
+    attribute's pinned code, or is non-``N/A`` when unpinned; inactive lanes
+    read ``N/A``.
+  * **CMIS passive-copper / flat-memory** (``cmis_active_optical`` false) —
+    every ``active_apsel_hostlane<n>`` reads ``N/A``.
+
+``host_lane_count`` / ``media_lane_count`` always equal ``BASE_ATTRIBUTES`` for
+both CMIS classes. On admin-down xcvrd clears all these fields to ``N/A``.
+
+The scenario verifiers (:func:`verify_datapath_recovered` /
+:func:`verify_datapath_cleared`) iterate the CMIS active-optical ports under test
+and **bulk-poll** (one ``show interfaces transceiver info`` per poll — the global
+CLI returns all logical ports across all ASICs in one shot — since the CLI can
+lag a shut/startup), aggregating per-port failures. They are scenario-agnostic —
+an orchestrator calls them after any disruptive operation (shut/no-shut, reboot,
+xcvrd restart, ...).
+"""
+import logging
+import re
+
+from tests.common.utilities import wait_until
+from tests.transceiver.attribute_parser.attribute_keys import (
+    BASE_ATTRIBUTES_KEY,
+    EEPROM_ATTRIBUTES_KEY,
+)
+from tests.transceiver.common import cli_helpers
+from tests.transceiver.common.eeprom_decode import is_cmis_active_optical
+
+logger = logging.getLogger(__name__)
+
+# Normalized (STATE_DB-style) per-host-lane apsel field key.
+_APSEL_RE = re.compile(r"^active_apsel_hostlane(\d+)$")
+
+# ``show interfaces transceiver info`` labels for the dynamic DataPath fields,
+# normalized to the STATE_DB-style keys above.
+_CLI_HOST_LANE_COUNT = "Host Lane Count"
+_CLI_MEDIA_LANE_COUNT = "Media Lane Count"
+_CLI_APSEL_RE = re.compile(
+    r"^Active application selected code assigned to host lane (\d+)$")
+
+# The string written for a dynamic DataPath field that is not applicable
+# (datapath down, or an inactive host lane).
+NA = "N/A"
+
+# Sentinel expected value meaning "active host lane whose apsel code is not
+# pinned by inventory": the field must simply be present and non-``N/A``.
+_NON_NA = object()
+
+_POLL_INTERVAL_SEC = 2
+
+
+def _normalize_cli_datapath_fields(cli_fields):
+    """Map ``show interfaces transceiver info`` labels to normalized DataPath keys.
+
+    Returns a ``{normalized_field: value}`` dict of only the dynamic DataPath
+    fields (lane counts + per-host-lane apsel codes) present in the CLI output.
+    """
+    normalized = {}
+    for label, value in cli_fields.items():
+        if label == _CLI_HOST_LANE_COUNT:
+            normalized["host_lane_count"] = value
+        elif label == _CLI_MEDIA_LANE_COUNT:
+            normalized["media_lane_count"] = value
+        else:
+            match = _CLI_APSEL_RE.match(label)
+            if match:
+                normalized["active_apsel_hostlane{}".format(match.group(1))] = value
+    return normalized
+
+
+def cmis_active_optical_ports(port_attributes_dict):
+    """Return the CMIS active-optical port names — the DataPath "ports under test".
+
+    A scenario shuts / reboots / restarts around this set and the DataPath
+    verifiers score it. Reusable across scenarios (shut/no-shut, reboot, xcvrd
+    restart, ...).
+    """
+    return [port for port, attrs in port_attributes_dict.items()
+            if attrs and is_cmis_active_optical(attrs.get(EEPROM_ATTRIBUTES_KEY, {}))]
+
+
+def _iter_targets(port_attributes_dict, ports):
+    """Yield ``(port, attrs)`` for each CMIS active-optical port under test.
+
+    ``ports`` (if not None) restricts to that subset; non-CMIS / non-active-optical
+    ports are skipped (DataPath fields do not apply to them).
+    """
+    for port, attrs in port_attributes_dict.items():
+        if ports is not None and port not in ports:
+            continue
+        if not attrs or not is_cmis_active_optical(attrs.get(EEPROM_ATTRIBUTES_KEY, {})):
+            continue
+        yield port, attrs
+
+
+def _read_targets_datapath(duthost, targets):
+    """Bulk-read normalized DataPath fields for ``targets`` — one CLI call.
+
+    ``targets`` is a list of ``(port, attrs)``. Issues a single
+    ``show interfaces transceiver info`` (no namespace flag — the global CLI
+    returns all logical ports across all ASICs in one shot) and returns
+    ``({port: {normalized_field: value}}, err)`` for the target ports, where
+    ``err`` is the CLI/parse error string (or ``None``). ``err`` is surfaced so a
+    *persistent* CLI failure is reported as itself, rather than being masked as
+    "no dynamic DataPath fields" when the parsed map comes back empty.
+    """
+    parsed_all, err = cli_helpers.show_interfaces_transceiver_info(duthost)
+    if err:
+        logger.debug("show interfaces transceiver info failed: %s", err)
+        parsed_all = {}
+    fields = {port: _normalize_cli_datapath_fields(parsed_all.get(port, {}))
+              for port, _ in targets}
+    return fields, err
+
+
+def _stray_flat_apsel_error(eeprom):
+    """Return an error string if inventory has flat ``active_apsel_hostlane<n>`` keys.
+
+    The pinned apsel codes must live in the nested ``active_apsel_hostlane`` dict
+    (``{"<lane>": code}``), NOT as flat ``active_apsel_hostlane<n>`` keys. Stray
+    flat keys are otherwise ignored, so every active lane would silently degrade
+    to the unpinned (non-``N/A``) check and a wrong apsel code would pass. This is
+    an inventory defect regardless of which check runs, so both the recovered/TC#4
+    path and the cleared (shut-side) path call it to fail loudly. Returns ``None``
+    when the inventory is well-formed.
+    """
+    stray_flat = sorted(key for key in eeprom if _APSEL_RE.match(key))
+    if stray_flat:
+        return (
+            "EEPROM_ATTRIBUTES has flat apsel keys {}; pin them under a nested "
+            "'active_apsel_hostlane' dict (e.g. {{\"1\": 1}}) instead"
+            .format(stray_flat))
+    return None
+
+
+def _expected_datapath_fields(port_attrs, present_fields, active_optical):
+    """Derive the expected steady-state value for each present dynamic field.
+
+    Absolute expectation from inventory (no live baseline). ``host_lane_count`` /
+    ``media_lane_count`` → ``BASE_ATTRIBUTES`` (as str) for every CMIS module.
+    Per-host-lane ``active_apsel_hostlane<n>``:
+      * ``active_optical`` True (CMIS active optical): the ``active_apsel_hostlane``
+        attribute's code for lane ``n`` when the lane is active (bit ``n-1`` set
+        in ``host_lane_mask``) and the attribute pins it; ``_NON_NA`` when active
+        but unpinned; ``N/A`` when inactive.
+      * ``active_optical`` False (CMIS passive-copper / flat-memory): ``N/A`` for
+        every lane (no DataPath application select).
+
+    ``present_fields`` is the keys of dynamic fields currently reported, so the
+    expectation is computed only for the lanes actually published.
+
+    Returns ``(expected_map, None)`` or ``(None, "<reason>")`` on an inventory gap.
+    """
+    base = port_attrs.get(BASE_ATTRIBUTES_KEY, {})
+    eeprom = port_attrs.get(EEPROM_ATTRIBUTES_KEY, {})
+
+    if "host_lane_count" not in base or "media_lane_count" not in base:
+        return None, "host_lane_count/media_lane_count missing from BASE_ATTRIBUTES"
+    try:
+        host_mask = int(str(base["host_lane_mask"]), 16)
+    except (KeyError, ValueError) as exc:
+        return None, "cannot resolve host_lane_mask from BASE_ATTRIBUTES ({})".format(exc)
+
+    apsel_attr = eeprom.get("active_apsel_hostlane")  # {"<lane>": code} or None
+
+    stray_err = _stray_flat_apsel_error(eeprom)
+    if stray_err:
+        return None, stray_err
+
+    expected = {
+        "host_lane_count": str(base["host_lane_count"]),
+        "media_lane_count": str(base["media_lane_count"]),
+    }
+    for field in present_fields:
+        match = _APSEL_RE.match(field)
+        if not match:
+            continue
+        lane = int(match.group(1))
+        if not active_optical:
+            # CMIS passive-copper / flat-memory: no DataPath app select.
+            expected[field] = NA
+            continue
+        is_active = bool(host_mask & (1 << (lane - 1)))
+        if not is_active:
+            expected[field] = NA
+        elif apsel_attr is not None and str(lane) in apsel_attr:
+            expected[field] = str(apsel_attr[str(lane)])
+        else:
+            # Active lane whose apsel code is not pinned by inventory.
+            expected[field] = _NON_NA
+    return expected, None
+
+
+def _field_matches(actual, expected):
+    """Return True if ``actual`` satisfies the ``expected`` value / sentinel."""
+    if expected is _NON_NA:
+        return actual is not None and actual != NA
+    return actual == expected
+
+
+def _compare_normalized(port_attrs, current, active_optical=True):
+    """Return failure strings comparing normalized DataPath fields vs inventory.
+
+    ``active_optical`` defaults to True — the scenario recovery check, whose ports
+    are all CMIS active optical; the TC#4 bulk path passes it explicitly per
+    module class.
+    """
+    if not current:
+        return ["no dynamic DataPath fields in show interfaces transceiver info"]
+    expected, err = _expected_datapath_fields(port_attrs, current, active_optical)
+    if err:
+        return [err]
+    failures = []
+    for field, value in expected.items():
+        actual = current.get(field)
+        if not _field_matches(actual, value):
+            want = "non-'N/A'" if value is _NON_NA else "'{}'".format(value)
+            failures.append("{}: expected {}, got '{}'".format(field, want, actual))
+    return failures
+
+
+def compare_datapath_fields(port_attrs, cli_fields, active_optical):
+    """Compare a port's already-parsed ``show interfaces transceiver info`` fields.
+
+    Pure (no I/O) — used by the EEPROM Generic TC 4 step-4 bulk check, which
+    parses one ``show interfaces transceiver info`` per ASIC and passes each
+    port's ``{cli_label: value}`` map here. Returns a list of failure strings.
+    """
+    return _compare_normalized(
+        port_attrs, _normalize_cli_datapath_fields(cli_fields), active_optical)
+
+
+def _cleared_failures(port_attrs, fields):
+    """Per-port failures for the cleared (datapath-down) check — all fields ``N/A``.
+
+    An absent/empty dynamic-field set is itself a failure (the fields must read
+    ``N/A``, not disappear) rather than a vacuous pass. A mis-formatted inventory
+    (flat ``active_apsel_hostlane<n>`` keys) is reported here too, so a port that
+    is only exercised by the shut-side check still surfaces the defect.
+    """
+    stray_err = _stray_flat_apsel_error(port_attrs.get(EEPROM_ATTRIBUTES_KEY, {}))
+    if stray_err:
+        return [stray_err]
+    if not fields:
+        return ["no dynamic DataPath fields in show interfaces transceiver info"]
+    return ["{}: expected 'N/A', got '{}'".format(field, value)
+            for field, value in fields.items() if value != NA]
+
+
+def _verify_targets(duthost, port_attributes_dict, wait_sec, ports, per_port_failures):
+    """Bulk-poll the CMIS active-optical target ports until ``per_port_failures``
+    returns ``[]`` for every one; aggregate per-port failure blocks.
+
+    ``per_port_failures(port_attrs, fields) -> list[str]`` is the per-port check.
+    Returns ``[]`` once all pass within ``wait_sec``; otherwise one failure block
+    per failing port. ``wait_sec == 0`` does a single **snapshot** check (no
+    polling) — for a pre-check on ports already at steady state, where there is
+    no transition to wait for. Scenario-agnostic (shut/no-shut, reboot, xcvrd
+    restart, ...).
+    """
+    targets = list(_iter_targets(port_attributes_dict, ports))
+    if not targets:
+        return []
+
+    def _all_ok():
+        fields, _ = _read_targets_datapath(duthost, targets)
+        return all(not per_port_failures(attrs, fields.get(port, {}))
+                   for port, attrs in targets)
+
+    if wait_until(wait_sec, _POLL_INTERVAL_SEC, 0, _all_ok):
+        return []
+
+    # Poll exhausted (or a ``wait_sec == 0`` snapshot, where ``wait_until`` never
+    # runs the predicate) — read once here to score the per-port failures. If the
+    # CLI itself failed, report that error (per port) instead of the generic
+    # "no dynamic DataPath fields", which would otherwise mask a real breakage.
+    current, err = _read_targets_datapath(duthost, targets)
+    failures = []
+    for port, attrs in targets:
+        if err and not current.get(port):
+            port_failures = ["show interfaces transceiver info failed: {}".format(err)]
+        else:
+            port_failures = per_port_failures(attrs, current.get(port, {}))
+        if port_failures:
+            failures.append(port + ":\n  " + "\n  ".join(port_failures))
+    return failures
+
+
+def verify_datapath_recovered(duthost, port_attributes_dict, wait_sec, ports=None):
+    """Assert every CMIS active-optical port under test has its DataPath fields at
+    the inventory-expected steady state (EEPROM Generic TC 4 step-4 absolute
+    check) — the template ``verify_<feature>_recovered``.
+
+    Iterates the ports under test (all CMIS active-optical, or the ``ports``
+    subset), bulk-polls up to ``wait_sec``, and aggregates per-port failure
+    blocks; ``[]`` when all pass. ``wait_sec == 0`` does a single snapshot check
+    (a pre-check on already-steady ports, where there is no transition to wait
+    for). Reusable after any disruptive operation.
+    """
+    return _verify_targets(
+        duthost, port_attributes_dict, wait_sec, ports, _compare_normalized)
+
+
+def verify_datapath_cleared(duthost, port_attributes_dict, wait_sec, ports=None):
+    """Assert every CMIS active-optical port under test has its DataPath fields
+    cleared to ``N/A`` (datapath down) — the shut/no-shut "while down" check.
+
+    Same iterate + bulk-poll + aggregate shape as :func:`verify_datapath_recovered`.
+    """
+    return _verify_targets(
+        duthost, port_attributes_dict, wait_sec, ports, _cleared_failures)

--- a/tests/transceiver/eeprom/test_datapath_scenario.py
+++ b/tests/transceiver/eeprom/test_datapath_scenario.py
@@ -1,0 +1,84 @@
+"""EEPROM Scenario Coverage — S1: DataPath field clear/restore on shut/no-shut.
+
+Implements scenario **S1** of the EEPROM plan
+(``docs/testplan/transceiver/eeprom_test_plan.md``) via the shared model: the
+``scenario_ops`` bulk operation helpers + the ``datapath`` verifiers. The test
+just orchestrates operation → verifier per the scenario template — all CMIS
+active-optical ports are shut together, verified cleared, brought back up
+together, then verified recovered; the verifiers iterate/aggregate internally.
+"""
+import logging
+
+import pytest
+
+from tests.transceiver.attribute_parser.attribute_keys import SYSTEM_ATTRIBUTES_KEY
+from tests.transceiver.common import scenario_ops
+from tests.transceiver.eeprom import datapath
+
+logger = logging.getLogger(__name__)
+
+
+def test_datapath_clear_restore_on_shut_noshut(duthost, port_attributes_dict):
+    """S1: DataPath fields clear to ``N/A`` on shut and restore on startup (bulk).
+
+    Follows the scenario-coverage skeleton: pre-check → bulk shut → verify
+    cleared → bulk startup → verify recovered → teardown. Per-port failures
+    aggregate into one ``pytest.fail``.
+    """
+    ports = datapath.cmis_active_optical_ports(port_attributes_dict)
+    if not ports:
+        pytest.skip("No CMIS active-optical ports to exercise for S1")
+
+    # Bulk settle waits: max of the System-shard per-port attrs across target
+    # ports (read directly so a missing key fails loudly), scaled to the number
+    # of ports since a bulk (all-at-once) shut/startup settles slower than a
+    # single port — see scenario_ops.scale_bulk_wait.
+    target_attrs = [port_attributes_dict[port] for port in ports]
+    shutdown_wait = scenario_ops.scale_bulk_wait(
+        max(a.get(SYSTEM_ATTRIBUTES_KEY, {})["port_shutdown_wait_sec"] for a in target_attrs),
+        len(ports))
+    # Per-port oper-up budget; used unscaled for the datapath republish poll
+    # (a per-port latency after link-up, not a bulk-throughput one) and scaled
+    # for the bulk oper-up waits below.
+    port_startup_wait = max(
+        a.get(SYSTEM_ATTRIBUTES_KEY, {})["port_startup_wait_sec"] for a in target_attrs)
+    startup_wait = scenario_ops.scale_bulk_wait(port_startup_wait, len(ports))
+
+    all_failures = []
+    # 1. Pre-check: DataPath already at steady state (so a post-op failure is
+    #    attributable to the shut/no-shut). Ports are already up and steady — no
+    #    transition to wait for — so this is a snapshot (``wait_sec=0``), unlike
+    #    the post-startup recovery which polls up to ``port_startup_wait``.
+    all_failures += datapath.verify_datapath_recovered(
+        duthost, port_attributes_dict, 0, ports=ports)
+
+    logger.info("S1: exercising DataPath clear/restore on %d port(s) "
+                "(shutdown_wait=%ss startup_wait=%ss)",
+                len(ports), shutdown_wait, startup_wait)
+    try:
+        # 2. Bulk shut, then verify DataPath cleared while down. On shutdown the
+        #    port is disabled (link drops) first and xcvrd clears the fields
+        #    after, so oper-down does NOT imply cleared yet — poll shutdown_wait.
+        all_failures += scenario_ops.perform_ports_shutdown(
+            duthost, ports, shutdown_wait)
+        all_failures += datapath.verify_datapath_cleared(
+            duthost, port_attributes_dict, shutdown_wait, ports=ports)
+
+        # 3. Bulk startup (waits for oper-up), then verify DataPath recovered.
+        #    oper-up does NOT guarantee xcvrd has already re-published the
+        #    datapath fields (TRANSCEIVER_INFO): a port can lag link-up by a
+        #    moment. That republish lag is a per-port latency (not scaled by the
+        #    fleet size), so poll up to the unscaled per-port port_startup_wait.
+        all_failures += scenario_ops.perform_ports_startup(
+            duthost, ports, startup_wait)
+        all_failures += datapath.verify_datapath_recovered(
+            duthost, port_attributes_dict, port_startup_wait, ports=ports)
+    finally:
+        # Teardown: ensure every exercised port is back up on any failure path.
+        scenario_ops.perform_ports_startup(duthost, ports, startup_wait)
+
+    if all_failures:
+        pytest.fail(
+            "DataPath clear/restore on shut/no-shut (S1) failures:\n"
+            + "\n".join(all_failures)
+        )

--- a/tests/transceiver/eeprom/test_eeprom_content.py
+++ b/tests/transceiver/eeprom/test_eeprom_content.py
@@ -10,6 +10,8 @@ from tests.transceiver.attribute_parser.attribute_keys import (
 )
 from tests.common.platform.interface_utils import is_first_subport
 from tests.transceiver.common import cli_helpers
+from tests.transceiver.common.eeprom_decode import ModuleFamily, classify
+from tests.transceiver.eeprom import datapath
 
 logger = logging.getLogger(__name__)
 
@@ -244,6 +246,26 @@ def _run_per_port_eeprom_check(
     return all_failures
 
 
+def _validate_datapath_fields(port, port_attrs, cli_fields):
+    """Generic TC#4 step 4: dynamic DataPath fields, by module class.
+
+    (a) non-CMIS (per :func:`eeprom_decode.classify`) or a port with no CLI
+    output (already reported as "not detected") → skipped; (b) CMIS active
+    optical (``cmis_active_optical`` true) and (c) CMIS passive-copper/flat-memory
+    (false) are delegated to :func:`datapath.compare_datapath_fields`, which
+    enforces the per-class ``active_apsel_hostlane<n>`` expectation with
+    ``host_lane_count`` / ``media_lane_count`` matching ``BASE_ATTRIBUTES``.
+    """
+    eeprom_attrs = port_attrs.get(EEPROM_ATTRIBUTES_KEY, {})
+    if not cli_fields:
+        return []  # not detected — already reported by _compare_eeprom_fields
+    if classify(eeprom_attrs) is not ModuleFamily.CMIS:
+        logger.debug("Port %s is non-CMIS, skipping DataPath step-4 check", port)
+        return []
+    active_optical = bool(eeprom_attrs.get("cmis_active_optical"))
+    return datapath.compare_datapath_fields(port_attrs, cli_fields, active_optical)
+
+
 def _run_bulk_eeprom_check(duthost, port_attributes_dict, source_label, key_mapping):
     """Bulk (all-sub-ports) check, used by the show-CLI variant.
 
@@ -279,9 +301,12 @@ def _run_bulk_eeprom_check(duthost, port_attributes_dict, source_label, key_mapp
         if not port_attrs:
             logger.debug("Port %s has no attributes, skipping", port)
             continue
+        cli_fields = parsed_by_port.get(port, {})
         port_failures = _compare_eeprom_fields(
-            port_attrs, parsed_by_port.get(port, {}), source_label, key_mapping,
+            port_attrs, cli_fields, source_label, key_mapping,
         )
+        # Generic TC#4 step 4: dynamic DataPath fields (by module class).
+        port_failures += _validate_datapath_fields(port, port_attrs, cli_fields)
         if port_failures:
             all_failures.append(port + ":\n  " + "\n  ".join(port_failures))
     return all_failures
@@ -332,7 +357,10 @@ def test_eeprom_content_verification_via_show_cli(duthost, port_attributes_dict)
 
     Mirror of :func:`test_eeprom_content_verification_via_sfputil` for the SONiC
     ``show`` CLI variant.  This variant additionally verifies firmware versions
-    (``Active Firmware`` / ``Inactive Firmware``), which only this CLI reports.
+    (``Active Firmware`` / ``Inactive Firmware``), which only this CLI reports,
+    and the Generic TC#4 step-4 dynamic DataPath fields (``host_lane_count`` /
+    ``media_lane_count`` and per-host-lane ``active_apsel_hostlane<n>``) by module
+    class via :func:`_validate_datapath_fields`.
 
     Runs on ALL sub-ports (not just the first): ``show interfaces transceiver
     info`` reads STATE_DB ``TRANSCEIVER_INFO``, which xcvrd populates per logical


### PR DESCRIPTION
### Description of PR

Summary: Adds absolute, inventory-derived verification of the dynamic **DataPath** fields exposed by `show interfaces transceiver info` for CMIS transceivers, and the shut/no-shut scenario that exercises them.

- **Generic TC#4 step-4**: for CMIS modules, verify `host_lane_count`/`media_lane_count` against `BASE_ATTRIBUTES` and each per-host-lane `active_apsel_hostlane<n>` against the `active_apsel_hostlane` inventory attribute (active lanes per `host_lane_mask`; inactive lanes `N/A`). CMIS passive-copper/flat-memory modules must report all-`N/A` apsel; non-CMIS modules are skipped.
- **Scenario S1**: DataPath fields clear to `N/A` on `config interface shutdown` and restore on `config interface startup` (bulk over all CMIS active-optical ports, poll + aggregate).

MSFT ADO - 38852775

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach

#### What is the motivation for this PR?

Extend the attribute-driven transceiver test framework (EEPROM category) to cover the dynamic DataPath fields, which reflect the module's active application-select configuration and are cleared/restored across datapath state transitions. This catches unintended apsel changes across firmware versions and validates xcvrd's clear/republish behavior on link down/up.

#### How did you do it?

- `tests/transceiver/eeprom/datapath.py` (new): per-module-class expectation derivation and bulk-polling `verify_datapath_recovered` / `verify_datapath_cleared` verifiers. Fails loudly on a mis-formatted (flat) `active_apsel_hostlane<n>` inventory instead of silently degrading, and surfaces a persistent CLI error rather than masking it as "no fields".
- `tests/transceiver/common/scenario_ops.py` (new): feature-agnostic bulk `perform_ports_shutdown` / `perform_ports_startup` operations with port-count wait scaling.
- `tests/transceiver/eeprom/test_datapath_scenario.py` (new): EEPROM scenario **S1** orchestration.
- `tests/transceiver/common/eeprom_decode.py`: `is_cmis_active_optical()` classifier.
- `tests/common/platform/interface_utils.py`: `wait_ports_oper_status()` bulk oper-status poll (single table dump per poll).
- `tests/transceiver/eeprom/test_eeprom_content.py`: wire the TC#4 step-4 DataPath check into the show-CLI variant.

On topologies without CMIS active-optical ports the scenario test skips.

#### How did you verify/test it?

- `flake8 --max-line-length=120` clean on all changed files.
- Unit-level harness over `datapath.py` covering: pinned-code match/mismatch, unpinned fallback, malformed-inventory guard (recovered + cleared paths), and persistent-CLI-error surfacing.
- To be validated on a VS/lab testbed with CMIS active-optical inventory.

#### Any platform specific information?

CMIS-only; non-CMIS modules are skipped. CMIS passive-copper/flat-memory ports are checked for all-`N/A` apsel.

#### Supported testbed topology if it's a new test case?

Any topology exposing CMIS active-optical transceivers; the scenario test `pytest.skip`s when none are present.

### Documentation

Behavior follows `docs/testplan/transceiver/eeprom_test_plan.md` (Generic TC 4 step-4 and Scenario S1). No new docs required.
