### PR TITLE
Skip interface checks when DUT has no front-panel interfaces

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -154,6 +154,9 @@ def check_interface_status(dut, asic_index, interfaces, xcvr_skip_list):
 
 # This API to check the interface information actoss all front end ASIC's
 def check_all_interface_information(dut, interfaces, xcvr_skip_list):
+    # No front-panel interfaces to check (e.g. SONiC BMC has no front-panel ports)
+    if len(interfaces) == 0:
+        return True
     for asic_index in dut.get_frontend_asic_ids():
         # Get the interfaces pertaining to that asic
         interface_list = get_port_map(dut, asic_index)


### PR DESCRIPTION
### Description of PR
Summary: Skip interface checks when DUT has no front-panel interfaces
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608 

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608
- [ ] N/A

### Test result
- master: PASS
- 202605: PASS

### Approach
#### What is the motivation for this PR?
There is no front-panel ports on SONiC BMC, so the function `check_all_interface_information()` fail

#### How did you do it?
In `check_all_interface_information`, return True early when the given interface list is empty. SONiC BMC images have no front-panel ports, so there is nothing to check; iterating ASICs and running transceiver detection in this case leads to spurious failures in tests like test_reload_configuration.

#### How did you verify/test it?
Regression pass

#### Any platform specific information?
BMC

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
