### PR TITLE
[dualtor] Skip unsupported VNET scale tests on dualtor

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -706,6 +706,12 @@ bgp/test_bgp_vnet.py:
     conditions:
       - "asic_type not in ['vs', 'cisco-8000', 'mellanox']"
 
+bgp/test_bgp_vnet_scale.py:
+  skip:
+    reason: "VNET scale test is not supported on dualtor topologies"
+    conditions:
+      - "'dualtor' in topo_name"
+
 bgp/test_bgpmon.py:
   skip:
     reason: "Not supported on T2 topology or topology backend"
@@ -6263,11 +6269,11 @@ vxlan/test_vxlan_underlay_ecmp.py:
 
 vxlan/test_vxlan_vnet_bgp_subintf.py:
   skip:
-    reason: "test_vxlan_vnet_bgp_subintf requires INNER_SRC_MAC_REWRITE_TYPE / SET_INNER_SRC_MAC; not supported on cisco-8000 202511 image (orchagent validate fails). Skip only when both apply."
-    conditions_logical_operator: and
+    reason: "test_vxlan_vnet_bgp_subintf is not supported on dualtor topologies. Also not supported on cisco-8000 202511 image due to INNER_SRC_MAC_REWRITE_TYPE / SET_INNER_SRC_MAC orchagent validate failure."
+    conditions_logical_operator: or
     conditions:
-      - "asic_type in ['cisco-8000']"
-      - "release in ['202511']"
+      - "'dualtor' in topo_name"
+      - "(asic_type in ['cisco-8000']) and (release in ['202511'])"
 
 #######################################
 #####            wan              #####


### PR DESCRIPTION
### Description of PR

Skip two VNET scale tests on dualtor topologies where they are not supported:
- `bgp/test_bgp_vnet_scale.py`
- `vxlan/test_vxlan_vnet_bgp_subintf.py`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
- Requested in PR discussion thread by maintainer/reviewer (no separate tracker provided)

Failure type: day-one issue

### Approach
#### What is the motivation for this PR?
On dualtor testbeds, these two test modules are not supported and can produce non-actionable failures/noise in PR validation.
This change aligns conditional marks with actual platform/topology support.

For `test_vxlan_vnet_bgp_subintf`, the existing Cisco-8000 + 202511 skip remains required due to
`INNER_SRC_MAC_REWRITE_TYPE / SET_INNER_SRC_MAC` orchestration validation constraints.

#### How did you do it?
Updated `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`:
1. Added skip rule for `bgp/test_bgp_vnet_scale.py` when:
   - `'dualtor' in topo_name`
2. Extended existing skip rule for `vxlan/test_vxlan_vnet_bgp_subintf.py`:
   - switch logical operator to `or`
   - add dualtor condition: `'dualtor' in topo_name`
   - keep existing condition: `(asic_type in ['cisco-8000']) and (release in ['202511'])`

#### How did you verify/test it?
- Parsed the updated YAML successfully with `yaml.safe_load(...)`.
- Verified the diff is scoped to one file only:
  - `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`

#### Any platform specific information?
- Dualtor topology specific skip added for both tests.
- Existing Cisco-8000 release-specific skip retained for `test_vxlan_vnet_bgp_subintf`.