### PR TITLE
[dualtor] Backport skip unsupported VNET scale tests on dualtor to 202605

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -632,6 +632,12 @@ bgp/test_bgp_vnet.py:
     conditions:
       - "asic_type not in ['vs', 'cisco-8000', 'mellanox']"
 
+bgp/test_bgp_vnet_scale.py:
+  skip:
+    reason: "VNET scale test is not supported on dualtor topologies"
+    conditions:
+      - "'dualtor' in topo_name"
+
 bgp/test_bgpmon.py:
   skip:
     reason: "Not supported on T2 topology or topology backend"
@@ -6113,11 +6119,11 @@ vxlan/test_vxlan_underlay_ecmp.py:
 
 vxlan/test_vxlan_vnet_bgp_subintf.py:
   skip:
-    reason: "test_vxlan_vnet_bgp_subintf requires INNER_SRC_MAC_REWRITE_TYPE / SET_INNER_SRC_MAC; not supported on cisco-8000 202511 image (orchagent validate fails). Skip only when both apply."
-    conditions_logical_operator: and
+    reason: "test_vxlan_vnet_bgp_subintf is not supported on dualtor topologies. Also not supported on cisco-8000 202511 image due to INNER_SRC_MAC_REWRITE_TYPE / SET_INNER_SRC_MAC orchagent validate failure."
+    conditions_logical_operator: or
     conditions:
-      - "asic_type in ['cisco-8000']"
-      - "release in ['202511']"
+      - "'dualtor' in topo_name"
+      - "(asic_type in ['cisco-8000']) and (release in ['202511'])"
 
 #######################################
 #####           wan_lacp          #####


### PR DESCRIPTION
### Description of PR

Backport of #26403 to `202605`.

Skip two VNET scale tests on dualtor topologies where they are not supported:
- `bgp/test_bgp_vnet_scale.py`
- `vxlan/test_vxlan_vnet_bgp_subintf.py`

### Type of change
- [ ] Bug fix
- [x] Test improvement (conditional skip for unsupported topology)
- [ ] New feature
- [ ] Breaking change

### Approach
#### What is the motivation for this PR?
Keep `202605` branch aligned with master for dualtor unsupported VNET-scale test handling and avoid non-actionable failures/noise on dualtor testbeds.

#### How did you do it?
Cherry-picked master commit:
- `21e6ef040` (`[dualtor] Skip unsupported VNET scale tests on dualtor`)

#### How did you verify/test it?
- Cherry-pick applied cleanly on `origin/202605`.
- Parsed updated YAML successfully with `yaml.safe_load(...)`.
- Verified diff only touches:
  - `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`

#### Any platform specific information?
- Dualtor topology specific skip for both tests.
- Existing Cisco-8000 + 202511 skip condition retained for `test_vxlan_vnet_bgp_subintf`.
