### PR TITLE
Handle pytest.fail.Exception in wait_until (#24902)

### DIFF
--- a/tests/bmp/test_frr_bmp_sanity.py
+++ b/tests/bmp/test_frr_bmp_sanity.py
@@ -1,4 +1,5 @@
 import pytest
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.monit import check_monit_expected_container_logging
 from tests.common.utilities import wait_until
 from bmp.helper import enable_bmp_feature, disable_bmp_feature
@@ -13,6 +14,7 @@ def test_frr_bmp_monit_log(duthosts, enum_frontend_dut_hostname, enum_asic_index
     duthost = duthosts[enum_frontend_dut_hostname]
     disable_bmp_feature(duthost)
 
-    wait_until(180, 60, 0, check_monit_expected_container_logging, duthost)
+    pytest_assert(wait_until(180, 60, 0, check_monit_expected_container_logging, duthost),
+                  "Monit logged unexpected container-not-running messages")
 
     enable_bmp_feature(duthost)

--- a/tests/common/helpers/monit.py
+++ b/tests/common/helpers/monit.py
@@ -11,4 +11,5 @@ def check_monit_expected_container_logging(duthost):
     """
     syslog_output = duthost.command("sudo grep 'ERR monit' /var/log/syslog")["stdout"]
     pytest_assert("Expected containers not running" not in syslog_output,
-                  f"Expected containers not running found in syslog. Output was:\n{syslog_output}")
+                  f"Expected containers not running found in syslog. Output was:\n{syslog_output}")  # noqa: E231
+    return True

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -148,7 +148,7 @@ def wait_until(timeout, interval, delay, condition, *args, **kwargs):
 
         try:
             check_result = condition(*args, **kwargs)
-        except Exception as e:
+        except (Exception, pytest.fail.Exception) as e:
             exc_info = sys.exc_info()
             details = traceback.format_exception(*exc_info)
             logger.error(

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -148,7 +148,7 @@ def wait_until(timeout, interval, delay, condition, *args, **kwargs):
 
         try:
             check_result = condition(*args, **kwargs)
-        except Exception as e:
+        except (Exception, pytest.fail.Exception) as e:
             exc_info = sys.exc_info()
             details = traceback.format_exception(*exc_info)
             logger.error(
@@ -683,7 +683,7 @@ def get_intf_by_sub_intf(sub_intf, vlan_id=None):
     Returns:
         str: interface name, e.g. Ethernet100
     """
-    if type(sub_intf) != str:
+    if not isinstance(sub_intf, str):
         sub_intf = str(sub_intf)
 
     if not vlan_id:

--- a/tests/monit/test_monit_status.py
+++ b/tests/monit/test_monit_status.py
@@ -127,5 +127,6 @@ def test_monit_reporting_message(duthosts, enum_rand_one_per_hwsku_frontend_host
 
     pytest_assert(wait_until(180, 60, 0, check_monit_last_output, duthost),
                   "Expected Monit reporting message not found")
-    wait_until(180, 60, 0, check_monit_expected_container_logging, duthost)
+    pytest_assert(wait_until(180, 60, 0, check_monit_expected_container_logging, duthost),
+                  "Monit logged unexpected container-not-running messages")
     logger.info("Checking the format of Monit alerting message was done!")

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -367,7 +367,8 @@ def validate_platform_dump_files(duthost, dump_folder_path, platform_dump_folder
 
 def gen_dump_file(duthost, since):
     logger.debug("Running show techsupport ... ")
-    wait_until(300, 20, 0, execute_command, duthost, str(since))
+    pytest_assert(wait_until(300, 20, 0, execute_command, duthost, str(since)),
+                  "show techsupport command failed to succeed within timeout")
     tar_file = [j for j in pytest.tar_stdout.split('\n') if j != ''][-1]
     return tar_file
 


### PR DESCRIPTION
Handle pytest.fail.Exception in wait_until (#24902)
Allow pytest_assert to trigger wait_until retries.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit
easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should
reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #24726

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: Ran full suite of GCU tests, and verified that the pytest.fail call that is inside wait_until in those tests does indeed trigger a wait_until retry as desired.  GCU tests were selected as this is where the API discrepancy in wait_until was first noticed.
- master: Change is already merged in master and has not resulted in any new test regressions.

### Approach
#### What is the motivation for this PR?
wait_until already handles Exception, and multiple places in the code
assume pytest.fail.Exception is handled as well. pytest.fail.Exception
actually derives from BaseException, which means it is currently
unhandled by wait_until, and so will not trigger retries (and
immediately fail tests).

#### How did you do it?
Added pytest.fail.Exception to the list of handled exception classes in
wait_until.

#### How did you verify/test it?
Manual test run.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

---------