### PR TITLE
[container_checker] Skip kube-owned host exclusions

### DIFF
--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -30,6 +30,7 @@ CONTAINER_CHECK_INTERVAL_SECS = 5     # Monit daemon runs every 10s in test; pol
 CONTAINER_STOP_THRESHOLD_SECS = 30
 CONTAINER_RESTART_THRESHOLD_SECS = 180
 MONIT_START_THRESHOLD_SECS = 360      # Max wait for Monit to become ready
+HOST_CHECKER_KUBE_OWNER_EXCLUSIONS = {"gnmi"}
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -229,6 +230,10 @@ def test_container_checker(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand
     disabled_containers = get_disabled_container_list(duthost)
 
     skip_containers = disabled_containers[:]
+    if service_name in HOST_CHECKER_KUBE_OWNER_EXCLUSIONS:
+        feature_table = duthost.get_running_config_facts().get("FEATURE", {})
+        if feature_table.get(service_name, {}).get("set_owner") == "kube":
+            skip_containers.append(service_name)
 
     # Skip 'radv' container on devices whose role is not T0/M0.
     # Skip 'radv' container on dualtor-aa as radv is forcefully killed on dualtor-aa (#13408 in sonic-buildimage)


### PR DESCRIPTION
### Description of PR

Summary:
Skip the native gNMI container-checker alert test when `FEATURE|gnmi.set_owner` is `kube`. KubeSonic-owned gNMI is intentionally excluded from the host checker, so stopping the native container must not produce `Expected containers not running: gnmi`. Local and legacy entries without `set_owner` remain covered.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Back port request

No backport requested.

### Tested branch

- [x] master
- [ ] N/A

### Test result

- `uvx --from pre-commit==4.2.0 pre-commit run --from-ref origin/master --to-ref HEAD`: passed
- `python3 -m py_compile tests/container_checker/test_container_checker.py`: passed
- Existing failure evidence: KVM t0, t1-lag, and t1-8-lag all failed only the gNMI parameter because the expected alert was correctly absent; retries reproduced the same result.

### Approach
#### What is the motivation for this PR?

The host container checker now follows FEATURE ownership for gNMI. The test still assumes every enabled native gNMI container is host-managed, causing deterministic failures on KubeSonic images.

#### How did you do it?

Read the running FEATURE table only for ownership-aware host-checker exclusions and add gNMI to the existing skip list when its owner is `kube`.

#### How did you verify/test it?

Pinned Flake8, all applicable pre-commit hooks, Python compilation, and independent code review passed. The failing KVM plans showed `FEATURE|gnmi.set_owner=kube` and no native-container alert, which is the expected product behavior.

#### Any platform specific information?

Observed consistently on KVM t0, t1-lag, and multi-ASIC t1-8-lag.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

Not applicable.
