### PR TITLE
[route]: Skip warm reboot tests on m0/m1/mx

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4992,11 +4992,11 @@ route/test_static_route.py::test_static_route_ecmp_ipv6:
 
 route/test_static_route.py::test_static_route_ecmp_warmboot:
   skip:
-    reason: "Warm reboot is not supported on dualtor topology or Arista-720DT"
+    reason: "Warm reboot is not supported on dualtor, m0, m1, or mx topologies"
     conditions_logical_operator: OR
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
-      - "'Arista-720DT' in hwsku"
+      - "topo_type in ['m0', 'm1', 'mx']"
 
 route/test_static_route.py::test_static_route_ipv6:
   xfail:
@@ -5006,19 +5006,19 @@ route/test_static_route.py::test_static_route_ipv6:
 
 route/test_static_route.py::test_static_route_ipv6_warmboot:
   skip:
-    reason: "Warm reboot is not supported on dualtor topology or Arista-720DT"
+    reason: "Warm reboot is not supported on dualtor, m0, m1, or mx topologies"
     conditions_logical_operator: OR
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
-      - "'Arista-720DT' in hwsku"
+      - "topo_type in ['m0', 'm1', 'mx']"
 
 route/test_static_route.py::test_static_route_warmboot:
   skip:
-    reason: "Warm reboot is not supported on dualtor topology or Arista-720DT"
+    reason: "Warm reboot is not supported on dualtor, m0, m1, or mx topologies"
     conditions_logical_operator: OR
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
-      - "'Arista-720DT' in hwsku"
+      - "topo_type in ['m0', 'm1', 'mx']"
 
 #######################################
 #####           sai_qualify       #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4992,9 +4992,11 @@ route/test_static_route.py::test_static_route_ecmp_ipv6:
 
 route/test_static_route.py::test_static_route_ecmp_warmboot:
   skip:
-    reason: "Warm reboot is not supported on dualtor topology"
+    reason: "Warm reboot is not supported on dualtor topology or Arista-720DT"
+    conditions_logical_operator: OR
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+      - "'Arista-720DT' in hwsku"
 
 route/test_static_route.py::test_static_route_ipv6:
   xfail:
@@ -5004,15 +5006,19 @@ route/test_static_route.py::test_static_route_ipv6:
 
 route/test_static_route.py::test_static_route_ipv6_warmboot:
   skip:
-    reason: "Warm reboot is not supported on dualtor topology"
+    reason: "Warm reboot is not supported on dualtor topology or Arista-720DT"
+    conditions_logical_operator: OR
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+      - "'Arista-720DT' in hwsku"
 
 route/test_static_route.py::test_static_route_warmboot:
   skip:
-    reason: "Warm reboot is not supported on dualtor topology"
+    reason: "Warm reboot is not supported on dualtor topology or Arista-720DT"
+    conditions_logical_operator: OR
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+      - "'Arista-720DT' in hwsku"
 
 #######################################
 #####           sai_qualify       #####


### PR DESCRIPTION
### Description of PR

Summary:
Skip `test_static_route_warmboot`, `test_static_route_ipv6_warmboot`, and `test_static_route_ecmp_warmboot` on all m0, m1, and mx topologies through centralized conditional marks. Preserve the existing dualtor exclusions.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38862000

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38862000
Failure type: day-one topology applicability gap

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: the conditional-mark YAML loads successfully; direct condition evaluation verifies all three cases skip for m0, m1, mx, and dualtor, while remaining runnable on t1.
- 202605: `testbed-bjw-can-720dt-3` (m0, `Arista-720DT-G48S4`) on `SONiC.20260510.06`; targeted `tests/run_tests.sh` completed with **3 skipped**, 0 failures, exit 0 in 43.88 seconds. Each case reported `Warm reboot is not supported on dualtor, m0, m1, or mx topologies`.
- 202605 prerequisite: the backport must also include conditional-mark node-ID normalization fix #25930 (`3cf07f4b6bf3`). Without it, standard `run_tests.sh` can produce `tests/...` node IDs and silently bypass centralized conditional marks.
- Nightly evidence: https://elastictest.org/scheduler/testplan/6a5b5cb0b2ac8cdc8af95b7d reported the three warm-reboot cases failing across all six 720DT mx testbeds.

### Approach
#### What is the motivation for this PR?

Recent m0/mx nightlies reported failures for the three static-route warm-reboot tests. Warm-reboot coverage is not applicable to m0, m1, or mx topologies, so these cases should not enter the reboot path on those topologies.

#### How did you do it?

Extended each existing dualtor conditional skip with an OR condition matching `topo_type in ['m0', 'm1', 'mx']`.

#### How did you verify/test it?

Reviewed the recent 720DT m0/mx failures and confirmed these are the three logical cases that invoke warm reboot. Validated the YAML and evaluated the conditions for m0, m1, mx, dualtor, and t1. On 202605, ran the three cases through `tests/run_tests.sh` with the required #25930 prerequisite; all three were conditionally skipped.

#### Any platform specific information?

The condition is topology-based and applies to every platform running m0, m1, or mx.

#### Supported testbed topology if it's a new test case?

Not a new test case. The new exclusions are m0, m1, and mx; the existing dualtor exclusions remain.

### Documentation

Not applicable.
