### PR TITLE
[dhcp_relay] Cover chained requests without Option 82

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -174,6 +174,9 @@ class DHCPTest(DataplaneBaseTest):
         self.portchannels_ip_list = self.test_params.get('portchannels_ip_list', None)
         self.agent_relay_mode = self.test_params.get('agent_relay_mode', None)
         self.max_hop_count = self.test_params.get('max_hop_count', None)
+        self.client_giaddr = self.test_params.get('client_giaddr', self.switch_loopback_ip)
+        self.include_client_option82 = self.test_params.get('include_client_option82', True)
+        self.expected_forward = self.test_params.get('expected_forward', None)
         self.client_vrf = self.test_params.get('client_vrf', None)
         self.dhcpv4_disable_flag = self.test_params.get('dhcpv4_disable_flag', None)
         if self.relay_agent == "sonic-relay-agent":
@@ -300,11 +303,12 @@ class DHCPTest(DataplaneBaseTest):
             discover_packet[scapy.IP].src = self.client_ip
             discover_packet[scapy.IP].dst = self.switch_loopback_ip
             discover_packet[scapy.BOOTP].hops = self.max_hop_count if self.max_hop_count == self.MAX_HOP_COUNT else 1
-            discover_packet[scapy.BOOTP].giaddr = self.switch_loopback_ip
-            discover_packet[scapy.DHCP].options.insert(
-                discover_packet[scapy.DHCP].options.index("end"),
-                (82, relay_option82)
-            )
+            discover_packet[scapy.BOOTP].giaddr = self.client_giaddr
+            if self.include_client_option82:
+                discover_packet[scapy.DHCP].options.insert(
+                    discover_packet[scapy.DHCP].options.index("end"),
+                    (82, relay_option82)
+                )
 
         return discover_packet
 
@@ -337,8 +341,10 @@ class DHCPTest(DataplaneBaseTest):
         else:
             source_ip = self.portchannels_ip_list[0]
 
-        if ((self.link_selection and self.source_interface) or
-           self.server_vrf or self.dual_tor or self.agent_relay_mode):
+        if self.agent_relay_mode and self.client_giaddr:
+            giaddr = self.client_giaddr
+        elif ((self.link_selection and self.source_interface) or
+              self.server_vrf or self.dual_tor):
             giaddr = self.switch_loopback_ip
         elif self.server_id_override or not self.dual_tor:
             giaddr = self.relay_iface_ip
@@ -349,7 +355,10 @@ class DHCPTest(DataplaneBaseTest):
                         dport=self.DHCP_SERVER_PORT, len=308)
 
         # Relay-side behavior based on agent_mode
-        if self.agent_relay_mode == "discard":
+        if not self.include_client_option82:
+            dhcp_options = [('message-type', 'discover'), ('end')]
+
+        elif self.agent_relay_mode == "discard":
             dhcp_options = [('message-type', 'discover'), (82, self.option82), ('end')]
 
         elif self.agent_relay_mode == "replace":
@@ -1203,11 +1212,33 @@ class DHCPTest(DataplaneBaseTest):
         logger.info("Expect receiving {} packets from port [{}]".format(packet_type, self.server_port_indices))
         log_dhcp_packet_info(pkt)
         num_expected_packets = self.num_dhcp_servers
-        if self.agent_relay_mode == "discard" or self.dhcpv4_disable_flag or self.max_hop_count == self.MAX_HOP_COUNT:
-            # Expected result: No packet sent
+        if self.expected_forward is None:
+            expected_forward = not (
+                self.agent_relay_mode == "discard"
+                or self.dhcpv4_disable_flag
+                or self.max_hop_count == self.MAX_HOP_COUNT
+            )
+        else:
+            expected_forward = self.expected_forward
+        if expected_forward:
+            packet_mask = mask
+        else:
             num_expected_packets = 0
+            unexpected_packet = (
+                scapy.Ether(src=self.uplink_mac)
+                / scapy.IP()
+                / scapy.UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
+            )
+            packet_mask = Mask(unexpected_packet)
+            packet_mask.set_do_not_care_scapy(scapy.Ether, "dst")
+            for field in ("version", "ihl", "tos", "len", "id", "flags",
+                          "frag", "ttl", "chksum", "src", "dst", "options"):
+                packet_mask.set_do_not_care_scapy(scapy.IP, field)
+            packet_mask.set_do_not_care_scapy(scapy.UDP, "chksum")
+            packet_mask.set_do_not_care_scapy(scapy.UDP, "len")
+            packet_mask.set_ignore_extra_bytes()
         captured_count = testutils.count_matched_packets_all_ports(
-            self, mask, self.server_port_indices)
+            self, packet_mask, self.server_port_indices)
         self.assertTrue(captured_count == num_expected_packets,
                         "Failed: %s packet counts are not equal %d != %d"
                         % (packet_type, captured_count, num_expected_packets))

--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -79,6 +79,7 @@ SINGLE_TOR_MODE = 'single'
 CLIENT_VRF_NAME = "Vrf01"   # Global macro for Client VRF
 MAX_HOP_COUNT = 16
 CONFIG_HOP_COUNT = 2
+DOWNSTREAM_RELAY_IP = '192.0.2.1'  # TEST-NET-1; synthetic downstream relay
 
 logger = logging.getLogger(__name__)
 
@@ -435,6 +436,67 @@ def test_dhcp_relay_agent_mode(
         # Restore the baseline DHCPV4_RELAY row shape that
         # enable_sonic_dhcpv4_relay_agent set up (dhcpv4_servers only,
         # no agent_relay_mode), by reusing the same helpers.
+        sonic_dhcp_relay_unconfig(duthost, dut_dhcp_relay_data)
+        sonic_dhcp_relay_config(duthost, dut_dhcp_relay_data)
+
+
+def test_dhcp_relay_chained_request_without_option82(
+        ptfhost,
+        dut_dhcp_relay_data,
+        validate_dut_routes_exist,
+        testing_config,
+        setup_standby_ports_on_rand_unselected_tor,
+        rand_unselected_dut,
+        toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa: F811
+        relay_agent  # noqa: F811
+):
+    """Verify native relay forwards a chained request without adding Option 82."""
+    testing_mode, duthost = testing_config
+
+    try:
+        for dhcp_relay in dut_dhcp_relay_data:
+            vlan = str(dhcp_relay['downlink_vlan_iface']['name'])
+            dhcp_servers = ",".join(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
+            duthost.shell(f'config dhcpv4_relay del {vlan}')
+            duthost.shell(f'config dhcpv4_relay add --dhcpv4-servers {dhcp_servers}'
+                          f' --agent-relay-mode discard {vlan}')
+
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "dhcp_relay_test.DHCPTest",
+                platform_dir="ptftests",
+                params={
+                    "hostname": duthost.hostname,
+                    "client_port_index": dhcp_relay['client_iface']['port_idx'],
+                    "other_client_port": repr(dhcp_relay['other_client_ports']),
+                    "client_iface_alias": str(dhcp_relay['client_iface']['alias']),
+                    "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+                    "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs']),
+                    "server_ip": dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'],
+                    "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                    "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
+                    "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
+                    "dest_mac_address": BROADCAST_MAC,
+                    "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
+                    "switch_loopback_ip": dhcp_relay['switch_loopback_ip'],
+                    "uplink_mac": str(dhcp_relay['uplink_mac']),
+                    "testing_mode": testing_mode,
+                    "kvm_support": True,
+                    "relay_agent": relay_agent,
+                    "agent_relay_mode": "discard",
+                    "client_giaddr": DOWNSTREAM_RELAY_IP,
+                    "include_client_option82": False,
+                    "expected_forward": True,
+                    "downlink_vlan_iface_name": str(dhcp_relay['downlink_vlan_iface']['name']),
+                },
+                log_file="/tmp/test_dhcp_relay_chained_no_option82.log",
+                is_python3=True
+            )
+    except LogAnalyzerError as err:
+        logger.error("Unable to find expected log in syslog")
+        raise err
+    finally:
         sonic_dhcp_relay_unconfig(duthost, dut_dhcp_relay_data)
         sonic_dhcp_relay_config(duthost, dut_dhcp_relay_data)
 


### PR DESCRIPTION
### Description of PR
Summary:
Add focused native-relay coverage for a chained request with a genuinely nonlocal TEST-NET `giaddr` and no Option 82 while agent mode is `discard`. The expected upstream packet preserves `giaddr`, increments hops, and still contains no Option 82.

This is a low-priority draft placeholder for a non-current deployment scenario. It depends on https://github.com/sonic-net/sonic-dhcp-relay/pull/125 and may intentionally fail on current images until that product dependency merges. **DRAFT — MUST NOT MERGE.**

Fixes # N/A — draft test placeholder; no issue is linked.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A; no backport requested.
Failure type: other — low-priority test coverage gap for a non-current deployment scenario.

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
- **NOT RUN:** no pytest, PTF, syntax-check, or hardware validation was executed.
- Validation is intentionally deferred until the higher-priority DHCP relay PRs merge.
- This draft must not merge before its dependency and validation TODOs are complete.

- Dependency TODO: rebase/validate after https://github.com/sonic-net/sonic-dhcp-relay/pull/125 merges.
- Validation TODO: run the focused native hardware/PTF case after the higher-priority DHCP relay PRs merge.

### Approach
#### What is the motivation for this PR?
Agent relay mode applies to packets carrying relay information, but native relay currently applies discard behavior to nonzero-giaddr requests even when Option 82 is absent.

#### How did you do it?
Allow the PTF input to omit Option 82 independently of agent mode, use TEST-NET-1 address 192.0.2.1 for the synthetic downstream relay, and explicitly require forwarding with the same giaddr and no inserted Option 82.

#### How did you verify/test it?
No validation was executed. Validation is deferred until the higher-priority DHCP relay PRs merge. This draft must not merge before the dependency and validation TODOs above are complete.

#### Any platform specific information?
Scoped to native sonic-relay-agent; ISC fixture behavior is intentionally not used for this native-only policy assertion.

#### Supported testbed topology if it's a new test case?
Existing t0 and m0 DHCP relay topologies; unsupported relay agents remain excluded.

### Documentation
No documentation update. This draft only adds or corrects DHCP relay test coverage.
