### PR TITLE
New queue watermark quantized qos test

### DIFF
--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -125,3 +125,30 @@ def run_dshell_command(duthost, command):
     if not wait_until(300, 20, 0, check_dshell_ready, duthost):
         raise RuntimeError("Debug shell is not ready on {}".format(duthost.hostname))
     return duthost.shell(command)
+
+
+def get_voq_quant_thresholds(duthost, interface, traffic_class):
+    """
+        Return the quantized VOQ congestion thresholds (in bytes) for a given
+        interface and traffic class on a Cisco-8000 device.
+
+        Runs the "show platform npu voq thresholds" serviceability command and
+        parses its JSON output, returning the "cong_level_to_bytes" list. These
+        are the exact watermark values the hardware will report as queue
+        occupancy crosses each successive congestion level.
+
+        Args:
+            duthost: The DUT host handle.
+            interface (str): The egress interface name (e.g. "Ethernet8").
+            traffic_class (int): The traffic class / queue index.
+
+        Returns:
+            list[int]: The congestion-level thresholds in bytes, ordered from
+                lowest to highest.
+    """
+    if duthost.facts["asic_type"] != "cisco-8000":
+        raise RuntimeError("VOQ quantized thresholds are only available on cisco-8000 platforms.")
+    cmd = "show platform npu voq thresholds -i {} -t {} -d".format(interface, traffic_class)
+    output = duthost.shell(cmd)["stdout"]
+    data = json.loads(output)
+    return [int(value) for value in data["cong_level_to_bytes"]]

--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -128,7 +128,7 @@ def run_dshell_command(duthost, command):
     return duthost.shell(command)
 
 
-def get_voq_quant_thresholds_cisco(duthost, interface, traffic_class):
+def get_voq_quant_thresholds_cisco(duthost, interface, traffic_class, asic_index=None):
     """
         Return the quantized queue watermark thresholds (in bytes) for a given
         interface and traffic class on a Cisco-8000 device.
@@ -137,12 +137,14 @@ def get_voq_quant_thresholds_cisco(duthost, interface, traffic_class):
             duthost: The DUT host handle.
             interface (str): The egress interface name.
             traffic_class (int): The traffic class / queue index.
+            asic_index (int, optional): ASIC index for multi-ASIC platforms.
+                Ignored on single-ASIC platforms.
 
         Returns:
             list[int]: The congestion-level thresholds in bytes, ordered from
                 lowest to highest.
     """
-    s1cli = CiscoS1Cli(duthost)
+    s1cli = CiscoS1Cli(duthost, asic_index=asic_index)
     port_oid = s1cli.get_port_oid(interface)
     queue_oid = s1cli.get_queue_oid(port_oid, traffic_class)
     return s1cli.get_queue_watermark_thresholds(queue_oid)

--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -128,7 +128,7 @@ def run_dshell_command(duthost, command):
     return duthost.shell(command)
 
 
-def get_voq_quant_thresholds(duthost, interface, traffic_class):
+def get_voq_quant_thresholds_cisco(duthost, interface, traffic_class):
     """
         Return the quantized queue watermark thresholds (in bytes) for a given
         interface and traffic class on a Cisco-8000 device.

--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -2,6 +2,7 @@ import json
 import re
 from tests.common.reboot import reboot
 from tests.common.utilities import wait_until
+from tests.common.cisco_s1_cli import CiscoS1Cli
 
 
 # =============================================================================
@@ -129,13 +130,8 @@ def run_dshell_command(duthost, command):
 
 def get_voq_quant_thresholds(duthost, interface, traffic_class):
     """
-        Return the quantized VOQ congestion thresholds (in bytes) for a given
+        Return the quantized queue watermark thresholds (in bytes) for a given
         interface and traffic class on a Cisco-8000 device.
-
-        Runs the "show platform npu voq thresholds" serviceability command and
-        parses its JSON output, returning the "cong_level_to_bytes" list. These
-        are the exact watermark values the hardware will report as queue
-        occupancy crosses each successive congestion level.
 
         Args:
             duthost: The DUT host handle.
@@ -146,9 +142,7 @@ def get_voq_quant_thresholds(duthost, interface, traffic_class):
             list[int]: The congestion-level thresholds in bytes, ordered from
                 lowest to highest.
     """
-    if duthost.facts["asic_type"] != "cisco-8000":
-        raise RuntimeError("VOQ quantized thresholds are only available on cisco-8000 platforms.")
-    cmd = "show platform npu voq thresholds -i {} -t {} -d".format(interface, traffic_class)
-    output = duthost.shell(cmd)["stdout"]
-    data = json.loads(output)
-    return [int(value) for value in data["cong_level_to_bytes"]]
+    s1cli = CiscoS1Cli(duthost)
+    port_oid = s1cli.get_port_oid(interface)
+    queue_oid = s1cli.get_queue_oid(port_oid, traffic_class)
+    return s1cli.get_queue_watermark_thresholds(queue_oid)

--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -135,7 +135,7 @@ def get_voq_quant_thresholds_cisco(duthost, interface, traffic_class):
 
         Args:
             duthost: The DUT host handle.
-            interface (str): The egress interface name (e.g. "Ethernet8").
+            interface (str): The egress interface name.
             traffic_class (int): The traffic class / queue index.
 
         Returns:

--- a/tests/common/cisco_s1_cli.py
+++ b/tests/common/cisco_s1_cli.py
@@ -1,0 +1,81 @@
+"""Helper wrapper for driving Cisco-only serviceability functionality.
+
+The :class:`S1Cli` class provides a small, reusable abstraction over the
+``s1-cli-sonic`` command so that Cisco-specific test helpers can be written
+cleanly without repeating command-construction and output-parsing boilerplate.
+"""
+import json
+
+
+class S1CliError(RuntimeError):
+    """Raised when an s1-cli-sonic operation fails or returns no usable data."""
+
+
+class CiscoS1Cli(object):
+    """Thin wrapper around the ``s1-cli-sonic`` serviceability CLI.
+
+    Construction validates that the target DUT/ASIC can run the CLI and raises
+    :class:`S1CliError` otherwise, so a successfully constructed instance can be
+    treated as ready to use.
+
+    Args:
+        duthost: The DUT host handle.
+        asic_index (int, optional): ASIC index for multi-ASIC platforms. Ignored
+            on single-ASIC platforms.
+    """
+
+    def __init__(self, duthost, asic_index=None):
+        if duthost.facts["asic_type"] != "cisco-8000":
+            raise S1CliError("s1-cli-sonic is only available on cisco-8000 platforms.")
+        self._duthost = duthost
+        self._asic_arg = ""
+        if asic_index is not None and duthost.is_multi_asic:
+            self._asic_arg = " --asic-num {}".format(asic_index)
+        probe = duthost.shell("which s1-cli-sonic", module_ignore_errors=True)
+        if probe["rc"] != 0:
+            raise S1CliError("s1-cli-sonic is not available on {}.".format(duthost.hostname))
+
+    def _run(self, command):
+        """Run an s1-cli-sonic command and return its parsed JSON payload."""
+        cmd = 's1-cli-sonic{} -c "{}" -j'.format(self._asic_arg, command)
+        result = self._duthost.shell(cmd, module_ignore_errors=True)
+        if result["rc"] != 0 or result["stderr"]:
+            raise S1CliError("Command failed: {} ({})".format(cmd, result["stderr"]))
+        try:
+            return json.loads(result["stdout"])
+        except ValueError as exc:
+            raise S1CliError("Could not parse JSON output of: {} ({})".format(cmd, exc))
+
+    @staticmethod
+    def _to_oid(decimal_oid):
+        """Convert a decimal OID (as returned in JSON) to the CLI hex form."""
+        return hex(int(decimal_oid))
+
+    def get_port_oid(self, interface):
+        """Return the SAI port OID (hex string) for a front-panel interface name."""
+        gid = None
+        for entry in self._run("show ports counters")["result"]:
+            if entry["sysport"]["sysport-cookie"] == interface:
+                gid = int(entry["sysport"]["sysport-gid"])
+                break
+        if gid is None:
+            raise S1CliError("Interface {} not found in port counters.".format(interface))
+
+        for entry in self._run("show sai ports status")["result"]:
+            if int(entry["gid"]) == gid:
+                return self._to_oid(entry["oid"])
+        raise S1CliError("No SAI port OID found for interface {}.".format(interface))
+
+    def get_queue_oid(self, port_oid, traffic_class):
+        """Return the SAI queue OID (hex string) for a port OID and queue index."""
+        for entry in self._run("show sai queue list port-oid {}".format(port_oid))["result"]:
+            if entry["index"] == traffic_class:
+                return self._to_oid(entry["queueOid"])
+        raise S1CliError(
+            "No queue OID found for port {} traffic class {}.".format(port_oid, traffic_class))
+
+    def get_queue_watermark_thresholds(self, queue_oid):
+        """Return the queue watermark thresholds (bytes), ordered lowest to highest."""
+        data = self._run("show sai queue watermark-thresholds queue-oid {}".format(queue_oid))
+        levels = sorted(data["result"], key=lambda item: item["congLevel"])
+        return [int(item["thresholdBytes"]) for item in levels]

--- a/tests/common/cisco_s1_cli.py
+++ b/tests/common/cisco_s1_cli.py
@@ -64,7 +64,7 @@ class CiscoS1Cli(object):
     def get_port_oid(self, interface):
         """Return the SAI port OID (hex string) for a front-panel interface name."""
         gid = None
-        for entry in self._run("show ports counters")["result"]:
+        for entry in self._run("show ports status")["result"]:
             if entry["sysport"]["sysport-cookie"] == interface:
                 gid = int(entry["sysport"]["sysport-gid"])
                 break

--- a/tests/common/cisco_s1_cli.py
+++ b/tests/common/cisco_s1_cli.py
@@ -1,13 +1,13 @@
 """Helper wrapper for driving Cisco-only serviceability functionality.
 
-The :class:`S1Cli` class provides a small, reusable abstraction over the
+The :class:`CiscoS1Cli` class provides a small, reusable abstraction over the
 ``s1-cli-sonic`` command so that Cisco-specific test helpers can be written
 cleanly without repeating command-construction and output-parsing boilerplate.
 """
 import json
 
 
-class S1CliError(RuntimeError):
+class CiscoS1CliError(RuntimeError):
     """Raised when an s1-cli-sonic operation fails or returns no usable data."""
 
 
@@ -15,7 +15,7 @@ class CiscoS1Cli(object):
     """Thin wrapper around the ``s1-cli-sonic`` serviceability CLI.
 
     Construction validates that the target DUT/ASIC can run the CLI and raises
-    :class:`S1CliError` otherwise, so a successfully constructed instance can be
+    :class:`CiscoS1CliError` otherwise, so a successfully constructed instance can be
     treated as ready to use.
 
     Args:
@@ -26,7 +26,7 @@ class CiscoS1Cli(object):
 
     def __init__(self, duthost, asic_index=None):
         if duthost.facts["asic_type"] != "cisco-8000":
-            raise S1CliError("s1-cli-sonic is only available on cisco-8000 platforms.")
+            raise CiscoS1CliError("s1-cli-sonic is only available on cisco-8000 platforms.")
         self._duthost = duthost
         self._asic_arg = ""
         if asic_index is not None and duthost.is_multi_asic:
@@ -34,7 +34,7 @@ class CiscoS1Cli(object):
         self._cache = {}
         probe = duthost.shell("which s1-cli-sonic", module_ignore_errors=True)
         if probe["rc"] != 0:
-            raise S1CliError("s1-cli-sonic is not available on {}.".format(duthost.hostname))
+            raise CiscoS1CliError("s1-cli-sonic is not available on {}.".format(duthost.hostname))
 
     def _run(self, command):
         """Run an s1-cli-sonic command and return its parsed JSON payload.
@@ -48,11 +48,11 @@ class CiscoS1Cli(object):
         cmd = 's1-cli-sonic{} -c "{}" -j'.format(self._asic_arg, command)
         result = self._duthost.shell(cmd, module_ignore_errors=True)
         if result["rc"] != 0 or result["stderr"]:
-            raise S1CliError("Command failed: {} ({})".format(cmd, result["stderr"]))
+            raise CiscoS1CliError("Command failed: {} ({})".format(cmd, result["stderr"]))
         try:
             payload = json.loads(result["stdout"])
         except ValueError as exc:
-            raise S1CliError("Could not parse JSON output of: {} ({})".format(cmd, exc))
+            raise CiscoS1CliError("Could not parse JSON output of: {} ({})".format(cmd, exc))
         self._cache[command] = payload
         return payload
 
@@ -69,19 +69,19 @@ class CiscoS1Cli(object):
                 gid = int(entry["sysport"]["sysport-gid"])
                 break
         if gid is None:
-            raise S1CliError("Interface {} not found in port counters.".format(interface))
+            raise CiscoS1CliError("Interface {} not found in port status.".format(interface))
 
         for entry in self._run("show sai ports status")["result"]:
             if int(entry["gid"]) == gid:
                 return self._to_oid(entry["oid"])
-        raise S1CliError("No SAI port OID found for interface {}.".format(interface))
+        raise CiscoS1CliError("No SAI port OID found for interface {}.".format(interface))
 
     def get_queue_oid(self, port_oid, traffic_class):
         """Return the SAI queue OID (hex string) for a port OID and queue index."""
         for entry in self._run("show sai queue list port-oid {}".format(port_oid))["result"]:
             if entry["index"] == traffic_class:
                 return self._to_oid(entry["queueOid"])
-        raise S1CliError(
+        raise CiscoS1CliError(
             "No queue OID found for port {} traffic class {}.".format(port_oid, traffic_class))
 
     def get_queue_watermark_thresholds(self, queue_oid):

--- a/tests/common/cisco_s1_cli.py
+++ b/tests/common/cisco_s1_cli.py
@@ -31,20 +31,30 @@ class CiscoS1Cli(object):
         self._asic_arg = ""
         if asic_index is not None and duthost.is_multi_asic:
             self._asic_arg = " --asic-num {}".format(asic_index)
+        self._cache = {}
         probe = duthost.shell("which s1-cli-sonic", module_ignore_errors=True)
         if probe["rc"] != 0:
             raise S1CliError("s1-cli-sonic is not available on {}.".format(duthost.hostname))
 
     def _run(self, command):
-        """Run an s1-cli-sonic command and return its parsed JSON payload."""
+        """Run an s1-cli-sonic command and return its parsed JSON payload.
+
+        Results are cached per instance keyed on the command, so repeated
+        lookups (e.g. resolving OIDs for many ports in a loop) do not re-invoke
+        the CLI. The queried data is static topology/hardware state.
+        """
+        if command in self._cache:
+            return self._cache[command]
         cmd = 's1-cli-sonic{} -c "{}" -j'.format(self._asic_arg, command)
         result = self._duthost.shell(cmd, module_ignore_errors=True)
         if result["rc"] != 0 or result["stderr"]:
             raise S1CliError("Command failed: {} ({})".format(cmd, result["stderr"]))
         try:
-            return json.loads(result["stdout"])
+            payload = json.loads(result["stdout"])
         except ValueError as exc:
             raise S1CliError("Could not parse JSON output of: {} ({})".format(cmd, exc))
+        self._cache[command] = payload
+        return payload
 
     @staticmethod
     def _to_oid(decimal_oid):

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4686,7 +4686,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark(\[|$):
   skip:
     reason: "Test case replaced by testQosSaiQSharedWatermarkQuantized for Cisco-8223."
     conditions:
-      - &cisco8223Replaced "asic_type in ['cisco-8000'] and platform.startswith('x86_64-8223')"
+      - "asic_type in ['cisco-8000'] and platform.startswith('x86_64-8223')"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts:
   skip:
@@ -4696,7 +4696,6 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts:
       - "asic_type not in ['cisco-8000']"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
-      - *cisco8223Replaced
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4681,6 +4681,13 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark:
     conditions:
       - "asic_type in ['marvell-teralynx'] and platform in ['x86_64-wistron_6512_32r-r0', 'x86_64-wistron_sw_to3200k-r0']"
 
+qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark(\[|$):
+  regex: true
+  skip:
+    reason: "Test case replaced by testQosSaiQSharedWatermarkQuantized for Cisco-8223."
+    conditions:
+      - &cisco8223Replaced "asic_type in ['cisco-8000'] and platform.startswith('x86_64-8223')"
+
 qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts:
   skip:
     reason: "All Port Watermark test is verified only on Cisco Platforms."
@@ -4689,6 +4696,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts:
       - "asic_type not in ['cisco-8000']"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
+      - *cisco8223Replaced
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
   skip:

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -591,13 +591,6 @@ class QosParamCisco(object):
             self.write_params("wm_q_shared_lossy", lossy_params)
 
     def __define_q_shared_watermark_quant(self):
-        # Quantized queue shared watermark test (currently exercised on p200).
-        # The hardware reports the queue shared watermark snapped to discrete
-        # congestion levels read at test time from the serviceability command
-        # "show platform npu voq thresholds". "fill_margin" is the number of
-        # packets to under-/over-fill each threshold by, giving slack for
-        # device transition nuance and stray background packets while keeping
-        # the watermark assertion exact (zero margin).
         quant_fill_margin = 10
         if self.should_autogen(["wm_q_shared_quant_lossless"]):
             lossless_params = {"dscp": 3,

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -713,6 +713,12 @@ class QosParamCisco(object):
             if self.dutAsic in ["gr2", "gr2x"]:
                 # Send a burst of leakout packets to optimize runtime. Expected leakout is around 250
                 params["pkts_num_leak_out"] = 200
+            if self.dutAsic == "p200":
+                # Watermark is quantized, functionality is validated by
+                # testQosSaiQSharedWatermarkQuantized. Maintain the watermark check on all
+                # ports by removing the upper bound restriction. This allows the lower
+                # bound to still be validated across the device.
+                params["ignore_upper_bound"] = True
             self.write_params("wm_q_wm_all_ports", params)
 
     def __define_pg_drop(self):

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -311,6 +311,7 @@ class QosParamCisco(object):
         self.__define_pg_shared_watermark()
         self.__define_buffer_pool_watermark()
         self.__define_q_shared_watermark()
+        self.__define_q_shared_watermark_quant()
         self.__define_lossy_queue_voq()
         self.__define_lossy_queue()
         self.__define_lossless_voq()
@@ -588,6 +589,32 @@ class QosParamCisco(object):
             if self.dutAsic in ["gr2", "gr2x"]:
                 lossy_params["pkts_num_margin"] = 9
             self.write_params("wm_q_shared_lossy", lossy_params)
+
+    def __define_q_shared_watermark_quant(self):
+        # Quantized queue shared watermark test (currently exercised on p200).
+        # The hardware reports the queue shared watermark snapped to discrete
+        # congestion levels read at test time from the serviceability command
+        # "show platform npu voq thresholds". "fill_margin" is the number of
+        # packets to under-/over-fill each threshold by, giving slack for
+        # device transition nuance and stray background packets while keeping
+        # the watermark assertion exact (zero margin).
+        quant_fill_margin = 10
+        if self.should_autogen(["wm_q_shared_quant_lossless"]):
+            lossless_params = {"dscp": 3,
+                               "ecn": 1,
+                               "queue": 3,
+                               "pkts_num_fill_min": 0,
+                               "fill_margin": quant_fill_margin,
+                               "cell_size": self.buffer_size}
+            self.write_params("wm_q_shared_quant_lossless", lossless_params)
+        if self.should_autogen(["wm_q_shared_quant_lossy"]):
+            lossy_params = {"dscp": self.dscp_queue0,
+                            "ecn": 1,
+                            "queue": 0,
+                            "pkts_num_fill_min": 0,
+                            "fill_margin": quant_fill_margin,
+                            "cell_size": self.buffer_size}
+            self.write_params("wm_q_shared_quant_lossy", lossy_params)
 
     def __define_lossy_queue_voq(self):
         if self.should_autogen(["lossy_queue_voq_1"]):

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -2573,6 +2573,9 @@ class TestQosSai(QosSaiBase):
         if "pkts_num_margin" in qosConfig[queueProfile].keys():
             testParams["pkts_num_margin"] = qosConfig[queueProfile]["pkts_num_margin"]
 
+        if "ignore_upper_bound" in qosConfig[queueProfile].keys():
+            testParams["ignore_upper_bound"] = qosConfig[queueProfile]["ignore_upper_bound"]
+
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.QWatermarkAllPortTest",
             testParams=testParams

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -2177,10 +2177,11 @@ class TestQosSai(QosSaiBase):
         self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         duthost = get_src_dst_asic_and_duts['dst_dut']
+        dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
         dst_port_id = dutConfig["testPorts"]["dst_port_id"]
         dst_port_name = dutConfig["dutInterfaces"][dst_port_id]
         queue = qosConfig[queueProfile]["queue"]
-        quant_thresholds = get_voq_quant_thresholds_cisco(duthost, dst_port_name, queue)
+        quant_thresholds = get_voq_quant_thresholds_cisco(duthost, dst_port_name, queue, dst_asic_index)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -2143,12 +2143,10 @@ class TestQosSai(QosSaiBase):
         """
             Test QoS SAI quantized queue shared watermark for lossless/lossy traffic.
 
-            On the Cisco-8000 p200 ASIC the queue shared watermark is heavily
-            quantized: the reported watermark snaps to discrete hardware congestion
-            levels rather than tracking the true occupancy. This test reads the
-            exact congestion level thresholds at runtime from the serviceability
-            command and verifies that the watermark jumps to the next threshold as
-            occupancy crosses each boundary.
+            Some asics have a quantized queue watermark that jumps between a list of
+            thresholds. This test reads the exact congestion level thresholds at runtime
+            from an asic-specific CLI and verifies that the watermark jumps to the next
+            threshold as occupancy crosses each boundary.
 
             Args:
                 queueProfile (pytest parameter): queue profile

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -48,6 +48,7 @@ from tests.common.helpers.ptf_tests_helper import (downstream_links, upstream_li
 from tests.common.utilities import get_ipv4_loopback_ip
 from tests.common.helpers.base_helper import read_logs
 from tests.common.mellanox_data import is_mellanox_device
+from tests.common.cisco_data import get_voq_quant_thresholds
 
 logger = logging.getLogger(__name__)
 
@@ -2130,6 +2131,91 @@ class TestQosSai(QosSaiBase):
 
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.QSharedWatermarkTest",
+            testParams=testParams
+        )
+
+    @pytest.mark.parametrize("queueProfile", ["wm_q_shared_quant_lossless", "wm_q_shared_quant_lossy"])
+    def testQosSaiQSharedWatermarkQuantized(
+        self, get_src_dst_asic_and_duts, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        resetWatermark, skip_src_dst_different_asic, skip_pacific_dst_asic, change_lag_lacp_timer,
+        blockGrpcTraffic
+    ):
+        """
+            Test QoS SAI quantized queue shared watermark for lossless/lossy traffic.
+
+            On the Cisco-8000 p200 ASIC the queue shared watermark is heavily
+            quantized: the reported watermark snaps to discrete hardware congestion
+            levels rather than tracking the true occupancy. This test reads the
+            exact congestion level thresholds at runtime from the serviceability
+            command and verifies that the watermark jumps to the next threshold as
+            occupancy crosses each boundary.
+
+            Args:
+                queueProfile (pytest parameter): queue profile
+                ptfhost (AnsibleHost): Packet Test Framework (PTF)
+                dutTestParams (Fixture, dict): DUT host test params
+                dutConfig (Fixture, dict): Map of DUT config containing dut interfaces, test port IDs, test port IPs,
+                    and test ports
+                dutQosConfig (Fixture, dict): Map containing DUT host QoS configuration
+                resetWatermark (Fixture): reset queue watermarks
+
+            Returns:
+                None
+
+            Raises:
+                RunAnsibleModuleFail if ptf test fails
+        """
+        if dutConfig["dutAsic"] != "p200":
+            pytest.skip("Quantized queue watermark test is only supported on the Cisco-8000 p200 ASIC")
+
+        portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
+        if queueProfile == "wm_q_shared_quant_lossless":
+            skip_test_on_no_lossless_pg(portSpeedCableLength)
+
+        qosConfig = dutQosConfig["param"][portSpeedCableLength]
+        if queueProfile not in list(qosConfig.keys()):
+            pytest.skip("Queue profile {} is not defined for this testbed".format(queueProfile))
+
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
+
+        duthost = get_src_dst_asic_and_duts['dst_dut']
+        dst_port_id = dutConfig["testPorts"]["dst_port_id"]
+        dst_port_name = dutConfig["dutInterfaces"][dst_port_id]
+        queue = qosConfig[queueProfile]["queue"]
+        quant_thresholds = get_voq_quant_thresholds(duthost, dst_port_name, queue)
+
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
+            "dscp": qosConfig[queueProfile]["dscp"],
+            "ecn": qosConfig[queueProfile]["ecn"],
+            "queue": queue,
+            "dst_port_id": dst_port_id,
+            "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
+            "src_port_id": dutConfig["testPorts"]["src_port_id"],
+            "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
+            "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
+            "pkts_num_leak_out": dutQosConfig["param"][portSpeedCableLength]["pkts_num_leak_out"],
+            "cell_size": qosConfig[queueProfile]["cell_size"],
+            "fill_margin": qosConfig[queueProfile]["fill_margin"],
+            "quant_thresholds": quant_thresholds,
+            "hwsku": dutTestParams['hwsku'],
+            "dut_asic": dutConfig["dutAsic"],
+            "ip_type": dutConfig["ip_type"]
+        })
+
+        if "platform_asic" in dutTestParams["basicParams"]:
+            testParams["platform_asic"] = dutTestParams["basicParams"]["platform_asic"]
+        else:
+            testParams["platform_asic"] = None
+
+        if "packet_size" in list(qosConfig[queueProfile].keys()):
+            testParams["packet_size"] = qosConfig[queueProfile]["packet_size"]
+
+        self.set_test_params_descriptor_size(dutQosConfig, testParams)
+
+        self.runPtfTest(
+            ptfhost, testCase="sai_qos_tests.QSharedWatermarkQuantizedTest",
             testParams=testParams
         )
 

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -2202,11 +2202,6 @@ class TestQosSai(QosSaiBase):
             "ip_type": dutConfig["ip_type"]
         })
 
-        if "platform_asic" in dutTestParams["basicParams"]:
-            testParams["platform_asic"] = dutTestParams["basicParams"]["platform_asic"]
-        else:
-            testParams["platform_asic"] = None
-
         if "packet_size" in list(qosConfig[queueProfile].keys()):
             testParams["packet_size"] = qosConfig[queueProfile]["packet_size"]
 

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -48,7 +48,7 @@ from tests.common.helpers.ptf_tests_helper import (downstream_links, upstream_li
 from tests.common.utilities import get_ipv4_loopback_ip
 from tests.common.helpers.base_helper import read_logs
 from tests.common.mellanox_data import is_mellanox_device
-from tests.common.cisco_data import get_voq_quant_thresholds
+from tests.common.cisco_data import get_voq_quant_thresholds_cisco
 
 logger = logging.getLogger(__name__)
 
@@ -2180,7 +2180,7 @@ class TestQosSai(QosSaiBase):
         dst_port_id = dutConfig["testPorts"]["dst_port_id"]
         dst_port_name = dutConfig["dutInterfaces"][dst_port_id]
         queue = qosConfig[queueProfile]["queue"]
-        quant_thresholds = get_voq_quant_thresholds(duthost, dst_port_name, queue)
+        quant_thresholds = get_voq_quant_thresholds_cisco(duthost, dst_port_name, queue)
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -6644,7 +6644,6 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
         asic_type = self.test_params['sonic_asic_type']
         cell_size = int(self.test_params['cell_size'])
         hwsku = self.test_params['hwsku']
-        platform_asic = self.test_params['platform_asic']
         dut_asic = self.test_params['dut_asic']
         ip_type = self.test_params.get('ip_type', 'ipv4')
         descriptor_size = int(self.test_params.get('descriptor_size', 0))
@@ -6708,10 +6707,6 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
             "First quantized threshold {} is too small for fill_margin {} (bytes_per_pkt {})".format(
                 thresholds[1], fill_margin, bytes_per_pkt)
 
-        skip_asserts = bool(platform_asic) and platform_asic == "broadcom-dnx"
-        if skip_asserts:
-            logging.info("Skipping quantized watermark assertions on broadcom-dnx")
-
         # Collect every mismatch instead of bailing on the first one so the test
         # reports a complete picture of the device's quantization behavior. Each
         # entry is (phase, threshold_idx, offset, target_pkts, expected, actual).
@@ -6729,7 +6724,7 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
                 self.dst_client, port_list['dst'][dst_port_id])
             print("Uncongested watermark: sent %d pkts, watermark %d, expected %d" % (
                 uncongested_pkts, q_wm_res[queue], thresholds[1]), file=sys.stderr)
-            if not skip_asserts and q_wm_res[queue] != thresholds[1]:
+            if q_wm_res[queue] != thresholds[1]:
                 failures.append(("uncongested", "-", "-", uncongested_pkts,
                                  thresholds[1], q_wm_res[queue]))
 
@@ -6754,7 +6749,7 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
                     expected = thresholds[expected_idx]
                     print("Threshold idx %d offset %d: target %d pkts, watermark %d, expected %d" % (
                         i, offset, target_pkts, watermark, expected), file=sys.stderr)
-                    if not skip_asserts and watermark != expected:
+                    if watermark != expected:
                         failures.append(("threshold", i, "{:+d}".format(offset),
                                          target_pkts, expected, watermark))
         finally:

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -6591,26 +6591,12 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
 
 class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
     """
-    Validate the quantized queue shared watermark behavior on Cisco-8000 p200.
-
-    On p200 the queue shared watermark is heavily quantized: as the real queue
-    occupancy crosses a hardware congestion level, the reported watermark snaps
-    to the value of the *next* congestion level. The exact level values are read
-    at runtime from the "show platform npu voq thresholds" serviceability command
-    and supplied in the 'quant_thresholds' test param (bytes, ascending, with
-    thresholds[0] == 0).
+    Validate quantized queue shared watermark behavior.
 
     Rule under test: if occupancy exceeds threshold[i], the reported watermark
     must display exactly threshold[i+1]. As a corollary, since threshold[0] == 0,
     any traffic at all - even uncongested - must report a non-zero watermark equal
     to threshold[1].
-
-    For each threshold boundary i (1 .. len-3, ignoring the final threshold which
-    has no i+1) the queue is filled to 'fill_margin' packets below the boundary
-    (watermark must still read threshold[i]) and then to 'fill_margin' packets
-    above the boundary (watermark must read threshold[i+1]). The fill_margin gives
-    slack for device transition nuance and stray background packets while keeping
-    the watermark assertion itself exact.
     """
 
     def fill_to_target(self, src_port_id, dst_port_id, pkt, queue, asic_type,
@@ -6618,14 +6604,6 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
         """
         Fill the egress queue to 'target_pkts' packets of occupancy, then return
         the queue shared watermark (bytes) for 'queue' on the dst port.
-
-        For refill-capable devices (e.g. p200) the queue is drained on read, so
-        each call re-disables tx, re-establishes the leakout baseline, and fills
-        to the absolute target before re-enabling tx to capture the peak.
-
-        For non-refill devices (e.g. gr2) tx stays disabled for the whole test and
-        occupancy persists; only the incremental delta since the last fill is sent.
-        Targets are visited in strictly increasing order so the delta is positive.
         """
         if refill_queue:
             self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -7223,6 +7223,7 @@ class QWatermarkAllPortTest(sai_base_test.ThriftInterfaceDataPlane):
         queue_list = [int(x) for x in queue_list]
         packet_length = self.test_params.get('packet_size', 64)
         pkts_num_leak_out = self.test_params.get('pkts_num_leak_out', 0)
+        ignore_upper_bound = self.test_params.get('ignore_upper_bound', False)
 
         cell_occupancy = (packet_length + cell_size - 1) // cell_size
         # Special tuning for cisco gr2 lossy traffic: subtract egress_lossy_pool
@@ -7295,12 +7296,19 @@ class QWatermarkAllPortTest(sai_base_test.ThriftInterfaceDataPlane):
                     qwm = qwms[queue]
                     lower = (expected_wm - margin) * cell_size
                     upper = (expected_wm + margin) * cell_size
-                    msg = "Queue: {}, lower {} {} = queue_wm {} = upper {} {}".format(
-                        queue, lower, offset_text(qwm - lower), qwm, upper, offset_text(qwm - upper))
+                    if ignore_upper_bound:
+                        msg = "Queue: {}, lower {} {} = queue_wm {}, upper ignored due to asic type".format(
+                            queue, lower, offset_text(qwm - lower), qwm)
+                    else:
+                        msg = "Queue: {}, lower {} {} = queue_wm {} = upper {} {}".format(
+                            queue, lower, offset_text(qwm - lower), qwm, upper, offset_text(qwm - upper))
                     log_message(msg, to_stderr=True)
-                    if not (lower <= qwm <= upper):
+                    if not (lower <= qwm):
                         failures.append((dst_port_ids[dst_i], queue))
-                        log_message("Failed check", to_stderr=True)
+                        log_message("Failed lower bound check", to_stderr=True)
+                    if not ignore_upper_bound and not (qwm <= upper):
+                        failures.append((dst_port_ids[dst_i], queue))
+                        log_message("Failed upper bound check", to_stderr=True)
             assert len(failures) == 0, "Failed on (dst port id, queue) for the following: {}".format(failures)
 
         finally:

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -6618,8 +6618,7 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
             if delta > 0:
                 send_packet(self, src_port_id, pkt, delta)
                 self.cur_pkts = target_pkts
-        # Allow the dut to sync up the counter values in counters_db.
-        time.sleep(8)
+        time.sleep(3)
         q_wm_res, _, _ = sai_thrift_read_port_watermarks(
             self.dst_client, port_list['dst'][dst_port_id])
         return q_wm_res[queue]
@@ -6725,7 +6724,7 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
             # to exactly threshold[1].
             uncongested_pkts = thr_to_pkts(thresholds[1]) - fill_margin
             send_packet(self, src_port_id, pkt, uncongested_pkts)
-            time.sleep(8)
+            time.sleep(3)
             q_wm_res, _, _ = sai_thrift_read_port_watermarks(
                 self.dst_client, port_list['dst'][dst_port_id])
             print("Uncongested watermark: sent %d pkts, watermark %d, expected %d" % (

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -6588,6 +6588,199 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
 
+
+class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
+    """
+    Validate the quantized queue shared watermark behavior on Cisco-8000 p200.
+
+    On p200 the queue shared watermark is heavily quantized: as the real queue
+    occupancy crosses a hardware congestion level, the reported watermark snaps
+    to the value of the *next* congestion level. The exact level values are read
+    at runtime from the "show platform npu voq thresholds" serviceability command
+    and supplied in the 'quant_thresholds' test param (bytes, ascending, with
+    thresholds[0] == 0).
+
+    Rule under test: if occupancy exceeds threshold[i], the reported watermark
+    must display exactly threshold[i+1]. As a corollary, since threshold[0] == 0,
+    any traffic at all - even uncongested - must report a non-zero watermark equal
+    to threshold[1].
+
+    For each threshold boundary i (1 .. len-3, ignoring the final threshold which
+    has no i+1) the queue is filled to 'fill_margin' packets below the boundary
+    (watermark must still read threshold[i]) and then to 'fill_margin' packets
+    above the boundary (watermark must read threshold[i+1]). The fill_margin gives
+    slack for device transition nuance and stray background packets while keeping
+    the watermark assertion itself exact.
+    """
+
+    def fill_to_target(self, src_port_id, dst_port_id, pkt, queue, asic_type,
+                       target_pkts, refill_queue):
+        """
+        Fill the egress queue to 'target_pkts' packets of occupancy, then return
+        the queue shared watermark (bytes) for 'queue' on the dst port.
+
+        For refill-capable devices (e.g. p200) the queue is drained on read, so
+        each call re-disables tx, re-establishes the leakout baseline, and fills
+        to the absolute target before re-enabling tx to capture the peak.
+
+        For non-refill devices (e.g. gr2) tx stays disabled for the whole test and
+        occupancy persists; only the incremental delta since the last fill is sent.
+        Targets are visited in strictly increasing order so the delta is positive.
+        """
+        if refill_queue:
+            self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+            # Enqueue exactly one packet past the (variable) leakout.
+            fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type)
+            to_send = target_pkts - 1
+            if to_send > 0:
+                send_packet(self, src_port_id, pkt, to_send)
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+        else:
+            delta = target_pkts - self.cur_pkts
+            if delta > 0:
+                send_packet(self, src_port_id, pkt, delta)
+                self.cur_pkts = target_pkts
+        # Allow the dut to sync up the counter values in counters_db.
+        time.sleep(8)
+        q_wm_res, _, _ = sai_thrift_read_port_watermarks(
+            self.dst_client, port_list['dst'][dst_port_id])
+        return q_wm_res[queue]
+
+    def runTest(self):
+        time.sleep(5)
+        switch_init(self.clients)
+
+        # Parse input parameters
+        dscp = int(self.test_params['dscp'])
+        ecn = int(self.test_params['ecn'])
+        router_mac = self.test_params['router_mac']
+        print("router_mac: %s" % (router_mac), file=sys.stderr)
+        queue = int(self.test_params['queue'])
+        dst_port_id = int(self.test_params['dst_port_id'])
+        dst_port_ip = self.test_params['dst_port_ip']
+        dst_port_mac = self.dataplane.get_mac(0, dst_port_id)
+        src_port_id = int(self.test_params['src_port_id'])
+        src_port_ip = self.test_params['src_port_ip']
+        src_port_vlan = self.test_params['src_port_vlan']
+        src_port_mac = self.dataplane.get_mac(0, src_port_id)
+
+        asic_type = self.test_params['sonic_asic_type']
+        cell_size = int(self.test_params['cell_size'])
+        hwsku = self.test_params['hwsku']
+        platform_asic = self.test_params['platform_asic']
+        dut_asic = self.test_params['dut_asic']
+        ip_type = self.test_params.get('ip_type', 'ipv4')
+        descriptor_size = int(self.test_params.get('descriptor_size', 0))
+        fill_margin = int(self.test_params.get('fill_margin', 10))
+        thresholds = [int(value) for value in self.test_params['quant_thresholds']]
+
+        if 'packet_size' in list(self.test_params.keys()):
+            packet_length = int(self.test_params['packet_size'])
+        else:
+            packet_length = 64
+
+        # Sanity check the threshold vector. We need threshold[0] == 0 (the empty
+        # queue level) and at least one testable boundary that has an i+1 neighbor
+        # excluding the final threshold.
+        assert len(thresholds) >= 4, \
+            "Expected at least 4 quantized thresholds, got {}".format(thresholds)
+        assert thresholds[0] == 0, \
+            "Expected first quantized threshold to be 0, got {}".format(thresholds)
+
+        cell_occupancy = (packet_length + cell_size + descriptor_size - 1) // cell_size
+        bytes_per_pkt = cell_occupancy * cell_size
+
+        # Prepare packet data
+        ttl = 64
+        pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
+        is_dualtor = self.test_params.get('is_dualtor', False)
+        def_vlan_mac = self.test_params.get('def_vlan_mac', None)
+        if is_dualtor and def_vlan_mac is not None:
+            pkt_dst_mac = def_vlan_mac
+
+        if ip_type == 'ipv6':
+            pkt = construct_ipv6_pkt(packet_length, pkt_dst_mac, src_port_mac,
+                                     src_port_ip, dst_port_ip, dscp, src_port_vlan,
+                                     ecn=ecn, ttl=ttl)
+        else:
+            pkt = construct_ip_pkt(packet_length, pkt_dst_mac, src_port_mac,
+                                   src_port_ip, dst_port_ip, dscp, src_port_vlan,
+                                   ecn=ecn, ttl=ttl)
+
+        print("dst_port_id: %d, src_port_id: %d, src_port_vlan: %s" %
+              (dst_port_id, src_port_id, src_port_vlan), file=sys.stderr)
+        # In case dst_port_id is part of a LAG, find out the actual dst port for
+        # the given IP parameters so egress blocking and queue reads target the
+        # correct member port.
+        if ip_type == 'ipv6':
+            dst_port_id = get_rx_port_ipv6(
+                self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, src_port_vlan)
+        else:
+            dst_port_id = get_rx_port(
+                self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, src_port_vlan)
+        print("actual dst_port_id: %d" % (dst_port_id), file=sys.stderr)
+
+        refill_queue = 'cisco-8000' in asic_type and dut_asic != 'gr2'
+
+        def thr_to_pkts(threshold_bytes):
+            return threshold_bytes // bytes_per_pkt
+
+        # The first non-zero threshold must be reachable while still leaving room
+        # for the fill_margin below it.
+        assert thr_to_pkts(thresholds[1]) > fill_margin, \
+            "First quantized threshold {} is too small for fill_margin {} (bytes_per_pkt {})".format(
+                thresholds[1], fill_margin, bytes_per_pkt)
+
+        try:
+            # Phase A: uncongested validation. Leave egress enabled and send a burst
+            # bounded strictly below threshold[1]. Even though traffic flows
+            # unimpeded, any transient occupancy must push the quantized watermark
+            # to exactly threshold[1].
+            uncongested_pkts = thr_to_pkts(thresholds[1]) - fill_margin
+            send_packet(self, src_port_id, pkt, uncongested_pkts)
+            time.sleep(8)
+            q_wm_res, _, _ = sai_thrift_read_port_watermarks(
+                self.dst_client, port_list['dst'][dst_port_id])
+            print("Uncongested watermark: sent %d pkts, watermark %d, expected %d" % (
+                uncongested_pkts, q_wm_res[queue], thresholds[1]), file=sys.stderr)
+            if platform_asic and platform_asic == "broadcom-dnx":
+                logging.info("Skipping quantized watermark assertions on broadcom-dnx")
+            else:
+                assert q_wm_res[queue] == thresholds[1], \
+                    "Uncongested queue watermark expected {}, got {}".format(
+                        thresholds[1], q_wm_res[queue])
+
+            # Establish the leakout baseline once for non-refill devices, which keep
+            # egress disabled and accumulate occupancy across measurements.
+            self.cur_pkts = 0
+            if not refill_queue:
+                self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+                if 'cisco-8000' in asic_type:
+                    fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type)
+                    self.cur_pkts = 1
+
+            # Phase B: per-threshold validation. Skip the final threshold since it
+            # has no i+1 neighbor to transition into.
+            for i in range(1, len(thresholds) - 2):
+                threshold_pkts = thr_to_pkts(thresholds[i])
+                for offset, expected_idx in ((-fill_margin, i), (fill_margin, i + 1)):
+                    target_pkts = threshold_pkts + offset
+                    watermark = self.fill_to_target(
+                        src_port_id, dst_port_id, pkt, queue, asic_type,
+                        target_pkts, refill_queue)
+                    expected = thresholds[expected_idx]
+                    print("Threshold idx %d offset %d: target %d pkts, watermark %d, expected %d" % (
+                        i, offset, target_pkts, watermark, expected), file=sys.stderr)
+                    if platform_asic and platform_asic == "broadcom-dnx":
+                        logging.info("Skipping quantized watermark assertions on broadcom-dnx")
+                        continue
+                    assert watermark == expected, \
+                        "Quantized queue watermark mismatch at threshold index {} ({:+d} pkts): " \
+                        "expected {}, got {} (hwsku {})".format(
+                            i, offset, expected, watermark, hwsku)
+        finally:
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+
 # TODO: buffer pool roid should be obtained via rpc calls
 # based on the pg or queue index
 # rather than fed in as test parameters due to the lack in SAI implement

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -6731,6 +6731,15 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
             "First quantized threshold {} is too small for fill_margin {} (bytes_per_pkt {})".format(
                 thresholds[1], fill_margin, bytes_per_pkt)
 
+        skip_asserts = bool(platform_asic) and platform_asic == "broadcom-dnx"
+        if skip_asserts:
+            logging.info("Skipping quantized watermark assertions on broadcom-dnx")
+
+        # Collect every mismatch instead of bailing on the first one so the test
+        # reports a complete picture of the device's quantization behavior. Each
+        # entry is (phase, threshold_idx, offset, target_pkts, expected, actual).
+        failures = []
+
         try:
             # Phase A: uncongested validation. Leave egress enabled and send a burst
             # bounded strictly below threshold[1]. Even though traffic flows
@@ -6743,12 +6752,9 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
                 self.dst_client, port_list['dst'][dst_port_id])
             print("Uncongested watermark: sent %d pkts, watermark %d, expected %d" % (
                 uncongested_pkts, q_wm_res[queue], thresholds[1]), file=sys.stderr)
-            if platform_asic and platform_asic == "broadcom-dnx":
-                logging.info("Skipping quantized watermark assertions on broadcom-dnx")
-            else:
-                assert q_wm_res[queue] == thresholds[1], \
-                    "Uncongested queue watermark expected {}, got {}".format(
-                        thresholds[1], q_wm_res[queue])
+            if not skip_asserts and q_wm_res[queue] != thresholds[1]:
+                failures.append(("uncongested", "-", "-", uncongested_pkts,
+                                 thresholds[1], q_wm_res[queue]))
 
             # Establish the leakout baseline once for non-refill devices, which keep
             # egress disabled and accumulate occupancy across measurements.
@@ -6771,15 +6777,21 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
                     expected = thresholds[expected_idx]
                     print("Threshold idx %d offset %d: target %d pkts, watermark %d, expected %d" % (
                         i, offset, target_pkts, watermark, expected), file=sys.stderr)
-                    if platform_asic and platform_asic == "broadcom-dnx":
-                        logging.info("Skipping quantized watermark assertions on broadcom-dnx")
-                        continue
-                    assert watermark == expected, \
-                        "Quantized queue watermark mismatch at threshold index {} ({:+d} pkts): " \
-                        "expected {}, got {} (hwsku {})".format(
-                            i, offset, expected, watermark, hwsku)
+                    if not skip_asserts and watermark != expected:
+                        failures.append(("threshold", i, "{:+d}".format(offset),
+                                         target_pkts, expected, watermark))
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+
+        if failures:
+            fail_tbl = texttable.TextTable(
+                ['Phase', 'Threshold Idx', 'Offset (pkts)', 'Target Pkts',
+                 'Expected (bytes)', 'Actual (bytes)'])
+            for phase, idx, offset, target_pkts, expected, actual in failures:
+                fail_tbl.add_row([phase, idx, offset, target_pkts, expected, actual])
+            assert False, \
+                "Quantized queue watermark mismatches on hwsku {} ({} of {} measurement(s) failed):\n{}".format(
+                    hwsku, len(failures), 1 + 2 * (len(thresholds) - 3), fail_tbl)
 
 # TODO: buffer pool roid should be obtained via rpc calls
 # based on the pg or queue index

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -6701,11 +6701,14 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
         def thr_to_pkts(threshold_bytes):
             return threshold_bytes // bytes_per_pkt
 
-        # The first non-zero threshold must be reachable while still leaving room
-        # for the fill_margin below it.
-        assert thr_to_pkts(thresholds[1]) > fill_margin, \
-            "First quantized threshold {} is too small for fill_margin {} (bytes_per_pkt {})".format(
-                thresholds[1], fill_margin, bytes_per_pkt)
+        # Confirm that each threshold is separated by at least the fill_margin, otherwise threshold checks will break.
+        for i in range(len(thresholds) - 1):
+            gap_pkts = thr_to_pkts(thresholds[i + 1]) - thr_to_pkts(thresholds[i])
+            assert gap_pkts > fill_margin, \
+                ("Quantized thresholds {} and {} (indices {}, {}) are only {} pkt(s) apart, "
+                 "which does not exceed fill_margin {} (bytes_per_pkt {}); the +/-fill_margin "
+                 "probes would cross between buckets").format(
+                    thresholds[i], thresholds[i + 1], i, i + 1, gap_pkts, fill_margin, bytes_per_pkt)
 
         # Collect every mismatch instead of bailing on the first one so the test
         # reports a complete picture of the device's quantization behavior. Each

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -6656,10 +6656,10 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
             packet_length = 64
 
         # Sanity check the threshold vector. We need threshold[0] == 0 (the empty
-        # queue level) and at least one testable boundary that has an i+1 neighbor
-        # excluding the final threshold.
-        assert len(thresholds) >= 4, \
-            "Expected at least 4 quantized thresholds, got {}".format(thresholds)
+        # queue level) and at least one testable boundary (index 1) plus its i+1
+        # neighbor to transition into, so a minimum of 3 thresholds.
+        assert len(thresholds) >= 3, \
+            "Expected at least 3 quantized thresholds, got {}".format(thresholds)
         assert thresholds[0] == 0, \
             "Expected first quantized threshold to be 0, got {}".format(thresholds)
 
@@ -6714,8 +6714,6 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
         # reports a complete picture of the device's quantization behavior. Each
         # entry is (phase, threshold_idx, offset, target_pkts, expected, actual).
         failures = []
-        # Accrue the measurement count as we go so the summary stays accurate if
-        # the set of checks changes.
         total_measurements = 0
 
         try:

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -6739,7 +6739,7 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
 
             # Phase B: per-threshold validation. Skip the final threshold since it
             # has no i+1 neighbor to transition into.
-            for i in range(1, len(thresholds) - 2):
+            for i in range(1, len(thresholds) - 1):
                 threshold_pkts = thr_to_pkts(thresholds[i])
                 for offset, expected_idx in ((-fill_margin, i), (fill_margin, i + 1)):
                     target_pkts = threshold_pkts + offset

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -6714,6 +6714,9 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
         # reports a complete picture of the device's quantization behavior. Each
         # entry is (phase, threshold_idx, offset, target_pkts, expected, actual).
         failures = []
+        # Accrue the measurement count as we go so the summary stays accurate if
+        # the set of checks changes.
+        total_measurements = 0
 
         try:
             # Phase A: uncongested validation. Leave egress enabled and send a burst
@@ -6727,6 +6730,7 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
                 self.dst_client, port_list['dst'][dst_port_id])
             print("Uncongested watermark: sent %d pkts, watermark %d, expected %d" % (
                 uncongested_pkts, q_wm_res[queue], thresholds[1]), file=sys.stderr)
+            total_measurements += 1
             if q_wm_res[queue] != thresholds[1]:
                 failures.append(("uncongested", "-", "-", uncongested_pkts,
                                  thresholds[1], q_wm_res[queue]))
@@ -6752,6 +6756,7 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
                     expected = thresholds[expected_idx]
                     print("Threshold idx %d offset %d: target %d pkts, watermark %d, expected %d" % (
                         i, offset, target_pkts, watermark, expected), file=sys.stderr)
+                    total_measurements += 1
                     if watermark != expected:
                         failures.append(("threshold", i, "{:+d}".format(offset),
                                          target_pkts, expected, watermark))
@@ -6766,7 +6771,7 @@ class QSharedWatermarkQuantizedTest(sai_base_test.ThriftInterfaceDataPlane):
                 fail_tbl.add_row([phase, idx, offset, target_pkts, expected, actual])
             assert False, \
                 "Quantized queue watermark mismatches on hwsku {} ({} of {} measurement(s) failed):\n{}".format(
-                    hwsku, len(failures), 1 + 2 * (len(thresholds) - 3), fail_tbl)
+                    hwsku, len(failures), total_measurements, fail_tbl)
 
 # TODO: buffer pool roid should be obtained via rpc calls
 # based on the pg or queue index


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

Added a new Cisco-specific test case to validate queue watermarks that are quantized. 

- New queue quantization test, only runs on Cisco-8223, skips otherwise.
- New CiscoS1Cli class wrapper to cleanly interface with the SiliconOne CLI for retrieving low-level device details, such as queue watermark quantization thresholds. 
- Skip testQosSaiQSharedWatermark for Cisco-8223, replaced by the new test. 
- Do not skip the entire testQosSaiQWatermarkAllPorts test, but specifically ignore the upper-bound check for Cisco-8223. Allows the test to run with a loosened check to confirm all queues across the device are increasing, without being too specific to the exact values (covered by the Quantization test). 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

master: 15ea0020ebb40262446b780c9109e0a1d25377db - `Results (836.13s (0:13:56)):     2 passed`

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Validated on Cisco-8223, passes new test (2 parametrizations) and the q wmk all port test, skips the q wmk test. 

#### Any platform specific information?
New test is cisco-specific. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
