### PR TITLE
iface_namingmode: require validation of at least one frontend interface in show interfaces counter

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -473,6 +473,7 @@ class TestShowInterfaces():
             "Parsed interfaces: {}"
         ).format(interfaces)
 
+        expected_interfaces = None
         if mode == 'alias':
             expected_interfaces = setup['port_alias']
         elif mode == 'default':
@@ -481,6 +482,10 @@ class TestShowInterfaces():
             pytest.fail(
                 "Unsupported interface naming mode: '{}'".format(mode)
             )
+
+        assert expected_interfaces is not None, (
+            "Failed to resolve expected interfaces for naming mode '{}'"
+        ).format(mode)
 
         matched_interfaces = set(interfaces) & set(expected_interfaces)
 

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -444,44 +444,57 @@ class TestShowInterfaces():
     def test_show_interfaces_counter(self, setup, setup_config_mode):
         """
         Checks whether 'show interfaces counter' lists the interface names
-        as per the configured naming mode
+        as per the configured naming mode.
+
+        Interfaces not present in the frontend port mappings, such as
+        SmartSwitch internal backplane ports, are ignored. At least one
+        mapped frontend interface must be present for the test to pass.
         """
         dutHostGuest, mode, ifmode = setup_config_mode
         regex_int = re.compile(r'(\S+)(\d+)')
-        interfaces = list()
+        interfaces = []
 
-        show_intf_counter = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show interfaces counter'.format(ifmode))
-        logger.info('show_intf_counter:\n{}'.format(show_intf_counter['stdout']))
+        show_intf_counter = dutHostGuest.shell(
+            'SONIC_CLI_IFACE_MODE={} show interfaces counter'.format(ifmode)
+        )
+        logger.info(
+            'show_intf_counter:\n{}'.format(show_intf_counter['stdout'])
+        )
 
         for line in show_intf_counter['stdout_lines']:
-            line = line.strip()
-            if regex_int.match(line):
-                interfaces.append(regex_int.match(line).group(0))
+            match = regex_int.match(line.strip())
+            if match:
+                interfaces.append(match.group(0))
 
-        assert (len(interfaces) > 0), (
-            "No interfaces were found in the output of 'show interfaces counter'. "
+        assert interfaces, (
+            "No interfaces were found in the output of "
+            "'show interfaces counter'. "
             "Expected at least one interface entry, but none were found.\n"
             "Parsed interfaces: {}"
         ).format(interfaces)
 
-        for item in interfaces:
-            if mode == 'alias':
-                if item not in setup['port_alias']:
-                    continue
-                assert item in setup['port_alias'], (
-                    "Interface '{}' not found in the list of port aliases. "
-                    "Expected the interface to match a known port alias in the test setup.\n"
-                    "Port aliases in setup: {}"
-                ).format(item, setup['port_alias'])
+        if mode == 'alias':
+            expected_interfaces = setup['port_alias']
+        elif mode == 'default':
+            expected_interfaces = setup['default_interfaces']
+        else:
+            pytest.fail(
+                "Unsupported interface naming mode: '{}'".format(mode)
+            )
 
-            elif mode == 'default':
-                if item not in setup['default_interfaces']:
-                    continue
-                assert item in setup['default_interfaces'], (
-                    "Interface '{}' not found in the list of default interfaces. "
-                    "Expected the interface to match a known default interface in the test setup.\n"
-                    "Default interfaces in setup: {}"
-                ).format(item, setup['default_interfaces'])
+        matched_interfaces = set(interfaces) & set(expected_interfaces)
+
+        assert matched_interfaces, (
+            "No mapped frontend interfaces were found in the output of "
+            "'show interfaces counter'.\n"
+            "Naming mode: {}\n"
+            "Parsed interfaces: {}\n"
+            "Expected interfaces: {}"
+        ).format(
+            mode,
+            interfaces,
+            expected_interfaces
+        )
 
     def test_show_interfaces_description(self, setup_config_mode, sample_intf):
         """


### PR DESCRIPTION
### Description of PR
Fix test_show_interfaces_counter to properly handle SmartSwitch internal interfaces while ensuring the test still validates frontend interface naming.

Fixes #26426

### Type of change

- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [x] 202511

### Test result
202511: Validated on a SmartSwitch testbed.
Confirmed test_show_interfaces_counter passes when show interfaces counter includes SmartSwitch internal/backplane interfaces that are not part of the frontend port mappings.
Confirmed the test still requires at least one expected frontend interface to be present, preventing false-positive passes when all parsed interfaces are skipped.
Approach
What is the motivation for this PR?

A previous change ignored interfaces that are not part of the frontend interface mappings (for example, SmartSwitch internal backplane interfaces). However, the associated assertions became unreachable, allowing the test to pass even when no expected frontend interfaces were validated.

How did you do it?

Updated test_show_interfaces_counter to:

Continue ignoring interfaces that are not present in the frontend port mappings.
Require that at least one expected frontend interface is found in the CLI output.
Remove the unreachable per-interface assertions introduced by the previous implementation.
How did you verify/test it?

Executed the iface_namingmode test on a SmartSwitch platform and verified that:

Internal SmartSwitch interfaces no longer cause the test to fail.
The test succeeds when expected frontend interfaces are present.
The test would fail if no expected frontend interfaces are found, preventing false-positive results.
Any platform specific information?

Yes. This change is primarily intended for SmartSwitch platforms, where show interfaces counter includes internal backplane interfaces that are not part of the frontend port mappings. The change is generic and preserves existing behavior on non-SmartSwitch platforms.