### PR TITLE
Add DOM basic operational range test

### DIFF
--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -208,6 +208,121 @@ def build_dom_polling_failures(duthost, dom_primary_ports):
     return failures
 
 
+def format_optional_float(value):
+    return "{:.2f}".format(value) if value is not None else "not-available"
+
+
+def format_dom_port_failure(port, active_lanes, expected_fields, field_failures):
+    """Prefix a port's failure block with its expected shape."""
+    return "{} [{} expected field(s), media lanes {}]:\n  {}".format(
+        port,
+        len(expected_fields),
+        active_lanes or "none",
+        "\n  ".join(field_failures),
+    )
+
+
+def validate_dom_plan_fields(
+    duthost,
+    dom_primary_ports,
+    sensor_by_port,
+    plan_by_port,
+    field_check,
+    include_freshness_only=False,
+):
+    """Drive primary-port DOM sensor validation and delegate per-field rules.
+
+    ``field_check(field, mapped_field, raw_value)`` returns an error string or
+    ``None``. The driver owns freshness, empty-sensor handling, missing-field
+    handling, aggregation, and checked field/port counts.
+    """
+    failures = []
+    checked_field_count = 0
+    checked_port_count = 0
+    now_utc = None
+
+    for port in dom_primary_ports:
+        sensor_data = sensor_by_port.get(port, {})
+        plan = plan_by_port.get(port, {})
+        expected_fields = plan.get("expected_fields", {})
+        active_lanes = plan.get("active_media_lanes", [])
+        field_failures = list(plan.get("errors", []))
+        max_age_min = plan.get("max_age_min")
+        has_field_checks = bool(expected_fields or field_failures)
+        has_plan_checks = has_field_checks or (include_freshness_only and max_age_min is not None)
+
+        if not has_plan_checks:
+            continue
+        checked_port_count += 1
+
+        if not sensor_data:
+            if expected_fields:
+                field_failures.append(
+                    "missing {} data for expected field(s): {}".format(
+                        STATE_DB_SENSOR_TABLE,
+                        ", ".join(expected_fields),
+                    )
+                )
+            elif max_age_min is not None:
+                if now_utc is None:
+                    now_utc = duthost.get_now_time(utc_timezone=True)
+                field_failures.extend(
+                    check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)["failures"]
+                )
+
+            if field_failures:
+                failures.append(format_dom_port_failure(port, active_lanes, expected_fields, field_failures))
+            continue
+
+        freshness_age_min = None
+        if max_age_min is not None and (has_field_checks or include_freshness_only):
+            if now_utc is None:
+                now_utc = duthost.get_now_time(utc_timezone=True)
+            freshness_result = check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)
+            field_failures.extend(freshness_result["failures"])
+            freshness_age_min = freshness_result["age_minutes"]
+
+        checked_fields = 0
+        for field, mapped_field in expected_fields.items():
+            if field not in sensor_data:
+                field_failures.append(
+                    "expected DOM field missing in STATE_DB sensor data: {}".format(field)
+                )
+                continue
+
+            raw_value = sensor_data[field]
+            error = field_check(field, mapped_field, raw_value)
+            if error:
+                field_failures.append(error)
+                continue
+
+            checked_fields += 1
+            logger.debug(
+                "DOM field PASS %s %s (source_attr=%s)",
+                port,
+                field,
+                mapped_field.source_attr,
+            )
+
+        checked_field_count += checked_fields
+
+        if field_failures:
+            failures.append(format_dom_port_failure(port, active_lanes, expected_fields, field_failures))
+            continue
+
+        logger.debug(
+            "DOM plan PASS %s: media_lanes=%s expected_fields=%s "
+            "freshness_age_min=%s freshness_limit_min=%s",
+            port,
+            active_lanes or "none",
+            ", ".join(expected_fields) or "none",
+            format_optional_float(freshness_age_min),
+            max_age_min if max_age_min is not None else "not-configured",
+        )
+
+    return failures, checked_field_count, checked_port_count
+
+
 def read_dom_sensor_data(duthost, ports):
     """Return ``({port: {field: value}}, errors)`` for current DOM sensor data."""
     ports = list(ports)

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -5,6 +5,7 @@ a list of self-describing strings.  Callers aggregate those strings into the
 final per-test failure message instead of raising immediately.
 """
 import logging
+import math
 from collections import defaultdict, namedtuple
 
 from tests.transceiver.attribute_parser.attribute_keys import (
@@ -15,6 +16,7 @@ from tests.transceiver.common.db_helpers import (
     check_entry_freshness,
     get_config_db_port_table,
     get_state_db_table,
+    parse_numeric,
     resolve_port_namespace,
 )
 
@@ -214,12 +216,36 @@ def format_optional_float(value):
 
 def format_dom_port_failure(port, active_lanes, expected_fields, field_failures):
     """Prefix a port's failure block with its expected shape."""
-    return "{} [{} expected field(s), media lanes {}]:\n  {}".format(
+    return "{} [{} expected field(s), lanes {}]:\n  {}".format(
         port,
         len(expected_fields),
         active_lanes or "none",
         "\n  ".join(field_failures),
     )
+
+
+def parse_min_max_range(mapped_field):
+    """Return ``(min_value, max_value, error)`` for a DOM ``{"min", "max"}`` range."""
+    attr_name = mapped_field.source_attr
+    attr_value = mapped_field.attr_value
+
+    if not isinstance(attr_value, dict):
+        return None, None, "{} must be a dict with min/max in DOM_ATTRIBUTES".format(attr_name)
+
+    min_value = parse_numeric(attr_value.get("min"))
+    max_value = parse_numeric(attr_value.get("max"))
+    if min_value is None or max_value is None:
+        return None, None, "{} missing numeric min/max in DOM_ATTRIBUTES".format(attr_name)
+    if not math.isfinite(min_value) or not math.isfinite(max_value):
+        return None, None, "{} has non-finite min/max in DOM_ATTRIBUTES".format(attr_name)
+    if min_value > max_value:
+        return None, None, "{} has invalid range [{}, {}]".format(
+            attr_name,
+            attr_value.get("min"),
+            attr_value.get("max"),
+        )
+
+    return min_value, max_value, None
 
 
 def validate_dom_plan_fields(
@@ -256,22 +282,10 @@ def validate_dom_plan_fields(
         checked_port_count += 1
 
         if not sensor_data:
-            if expected_fields:
-                field_failures.append(
-                    "missing {} data for expected field(s): {}".format(
-                        STATE_DB_SENSOR_TABLE,
-                        ", ".join(expected_fields),
-                    )
-                )
-            elif max_age_min is not None:
-                if now_utc is None:
-                    now_utc = duthost.get_now_time(utc_timezone=True)
-                field_failures.extend(
-                    check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)["failures"]
-                )
-
-            if field_failures:
-                failures.append(format_dom_port_failure(port, active_lanes, expected_fields, field_failures))
+            field_failures.append(
+                "no {} entry published for port".format(STATE_DB_SENSOR_TABLE)
+            )
+            failures.append(format_dom_port_failure(port, active_lanes, expected_fields, field_failures))
             continue
 
         freshness_age_min = None

--- a/tests/transceiver/dom/test_dom_availability.py
+++ b/tests/transceiver/dom/test_dom_availability.py
@@ -7,95 +7,22 @@ from natsort import natsorted
 from tests.transceiver.common.db_helpers import parse_numeric
 from tests.transceiver.dom.dom_helpers import (
     build_dom_availability_plan,
-    check_dom_sensor_freshness,
     read_dom_sensor_data,
+    validate_dom_plan_fields,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def _format_optional_float(value):
-    return "{:.2f}".format(value) if value is not None else "not-available"
-
-
-def _format_port_failure(port, active_lanes, expected_fields, field_failures):
-    """Prefix a port's failure block with its expected shape (lanes + field count)."""
-    return "{} [{} expected field(s), media lanes {}]:\n  {}".format(
-        port,
-        len(expected_fields),
-        active_lanes or "none",
-        "\n  ".join(field_failures),
-    )
-
-
-def _validate_dom_primary_ports(duthost, dom_primary_ports, sensor_by_port, availability_plan_by_port):
-    """Validate configured DOM fields and freshness for primary breakout subports."""
-    failures = []
-    checked_field_count = 0
-    checked_port_count = 0
-    now_utc = None
-
-    for port in dom_primary_ports:
-        sensor_data = sensor_by_port.get(port, {})
-        availability_plan = availability_plan_by_port.get(port, {})
-        expected_fields = availability_plan.get("expected_fields", {})
-        active_lanes = availability_plan.get("active_media_lanes", [])
-        field_failures = list(availability_plan.get("errors", []))
-        max_age_min = availability_plan.get("max_age_min")
-
-        if max_age_min is not None or expected_fields or field_failures:
-            checked_port_count += 1
-
-        freshness_age_min = None
-        if max_age_min is not None:
-            if now_utc is None:
-                now_utc = duthost.get_now_time(utc_timezone=True)
-            result = check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)
-            field_failures.extend(result["failures"])
-            freshness_age_min = result["age_minutes"]
-
-        if not sensor_data:
-            for field in expected_fields:
-                field_failures.append(
-                    "missing TRANSCEIVER_DOM_SENSOR data for expected field {}".format(field)
-                )
-            if field_failures:
-                failures.append(_format_port_failure(port, active_lanes, expected_fields, field_failures))
-            continue
-
-        checked_fields = 0
-        for field in expected_fields:
-            if field not in sensor_data:
-                field_failures.append(
-                    "expected DOM field missing in STATE_DB sensor data: {}".format(field)
-                )
-                continue
-            value = parse_numeric(sensor_data[field])
-            if value is None or not math.isfinite(value):
-                field_failures.append(
-                    "expected DOM field {} has no valid finite value (got {!r})".format(
-                        field, sensor_data[field]
-                    )
-                )
-                continue
-            checked_fields += 1
-
-        checked_field_count += checked_fields
-
-        if field_failures:
-            failures.append(_format_port_failure(port, active_lanes, expected_fields, field_failures))
-            continue
-
-        logger.debug(
-            "DOM availability PASS %s: media_lanes=%s expected_fields=%s freshness_age_min=%s freshness_limit_min=%s",
-            port,
-            active_lanes or "none",
-            ", ".join(expected_fields) or "none",
-            _format_optional_float(freshness_age_min),
-            max_age_min if max_age_min is not None else "not-configured",
+def _availability_field_check(field, _mapped_field, raw_value):
+    """Validate one expected DOM field is present with a finite numeric value."""
+    value = parse_numeric(raw_value)
+    if value is None or not math.isfinite(value):
+        return "expected DOM field {} has no valid finite value (got {!r})".format(
+            field,
+            raw_value,
         )
-
-    return failures, checked_field_count, checked_port_count
+    return None
 
 
 def _validate_dom_non_primary_ports(dom_non_primary_ports, sensor_by_port):
@@ -139,11 +66,13 @@ def test_dom_data_availability_verification(
     )
 
     all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in sensor_read_errors]
-    primary_failures, checked_field_count, checked_primary_port_count = _validate_dom_primary_ports(
+    primary_failures, checked_field_count, checked_primary_port_count = validate_dom_plan_fields(
         duthost,
         dom_primary_ports,
         sensor_by_port,
         availability_plan_by_port,
+        _availability_field_check,
+        include_freshness_only=True,
     )
     non_primary_failures, checked_non_primary_port_count = _validate_dom_non_primary_ports(
         dom_non_primary_ports,

--- a/tests/transceiver/dom/test_dom_operational_range.py
+++ b/tests/transceiver/dom/test_dom_operational_range.py
@@ -6,25 +6,11 @@ import pytest
 from tests.transceiver.common.db_helpers import parse_numeric
 from tests.transceiver.dom.dom_helpers import (
     build_dom_availability_plan,
-    check_dom_sensor_freshness,
     read_dom_sensor_data,
+    validate_dom_plan_fields,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _format_optional_float(value):
-    return "{:.2f}".format(value) if value is not None else "not-available"
-
-
-def _format_port_failure(port, active_lanes, expected_fields, field_failures):
-    """Prefix a port's failure block with its expected shape."""
-    return "{} [{} expected field(s), media lanes {}]:\n  {}".format(
-        port,
-        len(expected_fields),
-        active_lanes or "none",
-        "\n  ".join(field_failures),
-    )
 
 
 def _parse_operational_range(mapped_field):
@@ -51,101 +37,28 @@ def _parse_operational_range(mapped_field):
     return min_value, max_value, None
 
 
-def _validate_dom_operational_ranges(
-    duthost,
-    dom_primary_ports,
-    sensor_by_port,
-    availability_plan_by_port,
-):
-    """Validate configured DOM sensor fields are fresh and within range."""
-    failures = []
-    checked_field_count = 0
-    checked_port_count = 0
-    now_utc = None
+def _operational_range_field_check(field, mapped_field, raw_value):
+    """Validate one DOM sensor value is finite and within its configured range."""
+    min_value, max_value, range_error = _parse_operational_range(mapped_field)
+    if range_error:
+        return range_error
 
-    for port in dom_primary_ports:
-        sensor_data = sensor_by_port.get(port, {})
-        availability_plan = availability_plan_by_port.get(port, {})
-        expected_fields = availability_plan.get("expected_fields", {})
-        active_lanes = availability_plan.get("active_media_lanes", [])
-        field_failures = list(availability_plan.get("errors", []))
-        max_age_min = availability_plan.get("max_age_min")
-        has_operational_checks = bool(expected_fields or field_failures)
+    numeric_value = parse_numeric(raw_value)
+    if numeric_value is None or not math.isfinite(numeric_value):
+        return "{} missing/non-finite operational value in STATE_DB (raw={!r})".format(
+            field,
+            raw_value,
+        )
 
-        if has_operational_checks:
-            checked_port_count += 1
+    if not min_value <= numeric_value <= max_value:
+        return "{} value {} out of range [{}, {}]".format(
+            field,
+            numeric_value,
+            min_value,
+            max_value,
+        )
 
-        freshness_age_min = None
-        if max_age_min is not None and has_operational_checks:
-            if now_utc is None:
-                now_utc = duthost.get_now_time(utc_timezone=True)
-            result = check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)
-            field_failures.extend(result["failures"])
-            freshness_age_min = result["age_minutes"]
-
-        if not sensor_data:
-            for field in expected_fields:
-                field_failures.append("{} DOM sensor table missing".format(field))
-            if field_failures:
-                failures.append(_format_port_failure(port, active_lanes, expected_fields, field_failures))
-            continue
-
-        checked_fields = 0
-        for field, mapped_field in expected_fields.items():
-            min_value, max_value, range_error = _parse_operational_range(mapped_field)
-            if range_error:
-                field_failures.append(range_error)
-                continue
-
-            if field not in sensor_data:
-                field_failures.append(
-                    "expected DOM field missing in STATE_DB sensor data: {}".format(field)
-                )
-                continue
-
-            raw_value = sensor_data[field]
-            numeric_value = parse_numeric(raw_value)
-            if numeric_value is None or not math.isfinite(numeric_value):
-                field_failures.append(
-                    "{} missing/non-finite operational value in STATE_DB (raw={!r})".format(
-                        field,
-                        raw_value,
-                    )
-                )
-                continue
-
-            if not min_value <= numeric_value <= max_value:
-                field_failures.append(
-                    "{} value {} out of range [{}, {}]".format(
-                        field,
-                        numeric_value,
-                        min_value,
-                        max_value,
-                    )
-                )
-                continue
-
-            checked_fields += 1
-            logger.debug(
-                "DOM operational range PASS %s %s=%s within [%s, %s] "
-                "(source_attr=%s media_lanes=%s freshness_age_min=%s freshness_limit_min=%s)",
-                port,
-                field,
-                numeric_value,
-                min_value,
-                max_value,
-                mapped_field.source_attr,
-                active_lanes or "none",
-                _format_optional_float(freshness_age_min),
-                max_age_min if max_age_min is not None else "not-configured",
-            )
-
-        checked_field_count += checked_fields
-
-        if field_failures:
-            failures.append(_format_port_failure(port, active_lanes, expected_fields, field_failures))
-
-    return failures, checked_field_count, checked_port_count
+    return None
 
 
 def test_dom_sensor_operational_range_validation(
@@ -163,11 +76,12 @@ def test_dom_sensor_operational_range_validation(
     )
 
     all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in sensor_read_errors]
-    range_failures, checked_field_count, checked_port_count = _validate_dom_operational_ranges(
+    range_failures, checked_field_count, checked_port_count = validate_dom_plan_fields(
         duthost,
         dom_primary_ports,
         sensor_by_port,
         availability_plan_by_port,
+        _operational_range_field_check,
     )
     all_failures.extend(range_failures)
 

--- a/tests/transceiver/dom/test_dom_operational_range.py
+++ b/tests/transceiver/dom/test_dom_operational_range.py
@@ -3,9 +3,12 @@ import math
 
 import pytest
 
+from tests.transceiver.attribute_parser.attribute_keys import DOM_ATTRIBUTES_KEY
 from tests.transceiver.common.db_helpers import parse_numeric
 from tests.transceiver.dom.dom_helpers import (
+    OPERATIONAL_SUFFIX,
     build_dom_availability_plan,
+    parse_min_max_range,
     read_dom_sensor_data,
     validate_dom_plan_fields,
 )
@@ -13,33 +16,18 @@ from tests.transceiver.dom.dom_helpers import (
 logger = logging.getLogger(__name__)
 
 
-def _parse_operational_range(mapped_field):
-    """Return ``(min_value, max_value, error)`` for one mapped DOM field."""
-    attr_name = mapped_field.source_attr
-    attr_value = mapped_field.attr_value
-
-    if not isinstance(attr_value, dict):
-        return None, None, "{} must be a dict with min/max in DOM_ATTRIBUTES".format(attr_name)
-
-    min_value = parse_numeric(attr_value.get("min"))
-    max_value = parse_numeric(attr_value.get("max"))
-    if min_value is None or max_value is None:
-        return None, None, "{} missing numeric min/max in DOM_ATTRIBUTES".format(attr_name)
-    if not math.isfinite(min_value) or not math.isfinite(max_value):
-        return None, None, "{} has non-finite min/max in DOM_ATTRIBUTES".format(attr_name)
-    if min_value > max_value:
-        return None, None, "{} has invalid range [{}, {}]".format(
-            attr_name,
-            attr_value.get("min"),
-            attr_value.get("max"),
-        )
-
-    return min_value, max_value, None
+def _has_operational_range_attributes(port_attributes_dict, dom_primary_ports):
+    """Return True when any primary port has configured operational-range checks."""
+    for port in dom_primary_ports:
+        dom_attrs = port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {})
+        if any(attr_name.endswith(OPERATIONAL_SUFFIX) for attr_name in dom_attrs):
+            return True
+    return False
 
 
 def _operational_range_field_check(field, mapped_field, raw_value):
     """Validate one DOM sensor value is finite and within its configured range."""
-    min_value, max_value, range_error = _parse_operational_range(mapped_field)
+    min_value, max_value, range_error = parse_min_max_range(mapped_field)
     if range_error:
         return range_error
 
@@ -68,13 +56,15 @@ def test_dom_sensor_operational_range_validation(
     lport_to_first_subport_mapping,
 ):
     """Verify configured DOM sensor values are fresh and within operational ranges."""
-    sensor_by_port, sensor_read_errors = read_dom_sensor_data(duthost, dom_primary_ports)
     availability_plan_by_port = build_dom_availability_plan(
         port_attributes_dict,
         dom_primary_ports,
         lport_to_first_subport_mapping,
     )
+    if not _has_operational_range_attributes(port_attributes_dict, dom_primary_ports):
+        pytest.skip("No *_operational_range attributes configured for DOM operational range validation")
 
+    sensor_by_port, sensor_read_errors = read_dom_sensor_data(duthost, dom_primary_ports)
     all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in sensor_read_errors]
     range_failures, checked_field_count, checked_port_count = validate_dom_plan_fields(
         duthost,
@@ -84,9 +74,6 @@ def test_dom_sensor_operational_range_validation(
         _operational_range_field_check,
     )
     all_failures.extend(range_failures)
-
-    if not (all_failures or checked_port_count):
-        pytest.skip("No *_operational_range attributes configured for DOM operational range validation")
 
     if all_failures:
         pytest.fail("DOM operational range validation failures:\n" + "\n".join(all_failures))

--- a/tests/transceiver/dom/test_dom_operational_range.py
+++ b/tests/transceiver/dom/test_dom_operational_range.py
@@ -1,0 +1,184 @@
+import logging
+import math
+
+import pytest
+
+from tests.transceiver.common.db_helpers import parse_numeric
+from tests.transceiver.dom.dom_helpers import (
+    build_dom_availability_plan,
+    check_dom_sensor_freshness,
+    read_dom_sensor_data,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _format_optional_float(value):
+    return "{:.2f}".format(value) if value is not None else "not-available"
+
+
+def _format_port_failure(port, active_lanes, expected_fields, field_failures):
+    """Prefix a port's failure block with its expected shape."""
+    return "{} [{} expected field(s), media lanes {}]:\n  {}".format(
+        port,
+        len(expected_fields),
+        active_lanes or "none",
+        "\n  ".join(field_failures),
+    )
+
+
+def _parse_operational_range(mapped_field):
+    """Return ``(min_value, max_value, error)`` for one mapped DOM field."""
+    attr_name = mapped_field.source_attr
+    attr_value = mapped_field.attr_value
+
+    if not isinstance(attr_value, dict):
+        return None, None, "{} must be a dict with min/max in DOM_ATTRIBUTES".format(attr_name)
+
+    min_value = parse_numeric(attr_value.get("min"))
+    max_value = parse_numeric(attr_value.get("max"))
+    if min_value is None or max_value is None:
+        return None, None, "{} missing numeric min/max in DOM_ATTRIBUTES".format(attr_name)
+    if not math.isfinite(min_value) or not math.isfinite(max_value):
+        return None, None, "{} has non-finite min/max in DOM_ATTRIBUTES".format(attr_name)
+    if min_value > max_value:
+        return None, None, "{} has invalid range [{}, {}]".format(
+            attr_name,
+            attr_value.get("min"),
+            attr_value.get("max"),
+        )
+
+    return min_value, max_value, None
+
+
+def _validate_dom_operational_ranges(
+    duthost,
+    dom_primary_ports,
+    sensor_by_port,
+    availability_plan_by_port,
+):
+    """Validate configured DOM sensor fields are fresh and within range."""
+    failures = []
+    checked_field_count = 0
+    checked_port_count = 0
+    now_utc = None
+
+    for port in dom_primary_ports:
+        sensor_data = sensor_by_port.get(port, {})
+        availability_plan = availability_plan_by_port.get(port, {})
+        expected_fields = availability_plan.get("expected_fields", {})
+        active_lanes = availability_plan.get("active_media_lanes", [])
+        field_failures = list(availability_plan.get("errors", []))
+        max_age_min = availability_plan.get("max_age_min")
+        has_operational_checks = bool(expected_fields or field_failures)
+
+        if has_operational_checks:
+            checked_port_count += 1
+
+        freshness_age_min = None
+        if max_age_min is not None and has_operational_checks:
+            if now_utc is None:
+                now_utc = duthost.get_now_time(utc_timezone=True)
+            result = check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)
+            field_failures.extend(result["failures"])
+            freshness_age_min = result["age_minutes"]
+
+        if not sensor_data:
+            for field in expected_fields:
+                field_failures.append("{} DOM sensor table missing".format(field))
+            if field_failures:
+                failures.append(_format_port_failure(port, active_lanes, expected_fields, field_failures))
+            continue
+
+        checked_fields = 0
+        for field, mapped_field in expected_fields.items():
+            min_value, max_value, range_error = _parse_operational_range(mapped_field)
+            if range_error:
+                field_failures.append(range_error)
+                continue
+
+            if field not in sensor_data:
+                field_failures.append(
+                    "expected DOM field missing in STATE_DB sensor data: {}".format(field)
+                )
+                continue
+
+            raw_value = sensor_data[field]
+            numeric_value = parse_numeric(raw_value)
+            if numeric_value is None or not math.isfinite(numeric_value):
+                field_failures.append(
+                    "{} missing/non-finite operational value in STATE_DB (raw={!r})".format(
+                        field,
+                        raw_value,
+                    )
+                )
+                continue
+
+            if not min_value <= numeric_value <= max_value:
+                field_failures.append(
+                    "{} value {} out of range [{}, {}]".format(
+                        field,
+                        numeric_value,
+                        min_value,
+                        max_value,
+                    )
+                )
+                continue
+
+            checked_fields += 1
+            logger.debug(
+                "DOM operational range PASS %s %s=%s within [%s, %s] "
+                "(source_attr=%s media_lanes=%s freshness_age_min=%s freshness_limit_min=%s)",
+                port,
+                field,
+                numeric_value,
+                min_value,
+                max_value,
+                mapped_field.source_attr,
+                active_lanes or "none",
+                _format_optional_float(freshness_age_min),
+                max_age_min if max_age_min is not None else "not-configured",
+            )
+
+        checked_field_count += checked_fields
+
+        if field_failures:
+            failures.append(_format_port_failure(port, active_lanes, expected_fields, field_failures))
+
+    return failures, checked_field_count, checked_port_count
+
+
+def test_dom_sensor_operational_range_validation(
+    duthost,
+    dom_primary_ports,
+    port_attributes_dict,
+    lport_to_first_subport_mapping,
+):
+    """Verify configured DOM sensor values are fresh and within operational ranges."""
+    sensor_by_port, sensor_read_errors = read_dom_sensor_data(duthost, dom_primary_ports)
+    availability_plan_by_port = build_dom_availability_plan(
+        port_attributes_dict,
+        dom_primary_ports,
+        lport_to_first_subport_mapping,
+    )
+
+    all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in sensor_read_errors]
+    range_failures, checked_field_count, checked_port_count = _validate_dom_operational_ranges(
+        duthost,
+        dom_primary_ports,
+        sensor_by_port,
+        availability_plan_by_port,
+    )
+    all_failures.extend(range_failures)
+
+    if not (all_failures or checked_port_count):
+        pytest.skip("No *_operational_range attributes configured for DOM operational range validation")
+
+    if all_failures:
+        pytest.fail("DOM operational range validation failures:\n" + "\n".join(all_failures))
+
+    logger.info(
+        "DOM operational range validation passed: %d field(s) across %d port(s)",
+        checked_field_count,
+        checked_port_count,
+    )


### PR DESCRIPTION
  ### Description of PR

  Summary:
  Add DOM basic TC2 operational range validation for transceiver DOM sensor data.

  Fixes # (issue)
  N/A

  This PR is scoped to DOM basic TC2. TC1 availability validation and the initial shared DOM/common helper infrastructure are already
  available from master. This PR adds the TC2 operational range test and factors the shared DOM per-port validation driver so TC1 and TC2
  use the same field-plan validation flow with different per-field checks.

  ### Type of change

  - [ ] Bug fix
  - [x] Testbed and Framework(new/improvement)
  - [x] New Test case
      - [ ] Skipped for non-supported platforms
  - [x] Test case improvement

  ### Back port request

  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511
  - [ ] 202512
  - [ ] 202605

  Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
  N/A

  Failure type:
  N/A

  ### Tested branch

  - [x] master
  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511
  - [ ] 202512
  - [ ] 202605
  - [ ] N/A

  ### Test result

  - master: DOM basic TC2 operational range validation passed on `verify/dom-basic-tc2`.

  Test result summary:

  ```text
  collected 1 item
  tests/transceiver/dom/test_dom_operational_range.py::test_dom_sensor_operational_range_validation PASSED
  Results (23.10s):
         1 passed

  HTML report:

  file:///var/src/sonic-mgmt/dom_tests.html

  Test command:

  ./tests/run_tests.sh \
    -c "tests/transceiver/dom/test_dom_operational_range.py" \
    -n single-dut-mgmt56 \
    -d str-nexthop_4010-01 \
    -i "ansible/my_inventory/lab" \
    -f "ansible/testbed.yaml" \
    -u \
    -e "-rs -n 0 -p no:tests.common.plugins.memory_utilization --ignore-conditional-mark --skip_sanity --skip_yang --disable-warnings
    --skip_transceiver_template_validation --html=dom_tests.html --self-contained-html"

  Local checks:

  python3 -m py_compile tests/transceiver/dom/dom_helpers.py tests/transceiver/dom/test_dom_availability.py tests/transceiver/dom/
  test_dom_operational_range.py tests/transceiver/dom/conftest.py
  git diff --check

  ### Approach

  #### What is the motivation for this PR?

  This PR continues splitting the DOM basic tests into smaller, reviewable subsets. It adds DOM basic TC2 operational range validation on
  top of the merged TC1 DOM availability infrastructure.

  #### How did you do it?

  Added tests/transceiver/dom/test_dom_operational_range.py and refactored shared DOM validation helpers.

  The TC2 test:

  - Reads current DOM sensor data from TRANSCEIVER_DOM_SENSOR in STATE_DB using the shared DOM DB helper.
  - Uses resolved DOM attributes from port_attributes_dict.
  - Reuses the shared DOM availability plan to derive expected STATE_DB sensor fields from configured *_operational_range attributes.
  - Reuses the shared DOM field mapping path, including LANE_NUM expansion over module active media lanes for breakout ports.
  - Validates last_update_time freshness when data_max_age_min is configured for ports that have operational range checks.
  - Validates configured operational range entries are dicts with finite numeric min and max values.
  - Validates each expected STATE_DB sensor value is present, numeric, finite, and within the configured min/max operational range.
  - Skips the test when no DOM *_operational_range attributes are configured.
  - Aggregates per-port failures and logs per-field pass details for debugging.

  The shared helper refactor:

  - Moves common DOM formatting and primary-port validation flow into dom_helpers.py.
  - Lets TC1 and TC2 supply only their per-field validation callback.
  - Aligns empty TRANSCEIVER_DOM_SENSOR failure wording across TC1 and TC2.
  - Keeps the different TC1/TC2 validation rules separate while sharing the common driver.

  #### How did you verify/test it?

  Validated on the verify/dom-basic-tc2 branch in the lab using single-dut-mgmt56 and DUT str-nexthop_4010-01.

  The latest run passed with 1 passed in 23.10s.

  #### Any platform specific information?

  N/A

  #### Supported testbed topology if it's a new test case?

  Validated on mgmt-only single DUT testbed: single-dut-mgmt56

  ### Documentation

  The DOM basic TC2 behavior follows the DOM test plan: docs/testplan/transceiver/dom_test_plan.md


