### PR TITLE
[mellanox][saitests] Ensure CIR is set during the egress data plane test

### DIFF
--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -240,7 +240,7 @@ class ThriftInterface(BaseTest):
             dut_port_list.append(dut_port)
         self.original_dut_port_queue_scheduler_map = self.get_queue_scheduler_name(dut_port_list)
         cmd_set_block_data_plane_scheduler = \
-            f'sonic-db-cli CONFIG_DB hset "SCHEDULER|{BLOCK_DATA_PLANE_SCHEDULER_NAME}" "type" DWRR "weight" 15 "pir" 1'
+            f'sonic-db-cli CONFIG_DB hset "SCHEDULER|{BLOCK_DATA_PLANE_SCHEDULER_NAME}" "type" DWRR "weight" 15 "cir" 1 "pir" 1'
 
         self.exec_cmd_on_dut(self.server, self.test_params['dut_username'], self.test_params['dut_password'],
                              cmd_set_block_data_plane_scheduler)

--- a/tests/saitests/py3/sai_base_test.py
+++ b/tests/saitests/py3/sai_base_test.py
@@ -240,7 +240,8 @@ class ThriftInterface(BaseTest):
             dut_port_list.append(dut_port)
         self.original_dut_port_queue_scheduler_map = self.get_queue_scheduler_name(dut_port_list)
         cmd_set_block_data_plane_scheduler = \
-            f'sonic-db-cli CONFIG_DB hset "SCHEDULER|{BLOCK_DATA_PLANE_SCHEDULER_NAME}" "type" DWRR "weight" 15 "cir" 1 "pir" 1'
+            f'sonic-db-cli CONFIG_DB hset "SCHEDULER|{BLOCK_DATA_PLANE_SCHEDULER_NAME}" ' \
+            '"type" DWRR "weight" 15 "cir" 1 "pir" 1'
 
         self.exec_cmd_on_dut(self.server, self.test_params['dut_username'], self.test_params['dut_password'],
                              cmd_set_block_data_plane_scheduler)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Sets CIR to 1 in addition to PIR during the `disable_mellanox_egress_data_plane` test.

Summary:
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

This is to resolve "pir can't be configured without cir" errors in the test suite, originating from the sonic-scheduler YANG validator. Since the point of the test is to effectively disable egress, setting CIR to effectively 1 byte/s does not impact the test beyond satisfying this requirement. It is set to 1 vs. 0 because the scheduler has an additional requirement for CIR > 0.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/sonic-net/sonic-mgmt/issues/27095
Failure type: day-one issue

### Test Result
- 202605: 20260510.10 - validated on a Mellanox SN4600C (SPC3, `t0-64`). Image under test reports `build_version: 20260510.10`, `commit_id: 1e876c93bb`. The three cases below all reach `sai_thrift_port_tx_disable()` -> `disable_mellanox_egress_data_plane()`, which is the code path changed by this PR:

  ```
  qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit        PASSED   (2 passed, 18 skipped)
  qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark   PASSED   (2 passed,  8 skipped)
  qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue          PASSED   (1 passed,  4 skipped)

  Total: 21 passed, 33 skipped, 0 failed, 0 errors
  ```

- master: validated during development with `run_tests.sh` on a Mellanox SN4600C; this is the change that was reviewed and merged here.

### Approach
#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Made the edit, than validated previously failing tests due to this issue using run_tests.sh on the DUT which failed. In particular, this affects qos_probe tests.

