### PR TITLE
[platform_tests][test_reboot] Increase fast-reboot shutdown timeout 180s to 240s for Arista 7060CX/7260

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -62,7 +62,7 @@ reboot_ctrl_dict = {
     },
     REBOOT_TYPE_FAST: {
         "command": "fast-reboot",
-        "timeout": 180,
+        "timeout": 240,
         "wait": 120,
         "warmboot_finalizer_timeout": 180,
         "cause": "fast-reboot",


### PR DESCRIPTION
### Description of PR

Summary:
Increase the fast-reboot shutdown timeout in `reboot_ctrl_dict` from **180s to 240s**.

`platform_tests/test_reboot.py::test_fast_reboot` fails on Arista 7060CX-32S / 7260CX3 DUTs with `Exception: DUT <hostname> did not shutdown`. This `timeout` value gates `wait_for_shutdown()` (`tests/common/reboot.py` L219) — the time to wait for the DUT's SSH port to go absent after `fast-reboot` is issued. fast-reboot is the **only** reboot type in `reboot_ctrl_dict` using `timeout=180`; every other type uses `300`. On these Arista platforms the box legitimately takes 183–200s to drop SSH (extra pre-kexec work: FDB/ARP dump, warmboot prep, syncd shutdown), so 180s trips the exception. `test_warm_reboot` "did not reboot" in the same run is a downstream cascade.

Fixes # (issue)

ADO: 38852700

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512

### Approach
#### What is the motivation for this PR?

`test_fast_reboot` intermittently/consistently fails on Arista 7060CX-32S and 7260CX3 with `DUT did not shutdown`, because the fast-reboot shutdown-detection timeout (180s) is too tight for how long these platforms actually take to drop SSH after `fast-reboot`.

Measured across 3 physical devices, 10 fast-reboot loops each (SSH TCP:22 drop timing):

| Device | Platform | min | avg | max | loops > 180s |
|---|---|---|---|---|---|
| bjw3-can-7060-3 | Arista-7060CX-32S | 195 | 198 | 200 | 10/10 |
| bjw2-can-7060-9 | Arista-7060CX-32S | 188 | 196 | 199 | 10/10 |
| bjw2-can-7260-10 | Arista-7260CX3 | 172 | 183 | 185 | 9/10 |

Aggregate: **29/30 loops exceed 180s**, worst case **200s**. 180s has effectively no margin.


## Update: Confirmed as a 202605 fast-reboot regression (controlled A/B on physical DUTs)

Ran a controlled image A/B — **same physical DUT each time, only the SONiC image differs** — measuring fast-reboot shutdown time (interval from issuing `fast-reboot` to the DUT dropping SSH port 22) plus `boot_back` time. 202511 image build `20251110.40`.

| DUT | 202511 shutdown (avg) | 202605 shutdown (avg) | Regression |
|---|---|---|---|
| **Arista-7060CX-32S-C32** (bjw3-can-7060-3) | **109s** (107–110) | **198s** (195–200) | **+89s (~1.8×)** |
| **Arista-7260CX3** (bjw2-can-t0-7260-10) | **92s** (90–94) | **183s** (172–185) | **+91s (~2.0×)** |

#### How did you do it?

Changed `reboot_ctrl_dict[REBOOT_TYPE_FAST]["timeout"]` from `180` to `240` in `tests/common/reboot.py`, giving ~40s headroom over the observed 200s worst case. `warmboot_finalizer_timeout` is a separate value and is left unchanged.

Note: this `timeout` gates only `wait_for_shutdown()` (a control-plane SSH-drop wait), **not** any data-plane downtime SLA. `test_fast_reboot` performs no traffic/downtime measurement; fast-reboot's data-plane downtime is measured separately in the `advanced-reboot` suite and is unaffected by this change.

#### How did you verify/test it?

- Measured 30 fast-reboots across the 3 physical devices above; max shutdown time 200s < new 240s timeout with margin.
- `python3 -m py_compile tests/common/reboot.py` — OK.
- `flake8 --max-line-length=120 tests/common/reboot.py` — OK.

Name: liping_rerun_t0_202605_20260721133326_testbed-bjw2-can-t0-7060-10_test_reboot
Status / Result: FINISHED / SUCCESS
Branch: dev/xuliping/20260721_internal-202605_reboot-fixes-26351-26386
Image: internal-202605 sonic-aboot-broadcom-legacy-th.swi (bjw, 10.150.22.222)
Testbed: testbed-bjw2-can-t0-7060-10 (t0, Arista-7060CX)
Created: 2026-07-21 13:33:33

Module results:
platform_tests/test_reboot.py: 6 passed, 0 failed, 1 skipped, 0 errors

#### Any platform specific information?

Observed on Arista 7060CX-32S and 7260CX3. The change is platform-agnostic (a global default in `reboot_ctrl_dict`) and simply aligns fast-reboot closer to the other reboot types (all 300s), so no regression risk for platforms that already shut down quickly.

#### Supported testbed topology if it's a new test case?

N/A (not a new test case).

### Documentation

N/A
