### PR TITLE
[dualtor][cpu_sharper] Use safe reload to avoid mux inconsistency in `test_cpu_sharper` posttest check

### DIFF
--- a/tests/cpu_shaper/test_cpu_shaper.py
+++ b/tests/cpu_shaper/test_cpu_shaper.py
@@ -106,4 +106,4 @@ def test_cpu_queue_shaper(duthosts, localhost, enum_rand_one_per_hwsku_frontend_
 
     finally:
         duthost.shell("rm -f {}/{}".format(DEST_DIR, BCM_CINT_FILENAME))
-        config_reload(duthost)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
Fix the mux inconsistency in the posttest of `test_cpu_sharper`:

```
Error: failed on teardown with "Failed: !!!!!!!!!!!!!!!! Post-test sanity check failed: !!!!!!!!!!!!!!!![ { "failed": true, "failed_reason": "Active side mismatch for mb-bjw2-2-7-100, got upper_tor but expected lower_tor", "check_item": "mux_simulator", "action": "" }]"
```
- Microsoft ADO (number only): 38825206

#### How did you do it?
Use `safe_reload` in `config_reload` to ensure the all critical services are recovered before posttest check.

#### How did you verify/test it?
```
 cpu_shaper/test_cpu_shaper.py::test_cpu_queue_shaper[bjw-can-7260-14] ✓                                                                                                                   100% ██████████
============================================================================================ warnings summary ============================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
