### PR TITLE
[ansible/roles/vm_set]: attach BMC PTF container to mgmt bridge

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -171,8 +171,8 @@
       pull: "{{ 'missing' if (ptf_modified | default(false) | bool) else 'always' }}"
       state: started
       restart: no
-      network_mode: "{{ mgmt_bridge if ptf_use_docker_network | default(false) else 'none' }}"
-      networks: "{{ [{'name': mgmt_bridge, 'ipv4_address': ptf_ip | regex_replace('/.*', '')}] if ptf_use_docker_network | default(false) else omit }}"
+      network_mode: "{{ mgmt_bridge if ((ptf_use_docker_network | default(false)) or ('bmc' in topo)) else 'none' }}"
+      networks: "{{ [{'name': mgmt_bridge, 'ipv4_address': ptf_ip | regex_replace('/.*', '')}] if ((ptf_use_docker_network | default(false)) or ('bmc' in topo)) else omit }}"
       detach: True
       capabilities:
         - net_admin

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -135,8 +135,8 @@
       pull: yes
       state: started
       restart: yes
-      network_mode: "{{ mgmt_bridge if ptf_use_docker_network | default(false) else 'none' }}"
-      networks: "{{ [{'name': mgmt_bridge, 'ipv4_address': ptf_ip | regex_replace('/.*', '')}] if ptf_use_docker_network | default(false) else omit }}"
+      network_mode: "{{ mgmt_bridge if ((ptf_use_docker_network | default(false)) or ('bmc' in topo)) else 'none' }}"
+      networks: "{{ [{'name': mgmt_bridge, 'ipv4_address': ptf_ip | regex_replace('/.*', '')}] if ((ptf_use_docker_network | default(false)) or ('bmc' in topo)) else omit }}"
       detach: True
       capabilities:
         - net_admin


### PR DESCRIPTION
Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/26398

**Motivation:**
BMC (Baseboard Management Controller) topologies are data-plane portless and do not use the vm_topology bind operations that establish PTF container connectivity on standard topologies. This caused PTF containers to start without management interfaces, leading to connection failures during testbed preparation, pre-test, post-test operations like log collection.

**Root Cause:**
- PTF containers on BMC topologies were created with `network_mode: none`, leaving no management interface attached
- Post-test operations (Ansible connectivity checks, log collection) had no path to reach the PTF container
- The management bridge (`br1`) was not being used at container creation time

**Solution:**
Attach PTF containers to the management bridge (`mgmt_bridge`) at creation time for BMC topologies, ensuring immediate management connectivity without relying on post-creation bind operations.

### Type of change
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608

### Test result
- Validated on a BMC testbed with PTF container recreation (restart-ptf workflow)
  - PTF container created with network_mode: br1 (mgmt_bridge)
  - Management interface eth0 assigned an IP at creation time
  - Reachability checks pass immediately after container start
  - Post-test operations (log collection, validation) now succeed