### PR TITLE
Fix golden config reload on MX topology

### DIFF
--- a/tests/golden_config_infra/test_config_reload_with_rendered_golden_config.py
+++ b/tests/golden_config_infra/test_config_reload_with_rendered_golden_config.py
@@ -116,17 +116,21 @@ def golden_config_override_with_specific_template(duthost, safe_reload_ignored_d
     config_compare(golden_config, overrided_config)
 
 
-def test_rendered_golden_config_override(duthosts, rand_one_dut_hostname, setup_env):
+def test_rendered_golden_config_override(duthosts, rand_one_dut_hostname, setup_env, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     if duthost.is_multi_asic:
         pytest.skip("Skip this test on multi-asic platforms, \
                     since golden config format here is not compatible with multi-asics")
 
     safe_reload_ignored_dockers = []
+    topo_type = tbinfo["topo"]["type"]
     if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch"):
         # These are the critical services that are not included in the golden config template
         # nor the default config. After the minigraph load they will be disabled.
         safe_reload_ignored_dockers = ["dhcp_relay", "dhcp_server"]
+    elif topo_type == "mx":
+        # MX golden config disables dhcp_server after minigraph reload.
+        safe_reload_ignored_dockers = ["dhcp_server"]
 
     golden_config_override_with_general_template(duthost, safe_reload_ignored_dockers)
     golden_config_override_with_specific_template(duthost, safe_reload_ignored_dockers)


### PR DESCRIPTION
### Description of PR

Summary:
Fixes ADO: https://msazure.visualstudio.com/One/_workitems/edit/38854974

`test_rendered_golden_config_override` can fail on MX topology after the rendered golden config reload because the generated config disables `dhcp_server`, while the safe-reload critical service tracking list was captured before reload and still expects `dhcp_server` to be running. Ignore `dhcp_server` for MX reloads, matching the expected post-rendered-golden-config state.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38854974
Failure type: consistent nightly failure

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: `python -m py_compile tests/golden_config_infra/test_config_reload_with_rendered_golden_config.py`
- 202605: triage evidence from PBI 38854974 shows 48 failures in 30 days on MX with `dhcp_server` disabled after rendered golden config reload.

### Approach
#### What is the motivation for this PR?
Consistent 202605 nightly failures on MX topologies report `Failed: All critical services should be fully started!` because `dhcp_server` is disabled by the rendered golden config but still tracked as critical after reload.

#### How did you do it?
Use the `tbinfo` fixture to detect MX topology and pass `dhcp_server` in `safe_reload_ignored_dockers` for the rendered golden config reload.

#### How did you verify/test it?
Ran Python syntax compilation for the modified test file. The log evidence shows `dhcp_server` is the only critical service remaining false until timeout on MX.

#### Any platform specific information?
Observed on Arista-720DT-G48S4 and Nokia-7215 MX topologies in branch 20260510.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
