### PR TITLE
[reboot] Do not send Ctrl-C to console during bootloader/boot stage

### DIFF
--- a/tests/common/connections/console_host.py
+++ b/tests/common/connections/console_host.py
@@ -54,9 +54,12 @@ def ConsoleHost(console_type,
         "timeout": timeout_s
     }
 
-    # Only SSHConsoleConn consumes this; add it conditionally so the other
-    # console classes' __init__ signatures are unaffected.
-    if cancel_event is not None:
+    # Only SSHConsoleConn consumes cancel_event (it pops it before delegating to
+    # netmiko). The other console classes forward **kwargs straight to netmiko,
+    # which would raise "unexpected keyword argument 'cancel_event'" and break
+    # console-log collection on those console servers. Gate the injection on the
+    # resolved class so non-SSH console types are unaffected.
+    if cancel_event is not None and issubclass(ConsoleTypeMapper[console_type], SSHConsoleConn):
         params["cancel_event"] = cancel_event
 
     # Add linecard-specific parameters if provided

--- a/tests/common/connections/console_host.py
+++ b/tests/common/connections/console_host.py
@@ -38,7 +38,8 @@ def ConsoleHost(console_type,
                 supervisor_ip=None,
                 linecard_number=None,
                 slot_num=None,
-                hwsku=None):
+                hwsku=None,
+                cancel_event=None):
     if console_type not in ConsoleTypeMapper:
         raise ValueError("console type {} is not supported yet".format(console_type))
     params = {
@@ -52,6 +53,11 @@ def ConsoleHost(console_type,
         "console_device": console_device,
         "timeout": timeout_s
     }
+
+    # Only SSHConsoleConn consumes this; add it conditionally so the other
+    # console classes' __init__ signatures are unaffected.
+    if cancel_event is not None:
+        params["cancel_event"] = cancel_event
 
     # Add linecard-specific parameters if provided
     if supervisor_ip is not None:

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -29,7 +29,8 @@ BOOTLOADER_BANNER_RE = re.compile(
     r"GNU\s+GRUB|grub\s*>|grub\s+rescue\s*>|"     # GRUB menu / shell
     r"Hit\s+any\s+key\s+to\s+stop\s+autoboot|"    # U-Boot autoboot window
     r"\bautoboot\b|"                              # generic autoboot countdown
-    r"\bONIE\b|"                                  # ONIE installer / rescue
+    r"ONIE:|"                                     # ONIE installer / rescue (anchored;
+                                                  # bare \bONIE\b matches "ONIE Version")
     r"^\s*Booting\b|"                             # boot-in-progress (line-anchored)
     r"^\s*Loading\s+(?:Linux|initrd|initial\s+ramdisk|kernel|vmlinuz)",  # kernel/ramdisk load
     flags=re.I | re.M,

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -14,15 +14,25 @@ from paramiko.ssh_exception import SSHException
 # becomes permanently unreachable -- e.g. Arista Aboot's "Press Control-C now to enter
 # Aboot shell", plus GRUB, U-Boot and ONIE equivalents. The console must never write
 # control characters while in this state.
+#
+# The tokens are deliberately specific to avoid false positives on ordinary SONiC
+# shell output: the real Aboot states are the autoboot prompt ("Press Control-C ...")
+# and the shell prompt ("Aboot#") -- a bare "Aboot" word is NOT used because image
+# filenames like "sonic-aboot-broadcom.swi" would match it (the hyphens form word
+# boundaries) and wrongly suppress the leftover-shell Ctrl-C recovery. The generic
+# boot-in-progress verbs are line-anchored (re.M) and the "Loading" verb is scoped to
+# kernel/ramdisk loads so shell strings like "reloading"/"Loading configuration" do
+# not match.
 BOOTLOADER_BANNER_RE = re.compile(
-    r"Press\s+Control-?C|"                        # Arista Aboot autoboot window
-    r"\bAboot\b|Aboot#|"                          # Arista Aboot banner / shell
+    r"Press\s+Control[-\s]?C|"                    # Arista Aboot autoboot window
+    r"Aboot#|"                                    # Arista Aboot shell prompt
     r"GNU\s+GRUB|grub\s*>|grub\s+rescue\s*>|"     # GRUB menu / shell
     r"Hit\s+any\s+key\s+to\s+stop\s+autoboot|"    # U-Boot autoboot window
     r"\bautoboot\b|"                              # generic autoboot countdown
     r"\bONIE\b|"                                  # ONIE installer / rescue
-    r"\bBooting\b|\bLoading\b",                   # generic boot-in-progress
-    flags=re.I,
+    r"^\s*Booting\b|"                             # boot-in-progress (line-anchored)
+    r"^\s*Loading\s+(?:Linux|initrd|initial\s+ramdisk|kernel|vmlinuz)",  # kernel/ramdisk load
+    flags=re.I | re.M,
 )
 
 

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -156,14 +156,24 @@ class SSHConsoleConn(BaseConsoleConn):
         delay_factor = max(self.select_delay_factor(delay_factor), 1)
         for _ in range(max_attempts):
             try:
-                # Probe the current console state with a bare CR only -- never a
-                # Ctrl-C yet, so we cannot interrupt a bootloader autoboot window.
-                self.write_channel(self.RETURN)
-                # Accumulate output so a lagging prompt is reliably observed.
+                # Passively read the console FIRST -- do not send anything yet. If
+                # the DUT is sitting in a bootloader "hit any key to stop autoboot"
+                # window, ANY keypress (including a bare CR) aborts autoboot and
+                # traps the DUT in the bootloader, so we must observe before nudging.
                 output = ""
                 for _ in range(4):
                     time.sleep(0.5 * delay_factor)
                     output += self.read_channel()
+                # Only if the console stayed silent do we nudge it with a bare CR
+                # (never Ctrl-C) to coax a login prompt to echo. A silent console is
+                # not an active autoboot window -- those continuously print a
+                # countdown -- so a single CR here is safe and cannot interrupt
+                # autoboot.
+                if not output.strip():
+                    self.write_channel(self.RETURN)
+                    for _ in range(4):
+                        time.sleep(0.5 * delay_factor)
+                        output += self.read_channel()
             except Exception as e:
                 self.logger.warning(f"Error probing console state: {e}")
                 return

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -8,6 +8,24 @@ except ImportError:
 from paramiko.ssh_exception import SSHException
 
 
+# Bootloader / autoboot prompts seen on the serial console across SONiC platforms.
+# Sending a Ctrl-C (or any interrupt key) while the console shows one of these traps
+# the DUT in the bootloader and aborts autoboot, so SONiC never boots and the device
+# becomes permanently unreachable -- e.g. Arista Aboot's "Press Control-C now to enter
+# Aboot shell", plus GRUB, U-Boot and ONIE equivalents. The console must never write
+# control characters while in this state.
+BOOTLOADER_BANNER_RE = re.compile(
+    r"Press\s+Control-?C|"                        # Arista Aboot autoboot window
+    r"\bAboot\b|Aboot#|"                          # Arista Aboot banner / shell
+    r"GNU\s+GRUB|grub\s*>|grub\s+rescue\s*>|"     # GRUB menu / shell
+    r"Hit\s+any\s+key\s+to\s+stop\s+autoboot|"    # U-Boot autoboot window
+    r"\bautoboot\b|"                              # generic autoboot countdown
+    r"\bONIE\b|"                                  # ONIE installer / rescue
+    r"Booting\b|Loading\b",                       # generic boot-in-progress
+    flags=re.I,
+)
+
+
 class SSHConsoleConn(BaseConsoleConn):
     def __init__(self, **kwargs):
         if "console_username" not in kwargs \
@@ -111,6 +129,12 @@ class SSHConsoleConn(BaseConsoleConn):
         shell command and the login never happens. Detect a leftover shell
         prompt and send "exit" to return to a clean login prompt so each
         console test is independent of the previous one's teardown.
+
+        Control characters (Ctrl-C / "exit") are only ever sent once a leftover
+        SONiC shell prompt has been positively identified. If the console is in
+        a bootloader / boot stage (Arista Aboot, GRUB, U-Boot, ONIE) this method
+        sends nothing and returns, because a Ctrl-C during the bootloader's
+        autoboot window would trap the DUT in the bootloader and abort autoboot.
         """
         shell_prompt_patterns = (
             r'admin@.*:.*[\$#]',
@@ -121,9 +145,8 @@ class SSHConsoleConn(BaseConsoleConn):
         delay_factor = max(self.select_delay_factor(delay_factor), 1)
         for _ in range(max_attempts):
             try:
-                # Send Ctrl-C first to abort any pending command or PS2 continuation left by a prior session.
-                self.write_channel("\x03")
-                time.sleep(0.5 * delay_factor)
+                # Probe the current console state with a bare CR only -- never a
+                # Ctrl-C yet, so we cannot interrupt a bootloader autoboot window.
                 self.write_channel(self.RETURN)
                 # Accumulate output so a lagging prompt is reliably observed.
                 output = ""
@@ -133,15 +156,27 @@ class SSHConsoleConn(BaseConsoleConn):
             except Exception as e:
                 self.logger.warning(f"Error probing console state: {e}")
                 return
+            # Never send Ctrl-C / keys while the DUT is in a bootloader or boot
+            # stage: on Arista Aboot the "Press Control-C now to enter Aboot shell"
+            # window would trap the DUT at the Aboot# shell and abort autoboot so
+            # SONiC never boots (the same applies to GRUB / U-Boot / ONIE).
+            if BOOTLOADER_BANNER_RE.search(output):
+                self.logger.warning(
+                    "Console is in a bootloader/boot stage; skipping login-prompt "
+                    "recovery to avoid trapping autoboot")
+                return
             # Already at a login prompt -> nothing to recover.
             if re.search(r"login:\s*$", output, flags=re.I | re.M):
                 return
-            # Logged-in shell left over from a previous session -> log out.
+            # Logged-in shell left over from a previous session -> abort any pending
+            # command with Ctrl-C, then log out to return to a clean login prompt.
             if any(re.search(p, output) for p in shell_prompt_patterns):
                 self.logger.warning(
-                    "Console is at a leftover shell prompt; sending 'exit' to "
-                    "return to the login prompt")
+                    "Console is at a leftover shell prompt; sending Ctrl-C + 'exit' "
+                    "to return to the login prompt")
                 try:
+                    self.write_channel("\x03")
+                    time.sleep(0.5 * delay_factor)
                     self.write_channel("exit" + self.RETURN)
                     time.sleep(1 * delay_factor)
                 except Exception as e:

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -21,7 +21,7 @@ BOOTLOADER_BANNER_RE = re.compile(
     r"Hit\s+any\s+key\s+to\s+stop\s+autoboot|"    # U-Boot autoboot window
     r"\bautoboot\b|"                              # generic autoboot countdown
     r"\bONIE\b|"                                  # ONIE installer / rescue
-    r"Booting\b|Loading\b",                       # generic boot-in-progress
+    r"\bBooting\b|\bLoading\b",                   # generic boot-in-progress
     flags=re.I,
 )
 

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -66,8 +66,37 @@ class SSHConsoleConn(BaseConsoleConn):
         kwargs['device_type'] = "_ssh"
         super(SSHConsoleConn, self).__init__(**kwargs)
 
+    def _read_initial_console(self, max_reads=20, delay_factor=1):
+        """Passively read the initial console output WITHOUT writing anything.
+
+        session_preparation() must inspect the first console output (a console
+        server "port is in use" notice, or a bootloader "hit any key to stop
+        autoboot" banner) BEFORE it has classified the console state. Netmiko's
+        inherited _test_channel_read() is unsafe here: when its first read
+        returns empty it writes RETURN (an "any key" press) to coax data out,
+        and on a quiet bootloader autoboot window that CR aborts autoboot and
+        traps the DUT in the bootloader. This helper mirrors that
+        read-until-data behaviour but never writes a byte, so no key can reach
+        the DUT before the bootloader guards below run. It follows the same
+        passive "read first, classify, only then maybe nudge" idiom used by
+        _recover_to_login_prompt() and _is_at_sonic_prompt().
+        """
+        delay_factor = max(self.select_delay_factor(delay_factor), 1)
+        output = ""
+        for _ in range(max_reads):
+            output += self.read_channel()
+            if output:
+                break
+            time.sleep(0.5 * delay_factor)
+        return output
+
     def session_preparation(self):
-        session_init_msg = self._test_channel_read()
+        # Read the initial banner PASSIVELY -- never write to the channel before
+        # the console state is classified below. The inherited netmiko
+        # _test_channel_read() would write a RETURN on an empty read, which on a
+        # quiet autoboot window aborts autoboot and traps the DUT (see
+        # _read_initial_console).
+        session_init_msg = self._read_initial_console()
         self.logger.debug(session_init_msg)
         # Reset the bootloader-deferred signal at the start of every preparation so a
         # caller can consistently read whether login was deferred due to a boot stage.
@@ -318,7 +347,25 @@ class SSHConsoleConn(BaseConsoleConn):
                     self.write_channel(str(self.menu_port) + self.RETURN)
                     menu_port_sent = True
 
-                output = self.read_channel()
+                # Read the DUT serial line. In defer_on_bootloader mode, observe it
+                # PASSIVELY over a few reads before the loop can send any wake-up CR:
+                # a single read can land in an autoboot countdown gap and miss a
+                # bootloader banner, and a premature CR counts as "hit any key to stop
+                # autoboot" and would trap the DUT. This mirrors _recover_to_login_prompt()
+                # (read first, classify, only then maybe nudge). Non-defer callers keep the
+                # original single read, so ordinary login timing is unchanged, and the reads
+                # feed the same `output` the username detection below uses so a real
+                # login/username prompt is still handled normally.
+                if defer_on_bootloader and not user_sent:
+                    output = ""
+                    for _ in range(4):
+                        output += self.read_channel()
+                        if (BOOTLOADER_BANNER_RE.search(return_msg + output)
+                                or re.search(username_pattern, output, flags=re.I)):
+                            break
+                        time.sleep(0.5 * delay_factor)
+                else:
+                    output = self.read_channel()
                 return_msg += output
 
                 # Search for username pattern / send username

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -83,7 +83,7 @@ class SSHConsoleConn(BaseConsoleConn):
         """
         return super(SSHConsoleConn, self)._try_session_preparation(force_data=False)
 
-    def _read_initial_console(self, max_reads=20, delay_factor=1):
+    def _read_initial_console(self, max_reads=6, delay_factor=1):
         """Passively read the initial console output WITHOUT writing anything.
 
         session_preparation() must inspect the first console output (a console
@@ -97,6 +97,16 @@ class SSHConsoleConn(BaseConsoleConn):
         the DUT before the bootloader guards below run. It follows the same
         passive "read first, classify, only then maybe nudge" idiom used by
         _recover_to_login_prompt() and _is_at_sonic_prompt().
+
+        The wait is deliberately short (max_reads*0.5s). Because we suppress
+        netmiko's priming CR (see _try_session_preparation), a genuinely SILENT
+        console now returns nothing here; stopping early is safe because a silent
+        console is by definition NOT in an active autoboot window (autoboot prints
+        a continuous countdown that arrives within the first read or two) and the
+        console-server "port is in use" notice is sent immediately on connect.
+        Bounding the wait keeps session_preparation() well inside the reboot
+        console-log collector's ~10s budget (reboot.py collect_console_log); the
+        later guarded steps elicit the login prompt when needed.
         """
         delay_factor = max(self.select_delay_factor(delay_factor), 1)
         output = ""

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -69,6 +69,9 @@ class SSHConsoleConn(BaseConsoleConn):
     def session_preparation(self):
         session_init_msg = self._test_channel_read()
         self.logger.debug(session_init_msg)
+        # Reset the bootloader-deferred signal at the start of every preparation so a
+        # caller can consistently read whether login was deferred due to a boot stage.
+        self._bootloader_deferred = False
 
         if re.search(
             r"(Port is in use. Closing connection...|Cannot connect: line \[\d{2}\] is busy)",
@@ -115,6 +118,9 @@ class SSHConsoleConn(BaseConsoleConn):
             # During a bootloader "hit any key to stop autoboot" window those RETURNs would
             # abort autoboot and trap the DUT (and find_prompt() would raise since no prompt
             # exists yet). Return with zero writes so the caller can passively monitor boot.
+            # Mirror the menu-port path: record the deferral so callers can detect the
+            # non-interactive boot stage and avoid later writes that could abort autoboot.
+            self._bootloader_deferred = True
             return
         # Attempt all sonic password. A wrong password must not prevent a
         # subsequent correct password in the list from succeeding, so we

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -92,7 +92,16 @@ class SSHConsoleConn(BaseConsoleConn):
                                menu_port=self.menu_port,
                                pri_prompt_terminator=r".*login")
         # Exit any leftover shell from a previous test so we start at a clean login prompt.
-        self._recover_to_login_prompt()
+        # If the DUT is in a bootloader / boot stage, defer interactive login entirely:
+        # login_stage_2() sends periodic CRs while waiting for the username prompt, and on
+        # a "hit any key to stop autoboot" window (e.g. U-Boot) those CRs would abort
+        # autoboot and trap the DUT. Finalise the session without attempting login.
+        if self._recover_to_login_prompt():
+            self.logger.warning(
+                "DUT is in a bootloader/boot stage; deferring interactive login to "
+                "avoid interrupting autoboot")
+            self.session_preparation_finalise()
+            return
         # Attempt all sonic password. A wrong password must not prevent a
         # subsequent correct password in the list from succeeding, so we
         # re-synchronise the terminal back to a fresh "login:" prompt between
@@ -146,6 +155,13 @@ class SSHConsoleConn(BaseConsoleConn):
         a bootloader / boot stage (Arista Aboot, GRUB, U-Boot, ONIE) this method
         sends nothing and returns, because a Ctrl-C during the bootloader's
         autoboot window would trap the DUT in the bootloader and abort autoboot.
+
+        Returns:
+            bool: ``True`` if the console was found in a bootloader / boot stage
+            (interactive login must be deferred so the caller does not send any
+            keys -- even a bare CR aborts a "hit any key" autoboot window such as
+            U-Boot's). ``False`` otherwise (login prompt, recovered shell, or an
+            indeterminate state), in which case the normal login flow may proceed.
         """
         shell_prompt_patterns = (
             r'admin@.*:.*[\$#]',
@@ -176,19 +192,22 @@ class SSHConsoleConn(BaseConsoleConn):
                         output += self.read_channel()
             except Exception as e:
                 self.logger.warning(f"Error probing console state: {e}")
-                return
+                return False
             # Never send Ctrl-C / keys while the DUT is in a bootloader or boot
             # stage: on Arista Aboot the "Press Control-C now to enter Aboot shell"
             # window would trap the DUT at the Aboot# shell and abort autoboot so
-            # SONiC never boots (the same applies to GRUB / U-Boot / ONIE).
+            # SONiC never boots (the same applies to GRUB / U-Boot / ONIE). Signal
+            # the bootloader state to the caller so it also defers interactive
+            # login (login_stage_2 sends periodic CRs that would abort a "hit any
+            # key to stop autoboot" window such as U-Boot's).
             if BOOTLOADER_BANNER_RE.search(output):
                 self.logger.warning(
                     "Console is in a bootloader/boot stage; skipping login-prompt "
                     "recovery to avoid trapping autoboot")
-                return
+                return True
             # Already at a login prompt -> nothing to recover.
             if re.search(r"login:\s*$", output, flags=re.I | re.M):
-                return
+                return False
             # Logged-in shell left over from a previous session -> abort any pending
             # command with Ctrl-C, then log out to return to a clean login prompt.
             if any(re.search(p, output) for p in shell_prompt_patterns):
@@ -202,11 +221,12 @@ class SSHConsoleConn(BaseConsoleConn):
                     time.sleep(1 * delay_factor)
                 except Exception as e:
                     self.logger.warning(f"Error sending exit during recovery: {e}")
-                    return
+                    return False
                 continue
             # Unknown / transient state: try once more.
         # Best effort: clear whatever is pending so the login starts clean.
         self.clear_buffer()
+        return False
 
     def _resync_to_login_prompt(self, max_loops=20, delay_factor=1):
         """

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -40,8 +40,25 @@ BOOTLOADER_BANNER_RE = re.compile(
 )
 
 
+class ConsoleRebootStartedError(Exception):
+    """Raised to abort console I/O once the DUT reboot has started.
+
+    The reboot flow (tests/common/reboot.py) sets a cancel event right before it
+    reboots the DUT. If a console worker is still preparing its session at that
+    point, any further write to the serial line could land in the bootloader
+    autoboot window and trap the DUT, so write_channel() raises this to unwind
+    the (now useless) session preparation without sending another byte.
+    """
+    pass
+
+
 class SSHConsoleConn(BaseConsoleConn):
     def __init__(self, **kwargs):
+        # A threading.Event the reboot flow sets right before it reboots the DUT.
+        # Popped here so it never reaches netmiko's BaseConnection. Once set,
+        # every write to the DUT serial line is refused (see write_channel) so a
+        # late login/wake-up CR cannot abort bootloader autoboot.
+        self._cancel_event = kwargs.pop("cancel_event", None)
         if "console_username" not in kwargs \
                 or "console_password" not in kwargs:
             raise ValueError("Either console_username or console_password is not set")
@@ -68,6 +85,22 @@ class SSHConsoleConn(BaseConsoleConn):
         kwargs['host'] = kwargs['console_host']
         kwargs['device_type'] = "_ssh"
         super(SSHConsoleConn, self).__init__(**kwargs)
+
+    def write_channel(self, out):
+        """Single chokepoint for every byte we send to the DUT serial line.
+
+        All DUT-side writes -- login CRs, username/password, menu-port selection,
+        the silent-console CR nudge in _recover_to_login_prompt(), and find_prompt()
+        CRs -- go through here. If the reboot has already started, refuse the write
+        and abort: reboot.py's console worker is run via pool.apply_async().get(
+        timeout=10), and that timeout does NOT cancel the underlying ThreadPool
+        task, so without this guard a late CR from a still-running worker could
+        land in the bootloader autoboot window and trap the DUT.
+        """
+        if self._cancel_event is not None and self._cancel_event.is_set():
+            raise ConsoleRebootStartedError(
+                "Reboot started; aborting console write to keep bootloader autoboot intact")
+        return super(SSHConsoleConn, self).write_channel(out)
 
     def _try_session_preparation(self, force_data=False):
         """Suppress netmiko's pre-session priming CR (bootloader-safe).

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -66,6 +66,23 @@ class SSHConsoleConn(BaseConsoleConn):
         kwargs['device_type'] = "_ssh"
         super(SSHConsoleConn, self).__init__(**kwargs)
 
+    def _try_session_preparation(self, force_data=False):
+        """Suppress netmiko's pre-session priming CR (bootloader-safe).
+
+        netmiko's BaseConnection._open() calls _try_session_preparation() with
+        force_data=True, which writes a bare RETURN to the channel BEFORE
+        session_preparation() runs, to guarantee there is data to read. On a
+        serial console whose DUT may be sitting in a bootloader "hit any key to
+        stop autoboot" window at connect time, that unguarded CR counts as a
+        keypress, aborts autoboot and traps the DUT -- the exact failure this
+        class defends against everywhere else, but happening before any of our
+        bootloader classification can run. session_preparation() already reads
+        the initial banner passively via _read_initial_console() (which tolerates
+        a silent channel), so the priming CR is unnecessary. Force it off so no
+        byte reaches the DUT until the bootloader guards below have run.
+        """
+        return super(SSHConsoleConn, self)._try_session_preparation(force_data=False)
+
     def _read_initial_console(self, max_reads=20, delay_factor=1):
         """Passively read the initial console output WITHOUT writing anything.
 
@@ -160,7 +177,8 @@ class SSHConsoleConn(BaseConsoleConn):
             password = self.sonic_password[i]
             try:
                 self.login_stage_2(username=self.sonic_username,
-                                   password=password)
+                                   password=password,
+                                   defer_on_bootloader=True)
             except NetMikoAuthenticationException as e:
                 if i == len(self.sonic_password) - 1:
                     raise e
@@ -169,6 +187,17 @@ class SSHConsoleConn(BaseConsoleConn):
                 # password in the list.
                 self._resync_to_login_prompt()
             else:
+                if getattr(self, "_bootloader_deferred", False):
+                    # login_stage_2() saw a bootloader/boot banner on the DUT serial
+                    # line while waiting for the login prompt and stopped before
+                    # sending any wake-up CR. Defer interactive login (mirror the
+                    # menu-port and _recover_to_login_prompt paths) so a "hit any key
+                    # to stop autoboot" window missed by the earlier classification is
+                    # never aborted, and do NOT finalise (set_base_prompt would write).
+                    self.logger.warning(
+                        "DUT is in a bootloader/boot stage (direct console); deferring "
+                        "interactive login to avoid interrupting autoboot")
+                    return
                 break
 
         self.session_preparation_finalise()

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -90,7 +90,17 @@ class SSHConsoleConn(BaseConsoleConn):
             self.login_stage_2(username=self.username,
                                password=self.password,
                                menu_port=self.menu_port,
-                               pri_prompt_terminator=r".*login")
+                               pri_prompt_terminator=r".*login",
+                               defer_on_bootloader=True)
+            if getattr(self, "_bootloader_deferred", False):
+                # login_stage_2() saw a bootloader/boot banner on the DUT serial line
+                # after selecting the menu port and stopped before sending any DUT-side
+                # CR. Defer interactive login so we do not abort a "hit any key to stop
+                # autoboot" window; the caller can then passively monitor the boot.
+                self.logger.warning(
+                    "DUT is in a bootloader/boot stage (menu port); deferring "
+                    "interactive login to avoid interrupting autoboot")
+                return
         # Exit any leftover shell from a previous test so we start at a clean login prompt.
         # If the DUT is in a bootloader / boot stage, defer interactive login entirely:
         # login_stage_2() sends periodic CRs while waiting for the username prompt, and on
@@ -273,7 +283,8 @@ class SSHConsoleConn(BaseConsoleConn):
                       username_pattern=r"(?:user:|username|login:|user name)",
                       pwd_pattern=r"assword",
                       delay_factor=1,
-                      max_loops=20
+                      max_loops=20,
+                      defer_on_bootloader=False
                       ):
         """
         Perform a stage_2 login
@@ -289,6 +300,8 @@ class SSHConsoleConn(BaseConsoleConn):
         menu_port_sent = False
         user_sent = False
         password_sent = False
+        if defer_on_bootloader:
+            self._bootloader_deferred = False
         # The following prompt is only for SONiC
         # Need to add more login failure prompt for other system
         login_failure_prompt = r".*incorrect"
@@ -340,6 +353,15 @@ class SSHConsoleConn(BaseConsoleConn):
                 # Only send blank CR to wake up terminal when still waiting for username prompt;
                 # once username has been sent, stop sending CRs so no empty password arrives before 'Password:' prompt
                 if not user_sent:
+                    if defer_on_bootloader and BOOTLOADER_BANNER_RE.search(return_msg):
+                        # A bootloader/boot banner is on the DUT serial line: do NOT send
+                        # the wake-up CR -- it counts as "hit any key to stop autoboot"
+                        # and would trap the DUT. Signal the caller to defer login.
+                        self.logger.warning(
+                            "Console is in a bootloader/boot stage; deferring login to "
+                            "avoid aborting autoboot")
+                        self._bootloader_deferred = True
+                        return return_msg
                     self.write_channel(self.RETURN)
                 time.sleep(0.5 * delay_factor)
                 i += 1
@@ -349,6 +371,12 @@ class SSHConsoleConn(BaseConsoleConn):
                 raise NetMikoAuthenticationException(msg)
 
         # Last try to see if we already logged in
+        if defer_on_bootloader and BOOTLOADER_BANNER_RE.search(return_msg):
+            self.logger.warning(
+                "Console is in a bootloader/boot stage; deferring login to avoid "
+                "aborting autoboot")
+            self._bootloader_deferred = True
+            return return_msg
         self.write_channel(self.RETURN)
         time.sleep(0.5 * delay_factor)
         output = self.read_channel()
@@ -370,8 +398,19 @@ class SSHConsoleConn(BaseConsoleConn):
             bool: True if at SONiC prompt, False otherwise (including GRUB, ONIE, boot stages, etc.)
         """
         try:
-            # Send a CR and accumulate the echo to elicit the prompt (empty after login); harmless at GRUB/ONIE.
+            # Passively read the console FIRST -- never send a key before we know the
+            # state. If the DUT is in a bootloader/boot stage (e.g. a reboot autoboot
+            # window while cleanup() runs), a CR here counts as "hit any key to stop
+            # autoboot" and would trap the DUT, so classify from passive output and bail.
             output = ""
+            for _ in range(4):
+                time.sleep(0.5)
+                output += self.read_channel()
+            if BOOTLOADER_BANNER_RE.search(output):
+                self.logger.warning(
+                    "Console is in a bootloader/boot stage; not at a SONiC prompt")
+                return False
+            # Not a bootloader -> elicit the prompt (empty after login) with a CR.
             for _ in range(4):
                 self.write_channel(self.RETURN)
                 time.sleep(0.5)

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -24,7 +24,7 @@ from paramiko.ssh_exception import SSHException
 # kernel/ramdisk loads so shell strings like "reloading"/"Loading configuration" do
 # not match.
 BOOTLOADER_BANNER_RE = re.compile(
-    r"Press\s+Control[-\s]?C|"                    # Arista Aboot autoboot window
+    r"Press\s+Control[-\s]?C\s+now|"              # Arista Aboot autoboot window ("...now to enter Aboot shell")
     r"Aboot#|"                                    # Arista Aboot shell prompt
     r"GNU\s+GRUB|grub\s*>|grub\s+rescue\s*>|"     # GRUB menu / shell
     r"Hit\s+any\s+key\s+to\s+stop\s+autoboot|"    # U-Boot autoboot window
@@ -127,6 +127,10 @@ class SSHConsoleConn(BaseConsoleConn):
         self.logger.debug(session_init_msg)
         # Reset the bootloader-deferred signal at the start of every preparation so a
         # caller can consistently read whether login was deferred due to a boot stage.
+        # It is set at any of several checkpoints that can be the FIRST to observe a
+        # boot banner (initial read, menu-port login, _recover_to_login_prompt, and
+        # login_stage_2's mid-wait / final-try) -- defense-in-depth so no single missed
+        # classification lets a key reach a 'hit any key to stop autoboot' window.
         self._bootloader_deferred = False
 
         if re.search(
@@ -160,6 +164,18 @@ class SSHConsoleConn(BaseConsoleConn):
                     "DUT is in a bootloader/boot stage (menu port); deferring "
                     "interactive login to avoid interrupting autoboot")
                 return
+        # The initial passive read itself may contain a one-shot bootloader/boot banner
+        # (e.g. a single "Hit any key to stop autoboot" or ONIE line) that then goes
+        # quiet. _recover_to_login_prompt() re-reads from scratch and, on a now-silent
+        # line, nudges with a bare CR -- which aborts autoboot on U-Boot/ONIE. Classify
+        # the first read here and defer immediately if it already shows a boot stage, so
+        # no key is ever sent even when the banner appeared only in that first read.
+        if BOOTLOADER_BANNER_RE.search(session_init_msg):
+            self.logger.warning(
+                "Initial console banner shows a bootloader/boot stage; deferring "
+                "interactive login to avoid interrupting autoboot")
+            self._bootloader_deferred = True
+            return
         # Exit any leftover shell from a previous test so we start at a clean login prompt.
         # If the DUT is in a bootloader / boot stage, defer interactive login entirely:
         # login_stage_2() sends periodic CRs while waiting for the username prompt, and on
@@ -495,8 +511,9 @@ class SSHConsoleConn(BaseConsoleConn):
             # window while cleanup() runs), a CR here counts as "hit any key to stop
             # autoboot" and would trap the DUT, so classify from passive output and bail.
             output = ""
-            for _ in range(4):
-                time.sleep(0.5)
+            for i in range(4):
+                if i:
+                    time.sleep(0.5)
                 output += self.read_channel()
             if BOOTLOADER_BANNER_RE.search(output):
                 self.logger.warning(

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -95,12 +95,16 @@ class SSHConsoleConn(BaseConsoleConn):
         # If the DUT is in a bootloader / boot stage, defer interactive login entirely:
         # login_stage_2() sends periodic CRs while waiting for the username prompt, and on
         # a "hit any key to stop autoboot" window (e.g. U-Boot) those CRs would abort
-        # autoboot and trap the DUT. Finalise the session without attempting login.
+        # autoboot and trap the DUT. Return immediately without attempting login.
         if self._recover_to_login_prompt():
             self.logger.warning(
                 "DUT is in a bootloader/boot stage; deferring interactive login to "
                 "avoid interrupting autoboot")
-            self.session_preparation_finalise()
+            # Do NOT call session_preparation_finalise() here: it runs set_base_prompt()
+            # -> find_prompt(), which writes RETURN(s) to the console to elicit a prompt.
+            # During a bootloader "hit any key to stop autoboot" window those RETURNs would
+            # abort autoboot and trap the DUT (and find_prompt() would raise since no prompt
+            # exists yet). Return with zero writes so the caller can passively monitor boot.
             return
         # Attempt all sonic password. A wrong password must not prevent a
         # subsequent correct password in the list from succeeding, so we

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -28,7 +28,10 @@ BOOTLOADER_BANNER_RE = re.compile(
     r"Aboot#|"                                    # Arista Aboot shell prompt
     r"GNU\s+GRUB|grub\s*>|grub\s+rescue\s*>|"     # GRUB menu / shell
     r"Hit\s+any\s+key\s+to\s+stop\s+autoboot|"    # U-Boot autoboot window
-    r"\bautoboot\b|"                              # generic autoboot countdown
+    r"autoboot\s+in\b|stop\s+autoboot|"           # autoboot countdown ("autoboot in N"),
+                                                  # "... stop autoboot". NOT a bare "autoboot"
+                                                  # word: that false-positives on shell/log
+                                                  # text (e.g. "fw_printenv | grep autoboot").
     r"ONIE:|"                                     # ONIE installer / rescue (anchored;
                                                   # bare \bONIE\b matches "ONIE Version")
     r"^\s*Booting\b|"                             # boot-in-progress (line-anchored)
@@ -80,6 +83,11 @@ class SSHConsoleConn(BaseConsoleConn):
         the initial banner passively via _read_initial_console() (which tolerates
         a silent channel), so the priming CR is unnecessary. Force it off so no
         byte reaches the DUT until the bootloader guards below have run.
+
+        The inherited ``force_data`` argument (netmiko's _open() passes ``True``) is
+        intentionally IGNORED, not removed: the override must keep the parameter to
+        accept netmiko's call signature, but we never honour it. Do not "fix" this by
+        threading the value through -- doing so re-introduces the priming CR.
         """
         return super(SSHConsoleConn, self)._try_session_preparation(force_data=False)
 
@@ -125,12 +133,15 @@ class SSHConsoleConn(BaseConsoleConn):
         # _read_initial_console).
         session_init_msg = self._read_initial_console()
         self.logger.debug(session_init_msg)
-        # Reset the bootloader-deferred signal at the start of every preparation so a
-        # caller can consistently read whether login was deferred due to a boot stage.
-        # It is set at any of several checkpoints that can be the FIRST to observe a
-        # boot banner (initial read, menu-port login, _recover_to_login_prompt, and
-        # login_stage_2's mid-wait / final-try) -- defense-in-depth so no single missed
-        # classification lets a key reach a 'hit any key to stop autoboot' window.
+        # Reset the bootloader-deferred signal at the start of every preparation. This is
+        # currently INTERNAL state only: it coordinates the early-returns within
+        # session_preparation()/login_stage_2() and has no external reader today (reboot.py
+        # just holds the connection open and later disconnects). It is set at any of several
+        # checkpoints that can be the FIRST to observe a boot banner (initial read, menu-port
+        # login, _recover_to_login_prompt, and login_stage_2's mid-wait / final-try) --
+        # defense-in-depth so no single missed classification lets a key reach a
+        # 'hit any key to stop autoboot' window. Kept as an instance flag so a future caller
+        # (e.g. the reboot collector) could detect a deferred boot-stage login if needed.
         self._bootloader_deferred = False
 
         if re.search(
@@ -285,10 +296,13 @@ class SSHConsoleConn(BaseConsoleConn):
                     time.sleep(0.5 * delay_factor)
                     output += self.read_channel()
                 # Only if the console stayed silent do we nudge it with a bare CR
-                # (never Ctrl-C) to coax a login prompt to echo. A silent console is
-                # not an active autoboot window -- those continuously print a
-                # countdown -- so a single CR here is safe and cannot interrupt
-                # autoboot.
+                # (never Ctrl-C) to coax a login prompt to echo. This rests on the
+                # assumption that an active autoboot window REPAINTS its countdown, so a
+                # fully silent probe window is not one -- true for Aboot and the common
+                # U-Boot countdown. The boundary of that guarantee is a rare U-Boot build
+                # that prints "press any key" once and then waits silently; that case is
+                # caught earlier by classifying session_init_msg in session_preparation(),
+                # before this passive re-read could see only silence.
                 if not output.strip():
                     self.write_channel(self.RETURN)
                     for _ in range(4):

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -613,8 +613,18 @@ class SSHConsoleConn(BaseConsoleConn):
         Only send 'exit' if we're certain the DUT is at a SONiC prompt.
         This prevents issues during reboot when DUT might be in GRUB or other boot stages.
         """
-        # If we are in SONiC and session is ready, send an exit to logout
-        if self._is_at_sonic_prompt():
+        # A console whose session preparation was deferred (DUT still in the
+        # bootloader/boot stage) has no SONiC prompt to probe. Probing would call
+        # _is_at_sonic_prompt(), which sends up to four RETURNs when the one-shot
+        # bootloader banner is no longer buffered -- those CRs would land in an
+        # autoboot "hit any key" window and trap the DUT. Skip all interactive
+        # probing and just close the transport below.
+        if getattr(self, "_bootloader_deferred", False):
+            self.logger.warning(
+                "Session preparation was deferred (bootloader/boot stage); "
+                "closing console transport without prompt probing")
+        # Otherwise, if we are in SONiC and the session is ready, exit to logout.
+        elif self._is_at_sonic_prompt():
             self.logger.warning("At SONiC prompt, sending exit to logout")
             try:
                 self.send_command(command_string="exit", expect_string="login:")

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -579,7 +579,7 @@ def create_linecard_console(supervisor, linecard_duthost, inv_files, creds):
         pytest.skip(f"Linecard console not supported: {str(e)}")
 
 
-def create_duthost_console(duthost, localhost, conn_graph_facts, creds):  # noqa: F811
+def create_duthost_console(duthost, localhost, conn_graph_facts, creds, cancel_event=None):  # noqa: F811
     dut_hostname = duthost.hostname
     console_host = conn_graph_facts['device_console_info'][dut_hostname]['ManagementIp']
     if "/" in console_host:
@@ -656,6 +656,7 @@ def create_duthost_console(duthost, localhost, conn_graph_facts, creds):  # noqa
                 console_username=console_username,
                 console_password=creds["console_password"][console_type],
                 console_device=console_device,
+                cancel_event=cancel_event,
             )
         except Exception as e:
             logger.warning(f"Attempt {attempt}/3 failed: {e}")

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -386,8 +386,13 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         prev_reboot_cause_history = duthost.show_and_parse("show reboot-cause history")
 
     console_obj = None
+    # Set right before the reboot to tell a still-running console worker to stop
+    # writing to the DUT serial line (see below): console_thread_res.get(timeout=)
+    # does NOT cancel the ThreadPool task, so the worker can outlive the timeout.
+    reboot_started_event = threading.Event()
     console_thread_res = pool.apply_async(
-        collect_console_log, args=(duthost, localhost))
+        collect_console_log, args=(duthost, localhost),
+        kwds={"cancel_event": reboot_started_event})
 
     # Block and wait for console to be ready before starting reboot
     console_wait_max_seconds = 10
@@ -397,6 +402,12 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     except Exception as e:
         logger.warning(f"Console connection timed out or failed: {e}, proceeding with reboot anyway")
         console_obj = None
+
+    # The reboot is about to start. Signal any console worker still running its
+    # session preparation (the get(timeout=) above did not cancel it) to stop
+    # writing to the DUT: a late login/wake-up CR must not land in the bootloader
+    # autoboot window and trap the DUT -- the exact race this fix guards against.
+    reboot_started_event.set()
 
     # Perform reboot
     if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch") \
@@ -746,9 +757,10 @@ def check_determine_reboot_cause_service(dut):
             Current sub-state: {sub_state}"
 
 
-def try_create_dut_console(duthost, localhost, conn_graph_facts, creds):
+def try_create_dut_console(duthost, localhost, conn_graph_facts, creds, cancel_event=None):
     try:
-        dut_sonsole = create_duthost_console(duthost, localhost, conn_graph_facts, creds)
+        dut_sonsole = create_duthost_console(duthost, localhost, conn_graph_facts, creds,
+                                             cancel_event=cancel_event)
     except Exception as err:
         logger.warning(f"Fail to create dut console. Please check console config or if console works or not. {err}")
         return None
@@ -756,7 +768,7 @@ def try_create_dut_console(duthost, localhost, conn_graph_facts, creds):
     return dut_sonsole
 
 
-def collect_console_log(duthost, localhost):
+def collect_console_log(duthost, localhost, cancel_event=None):
     """
     Collect console log during reboot.
 
@@ -766,13 +778,17 @@ def collect_console_log(duthost, localhost):
     Args:
         duthost: DUT host object
         localhost: localhost object
+        cancel_event: optional threading.Event the caller sets right before it
+            reboots the DUT. Once set, the console connection stops writing to the
+            DUT serial line so a late CR cannot interrupt bootloader autoboot.
 
     Returns:
         ConsoleHost object if successful, None otherwise
     """
     creds = creds_on_dut(duthost)
     conn_graph_facts = get_graph_facts(duthost, localhost, [duthost.hostname])
-    dut_console = try_create_dut_console(duthost, localhost, conn_graph_facts, creds)
+    dut_console = try_create_dut_console(duthost, localhost, conn_graph_facts, creds,
+                                         cancel_event=cancel_event)
     if dut_console:
         logger.info("Console connection established successfully")
     else:

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -759,13 +759,13 @@ def check_determine_reboot_cause_service(dut):
 
 def try_create_dut_console(duthost, localhost, conn_graph_facts, creds, cancel_event=None):
     try:
-        dut_sonsole = create_duthost_console(duthost, localhost, conn_graph_facts, creds,
+        dut_console = create_duthost_console(duthost, localhost, conn_graph_facts, creds,
                                              cancel_event=cancel_event)
     except Exception as err:
         logger.warning(f"Fail to create dut console. Please check console config or if console works or not. {err}")
         return None
     logger.info("creating dut console succeeds")
-    return dut_sonsole
+    return dut_console
 
 
 def collect_console_log(duthost, localhost, cancel_event=None):

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -864,6 +864,17 @@ def collect_mgmt_config_by_console(duthost, localhost):
     conn_graph_facts = get_graph_facts(duthost, localhost, [duthost.hostname])
     dut_console = try_create_dut_console(duthost, localhost, conn_graph_facts, creds)
     if dut_console:
+        # try_create_dut_console may hand back a console that deferred its
+        # session preparation because the DUT was still in the bootloader/boot
+        # stage. Such an object has no established prompt, so send_command would
+        # just time out (and, historically, could nudge the bootloader). Skip the
+        # console commands in that case rather than driving a half-initialized
+        # session.
+        if getattr(dut_console, "_bootloader_deferred", False):
+            logger.warning("DUT appears stuck in bootloader/boot stage; "
+                           "skipping console mgmt-config commands")
+            dut_console.disconnect()
+            return
         dut_console.send_command("ip a s eth0")
         dut_console.send_command("show ip int")
         dut_console.disconnect()

--- a/tests/common/unit_tests/connections/unit_test_console_host.py
+++ b/tests/common/unit_tests/connections/unit_test_console_host.py
@@ -1,0 +1,109 @@
+"""
+Unit tests for tests/common/connections/console_host.py.
+
+The reboot console-log collector passes a ``cancel_event`` down to the console
+factory so it can abort a slow session-preparation the instant a reboot starts
+(see #26351). Only ``SSHConsoleConn`` knows how to consume that kwarg -- it pops
+it before delegating to netmiko. Every other console class forwards ``**kwargs``
+straight into netmiko, which raises ``TypeError: __init__() got an unexpected
+keyword argument 'cancel_event'`` and silently breaks console-log collection on
+telnet / conserver console servers (the exception is swallowed by the
+try_create_dut_console retry loop).
+
+These tests pin the contract: ``cancel_event`` is injected ONLY when the resolved
+console class is (a subclass of) ``SSHConsoleConn`` and is never leaked to the
+other console classes.
+
+Follows the repo unit-test convention (unit_test_*.py, run with --noconftest).
+"""
+
+import os
+import sys
+import threading
+from unittest import mock
+
+import pytest
+
+# Make the repo root importable so ``tests.common.connections.console_host``
+# resolves regardless of the pytest invocation directory. Mirrors the existing
+# repo unit-test convention (see tests/common/unit_tests/devices/).
+_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(_TEST_DIR)))
+)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from tests.common.connections import console_host as console_host_mod  # noqa: E402
+from tests.common.connections.console_host import ConsoleHost  # noqa: E402
+from tests.common.connections.base_console_conn import (  # noqa: E402
+    CONSOLE_SSH,
+    CONSOLE_SSH_CISCO_CONFIG,
+    CONSOLE_SSH_MENU_PORTS,
+    CONSOLE_SSH_DIGI_CONFIG,
+    CONSOLE_SSH_SONIC_CONFIG,
+    CONSOLE_TELNET,
+    CONSOLE_CONSERVER,
+)
+
+
+_COMMON_KWARGS = dict(
+    console_host="10.0.0.1",
+    console_port="2001",
+    sonic_username="admin",
+    sonic_password="password",
+    console_username="cadmin",
+    console_password="cpassword",
+)
+
+# console_type -> the class ConsoleHost resolves it to.
+SSH_CONSOLE_TYPES = [
+    CONSOLE_SSH,
+    CONSOLE_SSH_CISCO_CONFIG,
+    CONSOLE_SSH_MENU_PORTS,
+    CONSOLE_SSH_DIGI_CONFIG,
+    CONSOLE_SSH_SONIC_CONFIG,
+]
+NON_SSH_CONSOLE_TYPES = [
+    CONSOLE_TELNET,
+    CONSOLE_CONSERVER,
+]
+
+
+def _capture_init_kwargs(console_type, cancel_event):
+    """Instantiate ConsoleHost with the real class __init__ patched to a no-op
+    that records the kwargs it was called with. Returns the captured kwargs."""
+    cls = console_host_mod.ConsoleTypeMapper[console_type]
+    with mock.patch.object(cls, "__init__", return_value=None) as mocked_init:
+        ConsoleHost(
+            console_type=console_type,
+            cancel_event=cancel_event,
+            **_COMMON_KWARGS,
+        )
+    assert mocked_init.call_count == 1
+    return mocked_init.call_args.kwargs
+
+
+@pytest.mark.parametrize("console_type", SSH_CONSOLE_TYPES)
+def test_cancel_event_injected_for_ssh_console(console_type):
+    event = threading.Event()
+    kwargs = _capture_init_kwargs(console_type, event)
+    assert kwargs.get("cancel_event") is event
+
+
+@pytest.mark.parametrize("console_type", NON_SSH_CONSOLE_TYPES)
+def test_cancel_event_not_leaked_to_non_ssh_console(console_type):
+    event = threading.Event()
+    kwargs = _capture_init_kwargs(console_type, event)
+    assert "cancel_event" not in kwargs, (
+        "cancel_event must not be forwarded to {}; it would reach netmiko and "
+        "raise an unexpected-keyword TypeError".format(console_type)
+    )
+
+
+@pytest.mark.parametrize("console_type", SSH_CONSOLE_TYPES + NON_SSH_CONSOLE_TYPES)
+def test_no_cancel_event_never_injected(console_type):
+    # When the caller does not supply a cancel_event, no console type should
+    # receive the kwarg at all.
+    kwargs = _capture_init_kwargs(console_type, None)
+    assert "cancel_event" not in kwargs

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -71,7 +71,12 @@ NEGATIVE_CASES = [
     "  Current: sonic-aboot-broadcom.swi",
     "Next: sonic-aboot-broadcom-legacy-th.swi",
     "admin@sonic:~$ sudo sonic-installer list",
+    "admin@sonic:~$ sudo sonic-installer install sonic-aboot-broadcom.swi",
     "admin@sonic:~$ ls /host/image-aboot-20240101/",
+    # "show platform summary" prints an "ONIE Version" field -- must NOT match
+    # (a bare \bONIE\b would hit; the token is anchored to "ONIE:").
+    "ONIE Version         : 2020.11",
+    "admin@sonic:~$ show platform summary",
     # Generic progress text that is not a kernel/ramdisk load must NOT match.
     "Loading configuration",
     "admin@sonic:~$ app: Loading modules ...",

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -46,6 +46,7 @@ POSITIVE_CASES = [
     "Booting flash:sonic and installing image",
     "Loading Linux 6.1.0 ...",
     "Loading initial ramdisk ...",
+    "Loading vmlinuz-6.1.0-22-2-amd64",
     "GNU GRUB  version 2.06",
     "grub> ",
     "grub rescue> ",
@@ -65,6 +66,15 @@ NEGATIVE_CASES = [
     "root@sonic:~# apt-get: Downloading firmware",
     "sonic login: ",
     "admin@sonic:~$ sudo config reload -y",
+    # Image filenames contain "aboot" with hyphen word boundaries -- must NOT match
+    # (this is the false-positive class Copilot flagged; a bare \bAboot\b would hit).
+    "  Current: sonic-aboot-broadcom.swi",
+    "Next: sonic-aboot-broadcom-legacy-th.swi",
+    "admin@sonic:~$ sudo sonic-installer list",
+    "admin@sonic:~$ ls /host/image-aboot-20240101/",
+    # Generic progress text that is not a kernel/ramdisk load must NOT match.
+    "Loading configuration",
+    "admin@sonic:~$ app: Loading modules ...",
 ]
 
 

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for tests/common/connections/ssh_console_conn.py.
+
+These tests guard the console-state classifier that decides whether the reboot
+console-log collector may send a Ctrl-C during recovery. Sending Ctrl-C while the
+DUT is in a bootloader/boot stage (e.g. Arista Aboot autoboot window) traps the
+box in the bootloader and aborts autoboot, so SONiC never boots and the device
+becomes permanently unreachable (the regression PR #26351 fixes).
+
+The critical property is ``BOOTLOADER_BANNER_RE``:
+  * it MUST match real bootloader / boot-in-progress banners (so Ctrl-C is
+    suppressed while booting), and
+  * it MUST NOT match ordinary SONiC shell output that merely *contains* a boot
+    substring (e.g. "reloading", "downloading") -- a false positive there causes
+    ``_recover_to_login_prompt`` to skip the Ctrl-C + exit recovery on a genuine
+    leftover shell prompt, re-introducing the username-as-shell-command desync.
+
+Follows the repo unit-test convention (unit_test_*.py, run with --noconftest).
+"""
+
+import os
+import sys
+
+import pytest
+
+# Make the repo root importable so ``tests.common.connections.ssh_console_conn``
+# resolves regardless of the pytest invocation directory. Mirrors the existing
+# repo unit-test convention (see tests/common/unit_tests/devices/). Runs in the
+# full-dependency unit-test lane.
+_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(_TEST_DIR)))
+)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from tests.common.connections.ssh_console_conn import BOOTLOADER_BANNER_RE  # noqa: E402
+
+
+# Real bootloader / boot-in-progress banners -- Ctrl-C MUST be suppressed here.
+POSITIVE_CASES = [
+    "Press Control-C now to enter Aboot shell",
+    "Press Control C now to enter Aboot shell",
+    "Aboot#",
+    "Aboot# ",
+    "Booting flash:sonic and installing image",
+    "Loading Linux 6.1.0 ...",
+    "Loading initial ramdisk ...",
+    "GNU GRUB  version 2.06",
+    "grub> ",
+    "grub rescue> ",
+    "Hit any key to stop autoboot:  3",
+    "autoboot in 5 seconds",
+    "ONIE: Starting ONIE Service Discovery",
+]
+
+# Ordinary SONiC shell / command output -- these merely CONTAIN a boot substring
+# but are NOT a bootloader state, so Ctrl-C recovery must NOT be skipped.
+NEGATIVE_CASES = [
+    "admin@sonic-dut:~$ ",
+    "root@sonic:~# ",
+    "show reloading table",
+    "Reloading service",
+    "admin@sonic:~$ downloading package index",
+    "root@sonic:~# apt-get: Downloading firmware",
+    "sonic login: ",
+    "admin@sonic:~$ sudo config reload -y",
+]
+
+
+@pytest.mark.parametrize("text", POSITIVE_CASES)
+def test_bootloader_banner_matches_real_boot_states(text):
+    assert BOOTLOADER_BANNER_RE.search(text) is not None, (
+        f"expected a bootloader/boot banner match for {text!r}"
+    )
+
+
+@pytest.mark.parametrize("text", NEGATIVE_CASES)
+def test_bootloader_banner_ignores_ordinary_shell_output(text):
+    assert BOOTLOADER_BANNER_RE.search(text) is None, (
+        f"unexpected bootloader match for {text!r} -- a false positive here makes "
+        f"_recover_to_login_prompt skip the Ctrl-C + exit recovery on a leftover shell"
+    )

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -302,6 +302,42 @@ def test_is_at_sonic_prompt_detects_shell_when_not_bootloader():
         f"non-bootloader probe must only nudge with a bare CR, got {written!r}")
 
 
+def test_cleanup_deferred_session_makes_no_writes():
+    """Deferred-session teardown (reboot.py collect_mgmt_config_by_console ->
+    disconnect() -> cleanup()) must NOT probe the prompt: _is_at_sonic_prompt()
+    would send RETURNs into a one-shot bootloader autoboot window (the banner has
+    already been consumed, so it no longer matches). cleanup() must close the
+    transport without any write_channel()/send_command() call."""
+    conn = _make_console([])
+    conn._bootloader_deferred = True
+    conn.send_command = mock.MagicMock()
+    conn._is_at_sonic_prompt = mock.MagicMock()
+    rc = conn.remote_conn = mock.MagicMock()
+
+    SSHConsoleConn.cleanup(conn)
+
+    conn._is_at_sonic_prompt.assert_not_called()
+    conn.send_command.assert_not_called()
+    assert _written(conn) == [], (
+        f"a deferred-session cleanup must write nothing, got {_written(conn)!r}")
+    rc.close.assert_called_once()
+
+
+def test_cleanup_at_sonic_prompt_still_sends_exit():
+    """Sanity: a non-deferred session still probes and logs out at a SONiC prompt,
+    so the deferred short-circuit does not disable normal cleanup."""
+    conn = _make_console([])
+    conn._bootloader_deferred = False
+    conn.send_command = mock.MagicMock()
+    conn._is_at_sonic_prompt = mock.MagicMock(return_value=True)
+    rc = conn.remote_conn = mock.MagicMock()
+
+    SSHConsoleConn.cleanup(conn)
+
+    conn.send_command.assert_called_once()
+    rc.close.assert_called_once()
+
+
 @pytest.mark.parametrize("banner", [
     "Press Control-C now to enter Aboot shell\n",
     "Hit any key to stop autoboot:  3\n",

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -366,3 +366,59 @@ def test_session_preparation_menu_port_defers_when_banner_lags_first_read():
     assert getattr(conn, "_bootloader_deferred", False) is True, "must defer login"
     conn._recover_to_login_prompt.assert_not_called()
     conn.session_preparation_finalise.assert_not_called()
+
+
+def test_try_session_preparation_writes_no_priming_cr():
+    """Fix C: netmiko's BaseConnection._open() calls _try_session_preparation()
+    with force_data=True, which writes a bare CR to the channel BEFORE
+    session_preparation() runs. On a DUT sitting in a bootloader autoboot window
+    at connect time that CR aborts autoboot and traps the box -- earlier than any
+    of our own guards. SSHConsoleConn overrides _try_session_preparation to force
+    force_data=False, so NO byte is written before session_preparation() runs."""
+    conn = SSHConsoleConn.__new__(SSHConsoleConn)
+    conn.RETURN = RETURN
+    conn.logger = mock.MagicMock()
+    conn.write_channel = mock.MagicMock()
+    conn.disconnect = mock.MagicMock()
+    conn.session_preparation = mock.MagicMock()
+
+    SSHConsoleConn._try_session_preparation(conn)
+
+    conn.write_channel.assert_not_called()
+    conn.session_preparation.assert_called_once()
+
+
+def test_session_preparation_direct_path_defers_on_bootloader():
+    """Fix B: on a direct (non-menu) console the sonic-password login loop now
+    calls login_stage_2(defer_on_bootloader=True). If login_stage_2 detects a
+    bootloader banner mid-wait (a live autoboot that the earlier
+    _recover_to_login_prompt classification missed) it sets _bootloader_deferred;
+    session_preparation must then return WITHOUT calling
+    session_preparation_finalise() (whose set_base_prompt writes CRs that would
+    abort autoboot)."""
+    conn = SSHConsoleConn.__new__(SSHConsoleConn)
+    conn.RETURN = RETURN
+    conn.logger = mock.MagicMock()
+    conn.console_type = "ssh"          # not a "*config" menu type
+    conn.menu_port = None              # direct path, no menu port
+    conn.username = "console_user:2001"
+    conn.sonic_username = "admin"
+    conn.sonic_password = ["pw1"]
+    conn._read_initial_console = mock.MagicMock(return_value="")
+    conn._recover_to_login_prompt = mock.MagicMock(return_value=False)
+    conn.session_preparation_finalise = mock.MagicMock()
+    conn.write_channel = mock.MagicMock()
+
+    def _defer(**kwargs):
+        assert kwargs.get("defer_on_bootloader") is True, \
+            "direct-path login must pass defer_on_bootloader=True"
+        conn._bootloader_deferred = True
+        return ""
+    conn.login_stage_2 = mock.MagicMock(side_effect=_defer)
+
+    with mock.patch("tests.common.connections.ssh_console_conn.time.sleep"):
+        SSHConsoleConn.session_preparation(conn)
+
+    conn.login_stage_2.assert_called_once()
+    conn.session_preparation_finalise.assert_not_called()
+    assert getattr(conn, "_bootloader_deferred", False) is True

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -422,3 +422,27 @@ def test_session_preparation_direct_path_defers_on_bootloader():
     conn.login_stage_2.assert_called_once()
     conn.session_preparation_finalise.assert_not_called()
     assert getattr(conn, "_bootloader_deferred", False) is True
+
+
+def test_read_initial_console_bounded_on_silent_console():
+    """Fix D (regression guard for Fix C): suppressing netmiko's priming CR means
+    a genuinely SILENT console returns no data here. The passive read must be
+    BOUNDED to a few reads so session_preparation() stays well inside reboot.py
+    collect_console_log()'s ~10s budget -- otherwise the console-log collection
+    during reboot would time out and silently produce no log. With the default
+    (0.5s per empty read) a bound of <=6 keeps the worst case around 3s; the old
+    unbounded value (20) burned the entire 10s budget on a silent console."""
+    conn = SSHConsoleConn.__new__(SSHConsoleConn)
+    conn.logger = mock.MagicMock()
+    conn.select_delay_factor = mock.MagicMock(return_value=1)
+    conn.write_channel = mock.MagicMock()
+    conn.read_channel = mock.MagicMock(return_value="")
+
+    with mock.patch("tests.common.connections.ssh_console_conn.time.sleep") as slept:
+        out = SSHConsoleConn._read_initial_console(conn)
+
+    assert out == ""
+    conn.write_channel.assert_not_called()          # still never writes a byte
+    assert conn.read_channel.call_count <= 6, \
+        "silent-console read must be bounded (<=6) to fit collect_console_log's 10s budget"
+    assert slept.call_count <= 6

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -203,6 +203,7 @@ def test_session_preparation_defers_login_in_bootloader():
     conn.set_base_prompt.assert_not_called()
     conn.find_prompt.assert_not_called()
     conn.write_channel.assert_not_called()
+    assert conn._bootloader_deferred is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -22,6 +22,7 @@ Follows the repo unit-test convention (unit_test_*.py, run with --noconftest).
 import collections
 import os
 import sys
+import threading
 from unittest import mock
 
 import pytest
@@ -37,7 +38,11 @@ _REPO_ROOT = os.path.dirname(
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-from tests.common.connections.ssh_console_conn import BOOTLOADER_BANNER_RE, SSHConsoleConn  # noqa: E402
+from tests.common.connections.ssh_console_conn import (  # noqa: E402
+    BOOTLOADER_BANNER_RE,
+    SSHConsoleConn,
+    ConsoleRebootStartedError,
+)
 
 
 # Real bootloader / boot-in-progress banners -- Ctrl-C MUST be suppressed here.
@@ -492,3 +497,78 @@ def test_session_preparation_defers_when_bootloader_only_in_initial_read():
         f"wrote {_written(conn)!r} -- even a bare CR can abort a 'hit any key' window")
     conn.login_stage_2.assert_not_called()
     conn.session_preparation_finalise.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Cancel-event tests: once the reboot has started, the console worker must stop
+# writing to the DUT serial line. reboot.py runs collect_console_log() via
+# pool.apply_async().get(timeout=10); that timeout does NOT cancel the underlying
+# ThreadPool task, so a worker still preparing its session could send a late CR
+# into the bootloader autoboot window and trap the DUT -- the exact race this
+# guards. reboot.py sets a threading.Event right before rebooting; SSHConsoleConn
+# refuses every write_channel() once it is set.
+# ---------------------------------------------------------------------------
+
+
+def _make_gate_console(cancel_event):
+    """A bare SSHConsoleConn wired only for write_channel() gate testing."""
+    conn = SSHConsoleConn.__new__(SSHConsoleConn)
+    conn.RETURN = RETURN
+    conn.logger = mock.MagicMock()
+    conn.select_delay_factor = mock.MagicMock(return_value=1)
+    conn.clear_buffer = mock.MagicMock()
+    conn._cancel_event = cancel_event
+    return conn
+
+
+def test_write_channel_delegates_when_not_cancelled():
+    """With no cancel event / an unset one, write_channel() passes bytes through."""
+    for cancel_event in (None, threading.Event()):
+        conn = _make_gate_console(cancel_event)
+        with mock.patch("netmiko.base_connection.BaseConnection.write_channel") as sup:
+            SSHConsoleConn.write_channel(conn, conn.RETURN)
+        sup.assert_called_once_with(conn.RETURN)
+
+
+def test_write_channel_aborts_once_reboot_started():
+    """Once the cancel event is set, write_channel() raises and sends NO byte."""
+    cancel_event = threading.Event()
+    cancel_event.set()
+    conn = _make_gate_console(cancel_event)
+    with mock.patch("netmiko.base_connection.BaseConnection.write_channel") as sup:
+        with pytest.raises(ConsoleRebootStartedError):
+            SSHConsoleConn.write_channel(conn, conn.RETURN)
+        sup.assert_not_called()
+
+
+def test_worker_stops_nudging_silent_console_when_reboot_starts():
+    """End-to-end: a silent-console recovery begins BEFORE the reboot sends its first
+    bare-CR nudge, but the reboot then starts -- the worker must not send any further
+    CR. Simulates reboot.py setting the event immediately after the first CR reaches
+    the DUT serial line; a second nudge would risk aborting a 'hit any key' autoboot
+    window on U-Boot/ONIE."""
+    cancel_event = threading.Event()
+    conn = _make_gate_console(cancel_event)
+    conn.read_channel = mock.MagicMock(return_value="")  # fully silent console
+
+    writes = []
+
+    def record_and_start_reboot(out):
+        # The real bytes that reach the DUT serial line. The reboot begins right
+        # after the first CR lands, so subsequent write_channel() calls must abort.
+        writes.append(out)
+        cancel_event.set()
+
+    with mock.patch("netmiko.base_connection.BaseConnection.write_channel",
+                    side_effect=record_and_start_reboot):
+        with mock.patch("tests.common.connections.ssh_console_conn.time.sleep"):
+            result = SSHConsoleConn._recover_to_login_prompt(conn, max_attempts=4, delay_factor=1)
+
+    # _recover_to_login_prompt swallows the abort (its I/O is wrapped in
+    # try/except -> return False); the guarantee we assert is that exactly ONE CR
+    # ever reached the DUT and it was a bare RETURN (never Ctrl-C).
+    assert result is False
+    assert writes == [RETURN], (
+        f"exactly one bare-CR nudge may reach the DUT before the reboot starts, "
+        f"got {writes!r} -- a second write would risk aborting bootloader autoboot")
+    assert CTRL_C not in writes

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -18,8 +18,10 @@ The critical property is ``BOOTLOADER_BANNER_RE``:
 Follows the repo unit-test convention (unit_test_*.py, run with --noconftest).
 """
 
+import collections
 import os
 import sys
+from unittest import mock
 
 import pytest
 
@@ -34,7 +36,7 @@ _REPO_ROOT = os.path.dirname(
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-from tests.common.connections.ssh_console_conn import BOOTLOADER_BANNER_RE  # noqa: E402
+from tests.common.connections.ssh_console_conn import BOOTLOADER_BANNER_RE, SSHConsoleConn  # noqa: E402
 
 
 # Real bootloader / boot-in-progress banners -- Ctrl-C MUST be suppressed here.
@@ -96,3 +98,95 @@ def test_bootloader_banner_ignores_ordinary_shell_output(text):
         f"unexpected bootloader match for {text!r} -- a false positive here makes "
         f"_recover_to_login_prompt skip the Ctrl-C + exit recovery on a leftover shell"
     )
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests: prove no key is written to the channel once a bootloader
+# banner is seen, and that the silent-console path only ever nudges with a bare
+# CR (never Ctrl-C). These mock the serial channel so they assert on the actual
+# bytes written, not just the classifier regex.
+# ---------------------------------------------------------------------------
+
+CTRL_C = "\x03"
+RETURN = "\r"
+
+
+def _make_console(read_chunks):
+    """Build an SSHConsoleConn with a mocked serial channel.
+
+    ``__new__`` bypasses the network-connecting __init__; we attach just the
+    attributes/methods ``_recover_to_login_prompt`` / ``session_preparation``
+    touch. ``read_channel`` yields ``read_chunks`` in order, then "" forever.
+    """
+    conn = SSHConsoleConn.__new__(SSHConsoleConn)
+    conn.RETURN = RETURN
+    conn.logger = mock.MagicMock()
+    conn.select_delay_factor = mock.MagicMock(return_value=1)
+    conn.clear_buffer = mock.MagicMock()
+    conn.write_channel = mock.MagicMock()
+    queue = collections.deque(read_chunks)
+    conn.read_channel = mock.MagicMock(side_effect=lambda: queue.popleft() if queue else "")
+    return conn
+
+
+def _written(conn):
+    """All positional payloads passed to write_channel."""
+    return [c.args[0] for c in conn.write_channel.call_args_list if c.args]
+
+
+@pytest.mark.parametrize("banner", [
+    "Press Control-C now to enter Aboot shell\n",
+    "Hit any key to stop autoboot:  3\n",
+    "GNU GRUB  version 2.06\n",
+    "ONIE: Starting ONIE Service Discovery\n",
+])
+def test_recover_writes_no_key_when_bootloader_detected(banner):
+    """No byte (CR or Ctrl-C) may be written once a bootloader banner is seen."""
+    conn = _make_console([banner])
+    with mock.patch("tests.common.connections.ssh_console_conn.time.sleep"):
+        result = SSHConsoleConn._recover_to_login_prompt(conn, max_attempts=4, delay_factor=1)
+    assert result is True, "bootloader/boot stage must be reported to the caller"
+    assert _written(conn) == [], (
+        f"no key must be written after a bootloader banner, but got {_written(conn)!r} "
+        f"-- any keypress (including CR) can abort a 'hit any key' autoboot window"
+    )
+
+
+def test_recover_silent_console_nudges_with_cr_only():
+    """A silent console is nudged with a bare CR, never Ctrl-C."""
+    conn = _make_console([])  # channel stays silent forever
+    with mock.patch("tests.common.connections.ssh_console_conn.time.sleep"):
+        result = SSHConsoleConn._recover_to_login_prompt(conn, max_attempts=2, delay_factor=1)
+    written = _written(conn)
+    assert result is False
+    assert CTRL_C not in written, "Ctrl-C must never be sent to a silent/booting console"
+    assert written and all(k == RETURN for k in written), (
+        f"silent console must only be nudged with a bare CR, got {written!r}"
+    )
+
+
+def test_recover_sends_ctrl_c_only_on_leftover_shell():
+    """A positively identified leftover shell still gets Ctrl-C + exit recovery."""
+    conn = _make_console(["admin@sonic-dut:~$ \n", "", "", "", "sonic login: \n"])
+    with mock.patch("tests.common.connections.ssh_console_conn.time.sleep"):
+        SSHConsoleConn._recover_to_login_prompt(conn, max_attempts=2, delay_factor=1)
+    written = _written(conn)
+    assert CTRL_C in written, "leftover shell recovery must still send Ctrl-C"
+    assert any(w.startswith("exit") for w in written), "recovery must send 'exit'"
+
+
+def test_session_preparation_defers_login_in_bootloader():
+    """session_preparation must skip login_stage_2 when a bootloader is detected."""
+    conn = SSHConsoleConn.__new__(SSHConsoleConn)
+    conn.logger = mock.MagicMock()
+    conn.console_type = "ssh"  # not a "*config" menu type
+    conn.menu_port = None
+    conn._test_channel_read = mock.MagicMock(return_value="")
+    conn._recover_to_login_prompt = mock.MagicMock(return_value=True)
+    conn.login_stage_2 = mock.MagicMock()
+    conn.session_preparation_finalise = mock.MagicMock()
+
+    SSHConsoleConn.session_preparation(conn)
+
+    conn.login_stage_2.assert_not_called()
+    conn.session_preparation_finalise.assert_called_once()

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -83,6 +83,12 @@ NEGATIVE_CASES = [
     # Generic progress text that is not a kernel/ramdisk load must NOT match.
     "Loading configuration",
     "admin@sonic:~$ app: Loading modules ...",
+    # "Press Control-C" without the Aboot autoboot phrasing ("now") must NOT match
+    # (external review Finding 2: a tool or log line saying "Press Control-C to abort"
+    # would otherwise defer login for the whole session and break send_command paths
+    # like collect_mgmt_config_by_console()).
+    "Press Control-C to abort the operation",
+    "admin@sonic:~$ tool: Please Press Control-C to stop",
 ]
 
 
@@ -446,3 +452,37 @@ def test_read_initial_console_bounded_on_silent_console():
     assert conn.read_channel.call_count <= 6, \
         "silent-console read must be bounded (<=6) to fit collect_console_log's 10s budget"
     assert slept.call_count <= 6
+
+
+def test_session_preparation_defers_when_bootloader_only_in_initial_read():
+    """Regression guard for the initial-read classification gap (external review
+    Finding 1). A one-shot bootloader banner can appear ONLY in the first console
+    read (session_init_msg) and then the line goes silent. Without classifying that
+    first read, _recover_to_login_prompt() re-reads a now-silent line, takes its
+    ``not output.strip()`` branch and nudges with a bare CR -- which aborts autoboot
+    on U-Boot/ONIE. session_preparation() must classify the initial read and defer
+    with ZERO writes. Distinct from
+    test_session_preparation_initial_probe_writes_no_key_in_bootloader, which feeds
+    the banner on EVERY read (so _recover_to_login_prompt still sees it)."""
+    # Banner is returned exactly once (the first read), then read_channel() -> "" forever.
+    conn = _make_console(["Hit any key to stop autoboot:  3\n"])
+    conn.console_type = "ssh"
+    conn.menu_port = None
+    conn.username = "console_user:7001"
+    conn.sonic_username = "admin"
+    conn.sonic_password = ["pw"]
+    conn.login_stage_2 = mock.MagicMock()
+    conn.session_preparation_finalise = mock.MagicMock()
+    conn.set_base_prompt = mock.MagicMock()
+    conn.find_prompt = mock.MagicMock()
+
+    with mock.patch("tests.common.connections.ssh_console_conn.time.sleep"):
+        SSHConsoleConn.session_preparation(conn)
+
+    assert conn._bootloader_deferred is True, \
+        "must defer login when the bootloader banner is only in the first read"
+    assert _written(conn) == [], (
+        f"must write nothing when the initial read shows a bootloader banner, but "
+        f"wrote {_written(conn)!r} -- even a bare CR can abort a 'hit any key' window")
+    conn.login_stage_2.assert_not_called()
+    conn.session_preparation_finalise.assert_not_called()

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -89,6 +89,12 @@ NEGATIVE_CASES = [
     # like collect_mgmt_config_by_console()).
     "Press Control-C to abort the operation",
     "admin@sonic:~$ tool: Please Press Control-C to stop",
+    # A shell/log line that merely mentions the word "autoboot" (without the real
+    # countdown phrasing "autoboot in N" / "stop autoboot") must NOT match -- the bare
+    # \bautoboot\b token was tightened for this (external review Finding 1); otherwise a
+    # U-Boot env dump would defer login and break send_command paths.
+    "admin@sonic:~$ fw_printenv | grep autoboot",
+    "admin@sonic:~$ echo 'set autoboot flag' >> notes.txt",
 ]
 
 

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -176,7 +176,13 @@ def test_recover_sends_ctrl_c_only_on_leftover_shell():
 
 
 def test_session_preparation_defers_login_in_bootloader():
-    """session_preparation must skip login_stage_2 when a bootloader is detected."""
+    """session_preparation must skip login_stage_2 AND avoid any console write when a
+    bootloader is detected.
+
+    session_preparation_finalise() -> set_base_prompt() -> find_prompt() writes RETURN(s)
+    to the console, which would abort a "hit any key to stop autoboot" window, so the
+    bootloader path must not call it.
+    """
     conn = SSHConsoleConn.__new__(SSHConsoleConn)
     conn.logger = mock.MagicMock()
     conn.console_type = "ssh"  # not a "*config" menu type
@@ -185,8 +191,14 @@ def test_session_preparation_defers_login_in_bootloader():
     conn._recover_to_login_prompt = mock.MagicMock(return_value=True)
     conn.login_stage_2 = mock.MagicMock()
     conn.session_preparation_finalise = mock.MagicMock()
+    conn.set_base_prompt = mock.MagicMock()
+    conn.find_prompt = mock.MagicMock()
+    conn.write_channel = mock.MagicMock()
 
     SSHConsoleConn.session_preparation(conn)
 
     conn.login_stage_2.assert_not_called()
-    conn.session_preparation_finalise.assert_called_once()
+    conn.session_preparation_finalise.assert_not_called()
+    conn.set_base_prompt.assert_not_called()
+    conn.find_prompt.assert_not_called()
+    conn.write_channel.assert_not_called()

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -203,3 +203,82 @@ def test_session_preparation_defers_login_in_bootloader():
     conn.set_base_prompt.assert_not_called()
     conn.find_prompt.assert_not_called()
     conn.write_channel.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests for the two remaining "send keys before knowing the console
+# state" paths (both pre-existing/legacy, hardened here so the whole file is
+# bootloader-safe): (1) the menu_port login path, which calls login_stage_2()
+# before recovery, and (2) _is_at_sonic_prompt(), which cleanup() calls during
+# reboot teardown. Each must observe the console passively and send NO DUT-side
+# key once a bootloader banner is seen.
+# ---------------------------------------------------------------------------
+
+
+def test_session_preparation_menu_port_defers_login_in_bootloader():
+    """A menu_port console must select the console-server port but then send NO
+    DUT-side key (no CR / username / login / finalise) once a bootloader banner
+    is observed on the DUT serial line."""
+    conn = SSHConsoleConn.__new__(SSHConsoleConn)
+    conn.RETURN = RETURN
+    conn.host = "dut"
+    conn.logger = mock.MagicMock()
+    conn.console_type = "ssh"            # not a "*config" menu type
+    conn.menu_port = 7
+    conn.username = "console_user"
+    conn.password = "console_pw"
+    conn.sonic_username = "admin"
+    conn.sonic_password = ["pw"]
+    conn._test_channel_read = mock.MagicMock(return_value="")
+    conn.select_delay_factor = mock.MagicMock(return_value=1)
+    # write_and_poll() (real, inherited) selects the console-server port; its
+    # read_until_pattern() is stubbed. After port selection the DUT serial shows
+    # an autoboot banner, then stays silent.
+    conn.read_until_pattern = mock.MagicMock(return_value="Selection:")
+    conn.read_channel = mock.MagicMock(side_effect=(
+        ["Press Control-C now to enter Aboot shell\n"] + [""] * 40))
+    conn.write_channel = mock.MagicMock()
+    conn._recover_to_login_prompt = mock.MagicMock()
+    conn.session_preparation_finalise = mock.MagicMock()
+
+    with mock.patch("tests.common.connections.ssh_console_conn.time.sleep"):
+        SSHConsoleConn.session_preparation(conn)
+
+    # Only the console-server menu selection may be written -- never a DUT-side CR.
+    assert _written(conn) == ["menu ports" + RETURN, "7" + RETURN], (
+        f"only the console-server port selection may be written, got {_written(conn)!r}")
+    assert RETURN not in _written(conn), "no bare DUT-side wake-up CR may be sent"
+    assert CTRL_C not in _written(conn), "no Ctrl-C may be sent"
+    # The bootloader-safe recovery and the CR-writing finalise must be skipped.
+    conn._recover_to_login_prompt.assert_not_called()
+    conn.session_preparation_finalise.assert_not_called()
+
+
+@pytest.mark.parametrize("banner", [
+    "Press Control-C now to enter Aboot shell\n",
+    "Hit any key to stop autoboot:  3\n",
+    "GNU GRUB  version 2.06\n",
+    "ONIE: Starting ONIE Service Discovery\n",
+])
+def test_is_at_sonic_prompt_writes_no_key_in_bootloader(banner):
+    """cleanup()'s prompt probe must send no key while the DUT is in a bootloader/
+    boot stage -- during a reboot that CR would abort autoboot."""
+    conn = _make_console([banner])
+    with mock.patch("tests.common.connections.ssh_console_conn.time.sleep"):
+        result = SSHConsoleConn._is_at_sonic_prompt(conn)
+    assert result is False, "a bootloader/boot stage is not a SONiC prompt"
+    assert _written(conn) == [], (
+        f"no key may be written when a bootloader banner is present, got {_written(conn)!r}")
+
+
+def test_is_at_sonic_prompt_detects_shell_when_not_bootloader():
+    """When not in a bootloader, the probe still nudges with a CR (never Ctrl-C)
+    and correctly detects the SONiC shell prompt."""
+    conn = _make_console(["", "", "", "", "admin@sonic:~$ \n"])
+    with mock.patch("tests.common.connections.ssh_console_conn.time.sleep"):
+        result = SSHConsoleConn._is_at_sonic_prompt(conn)
+    assert result is True
+    written = _written(conn)
+    assert CTRL_C not in written, "Ctrl-C must never be sent to probe the prompt"
+    assert written and all(k == RETURN for k in written), (
+        f"non-bootloader probe must only nudge with a bare CR, got {written!r}")

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -188,7 +188,7 @@ def test_session_preparation_defers_login_in_bootloader():
     conn.logger = mock.MagicMock()
     conn.console_type = "ssh"  # not a "*config" menu type
     conn.menu_port = None
-    conn._test_channel_read = mock.MagicMock(return_value="")
+    conn._read_initial_console = mock.MagicMock(return_value="")
     conn._recover_to_login_prompt = mock.MagicMock(return_value=True)
     conn.login_stage_2 = mock.MagicMock()
     conn.session_preparation_finalise = mock.MagicMock()
@@ -230,7 +230,7 @@ def test_session_preparation_menu_port_defers_login_in_bootloader():
     conn.password = "console_pw"
     conn.sonic_username = "admin"
     conn.sonic_password = ["pw"]
-    conn._test_channel_read = mock.MagicMock(return_value="")
+    conn._read_initial_console = mock.MagicMock(return_value="")
     conn.select_delay_factor = mock.MagicMock(return_value=1)
     # write_and_poll() (real, inherited) selects the console-server port; its
     # read_until_pattern() is stubbed. After port selection the DUT serial shows
@@ -283,3 +283,86 @@ def test_is_at_sonic_prompt_detects_shell_when_not_bootloader():
     assert CTRL_C not in written, "Ctrl-C must never be sent to probe the prompt"
     assert written and all(k == RETURN for k in written), (
         f"non-bootloader probe must only nudge with a bare CR, got {written!r}")
+
+
+@pytest.mark.parametrize("banner", [
+    "Press Control-C now to enter Aboot shell\n",
+    "Hit any key to stop autoboot:  3\n",
+    "GNU GRUB  version 2.06\n",
+    "ONIE: Starting ONIE Service Discovery\n",
+])
+def test_session_preparation_initial_probe_writes_no_key_in_bootloader(banner):
+    """Regression guard for the FIRST console read in session_preparation.
+
+    Netmiko's inherited _test_channel_read() writes RETURN on an empty read; on a
+    quiet bootloader "hit any key to stop autoboot" window that CR aborts autoboot
+    and traps the DUT. This exercises the REAL initial probe (_read_initial_console)
+    AND the real _recover_to_login_prompt classification -- nothing that writes is
+    stubbed away -- and asserts session_preparation sends NO DUT-side key while a
+    bootloader banner is present, and defers login.
+    """
+    # The autoboot window prints its banner continuously, so every read returns it.
+    conn = _make_console([banner] * 60)
+    conn.console_type = "ssh"            # not a "*config" menu type
+    conn.menu_port = None
+    conn.username = "console_user:7001"
+    conn.sonic_username = "admin"
+    conn.sonic_password = ["pw"]
+    conn.login_stage_2 = mock.MagicMock()
+    conn.session_preparation_finalise = mock.MagicMock()
+    conn.set_base_prompt = mock.MagicMock()
+    conn.find_prompt = mock.MagicMock()
+
+    with mock.patch("tests.common.connections.ssh_console_conn.time.sleep"):
+        SSHConsoleConn.session_preparation(conn)
+
+    assert conn._bootloader_deferred is True, "must defer login in a bootloader state"
+    assert _written(conn) == [], (
+        f"session_preparation's initial probe must write nothing while a bootloader "
+        f"banner is present, but wrote {_written(conn)!r} -- any keypress (including "
+        f"a bare CR) can abort a 'hit any key to stop autoboot' window")
+    conn.login_stage_2.assert_not_called()
+    conn.session_preparation_finalise.assert_not_called()
+    conn.set_base_prompt.assert_not_called()
+    conn.find_prompt.assert_not_called()
+
+
+def test_session_preparation_menu_port_defers_when_banner_lags_first_read():
+    """Regression guard for residual A: on a menu_port console the autoboot
+    banner may not be in the buffer on the FIRST read after port selection (a
+    single read can land in a countdown gap). login_stage_2 must observe the DUT
+    serial passively over a few reads before risking a wake-up CR, so a lagging
+    bootloader banner still defers login and NO DUT-side key is sent. With the
+    old single-read code the first empty read would have triggered a CR."""
+    conn = SSHConsoleConn.__new__(SSHConsoleConn)
+    conn.RETURN = RETURN
+    conn.host = "dut"
+    conn.logger = mock.MagicMock()
+    conn.console_type = "ssh"            # not a "*config" menu type
+    conn.menu_port = 7
+    conn.username = "console_user"
+    conn.password = "console_pw"
+    conn.sonic_username = "admin"
+    conn.sonic_password = ["pw"]
+    conn._read_initial_console = mock.MagicMock(return_value="")
+    conn.select_delay_factor = mock.MagicMock(return_value=1)
+    conn.read_until_pattern = mock.MagicMock(return_value="Selection:")
+    # First two reads after port selection are empty (countdown gap); the banner
+    # only appears on the third read -- the single-read path would CR before it.
+    conn.read_channel = mock.MagicMock(side_effect=(
+        ["", "", "Hit any key to stop autoboot:  3\n"] + [""] * 40))
+    conn.write_channel = mock.MagicMock()
+    conn._recover_to_login_prompt = mock.MagicMock()
+    conn.session_preparation_finalise = mock.MagicMock()
+
+    with mock.patch("tests.common.connections.ssh_console_conn.time.sleep"):
+        SSHConsoleConn.session_preparation(conn)
+
+    # Only the console-server menu selection may be written -- never a DUT-side CR.
+    assert _written(conn) == ["menu ports" + RETURN, "7" + RETURN], (
+        f"only the console-server port selection may be written, got {_written(conn)!r}")
+    assert RETURN not in _written(conn), "no bare DUT-side wake-up CR may be sent"
+    assert CTRL_C not in _written(conn), "no Ctrl-C may be sent"
+    assert getattr(conn, "_bootloader_deferred", False) is True, "must defer login"
+    conn._recover_to_login_prompt.assert_not_called()
+    conn.session_preparation_finalise.assert_not_called()

--- a/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_ssh_console_conn.py
@@ -5,7 +5,8 @@ These tests guard the console-state classifier that decides whether the reboot
 console-log collector may send a Ctrl-C during recovery. Sending Ctrl-C while the
 DUT is in a bootloader/boot stage (e.g. Arista Aboot autoboot window) traps the
 box in the bootloader and aborts autoboot, so SONiC never boots and the device
-becomes permanently unreachable (the regression PR #26351 fixes).
+becomes permanently unreachable. The regression was introduced by #24288; this
+PR (#26351) fixes it.
 
 The critical property is ``BOOTLOADER_BANNER_RE``:
   * it MUST match real bootloader / boot-in-progress banners (so Ctrl-C is


### PR DESCRIPTION
### Description of PR

Summary:
The reboot console-log collector (PR #24288) opens a netmiko console session around reboot events. Its `_recover_to_login_prompt()` unconditionally wrote a Ctrl-C (`\x03`) to the serial line to clear any pending command before logging in. When that recovery runs concurrently with a reboot and the console happens to be in the bootloader autoboot window, the Ctrl-C traps the DUT in the bootloader (e.g. Arista Aboot: `Press Control-C now to enter Aboot shell` -> `Aboot#` shell), which aborts autoboot. SONiC then never boots and the device becomes **permanently unreachable**, failing the reboot tests with `dut not start: timed out`.

This PR makes console recovery bootloader-safe: probe the console with a bare CR first and classify its state. Only send Ctrl-C once a leftover SONiC shell prompt is positively identified. If the console shows a bootloader / boot stage (Arista Aboot, GRUB, U-Boot, ONIE), send nothing and return.

Fixes # (SONiC nightly reboot-unreachable regression on Arista 7060CX / 7260)

ADO: 38852700

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512

### Approach
#### What is the motivation for this PR?
After PR #24288 (keep the console open across reboot events) merged, SONiC nightly reboot tests began going permanently unreachable on Arista Aboot platforms (7060CX / 7260), fleet-wide from the week of 2026-05-31. Root cause: the console recovery path blindly sends Ctrl-C, which interrupts the Arista Aboot autoboot window and drops the DUT to the `Aboot#` bootloader shell, so SONiC never boots.

#### How did you do it?
In `tests/common/connections/ssh_console_conn.py`:
- Added `BOOTLOADER_BANNER_RE` matching Aboot / GRUB / U-Boot / ONIE autoboot and boot-in-progress banners.
- `_recover_to_login_prompt()` now probes with a bare CR (no Ctrl-C) and classifies the console state. If a bootloader/boot banner is seen, it logs and returns without writing any control character. Ctrl-C + `exit` are only sent when a leftover SONiC shell prompt is positively identified.

#### How did you verify/test it?
Fix branch verified on real hardware across **all three interactive-bootloader families** (Arista Aboot, GRUB, U-Boot) via Elastictest on internal-202605.

**1. Hardware A/B (causation proof)** on an Arista console: same box, same image, same `reboot` command. With a Ctrl-C burst at the Aboot banner the DUT is trapped at `Aboot#`; without it the identical reboot boots cleanly to login. Confirms Ctrl-C during the autoboot window is the trigger.

**2. Repeat x10 reboot verification across bootloaders** — `platform_tests/test_reboot.py` run with each reboot case repeated 10x (retry_times=0, so a flake cannot be masked). **All three families pass with 0 failures.**

| Bootloader | Platform / Testbed | Job (repeat x10) | Result |
|---|---|---|---|
| Arista Aboot | Arista-7260 / tbtk5a-t0-7260-3 | [6a67faa7](https://elastictest.org/scheduler/testplan/6a67faa7c738d690ad9c167e) | FINISHED / SUCCESS — tests=89, pass=77, **fail=0**, skip=12 |
| GRUB | Mellanox-SN4600C / vms63-t1-4600-5 | [6a684524](https://elastictest.org/scheduler/testplan/6a684524f481df03c4e59a0e) | FINISHED / SUCCESS — tests=89, pass=56, **fail=0**, skip=33 |
| U-Boot | Nokia-7215-A1 (arm64) / testbed-bjw2-can-7215a1-3 | [6a688c35](https://elastictest.org/scheduler/testplan/6a688c35c4dbc22bce9cde30) | FINISHED / SUCCESS — **fail=0** |

Across all 10 reboot repeats on each bootloader the console log shows the normal autoboot banner (e.g. `Press Control-C now`) but the DUT is never trapped at a bootloader shell — no `Aboot#`, no `dut not start`, and no port-22 timeout.

**Re-verification on the latest commit (menu-port bootloader-safe fix, `ec5dc50`)** — same `platform_tests/test_reboot.py` repeat x10 / retry_times=0 methodology, re-run after addressing the menu-port review feedback. All three bootloader families re-verified with the new commit:

| Bootloader | Platform / Testbed | Job (repeat x10) | Result |
|---|---|---|---|
| Arista Aboot | Arista-7260 / tbtk5a-t0-7260-3 | [6a6aaaba](https://elastictest.org/scheduler/testplan/6a6aaabaeb2c1b23503d26fa) | FINISHED / SUCCESS — tests=89, pass=77, **fail=0**, skip=12 |
| GRUB | Mellanox-SN4600C / vms63-t1-4600-5 | [6a6aaabc](https://elastictest.org/scheduler/testplan/6a6aaabcc738d690ad9c1a99) | FINISHED / SUCCESS — tests=89, pass=55, fail=1\*, skip=33 |
| U-Boot | Nokia-7215-A1 (arm64) / testbed-bjw2-can-7215a1-3 | [6a6aaabe](https://elastictest.org/scheduler/testplan/6a6aaabeb63289adaeeedd56) | FINISHED / SUCCESS — tests=89, pass=56, **fail=0**, skip=33 |

\* The single GRUB failure is `test_cold_reboot[gnoi_based]` on repeat 6 of 10 — an unrelated infrastructure flake, **not** a bootloader trap. After the gNOI cold reboot the DUT mgmt SSH was transiently unreachable (`reboot.py:495 duthost.stat -> Host unreachable`), and the console-log collector could not attach to this DUT's Cisco console server at all (`Incompatible ssh peer (no acceptable kex algorithm)`), so the console-recovery code path under test never executed (`console_obj = None`). The other 9/10 identical repeats passed, and GRUB has no Ctrl-C autoboot window — no `Aboot#`, no `dut not start`.

**Re-verification on the final commit (`43aa4521` — all self-review + external-review findings addressed)** — same `platform_tests/test_reboot.py` repeat x10 / retry_times=0 methodology, re-run after the last round of fixes (tightened the `autoboot` token, classify the initial passive read, bound `_read_initial_console` to `max_reads=6`, and require `Press Control-C now`). All three bootloader families pass with **0 failures**. (Run on internal-202605 branch `dev/xuliping/20260721_internal-202605_reboot-fixes-26351-26386`; its `tests/common/connections/ssh_console_conn.py` is **byte-identical** to this PR head `43aa4521`.)

| Bootloader | Platform / Testbed | Job (repeat x10) | Result |
|---|---|---|---|
| Arista Aboot | Arista-7260 / tbtk5a-t0-7260-3 | [6a6bdfd5](https://elastictest.org/scheduler/testplan/6a6bdfd5c738d690ad9c1ce8) | FINISHED / SUCCESS — tests=89, pass=77, **fail=0**, skip=12 |
| GRUB | Mellanox-SN4600C / vms63-t1-4600-5 | [6a6bdfd7](https://elastictest.org/scheduler/testplan/6a6bdfd7c4dbc22bce9ce3a8) | FINISHED / SUCCESS — tests=89, pass=56, **fail=0**, skip=33 |
| U-Boot | Nokia-7215-A1 (arm64) / testbed-bjw2-can-7215a1-3 | [6a6bdfd9](https://elastictest.org/scheduler/testplan/6a6bdfd9b103fcbd8adfbd69) | FINISHED / SUCCESS — tests=89, pass=56, **fail=0**, skip=33 |

Notably the GRUB run on `vms63-t1-4600-5` — which hit an unrelated infra flake (`fail=1`) in the previous `ec5dc50` round — now completes all 10 repeats cleanly with **fail=0** after the testbed was recovered.

**3. Original single-run** — `platform_tests/test_reboot.py`: **6 passed / 1 skipped** (soft_reboot is S6100-only).
https://elastictest.org/scheduler/testplan/6a5f752d5c1a4704448797e6
Name: liping_rerun_t0_202605_20260721133326_testbed-bjw2-can-t0-7060-10_test_reboot
Status / Result: FINISHED / SUCCESS
Branch: dev/xuliping/20260721_internal-202605_reboot-fixes-26351-26386
Image: internal-202605 sonic-aboot-broadcom-legacy-th.swi (bjw, 10.150.22.222)
Testbed: testbed-bjw2-can-t0-7060-10 (t0, Arista-7060CX)

Module results:
platform_tests/test_reboot.py: 6 passed, 0 failed, 1 skipped, 0 errors

#### Any platform specific information?
The trap is specific to platforms with an interactive bootloader autoboot window — Arista Aboot (7060CX / 7260 / 7050) is the most affected; GRUB (Cisco / Mellanox) and U-Boot/ONIE (Nokia) are covered by the same guard and verified above. Platforms without such a window are unaffected. The change touches only the shared console recovery path and is a no-op unless the console is at a bootloader/shell prompt.

#### Supported testbed topology if it's a new test case?
N/A (bug fix, existing tests).

### Documentation
N/A



---

**Re-verification on the review-fix commit (`6433f7d3` — `cancel_event` gating + deferred-console guard)** — after addressing the reviewer/Copilot finding that `cancel_event` was injected into **all** console types in `ConsoleHost`, while only `SSHConsoleConn` consumes it: telnet/conserver classes forward `**kwargs` to netmiko, raising an unexpected-keyword `TypeError` that silently disabled console-log collection on non-SSH console servers. The injection is now gated on the resolved console class (`issubclass(..., SSHConsoleConn)`). Also guards `collect_mgmt_config_by_console()` against running `send_command` on a console whose session preparation was deferred (DUT in bootloader/boot stage, `_bootloader_deferred`), and fixes a `dut_sonsole` typo. A new `unit_test_console_host.py` pins the `cancel_event` gating for SSH vs non-SSH console types (74 unit tests pass). Same `platform_tests/test_reboot.py` repeat x10 / retry_times=0 methodology; all three bootloader families pass with **0 failures**. (Run on internal-202605 branch `dev/xuliping/20260721_internal-202605_reboot-fixes-26351-26386` at commit `6433f7d344`, whose changed files are byte-identical to this PR head.)

| Bootloader | Platform / Testbed | Job (repeat x10) | Result |
|---|---|---|---|
| Arista Aboot | Arista-7260 / tbtk5a-t0-7260-3 | [6a7145e0](https://elastictest.org/scheduler/testplan/6a7145e0eb2c1b23503d2fa2) | FINISHED / SUCCESS — tests=89, pass=77, **fail=0**, skip=12 |
| GRUB | Mellanox-SN4600C / vms63-t1-4600-5 | [6a7145e2](https://elastictest.org/scheduler/testplan/6a7145e2b103fcbd8adfc3f7) | FINISHED / SUCCESS — tests=89, pass=56, **fail=0**, skip=33 |
| U-Boot | Nokia-7215-A1 (arm64) / testbed-bjw2-can-7215a1-3 | [6a714599](https://elastictest.org/scheduler/testplan/6a714599b103fcbd8adfc3f5) | FINISHED / SUCCESS — tests=89, pass=56, **fail=0**, skip=33 |

Image `SONiC.20260510.09`; all 10 `test_reboot.py` repeats PASSED on every platform (Aboot / GRUB / U-Boot), 0 failures across all runs.