### PR TITLE
[dhcp_relay] Cover DHCP relay forward agent mode

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -174,6 +174,7 @@ class DHCPTest(DataplaneBaseTest):
         self.portchannels_ip_list = self.test_params.get('portchannels_ip_list', None)
         self.agent_relay_mode = self.test_params.get('agent_relay_mode', None)
         self.max_hop_count = self.test_params.get('max_hop_count', None)
+        self.client_giaddr = self.test_params.get('client_giaddr', self.switch_loopback_ip)
         self.client_vrf = self.test_params.get('client_vrf', None)
         self.dhcpv4_disable_flag = self.test_params.get('dhcpv4_disable_flag', None)
         if self.relay_agent == "sonic-relay-agent":
@@ -210,6 +211,8 @@ class DHCPTest(DataplaneBaseTest):
         remote_id_string = self.uplink_mac if self.dual_tor else self.relay_iface_mac
         self.option82 += struct.pack('BB', self.REMOTE_ID_SUBOPTION, len(remote_id_string))
         self.option82 += remote_id_string.encode('utf-8')
+
+        self.client_option82 = b'\x01\x07Vlan100\x02\x06\x11\x22\x33\x44\x55\x66'
 
         link_selection_added = False  # set below; dual-tor block skips SubOption 5 if set
 
@@ -286,24 +289,14 @@ class DHCPTest(DataplaneBaseTest):
                 discover_packet[scapy.IP].dst = self.switch_loopback_ip
                 discover_packet[scapy.IP].src = self.client_ip
         else:
-            # Sub-option 1: Circuit ID (VLAN 100)
-            # Circuit ID sub-option type 1, length 7, data 'Vlan100'
-            circuit_id = b'\x01' + bytes([7]) + b'Vlan100'
-
-            # Sub-option 2: Remote ID (MAC address)
-            # Remote ID sub-option type 2, length 6, MAC address
-            remote_id = b'\x02' + bytes([6]) + bytes.fromhex("112233445566")
-            # Combine the new sub-options for relay
-            relay_option82 = circuit_id + remote_id
-
             discover_packet[scapy.Ether].dst = self.uplink_mac
             discover_packet[scapy.IP].src = self.client_ip
             discover_packet[scapy.IP].dst = self.switch_loopback_ip
             discover_packet[scapy.BOOTP].hops = self.max_hop_count if self.max_hop_count == self.MAX_HOP_COUNT else 1
-            discover_packet[scapy.BOOTP].giaddr = self.switch_loopback_ip
+            discover_packet[scapy.BOOTP].giaddr = self.client_giaddr
             discover_packet[scapy.DHCP].options.insert(
                 discover_packet[scapy.DHCP].options.index("end"),
-                (82, relay_option82)
+                (82, self.client_option82)
             )
 
         return discover_packet
@@ -337,8 +330,10 @@ class DHCPTest(DataplaneBaseTest):
         else:
             source_ip = self.portchannels_ip_list[0]
 
-        if ((self.link_selection and self.source_interface) or
-           self.server_vrf or self.dual_tor or self.agent_relay_mode):
+        if self.agent_relay_mode == "forward":
+            giaddr = self.client_giaddr
+        elif ((self.link_selection and self.source_interface) or
+              self.server_vrf or self.dual_tor or self.agent_relay_mode):
             giaddr = self.switch_loopback_ip
         elif self.server_id_override or not self.dual_tor:
             giaddr = self.relay_iface_ip
@@ -354,6 +349,9 @@ class DHCPTest(DataplaneBaseTest):
 
         elif self.agent_relay_mode == "replace":
             dhcp_options = [('message-type', 'discover'), (82, self.option82), ('end')]
+
+        elif self.agent_relay_mode == "forward":
+            dhcp_options = [('message-type', 'discover'), (82, self.client_option82), ('end')]
 
         elif self.agent_relay_mode == "append":
             # Sub-option 1: Circuit ID (VLAN 100)

--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -79,6 +79,7 @@ SINGLE_TOR_MODE = 'single'
 CLIENT_VRF_NAME = "Vrf01"   # Global macro for Client VRF
 MAX_HOP_COUNT = 16
 CONFIG_HOP_COUNT = 2
+DOWNSTREAM_RELAY_IP = '192.0.2.1'  # TEST-NET-1; synthetic downstream relay
 
 logger = logging.getLogger(__name__)
 
@@ -353,7 +354,8 @@ def test_dhcp_relay_option82_suboptions(ptfhost, dut_dhcp_relay_data, validate_d
 @pytest.mark.parametrize("test_mode", [
                                     "discard",
                                     "replace",
-                                    "append"
+                                    "append",
+                                    "forward"
                                 ])
 def test_dhcp_relay_agent_mode(
         ptfhost,
@@ -377,6 +379,7 @@ def test_dhcp_relay_agent_mode(
         - "discard": Drops packets containing Option 82.
         - "replace": Replaces existing Option 82 with new data before forwarding.
         - "append": Appends a new Option 82 to packets that already have it.
+        - "forward": Preserves an existing Option 82 unchanged.
 
     Key Actions:
         - Configures the device under test (DUT) with the selected relay mode.
@@ -422,6 +425,8 @@ def test_dhcp_relay_agent_mode(
                     "kvm_support": True,
                     "relay_agent": relay_agent,
                     "agent_relay_mode": test_mode,
+                    "client_giaddr": (DOWNSTREAM_RELAY_IP if test_mode == "forward"
+                                      else dhcp_relay['switch_loopback_ip']),
                     "downlink_vlan_iface_name": str(dhcp_relay['downlink_vlan_iface']['name']),
                 },
                 log_file="/tmp/test_dhcp_relay_agent_mode.log",


### PR DESCRIPTION
### Description of PR
Summary:
Extend the existing agent relay mode hardware/PTF coverage with `forward`. The new case sends a valid chained request with a synthetic nonlocal TEST-NET `giaddr`, then verifies that the relay preserves the existing Option 82 unchanged, preserves `giaddr`, and increments hops.

This is a low-priority draft placeholder for a non-current deployment scenario. The product dependencies are already merged: https://github.com/sonic-net/sonic-dhcp-relay/pull/106 and https://github.com/sonic-net/sonic-buildimage/pull/27029. Validation remains deferred, and **this DRAFT MUST NOT MERGE** until its TODOs are complete.

Fixes # N/A — draft test placeholder; no issue is linked.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A; no backport requested.
Failure type: other — low-priority test coverage gap for a non-current deployment scenario.

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
- **NOT RUN:** no pytest, PTF, syntax-check, or hardware validation was executed.
- Validation is intentionally deferred until the higher-priority DHCP relay PRs merge.
- This draft must not merge before its dependency and validation TODOs are complete.

- Dependency TODO: keep compatibility with already merged https://github.com/sonic-net/sonic-dhcp-relay/pull/106 and https://github.com/sonic-net/sonic-buildimage/pull/27029; coordinate/rebase with https://github.com/sonic-net/sonic-mgmt/pull/26325 if its shared PTF modeling lands first.
- Validation TODO: run the focused `forward` hardware/PTF case after the higher-priority DHCP relay PRs merge.

### Approach
#### What is the motivation for this PR?
The merged mode contract added `forward`, but sonic-mgmt did not exercise it. The prior Loopback0 chained-request model would also conflict with future local-giaddr spoof protection.

#### How did you do it?
Add `forward` to the existing mode parameterization, retain the incoming Option 82 bytes as the expected bytes, and use TEST-NET-1 address 192.0.2.1 as a genuinely nonlocal synthetic downstream-relay giaddr for this case.

#### How did you verify/test it?
No validation was executed. Validation is deferred until the higher-priority DHCP relay PRs merge. This draft must not merge before the dependency and validation TODOs above are complete.

#### Any platform specific information?
Native sonic-relay-agent mode coverage. No topology production address is hardcoded.

#### Supported testbed topology if it's a new test case?
Existing t0 and m0 DHCP relay topologies.

### Documentation
No documentation update. This draft only adds or corrects DHCP relay test coverage.
