### PR TITLE
[ip] Enable Monit refresh for IPv6 management test

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -388,19 +388,6 @@ golden_config_infra/test_config_reload_with_rendered_golden_config.py::test_rend
       - "asic_type in ['vpp']"
 
 #######################################
-#####           IP                #####
-#######################################
-ip/test_mgmt_ipv6_only.py::test_bgp_facts_ipv6_only:
-  enable_monit_refresh:
-    reason: >
-            The module-scoped IPv6 management setup performs config_reload. On low-RAM
-            sonic-vpp VMs, the first test can otherwise compare a stale pre-reload monit
-            baseline with fresh post-reload usage and raise a false memory alarm.
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-#######################################
 #####         Memory Checker      #####
 #######################################
 memory_checker/test_memory_checker.py::test_memory_checker:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -388,6 +388,19 @@ golden_config_infra/test_config_reload_with_rendered_golden_config.py::test_rend
       - "asic_type in ['vpp']"
 
 #######################################
+#####           IP                #####
+#######################################
+ip/test_mgmt_ipv6_only.py::test_bgp_facts_ipv6_only:
+  enable_monit_refresh:
+    reason: >
+            The module-scoped IPv6 management setup performs config_reload. On low-RAM
+            sonic-vpp VMs, the first test can otherwise compare a stale pre-reload monit
+            baseline with fresh post-reload usage and raise a false memory alarm.
+    conditions_logical_operator: or
+    conditions:
+      - "asic_type in ['vpp']"
+
+#######################################
 #####         Memory Checker      #####
 #######################################
 memory_checker/test_memory_checker.py::test_memory_checker:

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -104,6 +104,7 @@ def log_dut_tacacs(duthost, ptfhost):
         logging.debug(f"forced_mgmt_routes: {forced_mgmt_rte}, interface address: {intf_values[2]}")
 
 
+@pytest.mark.enable_monit_refresh
 def test_bgp_facts_ipv6_only(duthosts_ipv6_mgmt_only):  # noqa: F411, F811
     # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
     log_eth0_interface_info(duthosts_ipv6_mgmt_only)


### PR DESCRIPTION
### Description of PR

Summary:
Enable fresh Monit reads for `ip/test_mgmt_ipv6_only.py::test_bgp_facts_ipv6_only`. The module-scoped IPv6-only management fixture performs `config_reload`; without a refresh, the first test can compare stale pre-reload Monit data with fresh post-reload usage and raise a false memory-utilization teardown alarm even though the test body passes.

ADO: https://dev.azure.com/msazure/One/_workitems/edit/38873091

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/38873091
Failure type: other - intermittent stale-cache false alarm

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: static validation on current head: `py_compile`, `git diff --check`, YAML parsing, and the repository markers check (690/690 checked scripts) passed.
- master: current inline-marker head `3c87fede8d6d4d0f52c4bb6d83b38be9ed12502f` passed Azure build 1171080, including the complete t1-lag-vpp lane. The prior VPP-scoped head also passed `test_bgp_facts_ipv6_only` on attempt 0 in plan https://elastictest.org/scheduler/testplan/6a5f05e702aca30eeb7ad67b.
- 202605: exact commit `3c87fede8d6d4d0f52c4bb6d83b38be9ed12502f` passed `ip/test_mgmt_ipv6_only.py::test_bgp_facts_ipv6_only` 1/1 on t1-lag-vpp with `SONiC.202605.1169810-bf6195c76` (KVM build 1169810, pipeline 2818). Plan https://elastictest.org/scheduler/testplan/6a6100f8075809537fd94cc0 completed with 15 passed, 4 skipped, and zero failures/errors.

### Approach
#### What is the motivation for this PR?

On `t1-lag-vpp`, `test_bgp_facts_ipv6_only` intermittently errors during the autouse memory-utilization teardown although the test body passes. In the latest-attempt results from the last 30 days, 35 of 1,522 runs showed the same Monit memory alarm. The failures report a stale-looking baseline around 18% followed by current usage around 40%, while the same images also pass.

The test is the first case after the module-scoped `duthosts_ipv6_mgmt_only` fixture performs `config_reload`. The test body only reads BGP facts, so it is not expected to double system memory usage.

#### How did you do it?

Added the existing `@pytest.mark.enable_monit_refresh` marker directly to `test_bgp_facts_ipv6_only`, following the existing usage pattern in the repository.

This uses the memory-utilization plugin's intended stale-cache mitigation (`sudo monit validate` plus a freshness-aware `sudo monit status` read) instead of disabling memory checking.

#### How did you verify/test it?

Ran `py_compile`, `git diff --check`, YAML parsing, and the repository markers check successfully. Azure build 1171080 passed all current-head lanes, including t1-lag-vpp. The exact commit also passed the affected test on the 202605 VPP image in plan https://elastictest.org/scheduler/testplan/6a6100f8075809537fd94cc0.

#### Any platform specific information?

The false alarm was observed on low-memory sonic-vpp VMs. The refresh marker is attached to the test itself and therefore ensures fresh Monit data on every platform running this test.

#### Supported testbed topology if it's a new test case?

Not a new test case. The affected topology is t1-lag-vpp.

### Documentation

Not applicable.
