### PR TITLE
tests/generic_config_updater: use CTRLPLANE table for removable table in test_perf_multi_operation

### DIFF
--- a/tests/generic_config_updater/test_apply_patch_perf.py
+++ b/tests/generic_config_updater/test_apply_patch_perf.py
@@ -497,9 +497,9 @@ def test_perf_multi_operation(perf_ctx):
             "op": "add",
             "path": "/ACL_TABLE/{}".format(table_b),
             "value": {
-                "type": "L3",
+                "type": "CTRLPLANE",
                 "policy_desc": "Multi test B - to be removed",
-                "ports": up_ports[:min(4, len(up_ports))],
+                "services": ["SSH"],
                 "stage": "ingress"
             }
         }


### PR DESCRIPTION
### Description of PR

Fixes #26312

Summary:
This change updates the removable ACL table (`table_b`) in
`test_perf_multi_operation` to use a `CTRLPLANE` ACL table instead of an `L3`
ACL table.

The removable table is only created during setup and removed in the test patch.
It is never used for dataplane ACL rule operations or modified after creation.
Using a `CTRLPLANE` table preserves the purpose of the test while avoiding the
need to allocate an additional dataplane ACL table.

The primary test table (`table_a`) remains unchanged as an `L3` table with all
ports, preserving the intended leaf-list `REPLACE` performance scenario.

Fixes #26312

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Test update
- [ ] Documentation update

### How did you verify it

- Verified the file parses successfully using `python3 -m py_compile`.
- Confirmed the change is limited to `table_b`; `table_a` remains unchanged.
- Verified the `CTRLPLANE` ACL table structure matches existing patterns used in `tests/generic_config_updater/test_cacl.py`.
- Full runtime validation requires a SONiC testbed/CI environment.