### PR TITLE
[SmartSwitch] Prevent false memory utilization failures on SmartSwitch techsupport tests

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -7,6 +7,7 @@
     "Arista-7060CX": ["Arista-7060CX-32S-C32", "Arista-7060CX-32S-D48C8"],
     "Arista-7260CX3": ["Arista-7260CX3-C64", "Arista-7260CX3-D108C8", "Arista-7260CX3-D108C10"],
     "Nokia-IXR7220": ["Nokia-IXR7220-H6-O256"],
+    "Cisco-8102-SmartSwitch": ["Cisco-8102-28FH-DPU-O"],
     "Cisco-C8220TG": ["Cisco-C8220TG-48A-O", "Cisco-C8220TG-G1S2"],
     "Mellanox-SN6600":["Mellanox-SN6600_LD-V512C2", "Mellanox-SN6600_LD-V448P16C2"]
   },
@@ -381,6 +382,19 @@
         }
       },
       "memory_check": "parse_frr_memory_output"
+    }
+  ],
+  "Cisco-8102-SmartSwitch": [
+    {
+        "name": "free",
+        "memory_params": {
+            "used": {
+                "memory_increase_threshold": {
+                    "type": "percentage",
+                    "value": "30%"
+                }
+            }
+        }
     }
   ],
   "Cisco-C8220TG": [


### PR DESCRIPTION
### Description of PR

The memory utilization plugin uses a default 20% increase threshold for the
system memory reported by the `free` command.

On the Cisco-8102 SmartSwitch platform, generating a techsupport dump can
temporarily increase memory usage, primarily because of filesystem page cache.
The temporary increase can exceed the default threshold and cause a false
memory-utilization failure even though the memory is reclaimable and there is
no persistent memory leak.

This PR adds a platform-specific memory threshold override for
`Cisco-8102-28FH-DPU-O`, increasing only the `free` command's memory increase
threshold from 20% to 30%.

The memory utilization plugin remains enabled, and no changes are made to
`test_techsupport_no_secret.py`.

This change is scoped to Cisco SmartSwitch platforms only. While the show techsupport command is the same, SmartSwitch collects additional platform-specific information, including DPU state, chassis module state, midplane information, DPU-related services and logs, platform sensor data, and other SmartSwitch-specific diagnostics. As a result, the amount of data processed during techsupport generation is typically larger than on a standard 8102 platform.

In our testing, the observed memory increase on SmartSwitch has varied depending on the system state. Most runs showed approximately 9–14% memory growth, while an earlier reported failure observed a 25.2% increase (free:used increased from 5830 MB to 7298 MB), exceeding the existing 20% threshold. Since the memory plugin measures transient memory usage during techsupport collection, which can vary with the amount of platform state and diagnostics being gathered, this change increases the SmartSwitch-specific threshold to reduce intermittent false failures while leaving all other platforms unchanged.

### Type of change

- [x] Bug fix

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Testbed:

- Platform: Cisco-8102 SmartSwitch
- HWSKU: `Cisco-8102-28FH-DPU-O`
- Topology: `t1,any,smartswitch`
- Branch: `202511`

Validation:

```text
show_techsupport/test_techsupport_no_secret.py::test_secret_removed_from_show_techsupport PASSED

1 passed