### PR TITLE
[platform_tests] Skip NO-marked test files via collection policy

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -17,6 +17,41 @@ from tests.common.helpers.platform_api import bmc
 logger = logging.getLogger(__name__)
 
 
+
+# Skip selected platform_tests files on BMC DUTs.
+# Match by module path relative to tests/, e.g. "platform_tests/api/test_chassis.py".
+SKIP_NO_FILE_PATHS_FOR_BMC = {
+    "platform_tests/test_sai_ocp_version.py",
+    "platform_tests/daemon/test_chassisd.py",
+    "platform_tests/daemon/test_fancontrol.py",
+    "platform_tests/daemon/test_ledd.py",
+    "platform_tests/daemon/test_pcied.py",
+    "platform_tests/daemon/test_psud.py",
+    "platform_tests/api/test_chassis.py",
+    "platform_tests/api/test_chassis_fans.py",
+    "platform_tests/api/test_fan_drawer_fans.py",
+    "platform_tests/api/test_sfp.py",
+    "platform_tests/api/test_psu.py",
+    "platform_tests/api/test_psu_fans.py",
+    "platform_tests/api/test_thermal.py",
+    "platform_tests/api/test_bmc.py",
+    "platform_tests/api/test_component.py",
+    "platform_tests/api/test_fan_drawer.py",
+}
+
+
+@pytest.fixture(autouse=True, scope="module")
+def skip_no_marked_platform_tests_on_bmc(request, duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    if not duthost.is_bmc():
+        return
+
+    tests_root = os.path.join(str(request.config.rootpath), "tests")
+    module_path = os.path.relpath(str(request.node.fspath), tests_root).replace("\\", "/")
+
+    if module_path in SKIP_NO_FILE_PATHS_FOR_BMC:
+        pytest.skip("Skipped on BMC by NO-marked test selection policy")
+
 @pytest.fixture(autouse=True, scope="module")
 def skip_on_simx(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]


### PR DESCRIPTION
### Description of PR

Summary:
Skip selected `platform_tests` modules only when the DUT is a BMC (Baseboard Management Controller).

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608

### Approach
#### What is the motivation for this PR?

Some `platform_tests` files are intentionally not applicable to DUT with BMC type. The goal of this change is to keep the skip behavior limited to BMC DUTs and preserve normal execution on non-BMC systems.

#### How did you do it?

Implemented the conditional collection-time file-prefix skip hook with a BMC-aware module fixture in `tests/platform_tests/conftest.py`:
- Kept the selected file list as module paths relative to `tests/`
- Added an autouse module-scope fixture
- Checked `duthost.is_bmc()` before applying any skip
- Computed the current module path relative to the `tests/` root
- Called `pytest.skip(...)` only when the active DUT is BMC and the current module is in the selected list

#### How did you verify/test it?

Validated against the internal BMC platform batch log and confirmed:
- the selected modules are skipped on the BMC testbed

#### Any platform specific information?

Yes. This change is specifically intended for BMC DUT behavior. Non-BMC DUTs should continue to run these modules normally.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A