### PR TITLE
[pfcwd] Add egress-ACL + PFCWD coexistence regression test

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -854,6 +854,43 @@ def get_pfc_storm_baseline_counters(dut, storm_hndle):
     return baseline
 
 
+def is_acl_table_active(duthost, table_name):
+    """
+    True if the ACL table is Active per STATE_DB.
+
+    Reads the same source 'show acl table' renders: orchagent writes STATE_DB
+    ACL_TABLE_TABLE|<name> field 'status' ('Active' on a successful SAI create,
+    'Inactive'/'Pending creation' otherwise). A direct DB read avoids CLI text parsing.
+
+    Args:
+        duthost(AnsibleHost): DUT instance
+        table_name(string): ACL table name
+
+    Returns:
+        bool: True if status == 'Active'
+    """
+    status = duthost.shell(
+        "sonic-db-cli STATE_DB hget 'ACL_TABLE_TABLE|{}' status".format(table_name),
+        module_ignore_errors=True)["stdout"].strip()
+    return status == "Active"
+
+
+def get_process_cores(duthost, process_name):
+    """
+    Set of core files currently under /var/core for the given process name.
+
+    Args:
+        duthost(AnsibleHost): DUT instance
+        process_name(string): process name to match (e.g. 'orchagent')
+
+    Returns:
+        set(str): core file names
+    """
+    out = duthost.shell("ls -1 /var/core/ 2>/dev/null | grep {} || true".format(process_name),
+                        module_ignore_errors=True)["stdout"]
+    return set(out.split())
+
+
 def parser_show_pfcwd_stat(dut, select_port, select_queue):
     """
     CLI "show pfcwd stats" output:

--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -886,7 +886,9 @@ def get_process_cores(duthost, process_name):
     Returns:
         set(str): core file names
     """
-    out = duthost.shell("ls -1 /var/core/ 2>/dev/null | grep {} || true".format(process_name),
+    # Anchor to the '<exe>.<time>.<pid>...core.gz' convention so we match this process's own
+    # cores, not any filename that merely contains the name as a substring.
+    out = duthost.shell("ls -1 /var/core/ 2>/dev/null | grep -E '^{}\\.' || true".format(process_name),
                         module_ignore_errors=True)["stdout"]
     return set(out.split())
 

--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -875,6 +875,25 @@ def is_acl_table_active(duthost, table_name):
     return status == "Active"
 
 
+def get_acl_bind_port(duthost, port):
+    """
+    ACL bind point for a port: the parent PortChannel if the port is a LAG member.
+
+    A LAG member is not a valid ACL bind point, so egress ACL tables must bind to the
+    PortChannel instead of the physical member port.
+
+    Args:
+        duthost(AnsibleHost): DUT instance
+        port(string): physical port name
+
+    Returns:
+        string: parent PortChannel name, or the port itself if it is not a LAG member
+    """
+    pc_members = duthost.config_facts(
+        host=duthost.hostname, source="running")['ansible_facts'].get('PORTCHANNEL_MEMBER', {})
+    return next((pc for pc, members in pc_members.items() if port in members), port)
+
+
 def get_process_cores(duthost, process_name):
     """
     Set of core files currently under /var/core for the given process name.

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4151,6 +4151,12 @@ pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions:
     conditions:
       - "'dualtor-aa' in topo_name and https://github.com/sonic-net/sonic-mgmt/issues/15387"
 
+pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_config_fail_with_egress_acl:
+   skip:
+     reason: "Egress-ACL/PFCWD bank contention is a hardware behavior; not supported on VS platform."
+     conditions:
+        - "asic_type in ['vs']"
+
 pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic:
    skip:
      reason: "This test is applicable only for cisco-8000 / Pfcwd tests skipped on M* testbed."

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4153,9 +4153,9 @@ pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions:
 
 pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_config_fail_with_egress_acl:
    skip:
-     reason: "Egress-ACL/PFCWD bank contention is a hardware behavior; not supported on VS platform."
+     reason: "Egress-ACL/PFCWD bank contention is BRCM-DNX specific; test only applies to Broadcom DNX."
      conditions:
-        - "asic_type in ['vs']"
+        - "asic_subtype not in ['broadcom-dnx']"
 
 pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic:
    skip:

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -21,7 +21,8 @@ from tests.common import constants
 from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled, dualtor_ports  # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m  # noqa: F401, E501
 from tests.common.helpers.pfcwd_helper import send_background_traffic, check_pfc_storm_state, \
-    verify_pfc_storm_in_expected_state, parser_show_pfcwd_stat, is_pfcwd_hw_recovery_enabled
+    verify_pfc_storm_in_expected_state, parser_show_pfcwd_stat, is_pfcwd_hw_recovery_enabled, \
+    is_acl_table_active, get_process_cores
 from tests.common.utilities import wait_until
 from tests.common.cisco_data import is_cisco_device
 from tests.common.mellanox_data import is_mellanox_device
@@ -1487,3 +1488,115 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                     self.storm_hndle.stop_storm()
                 logger.info("--- Stop PFC WD ---")
                 self.dut.command("pfcwd stop")
+
+    def test_pfcwd_config_fail_with_egress_acl(
+            self,
+            request,
+            setup_pfc_test,
+            manage_lag_config,  # noqa: F811
+            setup_dut_test_params,
+            enum_fanout_graph_facts,  # noqa: F811
+            ptfhost,
+            duthosts,
+            enum_rand_one_per_hwsku_frontend_hostname,
+            fanouthosts,
+            setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,  # noqa: F811
+            toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,  # noqa: F811
+            set_pfc_time_cisco_8000  # noqa: F811
+            ):
+        """
+        Fill the egress ACL banks, then storm a queue so PFCWD tries to create its egress
+        ACL table against full banks. orchagent must log the failure and stay up, not abort
+        swss. Software recovery only; on hardware/DLR recovery no ACL table is
+        created (no-op skip).
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        setup_info = setup_pfc_test
+        setup_dut_info = setup_dut_test_params
+        ip_version = setup_info["ip_version"]
+        self.fanout_info = enum_fanout_graph_facts
+        self.ptf = ptfhost
+        self.dut = duthost
+        self.fanout = fanouthosts
+        self.timers = setup_info['pfc_timers']
+        self.ports = setup_info['selected_test_ports']
+        self.test_ports_info = setup_info['test_ports']
+        if self.dut.topo_type == 't2':
+            key, value = list(self.ports.items())[0]
+            self.ports = {key: value}
+        self.neighbors = setup_info['neighbors']
+        self.peer_dev_list = dict()
+        self.storm_hndle = None
+        self.is_dualtor = setup_dut_info['basicParams']['is_dualtor']
+        # Real PFC storm - the fake DEBUG_STORM cannot exercise the egress-ACL contention.
+        self.fake_storm = False
+
+        pytest_require(has_neighbor_device(setup_pfc_test),
+                       "No neighbors detected ('rx_port' is None) - required for PFC storm setup")
+        pytest_require(self.ports, "No pfcwd test ports selected")
+
+        port = list(self.ports)[0]
+        queue = 4
+        # init builds the real-storm (PFCStorm) handle.
+        self.setup_test_params(port, setup_info['vlan'], init=(not self.fake_storm), ip_version=ip_version)
+        fill_tables = []
+        try:
+            # Add egress L3 ACL tables until one fails to go Active (banks full) - that per-table
+            # STATE_DB failure is the exhaustion signal. fill_safety_cap only prevents a hung test
+            # on a platform with no egress-ACL/PFCWD contention (skip if hit); it is not a per-chip
+            # table count.
+            exhausted = False
+            fill_safety_cap = 256
+            for idx in range(fill_safety_cap):
+                table = "PFCWD_ACL_FILL_{}".format(idx)
+                duthost.shell("config acl add table {} L3 -s egress -p {}".format(table, port))
+                fill_tables.append(table)
+                if not wait_until(45, 5, 0, is_acl_table_active, duthost, table):
+                    exhausted = True
+                    logger.info("Egress ACL banks exhausted after %d L3 ACL table(s)", idx + 1)
+                    break
+            pytest_require(exhausted,
+                           "Egress ACL banks not exhausted after {} L3 ACL tables on {} - "
+                           "no PFCWD/egress-ACL bank contention on this platform".format(
+                               fill_safety_cap, duthost.facts.get("hwsku")))
+
+            # Storm inline, not run_test()/storm_detect_path(): those verify_wd_func() the drop
+            # action, which this test intentionally fails (egress-ACL create fails, ingress rolls back).
+            restore_time = self.timers['pfc_wd_restore_time_large']
+            detect_time = self.timers['pfc_wd_detect_time']
+            queues = [self.pfc_wd['queue_index']]
+            selected_test_ports = [self.pfc_wd['rx_port'][0]]
+            test_ports_info = {self.pfc_wd['rx_port'][0]: self.pfc_wd}
+            cores_before = get_process_cores(duthost, "orchagent")
+            with send_background_traffic(duthost, self.ptf, queues, selected_test_ports, test_ports_info):
+                start_wd_on_ports(duthost, port, restore_time, detect_time, "drop")
+                if not self.pfc_wd['fake_storm']:
+                    self.storm_hndle.start_storm()
+                else:
+                    PfcCmd.set_storm_status(duthost, self.queue_oid, "enabled")
+                # Give pfcwd time to detect the storm and attempt the ACL create.
+                wait_until(60, 5, 0, verify_pfc_storm_in_expected_state, duthost, port, queue, "storm")
+
+            # The failed create must not abort orchagent (a crash leaves a core).
+            new_cores = get_process_cores(duthost, "orchagent") - cores_before
+            pytest_assert(not new_cores,
+                          "orchagent crashed during the PFCWD egress-ACL storm; "
+                          "new core(s): {}".format(sorted(new_cores)))
+
+            # PFC_WD_SW_STATE_TABLE=='failed' proves the egress-ACL create failed AND the ingress
+            # rule rolled back (handler isValid()==false); anything else => not exercised, skip.
+            sw_status = duthost.shell(
+                "sonic-db-cli STATE_DB hget 'PFC_WD_SW_STATE_TABLE|{}:{}' status".format(port, queue),
+                module_ignore_errors=True)["stdout"].strip()
+            pytest_require(sw_status == "failed",
+                           "PFCWD egress-ACL create did not fail (status='{}') - no egress-ACL/"
+                           "PFCWD bank contention or HW/DLR recovery on this platform".format(
+                               sw_status or "<absent>"))
+        finally:
+            if self.storm_hndle:
+                self.storm_hndle.stop_storm()
+            else:
+                PfcCmd.set_storm_status(duthost, self.queue_oid, "disabled")
+            for table in fill_tables:
+                duthost.shell("config acl remove table {}".format(table), module_ignore_errors=True)
+            duthost.command("pfcwd stop")

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -1531,14 +1531,19 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         # Real PFC storm - the fake DEBUG_STORM cannot exercise the egress-ACL contention.
         self.fake_storm = False
 
+        # Crash detection relies on a new /var/core file; if cores aren't piped to a handler we
+        # can't detect a crash, so skip rather than risk a false pass.
+        pytest_require(duthost.shell("cat /proc/sys/kernel/core_pattern",
+                                     module_ignore_errors=True)["stdout"].strip().startswith("|"),
+                       "core dumps not piped/enabled - cannot reliably detect an orchagent crash")
         pytest_require(has_neighbor_device(setup_pfc_test),
                        "No neighbors detected ('rx_port' is None) - required for PFC storm setup")
         pytest_require(self.ports, "No pfcwd test ports selected")
 
         port = list(self.ports)[0]
-        queue = 4
         # init builds the real-storm (PFCStorm) handle.
         self.setup_test_params(port, setup_info['vlan'], init=(not self.fake_storm), ip_version=ip_version)
+        queue = self.pfc_wd['queue_index']
         fill_tables = []
         try:
             # Add egress L3 ACL tables until one fails to go Active (banks full) - that per-table
@@ -1549,7 +1554,11 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             fill_safety_cap = 256
             for idx in range(fill_safety_cap):
                 table = "PFCWD_ACL_FILL_{}".format(idx)
-                duthost.shell("config acl add table {} L3 -s egress -p {}".format(table, port))
+                res = duthost.shell("config acl add table {} L3 -s egress -p {}".format(table, port),
+                                    module_ignore_errors=True)
+                pytest_require(res["rc"] == 0,
+                               "egress ACL table create not supported here ({}): {}".format(
+                                   duthost.facts.get("asic_type"), (res["stderr"] or res["stdout"]).strip()))
                 fill_tables.append(table)
                 if not wait_until(45, 5, 0, is_acl_table_active, duthost, table):
                     exhausted = True

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -22,7 +22,7 @@ from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled, dua
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m  # noqa: F401, E501
 from tests.common.helpers.pfcwd_helper import send_background_traffic, check_pfc_storm_state, \
     verify_pfc_storm_in_expected_state, parser_show_pfcwd_stat, is_pfcwd_hw_recovery_enabled, \
-    is_acl_table_active, get_process_cores
+    is_acl_table_active, get_process_cores, get_acl_bind_port
 from tests.common.utilities import wait_until
 from tests.common.cisco_data import is_cisco_device
 from tests.common.mellanox_data import is_mellanox_device
@@ -1541,6 +1541,9 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         pytest_require(self.ports, "No pfcwd test ports selected")
 
         port = list(self.ports)[0]
+        # The storm targets the physical port; the fill tables bind to its LAG if any
+        # (a LAG member port is not a valid ACL bind point).
+        acl_bind_port = get_acl_bind_port(duthost, port)
         # init builds the real-storm (PFCStorm) handle.
         self.setup_test_params(port, setup_info['vlan'], init=(not self.fake_storm), ip_version=ip_version)
         queue = self.pfc_wd['queue_index']
@@ -1554,7 +1557,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             fill_safety_cap = 256
             for idx in range(fill_safety_cap):
                 table = "PFCWD_ACL_FILL_{}".format(idx)
-                res = duthost.shell("config acl add table {} L3 -s egress -p {}".format(table, port),
+                res = duthost.shell("config acl add table {} L3 -s egress -p {}".format(table, acl_bind_port),
                                     module_ignore_errors=True)
                 pytest_require(res["rc"] == 0,
                                "egress ACL table create not supported here ({}): {}".format(


### PR DESCRIPTION
### Description of PR
Adds a regression test `test_pfcwd_config_fail_with_egress_acl` that exercises PFC watchdog
software-recovery ACL creation against exhausted egress ACL banks. When the egress ACL banks
are full, `PfcWdAclHandler`'s egress ACL table create fails; the test verifies orchagent handles
this gracefully (stays up, rolls back the ingress drop rule, publishes
`PFC_WD_SW_STATE_TABLE|<port>:<queue> status=failed`) instead of aborting swss.

### Type of change
- [x] New Test case

### Approach
#### What is the motivation for this PR?
On Broadcom DNX, when PFC watchdog software recovery tries to create its egress ACL table while
the egress ACL banks are already exhausted, the SAI table create fails. Without proper handling
orchagent aborts (SIGABRT), taking down swss. This test provides regression coverage for that
egress-ACL / PFCWD coexistence path.

#### How did you do it?
- Fill the egress ACL banks by adding L3 egress ACL tables until one fails to become Active
  (read from STATE_DB `ACL_TABLE_TABLE|<name>.status`), which signals bank exhaustion. A high
  safety cap only guards against a hung test on a platform with no such contention (the test
  skips there); it is not a per-chip table count.
- Arm PFC watchdog with a real PFC storm so `PfcWdAclHandler` runs its egress-table create against
  the now-full banks (reusing `send_background_traffic` / `start_wd_on_ports`).
- Assert orchagent did not crash (no new `/var/core` file) and require
  `PFC_WD_SW_STATE_TABLE|<port>:<queue> status == "failed"` (the software-recovery signal that the
  create failed and the ingress drop rule was rolled back). If the contention was not exercised
  (banks did not fill / hardware-DLR recovery), the test skips rather than fails.
- Adds reusable helpers `is_acl_table_active` and `get_process_cores` to `pfcwd_helper.py`.

#### How did you verify/test it?
Ran on Broadcom DNX hardware (NH-5010-F), IPv4 and IPv6 - both PASS with 0 skipped (banks
exhausted, orchagent did not crash, `PFC_WD_SW_STATE_TABLE` published `failed`).

### Documentation
No documentation changes.
