### PR TITLE
[cherry-pick][202605] Add dual-ToR prober and neighbor mode golden config support

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -158,6 +158,10 @@
       set_fact:
         prober_type: "{{ testbed_facts['prober_type'] | default(None) }}"
 
+    - name: set neighbor_mode
+      set_fact:
+        neighbor_mode: "{{ testbed_facts['neighbor_mode'] | default(None) }}"
+
     - name: set lit mode
       set_fact:
         is_lit_mode: "{{ testbed_facts.get('is_lit_mode', topo in ['t1-smartswitch-ha', 't1-28-lag', 'smartswitch-t1', 't1-48-lag']) }}"
@@ -921,6 +925,7 @@
           hwsku: "{{ (lab_csv_result.stdout | from_json).hwsku if (port_override_from_links | default(false) | bool) and lab_csv_result is defined and lab_csv_result.rc == 0 and (lab_csv_result.stdout | from_json).hwsku else hwsku }}"
           vm_configuration: "{{ configuration if topo == 't1-filterleaf-lag' else omit }}"
           prober_type: "{{ prober_type | default(omit) }}"
+          neighbor_mode: "{{ neighbor_mode | default(omit) }}"
           is_lit_mode: "{{ is_lit_mode | default(true) }}"
           npu_index: "{{ dut_index | default(0) | int }}"
           bgp_confd_asn: "{{ bgp_confd_asn }}"

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -154,6 +154,10 @@
         is_bmc_topo: "{{ 'bmc' in topo }}"
       tags: always
 
+    - name: set prober_type
+      set_fact:
+        prober_type: "{{ testbed_facts['prober_type'] | default(None) }}"
+
     - name: set lit mode
       set_fact:
         is_lit_mode: "{{ testbed_facts.get('is_lit_mode', topo in ['t1-smartswitch-ha', 't1-28-lag', 'smartswitch-t1', 't1-48-lag']) }}"
@@ -916,6 +920,7 @@
           port_override_from_links: "{{ port_override_from_links | default(false) | bool }}"
           hwsku: "{{ (lab_csv_result.stdout | from_json).hwsku if (port_override_from_links | default(false) | bool) and lab_csv_result is defined and lab_csv_result.rc == 0 and (lab_csv_result.stdout | from_json).hwsku else hwsku }}"
           vm_configuration: "{{ configuration if topo == 't1-filterleaf-lag' else omit }}"
+          prober_type: "{{ prober_type | default(omit) }}"
           is_lit_mode: "{{ is_lit_mode | default(true) }}"
           npu_index: "{{ dut_index | default(0) | int }}"
           bgp_confd_asn: "{{ bgp_confd_asn }}"

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -182,6 +182,7 @@ class GenerateGoldenConfigDBModule(object):
                                     num_asics=dict(required=False, type='int', default=1),
                                     hwsku=dict(required=False, type='str', default=None),
                                     vm_configuration=dict(required=False, type='dict', default={}),
+                                    prober_type=dict(required=False, type='str', default=None),
                                     is_lit_mode=dict(required=False, type='bool', default=True),
                                     npu_index=dict(required=False, type='int', default=0),
                                     duts_list=dict(required=False, type='list', default=[]),
@@ -205,6 +206,7 @@ class GenerateGoldenConfigDBModule(object):
             self.hwsku = dut_hwsku
 
         self.vm_configuration = self.module.params['vm_configuration']
+        self.prober_type = self.module.params['prober_type']
         self.is_lit_mode = self.module.params['is_lit_mode']
         self.bgp_confd_asn = self.module.params['bgp_confd_asn']
         self.bgp_confd_peers = self.module.params['bgp_confd_peers']
@@ -1128,6 +1130,36 @@ class GenerateGoldenConfigDBModule(object):
 
         return json.dumps(golden_config, indent=4)
 
+    def generate_dualtor_golden_config_db(self):
+        """
+        Generate golden config for dualtor topology with prober_type support.
+        This adds prober_type to existing MUX_CABLE entries from minigraph.
+        """
+        rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
+        if rc != 0:
+            self.module.fail_json(msg="Failed to get config from minigraph: {}".format(err))
+        # Get existing config from minigraph
+        ori_config_db = json.loads(out)
+        golden_config_db = {}
+
+        # Preserve DEVICE_METADATA
+        if "DEVICE_METADATA" in ori_config_db:
+            golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
+        golden_config_db["DEVICE_METADATA"]["localhost"]["buffer_model"] = "traditional"
+
+        # Add prober_type to MUX_CABLE if it exists and prober_type is specified
+        if ("MUX_CABLE" in ori_config_db and "PORT" in ori_config_db
+           and self.prober_type != "" and self.prober_type is not None):
+            mux_cable_config = copy.deepcopy(ori_config_db["MUX_CABLE"])
+            port_config = copy.deepcopy(ori_config_db["PORT"])
+            # Add prober_type to each interface
+            for intf_name, intf_config in mux_cable_config.items():
+                intf_config["prober_type"] = self.prober_type
+            golden_config_db["MUX_CABLE"] = mux_cable_config
+            golden_config_db["PORT"] = port_config
+
+        return json.dumps(golden_config_db, indent=4)
+
     def override_port_table_from_platform(self, config):
         """
         Rebuild the PORT table from port_speeds + platform.json.
@@ -1237,6 +1269,9 @@ class GenerateGoldenConfigDBModule(object):
             config = self.generate_full_lossy_golden_config_db()
         elif self.topo_name in ["t1-filterleaf-lag"]:
             config = self.generate_filterleaf_golden_config_db()
+        elif "dualtor" in self.topo_name:
+            config = self.generate_dualtor_golden_config_db()
+            module_msg = module_msg + " for dualtor"
         elif "c0" in self.topo_name:
             config = self.generate_c0_golden_config_db()
             module_msg = module_msg + " for c0"

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -183,6 +183,7 @@ class GenerateGoldenConfigDBModule(object):
                                     hwsku=dict(required=False, type='str', default=None),
                                     vm_configuration=dict(required=False, type='dict', default={}),
                                     prober_type=dict(required=False, type='str', default=None),
+                                    neighbor_mode=dict(required=False, type='str', default=None),
                                     is_lit_mode=dict(required=False, type='bool', default=True),
                                     npu_index=dict(required=False, type='int', default=0),
                                     duts_list=dict(required=False, type='list', default=[]),
@@ -207,6 +208,7 @@ class GenerateGoldenConfigDBModule(object):
 
         self.vm_configuration = self.module.params['vm_configuration']
         self.prober_type = self.module.params['prober_type']
+        self.neighbor_mode = self.module.params['neighbor_mode']
         self.is_lit_mode = self.module.params['is_lit_mode']
         self.bgp_confd_asn = self.module.params['bgp_confd_asn']
         self.bgp_confd_peers = self.module.params['bgp_confd_peers']
@@ -1132,7 +1134,9 @@ class GenerateGoldenConfigDBModule(object):
 
     def generate_dualtor_golden_config_db(self):
         """
-        Generate golden config for dualtor topology with prober_type support.
+        Generate golden config for dualtor topology with prober_type and
+        neighbor_mode support.
+
         This adds prober_type to existing MUX_CABLE entries from minigraph.
         """
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
@@ -1147,14 +1151,18 @@ class GenerateGoldenConfigDBModule(object):
             golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
         golden_config_db["DEVICE_METADATA"]["localhost"]["buffer_model"] = "traditional"
 
-        # Add prober_type to MUX_CABLE if it exists and prober_type is specified
-        if ("MUX_CABLE" in ori_config_db and "PORT" in ori_config_db
-           and self.prober_type != "" and self.prober_type is not None):
+        if "MUX_CABLE" in ori_config_db and "PORT" in ori_config_db:
             mux_cable_config = copy.deepcopy(ori_config_db["MUX_CABLE"])
             port_config = copy.deepcopy(ori_config_db["PORT"])
-            # Add prober_type to each interface
+
             for intf_name, intf_config in mux_cable_config.items():
-                intf_config["prober_type"] = self.prober_type
+                # Set prober_type only when explicitly provided
+                if self.prober_type and self.prober_type != "":
+                    intf_config["prober_type"] = self.prober_type
+                # Set neighbor_mode only when explicitly provided
+                if self.neighbor_mode and self.neighbor_mode != "":
+                    intf_config["neighbor_mode"] = self.neighbor_mode
+
             golden_config_db["MUX_CABLE"] = mux_cable_config
             golden_config_db["PORT"] = port_config
 

--- a/ansible/testbed.yaml
+++ b/ansible/testbed.yaml
@@ -292,6 +292,7 @@
   ptf_ip: 10.255.0.210/24
   ptf_ipv6: 2001:db8:1::20/64
   prober_type: hardware
+  neighbor_mode: prefix-route
   server: server_1
   vm_base: VM0100
   dut:

--- a/ansible/testbed.yaml
+++ b/ansible/testbed.yaml
@@ -283,3 +283,21 @@
   inv_name: lab
   auto_recover: 'False'
   comment: BMC dual-mgmt testbed
+
+- conf-name: tor-dualtor3
+  group-name: tor-dualtor
+  topo: dualtor-aa
+  ptf_image_name: docker-ptf
+  ptf: ptf_dtor3
+  ptf_ip: 10.255.0.210/24
+  ptf_ipv6: 2001:db8:1::20/64
+  prober_type: hardware
+  server: server_1
+  vm_base: VM0100
+  dut:
+    - dtor3-dut0
+    - dtor3-dut1
+  inv_name: lab
+  auto_recover: 'True'
+  netns_mgmt_ip: 10.255.0.211/16
+  comment: dualtor setup example


### PR DESCRIPTION
### Description of PR
Summary:
Cherry-pick the following `master` commits to `202605` to support configuring `prober_type` and `neighbor_mode` in dual-ToR golden config generation:

ff59c00e2 Addition of prober_typer knob of MUX_CABLE as part of golden config (#20765)
2269833d1 [Dualtor] add support for neighbor mode in golden_config (#25674)

Fixes # (issue): N/A - backport of existing `master` commits.

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Allow dual-ToR testbeds on `202605` to select software or hardware probing and host-route or prefix-route neighbor mode through testbed configuration.

#### How did you do it?
Cherry-picked the two listed `master` commits in dependency order. The changes pass the testbed values to golden config generation and add them to existing `MUX_CABLE` entries when explicitly configured.

#### How did you verify/test it?
- `git diff --check upstream/202605...HEAD`
- `python3 -m py_compile ansible/library/generate_golden_config_db.py`

#### Any platform specific information?
The settings apply to dual-ToR topologies. Existing defaults remain unchanged when the knobs are not configured.

#### Supported testbed topology if it's a new test case?
Not a new test case. The framework changes target dual-ToR topologies.

### Documentation
The testbed configuration example is included in `ansible/testbed.yaml`.