### PR TITLE
[gcu] Reduce multi-op ACL table footprint

### DIFF
--- a/tests/generic_config_updater/test_apply_patch_perf.py
+++ b/tests/generic_config_updater/test_apply_patch_perf.py
@@ -52,6 +52,9 @@ MIN_OVERHEAD = 3
 # Deliberately generous to avoid false failures.
 FALLBACK_LOADDATA_TIME = 1.0
 
+CTRLPLANE_SERVICES = ["EXTERNAL_CLIENT", "NTP", "SNMP", "SSH"]
+REQUIRED_INGRESS_DATAPLANE_ACL_TABLES = 1
+
 
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_errors(duthosts, rand_one_dut_front_end_hostname,
@@ -271,6 +274,44 @@ def _cleanup_test_tables(duthost, table_prefix):
         module_ignore_errors=True)
 
 
+def _skip_if_insufficient_acl_table_resources(duthost):
+    """Skip if the dataplane ACL table needed by the test cannot be created."""
+    for namespace in duthost.get_frontend_asic_namespace_list():
+        acl_resources = duthost.get_crm_resources(namespace)["acl_resources"]
+        port_available = 0
+        for resource in acl_resources:
+            if (resource["stage"] == "INGRESS" and
+                    resource["bind_point"] == "PORT" and
+                    resource["resource_name"] == "acl_table"):
+                port_available = resource["available_count"]
+                break
+
+        if port_available < REQUIRED_INGRESS_DATAPLANE_ACL_TABLES:
+            pytest.skip(
+                "Not enough ingress PORT ACL table resources on namespace {} for multi-op test: "
+                "need PORT>={}, got PORT={}".format(
+                    namespace,
+                    REQUIRED_INGRESS_DATAPLANE_ACL_TABLES,
+                    port_available))
+
+
+def _get_free_ctrlplane_service(duthost):
+    """Return a CTRLPLANE ACL service not already bound to an ACL table."""
+    output = duthost.shell("sonic-cfggen -d --var-json ACL_TABLE")
+    acl_tables = json.loads(output["stdout"])
+
+    used_services = set()
+    for table in acl_tables.values():
+        used_services.update(table.get("services", []))
+
+    for service in CTRLPLANE_SERVICES:
+        if service not in used_services:
+            return service
+
+    pytest.skip("No free CTRLPLANE ACL service available for removable table")
+    return None
+
+
 # =============================================================================
 # Test 1: ACL port removal (REPLACE → N REMOVE moves)
 # =============================================================================
@@ -480,7 +521,11 @@ def test_perf_multi_operation(perf_ctx):
     table_a = "{}_MULTI_A".format(table_prefix)
     table_b = "{}_MULTI_B".format(table_prefix)
 
-    # Setup: create two tables — table A with ALL ports
+    _skip_if_insufficient_acl_table_resources(duthost)
+    table_b_service = _get_free_ctrlplane_service(duthost)
+
+    # Setup: create L3 table A with ALL ports. Table B only exists for
+    # table-removal coverage, so use CTRLPLANE to avoid another dataplane ACL table.
     half = num_ports // 2
     setup_patch = [
         {
@@ -497,9 +542,9 @@ def test_perf_multi_operation(perf_ctx):
             "op": "add",
             "path": "/ACL_TABLE/{}".format(table_b),
             "value": {
-                "type": "L3",
+                "type": "CTRLPLANE",
                 "policy_desc": "Multi test B - to be removed",
-                "ports": up_ports[:min(4, len(up_ports))],
+                "services": [table_b_service],
                 "stage": "ingress"
             }
         }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

**Summary:**
test_perf_multi_operation needs one ingress L3 ACL table with a large port
 list to exercise the port-list replace path. The second table only exists so
the same patch can remove a table.

On platforms with limited dataplane ACL resources, creating that removable
table as another ingress L3 table can fail with
 SAI_STATUS_INSUFFICIENT_RESOURCES.

Check CRM before setup for the required ingress dataplane ACL table. 
Create the removable table as a CTRLPLANE ACL table using a free service, preserving
  table-remove coverage without consuming another dataplane ACL table.

Fixes #26312 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

**Evidence of failure on 202605** 
[test_apply_patch_perf.log](https://github.com/user-attachments/files/30149517/test_apply_patch_perf.log)
[test_apply_patch_perf.xml](https://github.com/user-attachments/files/30149518/test_apply_patch_perf.xml)


Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
**202605**
***Failure*** 
[test_apply_patch_perf.log](https://github.com/user-attachments/files/30149525/test_apply_patch_perf.log)
[test_apply_patch_perf.xml](https://github.com/user-attachments/files/30149526/test_apply_patch_perf.xml)

***After Fix (Pass )***
[test_apply_patch_perf.py::test_perf_multi_operation.log](https://github.com/user-attachments/files/30149620/test_apply_patch_perf.py.test_perf_multi_operation.log)
[test_apply_patch_perf.py::test_perf_multi_operation.xml](https://github.com/user-attachments/files/30149621/test_apply_patch_perf.py.test_perf_multi_operation.xml)

**master**
***Failure*** 
[test_apply_patch_perf.log](https://github.com/user-attachments/files/30149613/test_apply_patch_perf.log)
[test_apply_patch_perf.xml](https://github.com/user-attachments/files/30149614/test_apply_patch_perf.xml)



### Approach

#### What is the motivation for this PR?
`test_perf_multi_operation`  can fail on platforms with limited ingress
 dataplane ACL table resources because it creates two ingress L3 ACL tables
 during setup. The first table is required to exercise the large port-list
 replace path. The second table only exists so the test can cover table
 removal.

#### How did you do it?
The main ACL table remains an ingress L3 port-bound ACL table. The removable
 table is changed to a CTRLPLANE ACL table using a free service, so the test
 still covers table removal without consuming another dataplane ACL table.

The test also checks CRM before setup and skips when the required ingress
  dataplane ACL table resource is unavailable.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran the test 10 times on the platform where it was failing 

#### Any platform specific information?
 Failed  on  Arista-7050CX3-32C-C32 ,Arista-7260CX3-C64 , Arista-7050CX3-32S-C32

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A