### PR TITLE
[dhcp_relay] Restore BOOTP VLAN giaddr expectation

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -1057,10 +1057,11 @@ class DHCPTest(DataplaneBaseTest):
         else:
             source_ip = self.portchannels_ip_list[0]
 
-        if ((self.link_selection and self.source_interface) or self.server_vrf or self.dual_tor):
-            giaddr = self.switch_loopback_ip
-        elif self.server_id_override or not self.dual_tor:
-            giaddr = self.relay_iface_ip
+        # Single-ToR DHCP and BOOTP use the client VLAN IP as giaddr. Dual-ToR DHCP
+        # uses Loopback0 because Option 82 Link Selection identifies the client link.
+        # BOOTP has no Option 82, so dual-ToR BOOTP must also use the client VLAN IP.
+        # ISC already does this; sonic-relay-agent requires the corresponding product fix.
+        giaddr = self.relay_iface_ip
 
         bootp_packet = self.create_bootp_packet(src_mac=self.uplink_mac, src_ip=source_ip, giaddr=giaddr,
                                                 sport=self.DHCP_SERVER_PORT, hops=2)

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -1057,9 +1057,8 @@ class DHCPTest(DataplaneBaseTest):
         else:
             source_ip = self.portchannels_ip_list[0]
 
-        # Single-ToR DHCP and BOOTP use the client VLAN IP as giaddr. Dual-ToR DHCP
-        # uses Loopback0 because Option 82 Link Selection identifies the client link.
-        # BOOTP has no Option 82, so dual-ToR BOOTP must also use the client VLAN IP.
+        # BOOTP has no Option 82 Link Selection, so giaddr must identify the receiving
+        # client VLAN in every topology.
         # ISC already does this; sonic-relay-agent requires the corresponding product fix.
         giaddr = self.relay_iface_ip
 


### PR DESCRIPTION
### Description of PR

Summary: Restore the BOOTP giaddr expectation to the receiving client VLAN for both single-ToR and dual-ToR. PR #19198 incorrectly extended the dual-ToR DHCP Loopback0 rule to BOOTP, which has no Option 82 Link Selection.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38538173

Dependency: https://github.com/sonic-net/sonic-dhcp-relay/pull/120

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: https://msazure.visualstudio.com/One/_workitems/edit/38538173
Failure type: regression

### Approach
#### What is the motivation for this PR?

BOOTP has no DHCP Option 82. Its giaddr must identify the client VLAN so the relay can return the reply to the correct downstream interface.

#### How did you do it?

Use relay_iface_ip unconditionally for the BOOTP packet expectation and document the DHCP/BOOTP and single/dual-ToR behavior split.

#### How did you verify/test it?

Cherry-picked this PR's exact head (`ab276dc75bba9237ccd5f863c082af0fb4857ad7`) onto `internal-202605` and tested on physical m0 and dual-ToR testbeds running `SONiC.20260510.06`, with a relay artifact containing the exact merged sonic-dhcp-relay PR #120 head (`92124a680747a4c4d6c4c1c8d1a31945e37f9ac2`).

- m0: default ISC and SONiC cases passed; unicast ISC and SONiC cases passed.
- dual-ToR: default ISC and SONiC cases passed; unicast ISC and SONiC cases passed.
- `test_dhcp_relay_default[sonic-relay-agent]` passed five consecutive runs on each topology.

The current PR `t0` failure used an image that predates sonic-dhcp-relay PR #120. Official CI must be rerun after the merged relay change reaches the test image.

#### Any platform specific information?

Applies to dual-ToR BOOTP for both ISC and SONiC relay agents.

#### Supported testbed topology if it is a new test case?

Not a new test case.

### Documentation

The behavior rationale is documented next to the corrected PTF expectation.

##### Work item tracking

- Microsoft ADO **(number only)**: 38538173
