### PR TITLE
vlan: fix lower ToR path for dualtor topologies

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -91,7 +91,7 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo, 
             interface_name = 'Ethernet1'
             dev_name = 'eth1'
         # in case of lower tor host we need to use the next portchannel
-        if "dualtor-aa" in tbinfo["topo"]["name"] and rand_one_dut_hostname == lower_tor_host.hostname:
+        if "dualtor" in tbinfo["topo"]["name"] and rand_one_dut_hostname == lower_tor_host.hostname:
             interface_name = 'Port-Channel2'
             dev_name = _portchannel_netdev_name(vm_info['host'], 2)
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
test_vlan_ping selects Port-Channel2 for the lower ToR only when the topology name contains dualtor-aa.

On dualtor-120 lower-ToR runs, the test still uses Port-Channel1 VM data while matching against the lower-ToR minigraph. The expected PTF port list can be empty, causing packet verification to fail.

Use the lower-ToR Port-Channel2 path for all dualtor topology names.
Summary:
Fixes #26316 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue 

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
 **202605** 
***Fail***
[test_vlan_ping_20260705_failed.log](https://github.com/user-attachments/files/30156558/test_vlan_ping_20260705_failed.log)
[test_vlan_ping_20260705_failed.xml](https://github.com/user-attachments/files/30156562/test_vlan_ping_20260705_failed.xml)
[test_vlan_ping_force_gd272_failed.log](https://github.com/user-attachments/files/30156563/test_vlan_ping_force_gd272_failed.log)
[test_vlan_ping_force_gd272_failed.xml](https://github.com/user-attachments/files/30156564/test_vlan_ping_force_gd272_failed.xml)


***Pass*** 
[test_vlan_ping_fix_gd272_pass.xml](https://github.com/user-attachments/files/30156552/test_vlan_ping_fix_gd272_pass.xml)

[test_vlan_ping_fix_gd272_pass.log](https://github.com/user-attachments/files/30156548/test_vlan_ping_fix_gd272_pass.log)




### Approach

#### What is the motivation for this PR?
test_vlan_ping can fail on lower-ToR runs for dualtor topologies other
  than dualtor-aa, such as dualtor-120.

The test already has lower-ToR handling, but the condition is too narrow.
It only applies when the topology name contains dualtor-aa.

#### How did you do it?
Changed the lower-ToR VM interface selection condition from dualtor-aa
  only to all topology names containing dualtor.
This preserves existing behavior for dualtor-aa and extends the same
  lower-ToR path to other dualtor topologies.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Verified on a dualtor-120 testbed.

  **Before the fix, lower-ToR runs produced:**
 `  vmhost_info["port_index_list"] = []`
      and packet verification failed.

  **After the fix, the same test passed.**

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
