### PR TITLE
Add missing num_asics ansible module param to generate_golden_config_db

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -927,6 +927,7 @@
           prober_type: "{{ prober_type | default(omit) }}"
           neighbor_mode: "{{ neighbor_mode | default(omit) }}"
           is_lit_mode: "{{ is_lit_mode | default(true) }}"
+          num_asics: "{{ num_asics }}"
           npu_index: "{{ dut_index | default(0) | int }}"
           bgp_confd_asn: "{{ bgp_confd_asn }}"
           bgp_confd_peers: "{{ bgp_confd_peers }}"


### PR DESCRIPTION
### Description of PR

Currently, num_asics ansible module param is not passed to generate_golden_config_db method. Implication of this is during golden_config_db generation script, incorrect code path assuming num_asics == 1 on multi-asic where it should be 2 instead. Because of this, expected `CONFED` fields in  `BGP_DEVICE_GLOBAL` and macsec config might be missing in per asic namespace in final generated config.

Summary:
Fixes #27294

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type: <!-- day-one issue / regression / other -->

### Approach
#### What is the motivation for this PR?

Generated golden_config_db could be missing `CONFED` field in `BGP_DEVICE_GLOBAL` in per asic namespace on mutli-asic
```
{
  "localhost": {"DNS_NAMESERVER": {...}, "BGP_DEVICE_GLOBAL": {"CONFED": {"asn": "65100", "peers": "65300"}} ,"FEATURE": {...}},
  "asic0": {"BGP_DEVICE_GLOBAL": {...}, "FEATURE": {...}},
  "asic1": {"BGP_DEVICE_GLOBAL": {...}, "FEATURE": {...}}
}
```

This is because, currently num_asics ansible module param is not passed to generate_golden_config_db method : [https://github.com/sonic-net/sonic-mgmt/blob/202605/ansible/config_sonic_basedon_testbed.yml#L920 . ](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/config_sonic_basedon_testbed.yml#L929)

When num_asics module param is accessed in the script it defaults to 1. This will execute an incorrect code path assuming num_asics == 1 on multi-asic where it should be 2 instead : https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/library/generate_golden_config_db.py#L943. The code is supposed to add CONFED config per namespace in full config.

#### How did you do it?

Pass in missing argument at the call site in `ansible/config_sonic_basedon_testbed.yml`

#### How did you verify/test it?

After fix, the golden config contains expected CONFED config per asic dut on 202605 branch:
```
{
  "localhost": {"DNS_NAMESERVER": {...}, "FEATURE": {...}},
  "asic0": {"BGP_DEVICE_GLOBAL": {"CONFED": {"asn": "65100", "peers": "65300"}}, "FEATURE": {...}},
  "asic1": {"BGP_DEVICE_GLOBAL": {"CONFED": {"asn": "65100", "peers": "65300"}}, "FEATURE": {...}}
}
```
Tested on golden image generation on mutli-asic

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation