### PR TITLE
Add DOM basic threshold validation test

### DIFF
--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -307,6 +307,129 @@ def build_dom_polling_failures(duthost, dom_primary_ports):
     return failures
 
 
+def format_optional_float(value):
+    return "{:.2f}".format(value) if value is not None else "not-available"
+
+
+def format_dom_port_failure(
+    port,
+    active_lanes,
+    expected_fields,
+    field_failures,
+    field_label="expected field(s)",
+):
+    """Prefix a port's failure block with its expected shape."""
+    lane_context = "" if active_lanes is None else ", media lanes {}".format(active_lanes or "none")
+    return "{} [{} {}{}]:\n  {}".format(
+        port,
+        len(expected_fields),
+        field_label,
+        lane_context,
+        "\n  ".join(field_failures),
+    )
+
+
+def validate_dom_plan_fields(
+    duthost,
+    dom_primary_ports,
+    sensor_by_port,
+    plan_by_port,
+    field_check,
+    include_freshness_only=False,
+):
+    """Drive primary-port DOM sensor validation and delegate per-field rules.
+
+    ``field_check(field, mapped_field, raw_value)`` returns an error string or
+    ``None``. The driver owns freshness, empty-sensor handling, missing-field
+    handling, aggregation, and checked field/port counts.
+    """
+    failures = []
+    checked_field_count = 0
+    checked_port_count = 0
+    now_utc = None
+
+    for port in dom_primary_ports:
+        sensor_data = sensor_by_port.get(port, {})
+        plan = plan_by_port.get(port, {})
+        expected_fields = plan.get("expected_fields", {})
+        active_lanes = plan.get("active_media_lanes", [])
+        field_failures = list(plan.get("errors", []))
+        max_age_min = plan.get("max_age_min")
+        has_field_checks = bool(expected_fields or field_failures)
+        has_plan_checks = has_field_checks or (include_freshness_only and max_age_min is not None)
+
+        if not has_plan_checks:
+            continue
+        checked_port_count += 1
+
+        if not sensor_data:
+            if expected_fields:
+                field_failures.append(
+                    "missing {} data for expected field(s): {}".format(
+                        STATE_DB_SENSOR_TABLE,
+                        ", ".join(expected_fields),
+                    )
+                )
+            elif max_age_min is not None:
+                if now_utc is None:
+                    now_utc = duthost.get_now_time(utc_timezone=True)
+                field_failures.extend(
+                    check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)["failures"]
+                )
+
+            if field_failures:
+                failures.append(format_dom_port_failure(port, active_lanes, expected_fields, field_failures))
+            continue
+
+        freshness_age_min = None
+        if max_age_min is not None and (has_field_checks or include_freshness_only):
+            if now_utc is None:
+                now_utc = duthost.get_now_time(utc_timezone=True)
+            freshness_result = check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)
+            field_failures.extend(freshness_result["failures"])
+            freshness_age_min = freshness_result["age_minutes"]
+
+        checked_fields = 0
+        for field, mapped_field in expected_fields.items():
+            if field not in sensor_data:
+                field_failures.append(
+                    "expected DOM field missing in STATE_DB sensor data: {}".format(field)
+                )
+                continue
+
+            raw_value = sensor_data[field]
+            error = field_check(field, mapped_field, raw_value)
+            if error:
+                field_failures.append(error)
+                continue
+
+            checked_fields += 1
+            logger.debug(
+                "DOM field PASS %s %s (source_attr=%s)",
+                port,
+                field,
+                mapped_field.source_attr,
+            )
+
+        checked_field_count += checked_fields
+
+        if field_failures:
+            failures.append(format_dom_port_failure(port, active_lanes, expected_fields, field_failures))
+            continue
+
+        logger.debug(
+            "DOM plan PASS %s: media_lanes=%s expected_fields=%s "
+            "freshness_age_min=%s freshness_limit_min=%s",
+            port,
+            active_lanes or "none",
+            ", ".join(expected_fields) or "none",
+            format_optional_float(freshness_age_min),
+            max_age_min if max_age_min is not None else "not-configured",
+        )
+
+    return failures, checked_field_count, checked_port_count
+
+
 def _read_dom_table_data(duthost, ports, table_name):
     """Return ``({port: {field: value}}, errors)`` for a current DOM STATE_DB table."""
     ports = list(ports)

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -5,6 +5,7 @@ a list of self-describing strings.  Callers aggregate those strings into the
 final per-test failure message instead of raising immediately.
 """
 import logging
+import math
 from collections import defaultdict, namedtuple
 
 from tests.transceiver.attribute_parser.attribute_keys import (
@@ -15,6 +16,7 @@ from tests.transceiver.common.db_helpers import (
     check_entry_freshness,
     get_config_db_port_table,
     get_state_db_table,
+    parse_numeric,
     resolve_port_namespace,
 )
 
@@ -319,7 +321,7 @@ def format_dom_port_failure(
     field_label="expected field(s)",
 ):
     """Prefix a port's failure block with its expected shape."""
-    lane_context = "" if active_lanes is None else ", media lanes {}".format(active_lanes or "none")
+    lane_context = "" if active_lanes is None else ", lanes {}".format(active_lanes or "none")
     return "{} [{} {}{}]:\n  {}".format(
         port,
         len(expected_fields),
@@ -327,6 +329,30 @@ def format_dom_port_failure(
         lane_context,
         "\n  ".join(field_failures),
     )
+
+
+def parse_min_max_range(mapped_field):
+    """Return ``(min_value, max_value, error)`` for a DOM ``{"min", "max"}`` range."""
+    attr_name = mapped_field.source_attr
+    attr_value = mapped_field.attr_value
+
+    if not isinstance(attr_value, dict):
+        return None, None, "{} must be a dict with min/max in DOM_ATTRIBUTES".format(attr_name)
+
+    min_value = parse_numeric(attr_value.get("min"))
+    max_value = parse_numeric(attr_value.get("max"))
+    if min_value is None or max_value is None:
+        return None, None, "{} missing numeric min/max in DOM_ATTRIBUTES".format(attr_name)
+    if not math.isfinite(min_value) or not math.isfinite(max_value):
+        return None, None, "{} has non-finite min/max in DOM_ATTRIBUTES".format(attr_name)
+    if min_value > max_value:
+        return None, None, "{} has invalid range [{}, {}]".format(
+            attr_name,
+            attr_value.get("min"),
+            attr_value.get("max"),
+        )
+
+    return min_value, max_value, None
 
 
 def validate_dom_plan_fields(
@@ -363,22 +389,10 @@ def validate_dom_plan_fields(
         checked_port_count += 1
 
         if not sensor_data:
-            if expected_fields:
-                field_failures.append(
-                    "missing {} data for expected field(s): {}".format(
-                        STATE_DB_SENSOR_TABLE,
-                        ", ".join(expected_fields),
-                    )
-                )
-            elif max_age_min is not None:
-                if now_utc is None:
-                    now_utc = duthost.get_now_time(utc_timezone=True)
-                field_failures.extend(
-                    check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)["failures"]
-                )
-
-            if field_failures:
-                failures.append(format_dom_port_failure(port, active_lanes, expected_fields, field_failures))
+            field_failures.append(
+                "no {} entry published for port".format(STATE_DB_SENSOR_TABLE)
+            )
+            failures.append(format_dom_port_failure(port, active_lanes, expected_fields, field_failures))
             continue
 
         freshness_age_min = None

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -178,7 +178,7 @@ def _operational_attr_for_threshold(attr_name):
     return THRESHOLD_TO_OPERATIONAL_ATTR.get(base_name)
 
 
-def build_dom_availability_plan(port_attributes_dict, dom_primary_ports, lport_to_first_subport_mapping):
+def build_dom_sensor_plan(port_attributes_dict, dom_primary_ports, lport_to_first_subport_mapping):
     """Return each port's expected DOM fields, active lanes, errors, and age limit.
 
     ``expected_fields`` is a ``{field: DomMappedField(source_attr, attr_value)}``
@@ -321,7 +321,7 @@ def format_dom_port_failure(
     field_label="expected field(s)",
 ):
     """Prefix a port's failure block with its expected shape."""
-    lane_context = "" if active_lanes is None else ", lanes {}".format(active_lanes or "none")
+    lane_context = "" if active_lanes is None else ", media lanes {}".format(active_lanes or "none")
     return "{} [{} {}{}]:\n  {}".format(
         port,
         len(expected_fields),
@@ -396,7 +396,7 @@ def validate_dom_plan_fields(
             continue
 
         freshness_age_min = None
-        if max_age_min is not None and (has_field_checks or include_freshness_only):
+        if max_age_min is not None:
             if now_utc is None:
                 now_utc = duthost.get_now_time(utc_timezone=True)
             freshness_result = check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -23,11 +23,33 @@ from tests.transceiver.common.db_helpers import (
 logger = logging.getLogger(__name__)
 
 STATE_DB_SENSOR_TABLE = "TRANSCEIVER_DOM_SENSOR"
+STATE_DB_THRESHOLD_TABLE = "TRANSCEIVER_DOM_THRESHOLD"
 
 OPERATIONAL_SUFFIX = "_operational_range"
+THRESHOLD_SUFFIX = "_threshold_range"
 LANE_NUM_PLACEHOLDER = "LANE_NUM"
 MEDIA_LANE_MASK_KEY = "media_lane_mask"
 DomMappedField = namedtuple("DomMappedField", ("source_attr", "attr_value"))
+DomThresholdMappedField = namedtuple("DomThresholdMappedField", ("source_attr", "attr_value", "threshold_key"))
+
+THRESHOLD_FIELD_SUFFIXES = ("lowalarm", "lowwarning", "highwarning", "highalarm")
+THRESHOLD_FIELD_PREFIXES = {
+    "temperature": "temp",
+    "voltage": "vcc",
+    "laser_temperature": "lasertemp",
+    "tx_bias": "txbias",
+    "tx_power": "txpower",
+    "rx_power": "rxpower",
+}
+THRESHOLD_TO_OPERATIONAL_ATTR = {
+    "temperature": "temperature_operational_range",
+    "voltage": "voltage_operational_range",
+    "laser_temperature": "laser_temperature_operational_range",
+    "tx_bias": "txLANE_NUMbias_operational_range",
+    "tx_power": "txLANE_NUMpower_operational_range",
+    "rx_power": "rxLANE_NUMpower_operational_range",
+}
+THRESHOLD_VALUE_TOLERANCE = 0.01
 
 DOM_POLLING_ENABLED_VALUES = ("", "enabled")
 DOM_POLLING_DISABLED_VALUE = "disabled"
@@ -117,15 +139,43 @@ DOM_FIELD_MAPPERS = (
 def map_dom_attribute_to_fields(attr_name, attr_value, active_media_lanes):
     """Map one DOM attribute to current STATE_DB field metadata.
 
-    The suffix dispatch is DOM-local: TC1/TC2 use the operational mapper today,
-    and future threshold/consistency families can add their own mapper here
-    without duplicating the LANE_NUM expansion path.
+    The suffix dispatch is DOM-local. TC1/TC2 use this operational mapper for
+    ``TRANSCEIVER_DOM_SENSOR``; TC3 uses separate threshold helpers because
+    ``TRANSCEIVER_DOM_THRESHOLD`` is transceiver-level and does not expand
+    LANE_NUM.
     """
     for suffix, mapper in DOM_FIELD_MAPPERS:
         if attr_name.endswith(suffix):
             return mapper(attr_name, attr_value, active_media_lanes)
     logger.debug("DOM attribute %s matched no field mapper; skipped", attr_name)
     return {}, []
+
+
+def map_dom_threshold_attribute_to_fields(attr_name, attr_value):
+    """Return ``({field: DomThresholdMappedField(source_attr, attr_value, threshold_key)}, errors)``."""
+    if not attr_name.endswith(THRESHOLD_SUFFIX):
+        logger.debug("DOM attribute %s is not a threshold range; skipped", attr_name)
+        return {}, []
+
+    base_name = attr_name[:-len(THRESHOLD_SUFFIX)]
+    prefix = THRESHOLD_FIELD_PREFIXES.get(base_name)
+    if prefix is None:
+        return {}, ["{} has no DOM threshold field mapping".format(attr_name)]
+
+    return {
+        "{}{}".format(prefix, suffix): DomThresholdMappedField(
+            attr_name,
+            attr_value,
+            suffix,
+        )
+        for suffix in THRESHOLD_FIELD_SUFFIXES
+    }, []
+
+
+def _operational_attr_for_threshold(attr_name):
+    """Return the configured operational-range attribute paired with a threshold attribute."""
+    base_name = attr_name[:-len(THRESHOLD_SUFFIX)]
+    return THRESHOLD_TO_OPERATIONAL_ATTR.get(base_name)
 
 
 def build_dom_availability_plan(port_attributes_dict, dom_primary_ports, lport_to_first_subport_mapping):
@@ -167,6 +217,55 @@ def build_dom_availability_plan(port_attributes_dict, dom_primary_ports, lport_t
             len(expected_fields),
             active_media_lanes or "none",
             dom_attrs.get("data_max_age_min"),
+        )
+
+    return plan_by_port
+
+
+def build_dom_threshold_plan(port_attributes_dict, dom_primary_ports):
+    """Return each port's expected threshold fields and paired operational ranges.
+
+    ``expected_fields`` is a ``{field: DomThresholdMappedField(...)}`` map for
+    ``TRANSCEIVER_DOM_THRESHOLD``. Threshold validation is transceiver-level, so
+    no LANE_NUM expansion is applied here.
+    """
+    plan_by_port = {}
+    for port in dom_primary_ports:
+        dom_attrs = port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {})
+        expected_fields = {}
+        threshold_attrs = {}
+        operational_ranges = {}
+        errors = []
+
+        for attr_name, attr_value in sorted(dom_attrs.items()):
+            if not attr_name.endswith(THRESHOLD_SUFFIX):
+                continue
+
+            threshold_attrs[attr_name] = attr_value
+            mapped_fields, field_errors = map_dom_threshold_attribute_to_fields(attr_name, attr_value)
+            expected_fields.update(mapped_fields)
+            errors.extend(field_errors)
+
+            operational_attr = _operational_attr_for_threshold(attr_name)
+            if operational_attr in dom_attrs:
+                operational_ranges[attr_name] = DomMappedField(
+                    operational_attr,
+                    dom_attrs[operational_attr],
+                )
+
+        plan_by_port[port] = {
+            "expected_fields": {field: expected_fields[field] for field in sorted(expected_fields)},
+            "threshold_attrs": threshold_attrs,
+            "operational_ranges": operational_ranges,
+            "errors": errors,
+        }
+        logger.debug(
+            "%s DOM threshold plan: %d expected field(s), %d threshold attr(s), "
+            "%d paired operational range attr(s)",
+            port,
+            len(expected_fields),
+            len(threshold_attrs),
+            len(operational_ranges),
         )
 
     return plan_by_port
@@ -214,12 +313,20 @@ def format_optional_float(value):
     return "{:.2f}".format(value) if value is not None else "not-available"
 
 
-def format_dom_port_failure(port, active_lanes, expected_fields, field_failures):
+def format_dom_port_failure(
+    port,
+    active_lanes,
+    expected_fields,
+    field_failures,
+    field_label="expected field(s)",
+):
     """Prefix a port's failure block with its expected shape."""
-    return "{} [{} expected field(s), lanes {}]:\n  {}".format(
+    lane_context = "" if active_lanes is None else ", lanes {}".format(active_lanes or "none")
+    return "{} [{} {}{}]:\n  {}".format(
         port,
         len(expected_fields),
-        active_lanes or "none",
+        field_label,
+        lane_context,
         "\n  ".join(field_failures),
     )
 
@@ -337,10 +444,10 @@ def validate_dom_plan_fields(
     return failures, checked_field_count, checked_port_count
 
 
-def read_dom_sensor_data(duthost, ports):
-    """Return ``({port: {field: value}}, errors)`` for current DOM sensor data."""
+def _read_dom_table_data(duthost, ports, table_name):
+    """Return ``({port: {field: value}}, errors)`` for a current DOM STATE_DB table."""
     ports = list(ports)
-    sensor_data = {port: {} for port in ports}
+    table_data_by_port = {port: {} for port in ports}
     errors = []
     ports_by_namespace = defaultdict(list)
 
@@ -349,15 +456,15 @@ def read_dom_sensor_data(duthost, ports):
         ports_by_namespace[namespace].append(port)
 
     for namespace, namespace_ports in ports_by_namespace.items():
-        sensor_table, err = get_state_db_table(
+        dom_table, err = get_state_db_table(
             duthost,
-            STATE_DB_SENSOR_TABLE,
+            table_name,
             namespace=namespace,
         )
         if err:
             errors.append(
                 "{} namespace {}: {}".format(
-                    STATE_DB_SENSOR_TABLE,
+                    table_name,
                     namespace or "default",
                     err,
                 )
@@ -365,17 +472,28 @@ def read_dom_sensor_data(duthost, ports):
             continue
 
         for port in namespace_ports:
-            sensor_data[port] = sensor_table.get(port, {}) or {}
+            table_data_by_port[port] = dom_table.get(port, {}) or {}
 
     logger.debug(
-        "Read DOM sensor data for %d port(s) across %d namespace(s); "
+        "Read %s data for %d port(s) across %d namespace(s); "
         "%d port(s) returned data",
+        table_name,
         len(ports),
         len(ports_by_namespace),
-        sum(1 for port_data in sensor_data.values() if port_data),
+        sum(1 for port_data in table_data_by_port.values() if port_data),
     )
 
-    return sensor_data, errors
+    return table_data_by_port, errors
+
+
+def read_dom_sensor_data(duthost, ports):
+    """Return ``({port: {field: value}}, errors)`` for current DOM sensor data."""
+    return _read_dom_table_data(duthost, ports, STATE_DB_SENSOR_TABLE)
+
+
+def read_dom_threshold_data(duthost, ports):
+    """Return ``({port: {field: value}}, errors)`` for current DOM threshold data."""
+    return _read_dom_table_data(duthost, ports, STATE_DB_THRESHOLD_TABLE)
 
 
 def check_dom_sensor_freshness(sensor_data, max_age_min, now_utc):

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -21,11 +21,33 @@ from tests.transceiver.common.db_helpers import (
 logger = logging.getLogger(__name__)
 
 STATE_DB_SENSOR_TABLE = "TRANSCEIVER_DOM_SENSOR"
+STATE_DB_THRESHOLD_TABLE = "TRANSCEIVER_DOM_THRESHOLD"
 
 OPERATIONAL_SUFFIX = "_operational_range"
+THRESHOLD_SUFFIX = "_threshold_range"
 LANE_NUM_PLACEHOLDER = "LANE_NUM"
 MEDIA_LANE_MASK_KEY = "media_lane_mask"
 DomMappedField = namedtuple("DomMappedField", ("source_attr", "attr_value"))
+DomThresholdMappedField = namedtuple("DomThresholdMappedField", ("source_attr", "attr_value", "threshold_key"))
+
+THRESHOLD_FIELD_SUFFIXES = ("lowalarm", "lowwarning", "highwarning", "highalarm")
+THRESHOLD_FIELD_PREFIXES = {
+    "temperature": "temp",
+    "voltage": "vcc",
+    "laser_temperature": "lasertemp",
+    "tx_bias": "txbias",
+    "tx_power": "txpower",
+    "rx_power": "rxpower",
+}
+THRESHOLD_TO_OPERATIONAL_ATTR = {
+    "temperature": "temperature_operational_range",
+    "voltage": "voltage_operational_range",
+    "laser_temperature": "laser_temperature_operational_range",
+    "tx_bias": "txLANE_NUMbias_operational_range",
+    "tx_power": "txLANE_NUMpower_operational_range",
+    "rx_power": "rxLANE_NUMpower_operational_range",
+}
+THRESHOLD_VALUE_TOLERANCE = 0.01
 
 DOM_POLLING_ENABLED_VALUES = ("", "enabled")
 DOM_POLLING_DISABLED_VALUE = "disabled"
@@ -115,15 +137,43 @@ DOM_FIELD_MAPPERS = (
 def map_dom_attribute_to_fields(attr_name, attr_value, active_media_lanes):
     """Map one DOM attribute to current STATE_DB field metadata.
 
-    The suffix dispatch is DOM-local: TC1/TC2 use the operational mapper today,
-    and future threshold/consistency families can add their own mapper here
-    without duplicating the LANE_NUM expansion path.
+    The suffix dispatch is DOM-local. TC1/TC2 use this operational mapper for
+    ``TRANSCEIVER_DOM_SENSOR``; TC3 uses separate threshold helpers because
+    ``TRANSCEIVER_DOM_THRESHOLD`` is transceiver-level and does not expand
+    LANE_NUM.
     """
     for suffix, mapper in DOM_FIELD_MAPPERS:
         if attr_name.endswith(suffix):
             return mapper(attr_name, attr_value, active_media_lanes)
     logger.debug("DOM attribute %s matched no field mapper; skipped", attr_name)
     return {}, []
+
+
+def map_dom_threshold_attribute_to_fields(attr_name, attr_value):
+    """Return ``({field: DomThresholdMappedField(source_attr, attr_value, threshold_key)}, errors)``."""
+    if not attr_name.endswith(THRESHOLD_SUFFIX):
+        logger.debug("DOM attribute %s is not a threshold range; skipped", attr_name)
+        return {}, []
+
+    base_name = attr_name[:-len(THRESHOLD_SUFFIX)]
+    prefix = THRESHOLD_FIELD_PREFIXES.get(base_name)
+    if prefix is None:
+        return {}, ["{} has no DOM threshold field mapping".format(attr_name)]
+
+    return {
+        "{}{}".format(prefix, suffix): DomThresholdMappedField(
+            attr_name,
+            attr_value,
+            suffix,
+        )
+        for suffix in THRESHOLD_FIELD_SUFFIXES
+    }, []
+
+
+def _operational_attr_for_threshold(attr_name):
+    """Return the configured operational-range attribute paired with a threshold attribute."""
+    base_name = attr_name[:-len(THRESHOLD_SUFFIX)]
+    return THRESHOLD_TO_OPERATIONAL_ATTR.get(base_name)
 
 
 def build_dom_availability_plan(port_attributes_dict, dom_primary_ports, lport_to_first_subport_mapping):
@@ -170,6 +220,55 @@ def build_dom_availability_plan(port_attributes_dict, dom_primary_ports, lport_t
     return plan_by_port
 
 
+def build_dom_threshold_plan(port_attributes_dict, dom_primary_ports):
+    """Return each port's expected threshold fields and paired operational ranges.
+
+    ``expected_fields`` is a ``{field: DomThresholdMappedField(...)}`` map for
+    ``TRANSCEIVER_DOM_THRESHOLD``. Threshold validation is transceiver-level, so
+    no LANE_NUM expansion is applied here.
+    """
+    plan_by_port = {}
+    for port in dom_primary_ports:
+        dom_attrs = port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {})
+        expected_fields = {}
+        threshold_attrs = {}
+        operational_ranges = {}
+        errors = []
+
+        for attr_name, attr_value in sorted(dom_attrs.items()):
+            if not attr_name.endswith(THRESHOLD_SUFFIX):
+                continue
+
+            threshold_attrs[attr_name] = attr_value
+            mapped_fields, field_errors = map_dom_threshold_attribute_to_fields(attr_name, attr_value)
+            expected_fields.update(mapped_fields)
+            errors.extend(field_errors)
+
+            operational_attr = _operational_attr_for_threshold(attr_name)
+            if operational_attr in dom_attrs:
+                operational_ranges[attr_name] = DomMappedField(
+                    operational_attr,
+                    dom_attrs[operational_attr],
+                )
+
+        plan_by_port[port] = {
+            "expected_fields": {field: expected_fields[field] for field in sorted(expected_fields)},
+            "threshold_attrs": threshold_attrs,
+            "operational_ranges": operational_ranges,
+            "errors": errors,
+        }
+        logger.debug(
+            "%s DOM threshold plan: %d expected field(s), %d threshold attr(s), "
+            "%d paired operational range attr(s)",
+            port,
+            len(expected_fields),
+            len(threshold_attrs),
+            len(operational_ranges),
+        )
+
+    return plan_by_port
+
+
 def build_dom_polling_failures(duthost, dom_primary_ports):
     """Return DOM polling prerequisite failures for configured DOM ports."""
     failures = []
@@ -208,10 +307,10 @@ def build_dom_polling_failures(duthost, dom_primary_ports):
     return failures
 
 
-def read_dom_sensor_data(duthost, ports):
-    """Return ``({port: {field: value}}, errors)`` for current DOM sensor data."""
+def _read_dom_table_data(duthost, ports, table_name):
+    """Return ``({port: {field: value}}, errors)`` for a current DOM STATE_DB table."""
     ports = list(ports)
-    sensor_data = {port: {} for port in ports}
+    table_data_by_port = {port: {} for port in ports}
     errors = []
     ports_by_namespace = defaultdict(list)
 
@@ -220,15 +319,15 @@ def read_dom_sensor_data(duthost, ports):
         ports_by_namespace[namespace].append(port)
 
     for namespace, namespace_ports in ports_by_namespace.items():
-        sensor_table, err = get_state_db_table(
+        dom_table, err = get_state_db_table(
             duthost,
-            STATE_DB_SENSOR_TABLE,
+            table_name,
             namespace=namespace,
         )
         if err:
             errors.append(
                 "{} namespace {}: {}".format(
-                    STATE_DB_SENSOR_TABLE,
+                    table_name,
                     namespace or "default",
                     err,
                 )
@@ -236,17 +335,28 @@ def read_dom_sensor_data(duthost, ports):
             continue
 
         for port in namespace_ports:
-            sensor_data[port] = sensor_table.get(port, {}) or {}
+            table_data_by_port[port] = dom_table.get(port, {}) or {}
 
     logger.debug(
-        "Read DOM sensor data for %d port(s) across %d namespace(s); "
+        "Read %s data for %d port(s) across %d namespace(s); "
         "%d port(s) returned data",
+        table_name,
         len(ports),
         len(ports_by_namespace),
-        sum(1 for port_data in sensor_data.values() if port_data),
+        sum(1 for port_data in table_data_by_port.values() if port_data),
     )
 
-    return sensor_data, errors
+    return table_data_by_port, errors
+
+
+def read_dom_sensor_data(duthost, ports):
+    """Return ``({port: {field: value}}, errors)`` for current DOM sensor data."""
+    return _read_dom_table_data(duthost, ports, STATE_DB_SENSOR_TABLE)
+
+
+def read_dom_threshold_data(duthost, ports):
+    """Return ``({port: {field: value}}, errors)`` for current DOM threshold data."""
+    return _read_dom_table_data(duthost, ports, STATE_DB_THRESHOLD_TABLE)
 
 
 def check_dom_sensor_freshness(sensor_data, max_age_min, now_utc):

--- a/tests/transceiver/dom/test_dom_availability.py
+++ b/tests/transceiver/dom/test_dom_availability.py
@@ -6,7 +6,7 @@ from natsort import natsorted
 
 from tests.transceiver.common.db_helpers import parse_numeric
 from tests.transceiver.dom.dom_helpers import (
-    build_dom_availability_plan,
+    build_dom_sensor_plan,
     read_dom_sensor_data,
     validate_dom_plan_fields,
 )
@@ -59,7 +59,7 @@ def test_dom_data_availability_verification(
     """Verify configured DOM sensor data is present and fresh in STATE_DB."""
     sensor_ports = natsorted(set(dom_primary_ports) | set(dom_non_primary_ports))
     sensor_by_port, sensor_read_errors = read_dom_sensor_data(duthost, sensor_ports)
-    availability_plan_by_port = build_dom_availability_plan(
+    sensor_plan_by_port = build_dom_sensor_plan(
         port_attributes_dict,
         dom_primary_ports,
         lport_to_first_subport_mapping,
@@ -70,7 +70,7 @@ def test_dom_data_availability_verification(
         duthost,
         dom_primary_ports,
         sensor_by_port,
-        availability_plan_by_port,
+        sensor_plan_by_port,
         _availability_field_check,
         include_freshness_only=True,
     )

--- a/tests/transceiver/dom/test_dom_availability.py
+++ b/tests/transceiver/dom/test_dom_availability.py
@@ -7,95 +7,22 @@ from natsort import natsorted
 from tests.transceiver.common.db_helpers import parse_numeric
 from tests.transceiver.dom.dom_helpers import (
     build_dom_availability_plan,
-    check_dom_sensor_freshness,
     read_dom_sensor_data,
+    validate_dom_plan_fields,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def _format_optional_float(value):
-    return "{:.2f}".format(value) if value is not None else "not-available"
-
-
-def _format_port_failure(port, active_lanes, expected_fields, field_failures):
-    """Prefix a port's failure block with its expected shape (lanes + field count)."""
-    return "{} [{} expected field(s), media lanes {}]:\n  {}".format(
-        port,
-        len(expected_fields),
-        active_lanes or "none",
-        "\n  ".join(field_failures),
-    )
-
-
-def _validate_dom_primary_ports(duthost, dom_primary_ports, sensor_by_port, availability_plan_by_port):
-    """Validate configured DOM fields and freshness for primary breakout subports."""
-    failures = []
-    checked_field_count = 0
-    checked_port_count = 0
-    now_utc = None
-
-    for port in dom_primary_ports:
-        sensor_data = sensor_by_port.get(port, {})
-        availability_plan = availability_plan_by_port.get(port, {})
-        expected_fields = availability_plan.get("expected_fields", {})
-        active_lanes = availability_plan.get("active_media_lanes", [])
-        field_failures = list(availability_plan.get("errors", []))
-        max_age_min = availability_plan.get("max_age_min")
-
-        if max_age_min is not None or expected_fields or field_failures:
-            checked_port_count += 1
-
-        freshness_age_min = None
-        if max_age_min is not None:
-            if now_utc is None:
-                now_utc = duthost.get_now_time(utc_timezone=True)
-            result = check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)
-            field_failures.extend(result["failures"])
-            freshness_age_min = result["age_minutes"]
-
-        if not sensor_data:
-            for field in expected_fields:
-                field_failures.append(
-                    "missing TRANSCEIVER_DOM_SENSOR data for expected field {}".format(field)
-                )
-            if field_failures:
-                failures.append(_format_port_failure(port, active_lanes, expected_fields, field_failures))
-            continue
-
-        checked_fields = 0
-        for field in expected_fields:
-            if field not in sensor_data:
-                field_failures.append(
-                    "expected DOM field missing in STATE_DB sensor data: {}".format(field)
-                )
-                continue
-            value = parse_numeric(sensor_data[field])
-            if value is None or not math.isfinite(value):
-                field_failures.append(
-                    "expected DOM field {} has no valid finite value (got {!r})".format(
-                        field, sensor_data[field]
-                    )
-                )
-                continue
-            checked_fields += 1
-
-        checked_field_count += checked_fields
-
-        if field_failures:
-            failures.append(_format_port_failure(port, active_lanes, expected_fields, field_failures))
-            continue
-
-        logger.debug(
-            "DOM availability PASS %s: media_lanes=%s expected_fields=%s freshness_age_min=%s freshness_limit_min=%s",
-            port,
-            active_lanes or "none",
-            ", ".join(expected_fields) or "none",
-            _format_optional_float(freshness_age_min),
-            max_age_min if max_age_min is not None else "not-configured",
+def _availability_field_check(field, _mapped_field, raw_value):
+    """Validate one expected DOM field is present with a finite numeric value."""
+    value = parse_numeric(raw_value)
+    if value is None or not math.isfinite(value):
+        return "expected DOM field {} has no valid finite value (got {!r})".format(
+            field,
+            raw_value,
         )
-
-    return failures, checked_field_count, checked_port_count
+    return None
 
 
 def _validate_dom_non_primary_ports(dom_non_primary_ports, sensor_by_port):
@@ -139,11 +66,13 @@ def test_dom_data_availability_verification(
     )
 
     all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in sensor_read_errors]
-    primary_failures, checked_field_count, checked_primary_port_count = _validate_dom_primary_ports(
+    primary_failures, checked_field_count, checked_primary_port_count = validate_dom_plan_fields(
         duthost,
         dom_primary_ports,
         sensor_by_port,
         availability_plan_by_port,
+        _availability_field_check,
+        include_freshness_only=True,
     )
     non_primary_failures, checked_non_primary_port_count = _validate_dom_non_primary_ports(
         dom_non_primary_ports,

--- a/tests/transceiver/dom/test_dom_operational_range.py
+++ b/tests/transceiver/dom/test_dom_operational_range.py
@@ -7,7 +7,7 @@ from tests.transceiver.attribute_parser.attribute_keys import DOM_ATTRIBUTES_KEY
 from tests.transceiver.common.db_helpers import parse_numeric
 from tests.transceiver.dom.dom_helpers import (
     OPERATIONAL_SUFFIX,
-    build_dom_availability_plan,
+    build_dom_sensor_plan,
     parse_min_max_range,
     read_dom_sensor_data,
     validate_dom_plan_fields,
@@ -55,22 +55,22 @@ def test_dom_sensor_operational_range_validation(
     port_attributes_dict,
     lport_to_first_subport_mapping,
 ):
-    """Verify configured DOM sensor values are fresh and within operational ranges."""
-    availability_plan_by_port = build_dom_availability_plan(
+    """Validate configured DOM operational ranges; freshness is checked with range fields."""
+    if not _has_operational_range_attributes(port_attributes_dict, dom_primary_ports):
+        pytest.skip("No *_operational_range attributes configured for DOM operational range validation")
+
+    sensor_plan_by_port = build_dom_sensor_plan(
         port_attributes_dict,
         dom_primary_ports,
         lport_to_first_subport_mapping,
     )
-    if not _has_operational_range_attributes(port_attributes_dict, dom_primary_ports):
-        pytest.skip("No *_operational_range attributes configured for DOM operational range validation")
-
     sensor_by_port, sensor_read_errors = read_dom_sensor_data(duthost, dom_primary_ports)
     all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in sensor_read_errors]
     range_failures, checked_field_count, checked_port_count = validate_dom_plan_fields(
         duthost,
         dom_primary_ports,
         sensor_by_port,
-        availability_plan_by_port,
+        sensor_plan_by_port,
         _operational_range_field_check,
     )
     all_failures.extend(range_failures)

--- a/tests/transceiver/dom/test_dom_operational_range.py
+++ b/tests/transceiver/dom/test_dom_operational_range.py
@@ -6,25 +6,11 @@ import pytest
 from tests.transceiver.common.db_helpers import parse_numeric
 from tests.transceiver.dom.dom_helpers import (
     build_dom_availability_plan,
-    check_dom_sensor_freshness,
     read_dom_sensor_data,
+    validate_dom_plan_fields,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _format_optional_float(value):
-    return "{:.2f}".format(value) if value is not None else "not-available"
-
-
-def _format_port_failure(port, active_lanes, expected_fields, field_failures):
-    """Prefix a port's failure block with its expected shape."""
-    return "{} [{} expected field(s), media lanes {}]:\n  {}".format(
-        port,
-        len(expected_fields),
-        active_lanes or "none",
-        "\n  ".join(field_failures),
-    )
 
 
 def _parse_operational_range(mapped_field):
@@ -51,101 +37,28 @@ def _parse_operational_range(mapped_field):
     return min_value, max_value, None
 
 
-def _validate_dom_operational_ranges(
-    duthost,
-    dom_primary_ports,
-    sensor_by_port,
-    availability_plan_by_port,
-):
-    """Validate configured DOM sensor fields are fresh and within range."""
-    failures = []
-    checked_field_count = 0
-    checked_port_count = 0
-    now_utc = None
+def _operational_range_field_check(field, mapped_field, raw_value):
+    """Validate one DOM sensor value is finite and within its configured range."""
+    min_value, max_value, range_error = _parse_operational_range(mapped_field)
+    if range_error:
+        return range_error
 
-    for port in dom_primary_ports:
-        sensor_data = sensor_by_port.get(port, {})
-        availability_plan = availability_plan_by_port.get(port, {})
-        expected_fields = availability_plan.get("expected_fields", {})
-        active_lanes = availability_plan.get("active_media_lanes", [])
-        field_failures = list(availability_plan.get("errors", []))
-        max_age_min = availability_plan.get("max_age_min")
-        has_operational_checks = bool(expected_fields or field_failures)
+    numeric_value = parse_numeric(raw_value)
+    if numeric_value is None or not math.isfinite(numeric_value):
+        return "{} missing/non-finite operational value in STATE_DB (raw={!r})".format(
+            field,
+            raw_value,
+        )
 
-        if has_operational_checks:
-            checked_port_count += 1
+    if not min_value <= numeric_value <= max_value:
+        return "{} value {} out of range [{}, {}]".format(
+            field,
+            numeric_value,
+            min_value,
+            max_value,
+        )
 
-        freshness_age_min = None
-        if max_age_min is not None and has_operational_checks:
-            if now_utc is None:
-                now_utc = duthost.get_now_time(utc_timezone=True)
-            result = check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)
-            field_failures.extend(result["failures"])
-            freshness_age_min = result["age_minutes"]
-
-        if not sensor_data:
-            for field in expected_fields:
-                field_failures.append("{} DOM sensor table missing".format(field))
-            if field_failures:
-                failures.append(_format_port_failure(port, active_lanes, expected_fields, field_failures))
-            continue
-
-        checked_fields = 0
-        for field, mapped_field in expected_fields.items():
-            min_value, max_value, range_error = _parse_operational_range(mapped_field)
-            if range_error:
-                field_failures.append(range_error)
-                continue
-
-            if field not in sensor_data:
-                field_failures.append(
-                    "expected DOM field missing in STATE_DB sensor data: {}".format(field)
-                )
-                continue
-
-            raw_value = sensor_data[field]
-            numeric_value = parse_numeric(raw_value)
-            if numeric_value is None or not math.isfinite(numeric_value):
-                field_failures.append(
-                    "{} missing/non-finite operational value in STATE_DB (raw={!r})".format(
-                        field,
-                        raw_value,
-                    )
-                )
-                continue
-
-            if not min_value <= numeric_value <= max_value:
-                field_failures.append(
-                    "{} value {} out of range [{}, {}]".format(
-                        field,
-                        numeric_value,
-                        min_value,
-                        max_value,
-                    )
-                )
-                continue
-
-            checked_fields += 1
-            logger.debug(
-                "DOM operational range PASS %s %s=%s within [%s, %s] "
-                "(source_attr=%s media_lanes=%s freshness_age_min=%s freshness_limit_min=%s)",
-                port,
-                field,
-                numeric_value,
-                min_value,
-                max_value,
-                mapped_field.source_attr,
-                active_lanes or "none",
-                _format_optional_float(freshness_age_min),
-                max_age_min if max_age_min is not None else "not-configured",
-            )
-
-        checked_field_count += checked_fields
-
-        if field_failures:
-            failures.append(_format_port_failure(port, active_lanes, expected_fields, field_failures))
-
-    return failures, checked_field_count, checked_port_count
+    return None
 
 
 def test_dom_sensor_operational_range_validation(
@@ -163,11 +76,12 @@ def test_dom_sensor_operational_range_validation(
     )
 
     all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in sensor_read_errors]
-    range_failures, checked_field_count, checked_port_count = _validate_dom_operational_ranges(
+    range_failures, checked_field_count, checked_port_count = validate_dom_plan_fields(
         duthost,
         dom_primary_ports,
         sensor_by_port,
         availability_plan_by_port,
+        _operational_range_field_check,
     )
     all_failures.extend(range_failures)
 

--- a/tests/transceiver/dom/test_dom_operational_range.py
+++ b/tests/transceiver/dom/test_dom_operational_range.py
@@ -3,9 +3,12 @@ import math
 
 import pytest
 
+from tests.transceiver.attribute_parser.attribute_keys import DOM_ATTRIBUTES_KEY
 from tests.transceiver.common.db_helpers import parse_numeric
 from tests.transceiver.dom.dom_helpers import (
+    OPERATIONAL_SUFFIX,
     build_dom_availability_plan,
+    parse_min_max_range,
     read_dom_sensor_data,
     validate_dom_plan_fields,
 )
@@ -13,33 +16,18 @@ from tests.transceiver.dom.dom_helpers import (
 logger = logging.getLogger(__name__)
 
 
-def _parse_operational_range(mapped_field):
-    """Return ``(min_value, max_value, error)`` for one mapped DOM field."""
-    attr_name = mapped_field.source_attr
-    attr_value = mapped_field.attr_value
-
-    if not isinstance(attr_value, dict):
-        return None, None, "{} must be a dict with min/max in DOM_ATTRIBUTES".format(attr_name)
-
-    min_value = parse_numeric(attr_value.get("min"))
-    max_value = parse_numeric(attr_value.get("max"))
-    if min_value is None or max_value is None:
-        return None, None, "{} missing numeric min/max in DOM_ATTRIBUTES".format(attr_name)
-    if not math.isfinite(min_value) or not math.isfinite(max_value):
-        return None, None, "{} has non-finite min/max in DOM_ATTRIBUTES".format(attr_name)
-    if min_value > max_value:
-        return None, None, "{} has invalid range [{}, {}]".format(
-            attr_name,
-            attr_value.get("min"),
-            attr_value.get("max"),
-        )
-
-    return min_value, max_value, None
+def _has_operational_range_attributes(port_attributes_dict, dom_primary_ports):
+    """Return True when any primary port has configured operational-range checks."""
+    for port in dom_primary_ports:
+        dom_attrs = port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {})
+        if any(attr_name.endswith(OPERATIONAL_SUFFIX) for attr_name in dom_attrs):
+            return True
+    return False
 
 
 def _operational_range_field_check(field, mapped_field, raw_value):
     """Validate one DOM sensor value is finite and within its configured range."""
-    min_value, max_value, range_error = _parse_operational_range(mapped_field)
+    min_value, max_value, range_error = parse_min_max_range(mapped_field)
     if range_error:
         return range_error
 
@@ -68,13 +56,15 @@ def test_dom_sensor_operational_range_validation(
     lport_to_first_subport_mapping,
 ):
     """Verify configured DOM sensor values are fresh and within operational ranges."""
-    sensor_by_port, sensor_read_errors = read_dom_sensor_data(duthost, dom_primary_ports)
     availability_plan_by_port = build_dom_availability_plan(
         port_attributes_dict,
         dom_primary_ports,
         lport_to_first_subport_mapping,
     )
+    if not _has_operational_range_attributes(port_attributes_dict, dom_primary_ports):
+        pytest.skip("No *_operational_range attributes configured for DOM operational range validation")
 
+    sensor_by_port, sensor_read_errors = read_dom_sensor_data(duthost, dom_primary_ports)
     all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in sensor_read_errors]
     range_failures, checked_field_count, checked_port_count = validate_dom_plan_fields(
         duthost,
@@ -84,9 +74,6 @@ def test_dom_sensor_operational_range_validation(
         _operational_range_field_check,
     )
     all_failures.extend(range_failures)
-
-    if not (all_failures or checked_port_count):
-        pytest.skip("No *_operational_range attributes configured for DOM operational range validation")
 
     if all_failures:
         pytest.fail("DOM operational range validation failures:\n" + "\n".join(all_failures))

--- a/tests/transceiver/dom/test_dom_operational_range.py
+++ b/tests/transceiver/dom/test_dom_operational_range.py
@@ -1,0 +1,184 @@
+import logging
+import math
+
+import pytest
+
+from tests.transceiver.common.db_helpers import parse_numeric
+from tests.transceiver.dom.dom_helpers import (
+    build_dom_availability_plan,
+    check_dom_sensor_freshness,
+    read_dom_sensor_data,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _format_optional_float(value):
+    return "{:.2f}".format(value) if value is not None else "not-available"
+
+
+def _format_port_failure(port, active_lanes, expected_fields, field_failures):
+    """Prefix a port's failure block with its expected shape."""
+    return "{} [{} expected field(s), media lanes {}]:\n  {}".format(
+        port,
+        len(expected_fields),
+        active_lanes or "none",
+        "\n  ".join(field_failures),
+    )
+
+
+def _parse_operational_range(mapped_field):
+    """Return ``(min_value, max_value, error)`` for one mapped DOM field."""
+    attr_name = mapped_field.source_attr
+    attr_value = mapped_field.attr_value
+
+    if not isinstance(attr_value, dict):
+        return None, None, "{} must be a dict with min/max in DOM_ATTRIBUTES".format(attr_name)
+
+    min_value = parse_numeric(attr_value.get("min"))
+    max_value = parse_numeric(attr_value.get("max"))
+    if min_value is None or max_value is None:
+        return None, None, "{} missing numeric min/max in DOM_ATTRIBUTES".format(attr_name)
+    if not math.isfinite(min_value) or not math.isfinite(max_value):
+        return None, None, "{} has non-finite min/max in DOM_ATTRIBUTES".format(attr_name)
+    if min_value > max_value:
+        return None, None, "{} has invalid range [{}, {}]".format(
+            attr_name,
+            attr_value.get("min"),
+            attr_value.get("max"),
+        )
+
+    return min_value, max_value, None
+
+
+def _validate_dom_operational_ranges(
+    duthost,
+    dom_primary_ports,
+    sensor_by_port,
+    availability_plan_by_port,
+):
+    """Validate configured DOM sensor fields are fresh and within range."""
+    failures = []
+    checked_field_count = 0
+    checked_port_count = 0
+    now_utc = None
+
+    for port in dom_primary_ports:
+        sensor_data = sensor_by_port.get(port, {})
+        availability_plan = availability_plan_by_port.get(port, {})
+        expected_fields = availability_plan.get("expected_fields", {})
+        active_lanes = availability_plan.get("active_media_lanes", [])
+        field_failures = list(availability_plan.get("errors", []))
+        max_age_min = availability_plan.get("max_age_min")
+        has_operational_checks = bool(expected_fields or field_failures)
+
+        if has_operational_checks:
+            checked_port_count += 1
+
+        freshness_age_min = None
+        if max_age_min is not None and has_operational_checks:
+            if now_utc is None:
+                now_utc = duthost.get_now_time(utc_timezone=True)
+            result = check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)
+            field_failures.extend(result["failures"])
+            freshness_age_min = result["age_minutes"]
+
+        if not sensor_data:
+            for field in expected_fields:
+                field_failures.append("{} DOM sensor table missing".format(field))
+            if field_failures:
+                failures.append(_format_port_failure(port, active_lanes, expected_fields, field_failures))
+            continue
+
+        checked_fields = 0
+        for field, mapped_field in expected_fields.items():
+            min_value, max_value, range_error = _parse_operational_range(mapped_field)
+            if range_error:
+                field_failures.append(range_error)
+                continue
+
+            if field not in sensor_data:
+                field_failures.append(
+                    "expected DOM field missing in STATE_DB sensor data: {}".format(field)
+                )
+                continue
+
+            raw_value = sensor_data[field]
+            numeric_value = parse_numeric(raw_value)
+            if numeric_value is None or not math.isfinite(numeric_value):
+                field_failures.append(
+                    "{} missing/non-finite operational value in STATE_DB (raw={!r})".format(
+                        field,
+                        raw_value,
+                    )
+                )
+                continue
+
+            if not min_value <= numeric_value <= max_value:
+                field_failures.append(
+                    "{} value {} out of range [{}, {}]".format(
+                        field,
+                        numeric_value,
+                        min_value,
+                        max_value,
+                    )
+                )
+                continue
+
+            checked_fields += 1
+            logger.debug(
+                "DOM operational range PASS %s %s=%s within [%s, %s] "
+                "(source_attr=%s media_lanes=%s freshness_age_min=%s freshness_limit_min=%s)",
+                port,
+                field,
+                numeric_value,
+                min_value,
+                max_value,
+                mapped_field.source_attr,
+                active_lanes or "none",
+                _format_optional_float(freshness_age_min),
+                max_age_min if max_age_min is not None else "not-configured",
+            )
+
+        checked_field_count += checked_fields
+
+        if field_failures:
+            failures.append(_format_port_failure(port, active_lanes, expected_fields, field_failures))
+
+    return failures, checked_field_count, checked_port_count
+
+
+def test_dom_sensor_operational_range_validation(
+    duthost,
+    dom_primary_ports,
+    port_attributes_dict,
+    lport_to_first_subport_mapping,
+):
+    """Verify configured DOM sensor values are fresh and within operational ranges."""
+    sensor_by_port, sensor_read_errors = read_dom_sensor_data(duthost, dom_primary_ports)
+    availability_plan_by_port = build_dom_availability_plan(
+        port_attributes_dict,
+        dom_primary_ports,
+        lport_to_first_subport_mapping,
+    )
+
+    all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in sensor_read_errors]
+    range_failures, checked_field_count, checked_port_count = _validate_dom_operational_ranges(
+        duthost,
+        dom_primary_ports,
+        sensor_by_port,
+        availability_plan_by_port,
+    )
+    all_failures.extend(range_failures)
+
+    if not (all_failures or checked_port_count):
+        pytest.skip("No *_operational_range attributes configured for DOM operational range validation")
+
+    if all_failures:
+        pytest.fail("DOM operational range validation failures:\n" + "\n".join(all_failures))
+
+    logger.info(
+        "DOM operational range validation passed: %d field(s) across %d port(s)",
+        checked_field_count,
+        checked_port_count,
+    )

--- a/tests/transceiver/dom/test_dom_threshold.py
+++ b/tests/transceiver/dom/test_dom_threshold.py
@@ -8,19 +8,11 @@ from tests.transceiver.dom.dom_helpers import (
     THRESHOLD_FIELD_SUFFIXES,
     THRESHOLD_VALUE_TOLERANCE,
     build_dom_threshold_plan,
+    format_dom_port_failure,
     read_dom_threshold_data,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _format_port_failure(port, expected_fields, field_failures):
-    """Prefix a port's failure block with its expected threshold shape."""
-    return "{} [{} expected threshold field(s)]:\n  {}".format(
-        port,
-        len(expected_fields),
-        "\n  ".join(field_failures),
-    )
 
 
 def _parse_threshold_range(attr_name, attr_value):
@@ -215,7 +207,15 @@ def _validate_dom_threshold_ranges(dom_primary_ports, threshold_by_port, thresho
                 )
 
         if field_failures:
-            failures.append(_format_port_failure(port, expected_fields, field_failures))
+            failures.append(
+                format_dom_port_failure(
+                    port,
+                    None,
+                    expected_fields,
+                    field_failures,
+                    field_label="expected threshold field(s)",
+                )
+            )
 
     return failures, checked_attr_count, checked_field_count, checked_port_count
 

--- a/tests/transceiver/dom/test_dom_threshold.py
+++ b/tests/transceiver/dom/test_dom_threshold.py
@@ -5,10 +5,12 @@ import pytest
 
 from tests.transceiver.common.db_helpers import parse_numeric
 from tests.transceiver.dom.dom_helpers import (
+    STATE_DB_THRESHOLD_TABLE,
     THRESHOLD_FIELD_SUFFIXES,
     THRESHOLD_VALUE_TOLERANCE,
     build_dom_threshold_plan,
     format_dom_port_failure,
+    parse_min_max_range,
     read_dom_threshold_data,
 )
 
@@ -49,30 +51,6 @@ def _parse_threshold_range(attr_name, attr_value):
     return thresholds, []
 
 
-def _parse_operational_range(mapped_field):
-    """Return ``(min_value, max_value, error)`` for one paired operational range."""
-    attr_name = mapped_field.source_attr
-    attr_value = mapped_field.attr_value
-
-    if not isinstance(attr_value, dict):
-        return None, None, "{} must be a dict with min/max in DOM_ATTRIBUTES".format(attr_name)
-
-    min_value = parse_numeric(attr_value.get("min"))
-    max_value = parse_numeric(attr_value.get("max"))
-    if min_value is None or max_value is None:
-        return None, None, "{} missing numeric min/max in DOM_ATTRIBUTES".format(attr_name)
-    if not math.isfinite(min_value) or not math.isfinite(max_value):
-        return None, None, "{} has non-finite min/max in DOM_ATTRIBUTES".format(attr_name)
-    if min_value > max_value:
-        return None, None, "{} has invalid range [{}, {}]".format(
-            attr_name,
-            attr_value.get("min"),
-            attr_value.get("max"),
-        )
-
-    return min_value, max_value, None
-
-
 def _threshold_hierarchy_error(attr_name, thresholds, source):
     if (
         thresholds["lowalarm"]
@@ -89,7 +67,7 @@ def _threshold_hierarchy_error(attr_name, thresholds, source):
 
 def _validate_operational_range_within_warning(threshold_attr, thresholds, operational_mapped_field):
     """Validate a paired operational range sits inside threshold warning bounds."""
-    op_min, op_max, range_error = _parse_operational_range(operational_mapped_field)
+    op_min, op_max, range_error = parse_min_max_range(operational_mapped_field)
     if range_error:
         return [range_error]
 
@@ -106,6 +84,14 @@ def _validate_operational_range_within_warning(threshold_attr, thresholds, opera
             thresholds["highwarning"],
         )
     ]
+
+
+def _has_threshold_range_attributes(threshold_plan_by_port):
+    """Return True when any primary port has configured threshold-range checks."""
+    return any(
+        plan.get("threshold_attrs") or plan.get("errors")
+        for plan in threshold_plan_by_port.values()
+    )
 
 
 def _validate_dom_threshold_ranges(dom_primary_ports, threshold_by_port, threshold_plan_by_port):
@@ -127,6 +113,21 @@ def _validate_dom_threshold_ranges(dom_primary_ports, threshold_by_port, thresho
         if has_threshold_checks:
             checked_port_count += 1
 
+        if has_threshold_checks and not threshold_data:
+            field_failures.append(
+                "no {} entry published for port".format(STATE_DB_THRESHOLD_TABLE)
+            )
+            failures.append(
+                format_dom_port_failure(
+                    port,
+                    None,
+                    expected_fields,
+                    field_failures,
+                    field_label="expected threshold field(s)",
+                )
+            )
+            continue
+
         for attr_name, attr_value in sorted(threshold_attrs.items()):
             attr_failure_count = len(field_failures)
             attr_expected_fields = {
@@ -142,12 +143,6 @@ def _validate_dom_threshold_ranges(dom_primary_ports, threshold_by_port, thresho
 
             if not attr_expected_fields:
                 field_failures.append("{} has no expected STATE_DB threshold fields".format(attr_name))
-                continue
-
-            if not threshold_data:
-                field_failures.append(
-                    "{} threshold table missing in STATE_DB".format(attr_name)
-                )
                 continue
 
             actual_thresholds = {}
@@ -226,9 +221,11 @@ def test_dom_threshold_validation(
     port_attributes_dict,
 ):
     """Verify configured DOM threshold ranges against STATE_DB threshold data."""
-    threshold_by_port, threshold_read_errors = read_dom_threshold_data(duthost, dom_primary_ports)
     threshold_plan_by_port = build_dom_threshold_plan(port_attributes_dict, dom_primary_ports)
+    if not _has_threshold_range_attributes(threshold_plan_by_port):
+        pytest.skip("No *_threshold_range attributes configured for DOM threshold validation")
 
+    threshold_by_port, threshold_read_errors = read_dom_threshold_data(duthost, dom_primary_ports)
     all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in threshold_read_errors]
     threshold_failures, checked_attr_count, checked_field_count, checked_port_count = (
         _validate_dom_threshold_ranges(
@@ -238,9 +235,6 @@ def test_dom_threshold_validation(
         )
     )
     all_failures.extend(threshold_failures)
-
-    if not (all_failures or checked_port_count):
-        pytest.skip("No *_threshold_range attributes configured for DOM threshold validation")
 
     if all_failures:
         pytest.fail("DOM threshold validation failures:\n" + "\n".join(all_failures))

--- a/tests/transceiver/dom/test_dom_threshold.py
+++ b/tests/transceiver/dom/test_dom_threshold.py
@@ -1,0 +1,253 @@
+import logging
+import math
+
+import pytest
+
+from tests.transceiver.common.db_helpers import parse_numeric
+from tests.transceiver.dom.dom_helpers import (
+    THRESHOLD_FIELD_SUFFIXES,
+    THRESHOLD_VALUE_TOLERANCE,
+    build_dom_threshold_plan,
+    read_dom_threshold_data,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _format_port_failure(port, expected_fields, field_failures):
+    """Prefix a port's failure block with its expected threshold shape."""
+    return "{} [{} expected threshold field(s)]:\n  {}".format(
+        port,
+        len(expected_fields),
+        "\n  ".join(field_failures),
+    )
+
+
+def _parse_threshold_range(attr_name, attr_value):
+    """Return ``(thresholds, errors)`` for one configured threshold attribute."""
+    if not isinstance(attr_value, dict):
+        return {}, [
+            "{} must be a dict with {} in DOM_ATTRIBUTES".format(
+                attr_name,
+                THRESHOLD_FIELD_SUFFIXES,
+            )
+        ]
+
+    thresholds = {}
+    errors = []
+    for threshold_key in THRESHOLD_FIELD_SUFFIXES:
+        value = parse_numeric(attr_value.get(threshold_key))
+        if value is None or not math.isfinite(value):
+            errors.append(
+                "{} missing/non-finite numeric {} in DOM_ATTRIBUTES".format(
+                    attr_name,
+                    threshold_key,
+                )
+            )
+            continue
+        thresholds[threshold_key] = value
+
+    if errors:
+        return {}, errors
+
+    hierarchy_error = _threshold_hierarchy_error(attr_name, thresholds, "configured")
+    if hierarchy_error:
+        return {}, [hierarchy_error]
+
+    return thresholds, []
+
+
+def _parse_operational_range(mapped_field):
+    """Return ``(min_value, max_value, error)`` for one paired operational range."""
+    attr_name = mapped_field.source_attr
+    attr_value = mapped_field.attr_value
+
+    if not isinstance(attr_value, dict):
+        return None, None, "{} must be a dict with min/max in DOM_ATTRIBUTES".format(attr_name)
+
+    min_value = parse_numeric(attr_value.get("min"))
+    max_value = parse_numeric(attr_value.get("max"))
+    if min_value is None or max_value is None:
+        return None, None, "{} missing numeric min/max in DOM_ATTRIBUTES".format(attr_name)
+    if not math.isfinite(min_value) or not math.isfinite(max_value):
+        return None, None, "{} has non-finite min/max in DOM_ATTRIBUTES".format(attr_name)
+    if min_value > max_value:
+        return None, None, "{} has invalid range [{}, {}]".format(
+            attr_name,
+            attr_value.get("min"),
+            attr_value.get("max"),
+        )
+
+    return min_value, max_value, None
+
+
+def _threshold_hierarchy_error(attr_name, thresholds, source):
+    if (
+        thresholds["lowalarm"]
+        < thresholds["lowwarning"]
+        < thresholds["highwarning"]
+        < thresholds["highalarm"]
+    ):
+        return None
+    return (
+        "{} {} hierarchy lowalarm < lowwarning < highwarning < highalarm "
+        "is violated".format(attr_name, source)
+    )
+
+
+def _validate_operational_range_within_warning(threshold_attr, thresholds, operational_mapped_field):
+    """Validate a paired operational range sits inside threshold warning bounds."""
+    op_min, op_max, range_error = _parse_operational_range(operational_mapped_field)
+    if range_error:
+        return [range_error]
+
+    if thresholds["lowwarning"] < op_min and op_max < thresholds["highwarning"]:
+        return []
+
+    return [
+        "{} operational range [{}, {}] is not within {} warning bounds ({}, {})".format(
+            operational_mapped_field.source_attr,
+            op_min,
+            op_max,
+            threshold_attr,
+            thresholds["lowwarning"],
+            thresholds["highwarning"],
+        )
+    ]
+
+
+def _validate_dom_threshold_ranges(dom_primary_ports, threshold_by_port, threshold_plan_by_port):
+    """Validate configured DOM threshold fields against STATE_DB threshold data."""
+    failures = []
+    checked_attr_count = 0
+    checked_field_count = 0
+    checked_port_count = 0
+
+    for port in dom_primary_ports:
+        threshold_data = threshold_by_port.get(port, {})
+        threshold_plan = threshold_plan_by_port.get(port, {})
+        expected_fields = threshold_plan.get("expected_fields", {})
+        threshold_attrs = threshold_plan.get("threshold_attrs", {})
+        operational_ranges = threshold_plan.get("operational_ranges", {})
+        field_failures = list(threshold_plan.get("errors", []))
+        has_threshold_checks = bool(expected_fields or threshold_attrs or field_failures)
+
+        if has_threshold_checks:
+            checked_port_count += 1
+
+        for attr_name, attr_value in sorted(threshold_attrs.items()):
+            attr_failure_count = len(field_failures)
+            attr_expected_fields = {
+                field: mapped_field
+                for field, mapped_field in expected_fields.items()
+                if mapped_field.source_attr == attr_name
+            }
+
+            expected_thresholds, threshold_errors = _parse_threshold_range(attr_name, attr_value)
+            field_failures.extend(threshold_errors)
+            if threshold_errors:
+                continue
+
+            if not attr_expected_fields:
+                field_failures.append("{} has no expected STATE_DB threshold fields".format(attr_name))
+                continue
+
+            if not threshold_data:
+                field_failures.append(
+                    "{} threshold table missing in STATE_DB".format(attr_name)
+                )
+                continue
+
+            actual_thresholds = {}
+            for field, mapped_field in attr_expected_fields.items():
+                raw_value = threshold_data.get(field)
+                actual_value = parse_numeric(raw_value)
+                if actual_value is None or not math.isfinite(actual_value):
+                    field_failures.append(
+                        "{} threshold field {} missing/non-finite in STATE_DB (raw={!r})".format(
+                            attr_name,
+                            field,
+                            raw_value,
+                        )
+                    )
+                    continue
+                actual_thresholds[mapped_field.threshold_key] = actual_value
+
+            if len(actual_thresholds) != len(THRESHOLD_FIELD_SUFFIXES):
+                continue
+
+            for threshold_key in THRESHOLD_FIELD_SUFFIXES:
+                expected_value = expected_thresholds[threshold_key]
+                actual_value = actual_thresholds[threshold_key]
+                if abs(actual_value - expected_value) > THRESHOLD_VALUE_TOLERANCE:
+                    field_failures.append(
+                        "{} expected {}={}, got {} from STATE_DB".format(
+                            attr_name,
+                            threshold_key,
+                            expected_value,
+                            actual_value,
+                        )
+                    )
+
+            hierarchy_error = _threshold_hierarchy_error(attr_name, actual_thresholds, "STATE_DB")
+            if hierarchy_error:
+                field_failures.append(hierarchy_error)
+
+            operational_mapped_field = operational_ranges.get(attr_name)
+            if operational_mapped_field:
+                field_failures.extend(
+                    _validate_operational_range_within_warning(
+                        attr_name,
+                        actual_thresholds,
+                        operational_mapped_field,
+                    )
+                )
+
+            if len(field_failures) == attr_failure_count:
+                checked_attr_count += 1
+                checked_field_count += len(attr_expected_fields)
+                logger.debug(
+                    "DOM threshold PASS %s %s fields=%s operational_attr=%s",
+                    port,
+                    attr_name,
+                    sorted(attr_expected_fields),
+                    operational_mapped_field.source_attr if operational_mapped_field else "not-configured",
+                )
+
+        if field_failures:
+            failures.append(_format_port_failure(port, expected_fields, field_failures))
+
+    return failures, checked_attr_count, checked_field_count, checked_port_count
+
+
+def test_dom_threshold_validation(
+    duthost,
+    dom_primary_ports,
+    port_attributes_dict,
+):
+    """Verify configured DOM threshold ranges against STATE_DB threshold data."""
+    threshold_by_port, threshold_read_errors = read_dom_threshold_data(duthost, dom_primary_ports)
+    threshold_plan_by_port = build_dom_threshold_plan(port_attributes_dict, dom_primary_ports)
+
+    all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in threshold_read_errors]
+    threshold_failures, checked_attr_count, checked_field_count, checked_port_count = (
+        _validate_dom_threshold_ranges(
+            dom_primary_ports,
+            threshold_by_port,
+            threshold_plan_by_port,
+        )
+    )
+    all_failures.extend(threshold_failures)
+
+    if not (all_failures or checked_port_count):
+        pytest.skip("No *_threshold_range attributes configured for DOM threshold validation")
+
+    if all_failures:
+        pytest.fail("DOM threshold validation failures:\n" + "\n".join(all_failures))
+
+    logger.info(
+        "DOM threshold validation passed: %d threshold attribute(s), %d field(s) across %d port(s)",
+        checked_attr_count,
+        checked_field_count,
+        checked_port_count,
+    )

--- a/tests/transceiver/dom/test_dom_threshold.py
+++ b/tests/transceiver/dom/test_dom_threshold.py
@@ -1,0 +1,247 @@
+import logging
+import math
+
+import pytest
+
+from tests.transceiver.common.db_helpers import parse_numeric
+from tests.transceiver.dom.dom_helpers import (
+    STATE_DB_THRESHOLD_TABLE,
+    THRESHOLD_FIELD_SUFFIXES,
+    THRESHOLD_VALUE_TOLERANCE,
+    build_dom_threshold_plan,
+    format_dom_port_failure,
+    parse_min_max_range,
+    read_dom_threshold_data,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_threshold_range(attr_name, attr_value):
+    """Return ``(thresholds, errors)`` for one configured threshold attribute."""
+    if not isinstance(attr_value, dict):
+        return {}, [
+            "{} must be a dict with {} in DOM_ATTRIBUTES".format(
+                attr_name,
+                THRESHOLD_FIELD_SUFFIXES,
+            )
+        ]
+
+    thresholds = {}
+    errors = []
+    for threshold_key in THRESHOLD_FIELD_SUFFIXES:
+        value = parse_numeric(attr_value.get(threshold_key))
+        if value is None or not math.isfinite(value):
+            errors.append(
+                "{} missing/non-finite numeric {} in DOM_ATTRIBUTES".format(
+                    attr_name,
+                    threshold_key,
+                )
+            )
+            continue
+        thresholds[threshold_key] = value
+
+    if errors:
+        return {}, errors
+
+    hierarchy_error = _threshold_hierarchy_error(attr_name, thresholds, "configured")
+    if hierarchy_error:
+        return {}, [hierarchy_error]
+
+    return thresholds, []
+
+
+def _threshold_hierarchy_error(attr_name, thresholds, source):
+    if (
+        thresholds["lowalarm"]
+        < thresholds["lowwarning"]
+        < thresholds["highwarning"]
+        < thresholds["highalarm"]
+    ):
+        return None
+    return (
+        "{} {} hierarchy lowalarm < lowwarning < highwarning < highalarm "
+        "is violated".format(attr_name, source)
+    )
+
+
+def _validate_operational_range_within_warning(threshold_attr, thresholds, operational_mapped_field):
+    """Validate a paired operational range sits inside threshold warning bounds."""
+    op_min, op_max, range_error = parse_min_max_range(operational_mapped_field)
+    if range_error:
+        return [range_error]
+
+    if thresholds["lowwarning"] < op_min and op_max < thresholds["highwarning"]:
+        return []
+
+    return [
+        "{} operational range [{}, {}] is not within {} warning bounds ({}, {})".format(
+            operational_mapped_field.source_attr,
+            op_min,
+            op_max,
+            threshold_attr,
+            thresholds["lowwarning"],
+            thresholds["highwarning"],
+        )
+    ]
+
+
+def _has_threshold_range_attributes(threshold_plan_by_port):
+    """Return True when any primary port has configured threshold-range checks."""
+    return any(
+        plan.get("threshold_attrs") or plan.get("errors")
+        for plan in threshold_plan_by_port.values()
+    )
+
+
+def _validate_dom_threshold_ranges(dom_primary_ports, threshold_by_port, threshold_plan_by_port):
+    """Validate configured DOM threshold fields against STATE_DB threshold data."""
+    failures = []
+    checked_attr_count = 0
+    checked_field_count = 0
+    checked_port_count = 0
+
+    for port in dom_primary_ports:
+        threshold_data = threshold_by_port.get(port, {})
+        threshold_plan = threshold_plan_by_port.get(port, {})
+        expected_fields = threshold_plan.get("expected_fields", {})
+        threshold_attrs = threshold_plan.get("threshold_attrs", {})
+        operational_ranges = threshold_plan.get("operational_ranges", {})
+        field_failures = list(threshold_plan.get("errors", []))
+        has_threshold_checks = bool(expected_fields or threshold_attrs or field_failures)
+
+        if has_threshold_checks:
+            checked_port_count += 1
+
+        if has_threshold_checks and not threshold_data:
+            field_failures.append(
+                "no {} entry published for port".format(STATE_DB_THRESHOLD_TABLE)
+            )
+            failures.append(
+                format_dom_port_failure(
+                    port,
+                    None,
+                    expected_fields,
+                    field_failures,
+                    field_label="expected threshold field(s)",
+                )
+            )
+            continue
+
+        for attr_name, attr_value in sorted(threshold_attrs.items()):
+            attr_failure_count = len(field_failures)
+            attr_expected_fields = {
+                field: mapped_field
+                for field, mapped_field in expected_fields.items()
+                if mapped_field.source_attr == attr_name
+            }
+
+            expected_thresholds, threshold_errors = _parse_threshold_range(attr_name, attr_value)
+            field_failures.extend(threshold_errors)
+            if threshold_errors:
+                continue
+
+            if not attr_expected_fields:
+                field_failures.append("{} has no expected STATE_DB threshold fields".format(attr_name))
+                continue
+
+            actual_thresholds = {}
+            for field, mapped_field in attr_expected_fields.items():
+                raw_value = threshold_data.get(field)
+                actual_value = parse_numeric(raw_value)
+                if actual_value is None or not math.isfinite(actual_value):
+                    field_failures.append(
+                        "{} threshold field {} missing/non-finite in STATE_DB (raw={!r})".format(
+                            attr_name,
+                            field,
+                            raw_value,
+                        )
+                    )
+                    continue
+                actual_thresholds[mapped_field.threshold_key] = actual_value
+
+            if len(actual_thresholds) != len(THRESHOLD_FIELD_SUFFIXES):
+                continue
+
+            for threshold_key in THRESHOLD_FIELD_SUFFIXES:
+                expected_value = expected_thresholds[threshold_key]
+                actual_value = actual_thresholds[threshold_key]
+                if abs(actual_value - expected_value) > THRESHOLD_VALUE_TOLERANCE:
+                    field_failures.append(
+                        "{} expected {}={}, got {} from STATE_DB".format(
+                            attr_name,
+                            threshold_key,
+                            expected_value,
+                            actual_value,
+                        )
+                    )
+
+            hierarchy_error = _threshold_hierarchy_error(attr_name, actual_thresholds, "STATE_DB")
+            if hierarchy_error:
+                field_failures.append(hierarchy_error)
+
+            operational_mapped_field = operational_ranges.get(attr_name)
+            if operational_mapped_field:
+                field_failures.extend(
+                    _validate_operational_range_within_warning(
+                        attr_name,
+                        actual_thresholds,
+                        operational_mapped_field,
+                    )
+                )
+
+            if len(field_failures) == attr_failure_count:
+                checked_attr_count += 1
+                checked_field_count += len(attr_expected_fields)
+                logger.debug(
+                    "DOM threshold PASS %s %s fields=%s operational_attr=%s",
+                    port,
+                    attr_name,
+                    sorted(attr_expected_fields),
+                    operational_mapped_field.source_attr if operational_mapped_field else "not-configured",
+                )
+
+        if field_failures:
+            failures.append(
+                format_dom_port_failure(
+                    port,
+                    None,
+                    expected_fields,
+                    field_failures,
+                    field_label="expected threshold field(s)",
+                )
+            )
+
+    return failures, checked_attr_count, checked_field_count, checked_port_count
+
+
+def test_dom_threshold_validation(
+    duthost,
+    dom_primary_ports,
+    port_attributes_dict,
+):
+    """Verify configured DOM threshold ranges against STATE_DB threshold data."""
+    threshold_plan_by_port = build_dom_threshold_plan(port_attributes_dict, dom_primary_ports)
+    if not _has_threshold_range_attributes(threshold_plan_by_port):
+        pytest.skip("No *_threshold_range attributes configured for DOM threshold validation")
+
+    threshold_by_port, threshold_read_errors = read_dom_threshold_data(duthost, dom_primary_ports)
+    all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in threshold_read_errors]
+    threshold_failures, checked_attr_count, checked_field_count, checked_port_count = (
+        _validate_dom_threshold_ranges(
+            dom_primary_ports,
+            threshold_by_port,
+            threshold_plan_by_port,
+        )
+    )
+    all_failures.extend(threshold_failures)
+
+    if all_failures:
+        pytest.fail("DOM threshold validation failures:\n" + "\n".join(all_failures))
+
+    logger.info(
+        "DOM threshold validation passed: %d threshold attribute(s), %d field(s) across %d port(s)",
+        checked_attr_count,
+        checked_field_count,
+        checked_port_count,
+    )


### PR DESCRIPTION
• ### Description of PR

  Summary:
  Add DOM basic TC3 threshold validation for transceiver DOM threshold data.

  Fixes # (issue)
  N/A

  This PR is scoped to DOM basic TC3 only. TC1 availability validation, TC2 operational range validation, and the shared DOM/common helper
  infrastructure are already available from master; this PR adds the TC3 threshold validation test and TC3-specific threshold mapping/check
  logic.

  ### Type of change

  - [ ] Bug fix
  - [x] Testbed and Framework(new/improvement)
  - [x] New Test case
      - [ ] Skipped for non-supported platforms
  - [ ] Test case improvement

  ### Back port request

  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511
  - [ ] 202512
  - [ ] 202605

  Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
  N/A

  Failure type:
  N/A

  ### Tested branch

  - [x] master
  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511
  - [ ] 202512
  - [ ] 202605
  - [ ] N/A

  ### Test result

  - master: DOM basic TC3 threshold validation passed on `verify/dom-basic-tc3`.

  Test command:

  ```bash
  ./tests/run_tests.sh \
    -c "tests/transceiver/dom/test_dom_threshold.py" \
    -n single-dut-mgmt60 \
    -d str-nexthop_4010-01 \
    -i "ansible/my_inventory/lab" \
    -f "ansible/testbed.yaml" \
    -u \
    -e "-rs -n 0 -p no:tests.common.plugins.memory_utilization --ignore-conditional-mark --skip_sanity --skip_yang --disable-warnings --skip_transceiver_template_validation --html=dom_tests.html --self-contained-html"

  Test output summary:

  Running: python3 -m pytest tests/transceiver/dom/test_dom_threshold.py --inventory ansible/my_inventory/lab --host-pattern str-
  nexthop_4010-01 --dpu-pattern None --testbed single-dut-mgmt60 --testbed_file ansible/testbed.yaml --log-cli-level warning --log-file-
  level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests
  --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log -rs -n 0 -p
  no:tests.common.plugins.memory_utilization --ignore-conditional-mark --skip_sanity --skip_yang --disable-warnings
  --skip_transceiver_template_validation --html=dom_tests.html --self-contained-html

  collected 1 item

  tests/transceiver/dom/test_dom_threshold.py::test_dom_threshold_validation PASSED

  Generated html report:
  file:///var/src/sonic-mgmt/dom_tests.html

  Results (23.25s):
         1 passed

  ### Approach

  #### What is the motivation for this PR?

  This PR continues splitting the DOM basic tests into smaller, reviewable subsets. It adds DOM basic TC3 threshold validation as a
  standalone test on top of the DOM shared helper infrastructure introduced by the earlier DOM basic test PRs.

  #### How did you do it?

  Added tests/transceiver/dom/test_dom_threshold.py and extended the DOM helper layer with threshold-specific planning and table-read
  support.

  The test:

  - Reads current DOM threshold data from TRANSCEIVER_DOM_THRESHOLD in STATE_DB.
  - Uses resolved DOM attributes from port_attributes_dict.
  - Dynamically selects configured *_threshold_range attributes.
  - Maps configured threshold attributes to STATE_DB threshold fields.
  - Validates all required threshold keys: lowalarm, lowwarning, highwarning, and highalarm.
  - Validates configured threshold values are numeric and finite.
  - Compares configured threshold values against STATE_DB values with a small numeric tolerance.
  - Validates threshold hierarchy: lowalarm < lowwarning < highwarning < highalarm.
  - Validates the paired operational {min, max} range is within the warning threshold bounds when both attributes are configured.
  - Skips the test before reading STATE_DB when no DOM *_threshold_range attributes are configured.
  - Reports a single clear failure when a TRANSCEIVER_DOM_THRESHOLD entry is not published for an expected port.
  - Aggregates per-port failures for easier debugging.

  The implementation reuses shared DOM helpers where the data model matches TC1/TC2:

  - format_dom_port_failure() for consistent per-port failure formatting.
  - parse_min_max_range() for paired operational {min, max} parsing.
  - Shared DOM STATE_DB table-read path for threshold table reads.
  - DOM-local threshold plan construction via build_dom_threshold_plan().

  TC3 keeps a threshold-specific validation driver because threshold ranges use a 4-key group shape, unlike TC1/TC2 per-field sensor
  checks.

  #### How did you verify/test it?

  Validated on the verify/dom-basic-tc3 branch in the lab using single-dut-mgmt60 and DUT str-nexthop_4010-01.

  The test passed with 1 passed in 23.25s.

  #### Any platform specific information?

  N/A

  #### Supported testbed topology if it's a new test case?

  Validated on mgmt-only single DUT testbed: single-dut-mgmt60

  ### Documentation

  The DOM basic TC3 behavior follows the DOM test plan: docs/testplan/transceiver/dom_test_plan.md

