### PR TITLE
[dut_basic_facts]: resolve real release (YYYYMM) from build_version on unstamped images

### DIFF
--- a/ansible/library/dut_basic_facts.py
+++ b/ansible/library/dut_basic_facts.py
@@ -4,11 +4,13 @@
 # Example output:
 try:
     from ansible.module_utils.parse_utils import parse_tabular_output
+    from ansible.module_utils.sonic_release_utils import guess_release_from_build_version
 except ImportError:
     # Add parent dir for using outside Ansible
     import sys
     sys.path.append('..')
     from module_utils.parse_utils import parse_tabular_output
+    from module_utils.sonic_release_utils import guess_release_from_build_version
 
 import os
 
@@ -76,16 +78,8 @@ def main():
             results['eth_mgmt_ctrl_available'] = True
 
         # In case a image does not have /etc/sonic/sonic_release, guess release from 'build_version'
-        if 'release' not in results or not results['release'] or results['release'] == 'none':
-            if 'build_version' in results:
-                if '201811' in results['build_version']:
-                    results['release'] = '201811'
-                elif '201911' in results['build_version']:
-                    results['release'] = '201911'
-                elif 'master' in results['build_version']:
-                    results['release'] = 'master'
-                else:
-                    results['release'] = 'unknown'
+        results['release'] = guess_release_from_build_version(
+            results.get('release'), results.get('build_version', ''))
 
         # get dut feature status
         command_list = ['show feature status', 'show features']

--- a/ansible/module_utils/sonic_release_utils.py
+++ b/ansible/module_utils/sonic_release_utils.py
@@ -1,0 +1,51 @@
+"""Utilities for resolving the SONiC release identifier.
+
+Kept dependency-free (only the stdlib ``re``) so it is importable both inside an
+Ansible module running on the DUT and directly from unit tests on the host.
+"""
+import re
+
+# A SONiC release token is a 6-digit YYYYMM value at the start of the version
+# string, e.g. '202605' in '202605.1166406-18a25e93d'. The same leading-6-digits
+# rule also resolves old date-stamped official images, e.g. '20181130.31' ->
+# '201811'.
+_RELEASE_TOKEN_RE = re.compile(r'(20\d{4})')
+
+
+def guess_release_from_build_version(release, build_version):
+    """Resolve the SONiC release, guessing from ``build_version`` when needed.
+
+    Images that ship ``/etc/sonic/sonic_release`` already carry a populated
+    ``release`` field (e.g. '202405'), which is returned unchanged. Self-built
+    and virtual-switch (VS/KVM) images do not stamp that file, so ``release``
+    arrives empty or ``'none'`` and must be guessed from ``build_version``:
+
+    * a leading 6-digit ``YYYYMM`` token -> that release (e.g. '202605'), which
+      also covers old date-stamped images ('20181130.31' -> '201811');
+    * a ``build_version`` containing 'master' -> 'master';
+    * anything else -> 'unknown'.
+
+    Note: prior to this helper the fallback only recognized '201811', '201911'
+    and 'master', so every other release (202012 ... 202605) on an unstamped VS
+    image collapsed to 'unknown', silently defeating any ``release``-based
+    conditional_mark skip on VS.
+
+    Args:
+        release (str): The release value already gathered (may be None/''/'none').
+        build_version (str): The image build version string.
+
+    Returns:
+        str: The resolved release identifier.
+    """
+    if release and release != 'none':
+        return release
+
+    build_version = build_version or ''
+    if 'master' in build_version:
+        return 'master'
+
+    match = _RELEASE_TOKEN_RE.match(build_version)
+    if match:
+        return match.group(1)
+
+    return 'unknown'

--- a/ansible/module_utils/test_sonic_release_utils.py
+++ b/ansible/module_utils/test_sonic_release_utils.py
@@ -1,0 +1,86 @@
+"""Unit tests for ansible/module_utils/sonic_release_utils.py.
+
+Run from the repo root with:
+    python -m pytest --noconftest ansible/module_utils/test_sonic_release_utils.py -v
+
+The module under test is pure (stdlib ``re`` only), so it is loaded directly from
+its file path to avoid any Ansible / sonic_py_common import dependency.
+"""
+import importlib.util
+import os
+
+import pytest
+
+_MODULE_PATH = os.path.join(os.path.dirname(__file__), "sonic_release_utils.py")
+_spec = importlib.util.spec_from_file_location("sonic_release_utils", _MODULE_PATH)
+sonic_release_utils = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sonic_release_utils)
+guess_release_from_build_version = sonic_release_utils.guess_release_from_build_version
+
+
+class TestGuessReleaseFromBuildVersion:
+    @pytest.mark.parametrize("release, build_version, expected", [
+        # An already-stamped release (real HW image) is returned unchanged and
+        # takes precedence over whatever build_version says.
+        ("202405", "202605.1166406-18a25e93d", "202405"),
+        ("202511", "", "202511"),
+        ("master", "202405.1-abc", "master"),
+    ])
+    def test_existing_release_is_kept(self, release, build_version, expected):
+        assert guess_release_from_build_version(release, build_version) == expected
+
+    @pytest.mark.parametrize("empty_release", [None, "", "none"])
+    @pytest.mark.parametrize("build_version, expected", [
+        ("202605.1166406-18a25e93d", "202605"),
+        ("202012.123-deadbeef", "202012"),
+        ("202205.7", "202205"),
+        ("202211.10-abc", "202211"),
+        ("202305.1", "202305"),
+        ("202311.2", "202311"),
+        ("202405.3", "202405"),
+        ("202411.4", "202411"),
+        ("202505.5", "202505"),
+        ("202511.6", "202511"),
+    ])
+    def test_release_guessed_from_build_version(self, empty_release, build_version, expected):
+        assert guess_release_from_build_version(empty_release, build_version) == expected
+
+    @pytest.mark.parametrize("empty_release", [None, "", "none"])
+    @pytest.mark.parametrize("build_version, expected", [
+        # Old date-stamped official images: leading 6 digits are the release.
+        ("20181130.31", "201811"),
+        ("20191130.44", "201911"),
+    ])
+    def test_old_date_stamped_images(self, empty_release, build_version, expected):
+        assert guess_release_from_build_version(empty_release, build_version) == expected
+
+    @pytest.mark.parametrize("empty_release", [None, "", "none"])
+    @pytest.mark.parametrize("build_version", [
+        "master.1-abcdef",
+        "master.20240101",
+    ])
+    def test_master_build_version(self, empty_release, build_version):
+        assert guess_release_from_build_version(empty_release, build_version) == "master"
+
+    @pytest.mark.parametrize("empty_release", [None, "", "none"])
+    @pytest.mark.parametrize("build_version", [
+        "",
+        None,
+        "foobar",
+        "1902-not-a-release",
+        "1234567",
+    ])
+    def test_unparseable_build_version_is_unknown(self, empty_release, build_version):
+        assert guess_release_from_build_version(empty_release, build_version) == "unknown"
+
+    def test_release_token_not_confused_with_build_number(self):
+        # '202605' is the release; the 7-digit build number '1166406' must not
+        # be picked up (anchored match at the start of the string).
+        assert guess_release_from_build_version("", "202605.1166406-18a25e93d") == "202605"
+
+    def test_regression_modern_release_no_longer_collapses_to_unknown(self):
+        # Before this helper the fallback only knew 201811/201911/master, so a
+        # 202605 VS image resolved to 'unknown' and defeated release-based
+        # conditional_mark skips. It must now resolve to the real release.
+        assert guess_release_from_build_version("none", "202605.1166406-18a25e93d") == "202605"
+        assert guess_release_from_build_version("none", "202605.1166406-18a25e93d") != "unknown"


### PR DESCRIPTION
### Description of PR
Summary:
On images without `/etc/sonic/sonic_release` (all VS/KVM and self-built images), the `release` fact produced by `ansible/library/dut_basic_facts.py` is guessed from `build_version`. The old fallback only recognized `201811`, `201911`, and `master`, so every other release (`202012` … `202605`) collapsed to `"unknown"` — even though `build_version` starts with the release token (e.g. `202605.1166406-...`).

Because the `release` fact is what the `conditional_mark` plugin evaluates, release-based skips such as `release in ['202605', ...]` silently never matched on VS, so tests intended to be skipped there ran anyway. This surfaced while triaging the CI failure on https://github.com/sonic-net/sonic-mgmt/pull/26270. This PR fixes the fallback so `release` resolves to the real `YYYYMM` release on unstamped/VS images.

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Make `release`-based `conditional_mark` conditions work correctly on VS/KVM (and any self-built) images. Today they can never match because `release` resolves to `"unknown"` on those images, which makes release-gated skips a silent no-op on VS.

#### How did you do it?
Extracted the release resolution into a pure, dependency-free helper `ansible/module_utils/sonic_release_utils.py::guess_release_from_build_version()`: an already-stamped `release` (real HW) is returned unchanged; otherwise a leading `YYYYMM` token is extracted via `re.match(r'(20\d{4})', ...)` (`202605.1166406-...` -> `202605`; old date-stamped `20181130.31` -> `201811`); `master` in `build_version` -> `master`; anything else -> `unknown`. `ansible/library/dut_basic_facts.py` now imports and calls the helper (mirroring the existing `parse_utils` import guard), replacing the hard-coded 201811/201911/master ladder.

#### How did you verify/test it?
Added `ansible/module_utils/test_sonic_release_utils.py` — 62 parametrized cases covering all modern releases, old date-stamped images, `master`, precedence of an already-stamped release, unparseable -> `unknown`, build-number-not-confused, and a regression guard that `202605` no longer collapses to `unknown`: `python3 -m pytest --noconftest ansible/module_utils/test_sonic_release_utils.py` -> 62 passed. `flake8 --max-line-length=120` clean; `py_compile` OK.

#### Any platform specific information?
Only affects the `release` fact derivation for images lacking `/etc/sonic/sonic_release` (VS/KVM, self-built). Real-HW images that stamp `release` are unchanged. Old-release exclusion lists are unaffected; the intended effect is that current-release skips now correctly fire on VS.

#### Supported testbed topology if it's a new test case?
N/A (framework fix).

### Documentation
No.
