### PR TITLE
[arp] Fix test_dut_ping_learns_mac dualtor skip marker

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -206,6 +206,7 @@ arp/test_arp_update.py::test_dut_arping_learns_mac:
 arp/test_arp_update.py::test_dut_ping_learns_mac:
   skip:
     reason: "Skip test_dut_ping_learns_mac on dualtor"
+    conditions_logical_operator: or
     conditions:
       - "'dualtor' in topo_name"
       - "'-v6-' in topo_name and https://github.com/sonic-net/sonic-mgmt/issues/24598"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix conditional mark for
  `arp/test_arp_update.py::test_dut_ping_learns_mac`.

  This test is intended to be skipped on dualtor topologies, but the marker
  currently has both a dualtor condition and a v6-only condition. Conditional
  marks evaluate multiple conditions as AND by default, so the test is not skipped
  on dualtor non-v6 topologies.

  This PR adds `conditions_logical_operator: or` so the test is skipped when
  either condition matches.

Summary:
Fixes #26421 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression 

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
**- 202605:**
[test_dut_ping_learns_mac_skip_validation_202605.log](https://github.com/user-attachments/files/30234245/test_dut_ping_learns_mac_skip_validation_202605.log)
[test_dut_ping_learns_mac_skip_validation_202605.xml](https://github.com/user-attachments/files/30234246/test_dut_ping_learns_mac_skip_validation_202605.xml)

### Approach


#### What is the motivation for this PR?
test_dut_ping_learns_mac was intended to be skipped on dualtor. A later
 v6-only skip condition was added to the same marker without specifying
 conditions_logical_operator: or. Because conditional marks use AND by default,
 the dualtor skip no longer applies on dualtor non-v6 topologies.

#### How did you do it?
Added conditions_logical_operator: or to the conditional mark for
 arp/test_arp_update.py::test_dut_ping_learns_mac.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
validated that the targeted test is skipped on a 202605 dualtor topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
