### PR TITLE
Update test_route_perf.py check to generalize for all TH5 + TH6 devices

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -107,9 +107,9 @@ def check_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_
     asic_id = enum_rand_one_frontend_asic_index
 
     if (asic == "broadcom"):
-        if "x86_64-arista_7060x6" in platform or "x86_64-nokia_ixr7220_h6" in platform:
-            # For TH5 (Arista 7060x6) and TH6 (Nokia IXR7220 H6) family devices,
-            # l3_alpm_template is set in config.bcm instead of l3_alpm_enable
+        if duthost.get_asic_name() in ["th5", "th6"]:
+            # For all TH5, TH6 family devices, l3_alpm_template is set in config.bcm
+            # instead of l3_alpm_enable
             # * 1 - Combined (By default)
             # * 2 - Parallel
             pytest_assert(

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -103,7 +103,6 @@ def check_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_
         return
 
     asic = duthost.facts["asic_type"]
-    platform = duthost.facts["platform"]
     asic_id = enum_rand_one_frontend_asic_index
 
     if (asic == "broadcom"):


### PR DESCRIPTION
### Description of PR

The test was failing for all but two platforms for TH5 + TH6. Generalised it to run correctly for all TH5 and TH6 platforms. Test was failing on `NH-4010` (TH5) and `NH-4210` (TH6)

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

Changed the code to check for ASIC name instead of platform, depends on https://github.com/sonic-net/sonic-mgmt/pull/23633 to do asic tokenization for `th6`

#### How did you verify/test it?

Run the test on failing platforms and verified that the test passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
