### PR TITLE
Configurable drop counters FDB entry bug

### DIFF
--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -194,6 +194,7 @@ def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_d
 
     try:
         # Add a static fdb entry
+        duthost.command("sonic-clear fdb all")
         apply_fdb_config(duthost, testbed_params['vlan_interface']['attachto'],
                          mock_server['server_dst_intf'], mock_server['server_dst_mac'],
                          "SET", "static")
@@ -209,13 +210,13 @@ def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_d
                      mock_server['server_dst_mac'], mock_server['server_dst_intf'])
         send_dropped_traffic(counter_type, pkt, rx_port)
     finally:
-        mock_server["fanout_neighbor"].no_shutdown(mock_server["fanout_intf"])
-        duthost.command("sonic-clear fdb all")
-        duthost.command("sonic-clear arp")
         # Delete the static fdb entry
         apply_fdb_config(duthost, testbed_params['vlan_interface']['attachto'],
                          mock_server['server_dst_intf'], mock_server['server_dst_mac'],
                          "DEL", "static")
+        duthost.command("sonic-clear fdb all")
+        duthost.command("sonic-clear arp")
+        mock_server["fanout_neighbor"].no_shutdown(mock_server["fanout_intf"])
         # FIXME: Add config reload on t0-backend as a workaround to keep DUT healthy because the following
         # drop packet testcases will suffer from the brcm_sai_get_port_stats errors flooded in syslog
         if "backend" in tbinfo["topo"]["name"]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR fixes a consistent test failure in `test_neighbor_link_down` within `tests/drop_packets/test_configurable_drop_counters.py` where verification fails with `fdb_count is 0`. 

During setup, the `mock_server` ping command causes the DUT to dynamically learn the mock server's MAC address on the ingress interface. When the test subsequently attempts to apply a static FDB entry, the Broadcom SAI driver throws a hard collision error: `SAI_STATUS_ITEM_ALREADY_EXISTS (rv:-6)`. The test previously missed this failure because `apply_fdb_config` only loosely verified the MAC's presence. When the port flapped during the test, the dynamic entry was flushed, resulting in a failure.

Adding an explicit FDB clear step before writing the static FDB entry resolves the collision and ensures the entry is programmed as static.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
To eliminate false negatives on Broadcom-based ASICs (e.g., Broadcom Hummingbird on `harp101`) where dynamic learning races ahead of static configuration.

Note on DUT Bug: This test failure is exposed because of a lack of idempotency in `fdborch` (`sonic-swss`) when handling dynamic-to-static transitions. This PR resolves the testbed issue via state isolation, but it might be good to a long-term pursue a fix in `fdborch.cpp` to catch `SAI_STATUS_ITEM_ALREADY_EXISTS` and promote the entry via `set_fdb_entry_attribute` instead of raising a syslog error.
#### How did you do it?
We clear the dynamic MAC table using `duthost.command("sonic-clear fdb all")` immediately before running `apply_fdb_config`.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Test now passes on XGS and previously was failing with `ERR swss#orchagent: :- addFdbEntry: Failed to create static FDB 72:06:00:01:00:10 in Vlan1000 on Ethernet32, rv:-6`

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
ansible: 2.20.7
rootdir: /var/AzDevOps/sonic-mgmt/tests
configfile: pytest.ini
plugins: allure-pytest-2.16.0, html-4.2.0, repeat-0.9.4, stress-1.0.1, cov-7.1.0, metadata-3.1.1, xdist-3.8.0, ansible-26.6.0
collected 6 items

drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[PORT_INGRESS_DROPS-L3_EGRESS_LINK_DOWN] PASSED [ 16%]
drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[SWITCH_INGRESS_DROPS-L3_EGRESS_LINK_DOWN] SKIPPED [ 33%]
drop_packets/test_configurable_drop_counters.py::test_dip_link_local[PORT_INGRESS_DROPS-DIP_LINK_LOCAL] PASSED [ 50%]
drop_packets/test_configurable_drop_counters.py::test_dip_link_local[SWITCH_INGRESS_DROPS-DIP_LINK_LOCAL] SKIPPED [ 66%]
drop_packets/test_configurable_drop_counters.py::test_sip_link_local[PORT_INGRESS_DROPS-SIP_LINK_LOCAL] PASSED [ 83%]
drop_packets/test_configurable_drop_counters.py::test_sip_link_local[SWITCH_INGRESS_DROPS-SIP_LINK_LOCAL] SKIPPED [100%]DEBUG:tests.conftest:[log_custom_msg] item: <Function test_sip_link_local[SWITCH_INGRESS_DROPS-SIP_LINK_LOCAL]>
DEBUG:root:[Parallel Fixture] Terminate parallel manager after teardown
INFO:root:[Parallel Fixture] Terminating parallel fixture manager
DEBUG:root:[Parallel Fixture] Running tasks to be terminated: []
DEBUG:root:[Parallel Fixture] Current worker threads: []
DEBUG:root:[Parallel Fixture] Current worker threads: []
DEBUG:root:[Parallel Fixture] The fixture manager is terminated:
stopped tasks [],
canceled tasks [],
pending tasks [],
done tasks [].
INFO:root:Can not get Allure report URL. Please check logs


------------------ generated xml file: /tmp/test-logs/tr.xml -------------------
=========================== short test summary info ============================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
