### PR TITLE
platform: fix passive SFP+ detection

### DIFF
--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -344,7 +344,7 @@ def parse_one_sfp_eeprom_info(sfp_eeprom_info):
     """
     pattern_top_layer_key_value = r"^(?P<key>Ethernet\d+):(?P<value>.*)"
     pattern_second_layer_key_value = r"(^\s{8}|\t{1})(?P<key>[a-zA-Z0-9][a-zA-Z0-9\s\/\(\)-]+):(?P<value>.*)"
-    pattern_third_layer_key_value = r"(^\s{16}|\t{2})(?P<key>[a-zA-Z0-9][a-zA-Z0-9\s\/]+):(?P<value>.*)"
+    pattern_third_layer_key_value = r"(^\s{16}|\t{2})(?P<key>[a-zA-Z0-9][a-zA-Z0-9\s\/\+]+):(?P<value>.*)"
 
     one_sfp_eeprom_info_dict = {}
     second_layer_dict = {}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The SFP EEPROM parser did not accept + in third-level keys, so it
  dropped SFP+CableTechnology from sfputil EEPROM output. As a result,
  passive SFP+ cables could be missed by get_passive_cable_port_list()
  and treated as non-passive or unknown.

This caused test_sfp_thresholds_match_xcvrd_tables to fail on
  passive copper ports with N/A DOM threshold values instead of taking the
  expected passive copper skip path.


Summary:
Fixes #26318 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202605

[test_sfp_thermal_state_db_202605_ld201_failed.log](https://github.com/user-attachments/files/30156881/test_sfp_thermal_state_db_202605_ld201_failed.log)
[test_sfp_thermal_state_db_202605_ld201_failed.xml](https://github.com/user-attachments/files/30156882/test_sfp_thermal_state_db_202605_ld201_failed.xml)



### Approach

#### What is the motivation for this PR?
Passive copper cables can legitimately report N/A for DOM temperature
threshold values. The test already has logic to skip this case when all
ports with threshold rows are passive copper ports.

However, a passive copper module on Ethernet132 was not classified as
passive copper because the EEPROM parser dropped this key:

 SFP+CableTechnology: Passive Cable

#### How did you do it?
Allowed + in the third-level EEPROM key parser.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran the same Test case  platform_tests/test_sfp_thermal_state_db.py::TestSfpThermalStateDb::test_sfp_thresholds_match_xcvrd_tables[ld201]
and confirmed a PASS

#### Any platform specific information?
Observed with an Arista passive copper cable:

  ```
Ethernet132
  Type: SFP/SFP+/SFP28
  Vendor: Arista Networks
  Model: CAB-Q-S-1M
  Connector: Copper pigtail
  Infiniband Compliance: 1X Copper Passive
  SFP+CableTechnology: Passive Cable
  dom_capability: N/A
```


#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
