### PR TITLE
NVIDIA BMC Leakage mocker, leakage simulation, aggregation, and escalation tests

### DIFF
--- a/tests/common/helpers/bmc_liquid_leakage_control_test_helper.py
+++ b/tests/common/helpers/bmc_liquid_leakage_control_test_helper.py
@@ -1,0 +1,145 @@
+import logging
+from abc import ABC, abstractmethod
+
+from tests.common.helpers.liquid_leakage_control_test_helper import LiquidLeakageMocker
+from tests.common.platform.bmc_utils import get_sensor_data, get_system_leak_status
+
+logger = logging.getLogger(__name__)
+
+VALID_SENSOR_STATES = ('None', 'MINOR', 'CRITICAL', 'FAULT')
+
+# CLI commands used to discover sensors and read their live status.
+LEAK_STATUS_CMD = 'show platform leak status'
+LEAK_PROFILES_CMD = 'show platform leak profiles'
+
+# Column headers as produced by show_and_parse (lowercased, hyphens preserved).
+COL_NAME = 'name'
+COL_LEAK_SENSOR_TYPE = 'leak-sensor-type'
+PROFILE_COL_SENSOR_TYPE = 'sensor-type'
+PROFILE_COL_MAX_MINOR_DURATION = 'max-minor-duration-sec'
+
+
+class LiquidLeakageMockerBMC(LiquidLeakageMocker, ABC):
+    """
+    BMC liquid leakage mocker base class.
+
+    Discovers leak sensors through the 'show platform leak' CLI and exposes
+    helpers to read per-sensor and system-wide leak status. Vendor-specific
+    subclasses must implement the hardware mocking hooks.
+    """
+
+    def __init__(self, dut):
+        super().__init__(dut)
+        self.sensors = self._discover_sensors()
+        self.sensor_names = list(self.sensors.keys())
+
+    def _discover_sensors(self):
+        """
+        Discover leak sensors from CLI, keyed by sensor name.
+
+        'show platform leak status' provides each sensor's name and sensor type,
+        and 'show platform leak profiles' provides max_minor_duration_sec per
+        sensor type. Returns {name: {'leak_sensor_type', 'max_minor_duration_sec'}}.
+        """
+        max_minor_by_type = self._get_max_minor_duration_by_type()
+        sensors = {}
+        for row in self.dut.show_and_parse(LEAK_STATUS_CMD):
+            name = row.get(COL_NAME)
+            if not name:
+                continue
+            sensor_type = row.get(COL_LEAK_SENSOR_TYPE)
+            sensors[name] = {
+                'leak_sensor_type': sensor_type,
+                'max_minor_duration_sec': max_minor_by_type.get(sensor_type),
+            }
+        logger.info("Discovered %d BMC leak sensor(s): %s", len(sensors), sensors)
+        return sensors
+
+    def _get_max_minor_duration_by_type(self):
+        """Parse 'show platform leak profiles' into {sensor_type: max_minor_duration_sec}."""
+        max_minor_by_type = {}
+        for row in self.dut.show_and_parse(LEAK_PROFILES_CMD):
+            sensor_type = row.get(PROFILE_COL_SENSOR_TYPE)
+            if not sensor_type:
+                continue
+            raw = row.get(PROFILE_COL_MAX_MINOR_DURATION)
+            max_minor_by_type[sensor_type] = self._parse_int(raw)
+        return max_minor_by_type
+
+    def get_device_leak_status(self):
+        """Return SYSTEM_LEAK_STATUS|system device_leak_status from STATE_DB."""
+        return get_system_leak_status(self.dut)
+
+    def get_sensor_name(self, index):
+        """Return the sensor name for a sensor by index."""
+        self._validate_sensor_index(index)
+        return self.sensor_names[index]
+
+    def get_sensor_status(self, index):
+        """
+        Return the current leak status for a sensor by index.
+
+        Reads LIQUID_COOLING_INFO|<name> from STATE_DB and returns a tuple of
+        (leak, leak_severity, leak_sensor_status):
+          - leak: True when the leaking field is 'Yes'.
+          - leak_severity: one of 'None', 'MINOR', or 'CRITICAL'.
+          - leak_sensor_status: raw leak_sensor_status string from STATE_DB.
+        """
+        name = self.get_sensor_name(index)
+        sensor_data = get_sensor_data(self.dut, name)
+        leak = self._normalize_leak_bool(sensor_data.get('leaking'))
+        leak_severity = self._normalize_severity(sensor_data.get('leak_severity'))
+        leak_sensor_status = sensor_data.get('leak_sensor_status')
+        return leak, leak_severity, leak_sensor_status
+
+    @abstractmethod
+    def restore_all_sensors(self):
+        """Restore all mocked leak sensors to their original state."""
+        pass
+
+    @abstractmethod
+    def set_sensor_state(self, index, state):
+        """
+        Set a sensor by index to the requested leak state.
+
+        :param index: Leak sensor index.
+        :param state: One of 'None', 'MINOR', or 'CRITICAL'.
+        """
+        pass
+
+    def deinit(self):
+        """Restore all sensors on teardown, then chain to the base mocker."""
+        self.restore_all_sensors()
+        super().deinit()
+
+    def _validate_sensor_index(self, index):
+        if index < 0 or index >= len(self.sensor_names):
+            raise ValueError(
+                "Sensor index {} out of range for {} discovered sensor(s)".format(
+                    index, len(self.sensor_names)))
+
+    def _validate_sensor_state(self, state):
+        if state not in VALID_SENSOR_STATES:
+            raise ValueError(
+                "Sensor state {!r} not in {}".format(state, VALID_SENSOR_STATES))
+
+    @staticmethod
+    def _normalize_severity(raw):
+        """Map a leak_severity field ('None', 'MINOR', 'CRITICAL', ...) to a valid state."""
+        severity = (raw or '').strip().upper()
+        if severity in ('MINOR', 'CRITICAL'):
+            return severity
+        return 'None'
+
+    @staticmethod
+    def _normalize_leak_bool(raw):
+        """Map a leaking field ('Yes', 'No', 'N/A', ...) to a bool."""
+        leak = (raw or '').strip().upper()
+        return leak == 'YES'
+
+    @staticmethod
+    def _parse_int(raw):
+        try:
+            return int(str(raw).strip())
+        except (TypeError, ValueError):
+            return None

--- a/tests/common/helpers/nvidia/nvidia_bmc_liquid_leakage_control_test_helper.py
+++ b/tests/common/helpers/nvidia/nvidia_bmc_liquid_leakage_control_test_helper.py
@@ -1,0 +1,111 @@
+import logging
+import os
+import shlex
+
+from tests.common.helpers.sensor_control_test_helper import mocker
+from tests.common.helpers.bmc_liquid_leakage_control_test_helper import LiquidLeakageMockerBMC
+
+logger = logging.getLogger(__name__)
+
+LEAKAGE_MOCKER_SCRIPT = 'sonic_bmc_nvidia_leakage_mocker.py'
+LEAKAGE_MOCKER_SRC = os.path.join(
+    'common', 'helpers', 'platform_api', 'scripts', 'nvidia', LEAKAGE_MOCKER_SCRIPT)
+DUT_LEAKAGE_MOCKER_PATH = os.path.join('/tmp', LEAKAGE_MOCKER_SCRIPT)
+
+# Map the abstract leak states to the mocker script's --severity bands.
+# The script drives the sensor's raw reading into the threshold band for the
+# requested severity (see sonic_bmc_nvidia_leakage_mocker.py threshold model):
+#   'ok'   -> reading in [min, max]     -> no leak      (state 'None')
+#   'warn' -> reading in [lwarn, warn]  -> MINOR leak
+#   'crit' -> reading in [lcrit, crit]  -> CRITICAL leak
+STATE_TO_SEVERITY = {
+    'None': 'ok',
+    'MINOR': 'warn',
+    'CRITICAL': 'crit',
+    'FAULT': 'error'
+}
+
+
+@mocker('LiquidLeakageMockerBMC')
+class LiquidLeakageMockerNvidiaBMC(LiquidLeakageMockerBMC):
+    """
+    NVIDIA BMC liquid leakage mocker.
+
+    Drives leak readings on the BMC by deploying and invoking
+    sonic_bmc_nvidia_leakage_mocker.py, which redirects each leakage channel's
+    hw-management ``input`` symlink to a mock file.
+
+    The mocker script addresses sensors by ``<a2d>/<channel>`` id rather than
+    the sensor index, so the constructor lists the discovered sensors and maps
+    each sensor name to its ``<a2d>/<channel>`` id.
+    """
+
+    def __init__(self, dut):
+        super().__init__(dut)
+        self.dut_script_path = DUT_LEAKAGE_MOCKER_PATH
+        self._deploy_mocker_script()
+        # Map sensor name -> mocker script '<a2d>/<channel>' id.
+        self.name_to_sensor_id = self._list_sensor_ids_by_name()
+
+    def _deploy_mocker_script(self):
+        logger.info("Deploying %s to %s on %s",
+                    LEAKAGE_MOCKER_SRC, self.dut_script_path, self.dut.hostname)
+        self.dut.copy(src=LEAKAGE_MOCKER_SRC, dest=self.dut_script_path, mode='0755')
+
+    def _run_mocker(self, *args):
+        quoted_args = " ".join(shlex.quote(str(arg)) for arg in args)
+        cmd = "python3 {} {}".format(shlex.quote(self.dut_script_path), quoted_args)
+        return self.dut.shell(cmd)
+
+    def _list_sensor_ids_by_name(self):
+        """
+        Parse the mocker 'list' output into a {sensor_name: '<a2d>/<channel>'} map.
+
+        Each line looks like:
+            1/1      name=Mngm_ADC0_Ch1_Flex_0
+        """
+        output = self._run_mocker('list')['stdout_lines']
+        name_to_sensor_id = {}
+        for line in output:
+            parts = line.split()
+            if len(parts) < 2 or not parts[1].startswith('name='):
+                continue
+            sensor_id = parts[0]
+            name = parts[1].split('=', 1)[1]
+            name_to_sensor_id[name] = sensor_id
+        logger.info("Mocker sensor name-to-id map: %s", name_to_sensor_id)
+        return name_to_sensor_id
+
+    def get_sensor_id_by_name(self, name):
+        """Return the mocker '<a2d>/<channel>' id for a sensor name, or raise if unknown."""
+        if name not in self.name_to_sensor_id:
+            raise ValueError(
+                "Sensor name {!r} not found in mocker sensor map {}".format(
+                    name, sorted(self.name_to_sensor_id)))
+        return self.name_to_sensor_id[name]
+
+    def restore_all_sensors(self):
+        """Restore all mocked leak sensors to their original input link."""
+        self._run_mocker('restore', '--all')
+
+    def set_sensor_state(self, index, state):
+        """
+        Set a sensor by index to the requested leak state.
+
+        The sensor index resolves to a sensor name, which is then mapped to the
+        mocker script's ``<a2d>/<channel>`` id.
+
+        :param index: Leak sensor index.
+        :param state: One of 'None', 'MINOR', 'CRITICAL', or 'FAULT'.
+        """
+        self._validate_sensor_state(state)
+        name = self.get_sensor_name(index)
+        sensor_id = self.get_sensor_id_by_name(name)
+        severity = STATE_TO_SEVERITY[state]
+        self._run_mocker('mock', '--sensor', sensor_id, '--severity', severity)
+
+    def deinit(self):
+        """Restore sensors (via super class), then remove the mocker script from the DUT."""
+        super().deinit()
+        logger.info("Removing %s from %s", self.dut_script_path, self.dut.hostname)
+        self.dut.file(path=self.dut_script_path, state='absent')

--- a/tests/common/helpers/platform_api/scripts/nvidia/sonic_bmc_nvidia_leakage_mocker.py
+++ b/tests/common/helpers/platform_api/scripts/nvidia/sonic_bmc_nvidia_leakage_mocker.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Mock NVIDIA AST2700 BMC hw-management leakage input readings.
+
+Unlike ``leakage_threshold_test.py`` (which rewrites the thresholds), this tool
+leaves the thresholds untouched and instead redirects the ``input`` symlink of a
+leakage channel:
+
+    /var/run/hw-management/leakage/<a2d>/<channel>/input
+        -> /sys/bus/i2c/devices/27-0049/iio:device0/in_voltage0_raw   (default)
+
+While mocked, ``input`` points at a plain mock file we own, so we can feed the
+platform code an arbitrary raw reading. The original link target is saved next
+to it (``input.orig``) so it can be restored exactly.
+
+Threshold model (see ``sonic_platform/leakage_sensor.py``):
+
+    scaled = input * scale
+    ordering:  lcrit <= crit <= lwarn <= warn <= min <= max
+    OK        when scaled in [min,   max]
+    CRITICAL  when scaled in [lcrit, crit]
+    MINOR     when scaled in [lwarn, warn]
+    ERROR     when scaled > max
+
+To place the reading in a band we read the thresholds and back-compute the raw
+value (``raw = scaled / scale``).
+
+Usage:
+    leakage_input_mock.py list
+    leakage_input_mock.py status
+    leakage_input_mock.py mock --all        --severity crit
+    leakage_input_mock.py mock --sensor 1/1 --severity warn
+    leakage_input_mock.py mock --sensor 1/1 --severity error
+    leakage_input_mock.py mock --sensor 1/1 --raw 123456   # arbitrary raw value
+    leakage_input_mock.py restore --sensor 1/1
+    leakage_input_mock.py restore --all
+
+The ``NvidiaBMCLeakageMock`` class is importable and meant to be reused from
+tests (point ``leakage_root`` at a fixture tree instead of the real sysfs).
+"""
+
+import argparse
+import os
+import sys
+
+HW_MGMT_ROOT = os.environ.get("HW_MGMT_ROOT", "/var/run/hw-management")
+DEFAULT_LEAKAGE_ROOT = os.path.join(HW_MGMT_ROOT, "leakage")
+
+THRESHOLD_FILES = ("scale", "lcrit", "crit", "lwarn", "warn", "min", "max")
+SEVERITIES = ("crit", "warn", "error", "ok")
+
+
+class LeakageMockError(Exception):
+    """Raised for mocking errors (missing sensor, unknown severity...)."""
+
+
+class LeakageMockSensor:
+    """A single discovered leakage channel."""
+
+    def __init__(self, a2d_index, channel_index, path, name=None):
+        self.a2d_index = a2d_index
+        self.channel_index = channel_index
+        self.path = path
+        self.name = name
+
+    @property
+    def id(self):
+        return "{}/{}".format(self.a2d_index, self.channel_index)
+
+    @property
+    def input_path(self):
+        return os.path.join(self.path, "input")
+
+
+class NvidiaBMCLeakageMock:
+    """
+    Mock/restore hw-management leakage ``input`` readings by swapping the symlink.
+
+    Thresholds are only ever read (to compute a raw value that lands the scaled
+    reading in the requested band); they are never modified. Mocking swaps
+    ``input`` to point at ``input.mock`` (our value file) and saves the original
+    link target in ``input.orig`` so restore is exact.
+    """
+
+    MOCK_SUFFIX = ".mock"
+    ORIG_SUFFIX = ".orig"
+
+    def __init__(self, leakage_root=None):
+        self.leakage_root = leakage_root or DEFAULT_LEAKAGE_ROOT
+
+    # ---- discovery -------------------------------------------------------
+
+    def discover(self):
+        """Return sorted ``LeakageMockSensor`` objects found under the root."""
+        if not os.path.isdir(self.leakage_root):
+            raise LeakageMockError("leakage root not found: " + self.leakage_root)
+        sensors = []
+        for a2d in sorted(os.listdir(self.leakage_root)):
+            a2d_path = os.path.join(self.leakage_root, a2d)
+            if not os.path.isdir(a2d_path):
+                continue
+            for chan in sorted(os.listdir(a2d_path)):
+                chan_path = os.path.join(a2d_path, chan)
+                if os.path.lexists(os.path.join(chan_path, "input")):
+                    name = self._read_text(os.path.join(chan_path, "channel_name"))
+                    sensors.append(LeakageMockSensor(a2d, chan, chan_path, name))
+        return sensors
+
+    def get_sensor(self, sensor_id):
+        """Return the sensor matching ``sensor_id`` ("<a2d>/<channel>") or raise."""
+        wanted = os.path.normpath(sensor_id)
+        sensors = self.discover()
+        for sensor in sensors:
+            if sensor.id == wanted:
+                return sensor
+        available = ", ".join(s.id for s in sensors) or "<none>"
+        raise LeakageMockError(
+            "sensor {!r} not found; available: {}".format(sensor_id, available)
+        )
+
+    def _resolve(self, sensor):
+        return sensor if isinstance(sensor, LeakageMockSensor) else self.get_sensor(sensor)
+
+    # ---- thresholds ------------------------------------------------------
+
+    def read_thresholds(self, sensor):
+        """Return a dict of ``scale`` + threshold floats for ``sensor``."""
+        sensor = self._resolve(sensor)
+        return {n: self._read_float(os.path.join(sensor.path, n)) for n in THRESHOLD_FILES}
+
+    def raw_for_severity(self, thresholds, severity):
+        """Back-compute the raw ``input`` value for ``severity`` (raw = scaled/scale)."""
+        sev = severity.lower()
+        if sev == "crit":
+            scaled = (thresholds["lcrit"] + thresholds["crit"]) / 2.0
+        elif sev == "warn":
+            scaled = (thresholds["lwarn"] + thresholds["warn"]) / 2.0
+        elif sev == "ok":
+            scaled = (thresholds["min"] + thresholds["max"]) / 2.0
+        elif sev == "error":
+            span = thresholds["max"] - thresholds["min"]
+            scaled = thresholds["max"] + (span if span > 0 else 1.0)
+        else:
+            raise LeakageMockError("unknown severity: " + severity)
+        return scaled / thresholds["scale"]
+
+    # ---- mock / restore --------------------------------------------------
+
+    def is_mocked(self, sensor):
+        sensor = self._resolve(sensor)
+        return os.path.exists(sensor.input_path + self.ORIG_SUFFIX)
+
+    def mock_sensor(self, sensor, severity=None, raw=None):
+        """
+        Redirect ``sensor``'s input to a mock file.
+
+        Provide either ``severity`` (crit/warn/error/ok, computed from thresholds)
+        or an explicit ``raw`` value. Returns the raw value written.
+        """
+        sensor = self._resolve(sensor)
+        if (severity is None) == (raw is None):
+            raise LeakageMockError("provide exactly one of severity or raw")
+        if raw is None:
+            raw = self.raw_for_severity(self.read_thresholds(sensor), severity)
+
+        input_path = sensor.input_path
+        mock_path = input_path + self.MOCK_SUFFIX
+        if not self.is_mocked(sensor):
+            os.symlink(os.readlink(input_path), input_path + self.ORIG_SUFFIX)
+        self._write_value(mock_path, raw)
+        self._replace_symlink(input_path, os.path.basename(mock_path))
+        return float(raw)
+
+    def restore_sensor(self, sensor):
+        """Restore ``sensor``'s original input link. Returns True if it acted."""
+        sensor = self._resolve(sensor)
+        input_path = sensor.input_path
+        orig_path = input_path + self.ORIG_SUFFIX
+        if not os.path.exists(orig_path):
+            return False
+        self._replace_symlink(input_path, os.readlink(orig_path))
+        for path in (orig_path, input_path + self.MOCK_SUFFIX):
+            if os.path.lexists(path):
+                os.remove(path)
+        return True
+
+    def mock_all(self, severity=None, raw=None):
+        return {s.id: self.mock_sensor(s, severity=severity, raw=raw) for s in self.discover()}
+
+    def restore_all(self):
+        return {s.id: self.restore_sensor(s) for s in self.discover()}
+
+    # ---- io helpers ------------------------------------------------------
+
+    @staticmethod
+    def _replace_symlink(link_path, target):
+        """Atomically point ``link_path`` at ``target`` (no gap for a reader)."""
+        tmp = link_path + ".tmp"
+        if os.path.lexists(tmp):
+            os.remove(tmp)
+        os.symlink(target, tmp)
+        os.replace(tmp, link_path)
+
+    @staticmethod
+    def _write_value(path, value):
+        """Atomically write ``value`` so a concurrent reader never sees a partial file."""
+        tmp = path + ".tmp"
+        with open(tmp, "w") as f:
+            f.write("{}\n".format(value))
+        os.replace(tmp, path)
+
+    @staticmethod
+    def _read_text(path):
+        try:
+            with open(path, "r") as f:
+                return f.read().strip()
+        except OSError:
+            return None
+
+    @staticmethod
+    def _read_float(path):
+        with open(path, 'r') as f:
+            return float(f.read().strip())
+
+
+# ------------------------------ CLI ---------------------------------------
+
+
+def _cmd_list(mock, _args):
+    for sensor in mock.discover():
+        print("{:<8} name={}".format(sensor.id, sensor.name or "<unknown>"))
+    return 0
+
+
+def _cmd_status(mock, _args):
+    for sensor in mock.discover():
+        thresholds = mock.read_thresholds(sensor)
+        scaled = mock._read_float(sensor.input_path) * thresholds["scale"]
+        state = "MOCKED" if mock.is_mocked(sensor) else "original"
+        print(
+            "{:<8} [{}] scaled={:.6f} -> {}".format(
+                sensor.id, state, scaled, os.readlink(sensor.input_path)
+            )
+        )
+    return 0
+
+
+def _select_sensors(mock, args):
+    return mock.discover() if args.all else [mock.get_sensor(args.sensor)]
+
+
+def _cmd_mock(mock, args):
+    if (args.severity is None) == (args.raw is None):
+        raise LeakageMockError("provide exactly one of --severity or --raw")
+    for sensor in _select_sensors(mock, args):
+        raw = mock.mock_sensor(sensor, severity=args.severity, raw=args.raw)
+        detail = "severity=" + args.severity if args.severity else "raw override"
+        print("mocked {:<8} {} -> raw={} ({})".format(sensor.id, detail, raw, sensor.input_path))
+    return 0
+
+
+def _cmd_restore(mock, args):
+    for sensor in _select_sensors(mock, args):
+        acted = mock.restore_sensor(sensor)
+        print("{} {:<8} ({})".format(
+            "restored" if acted else "skipped ", sensor.id, sensor.input_path
+        ))
+    return 0
+
+
+def _add_target_args(sub):
+    group = sub.add_mutually_exclusive_group(required=True)
+    group.add_argument("--sensor", metavar="<a2d>/<channel>", help="single sensor, e.g. '1/1'")
+    group.add_argument("--all", action="store_true", help="operate on every sensor")
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(
+        description="Mock NVIDIA AST2700 BMC leakage input readings via symlink swap.",
+    )
+    parser.add_argument(
+        "--root",
+        default=DEFAULT_LEAKAGE_ROOT,
+        help="leakage root dir (default: {})".format(DEFAULT_LEAKAGE_ROOT),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("list", help="list discovered leakage sensors")
+    sub.add_parser("status", help="show current reading and mock state per sensor")
+
+    mock_p = sub.add_parser("mock", help="redirect input to a mock reading")
+    _add_target_args(mock_p)
+    mock_p.add_argument("--severity", choices=SEVERITIES, help="band to synthesize from thresholds")
+    mock_p.add_argument("--raw", type=float, help="write this raw input value verbatim")
+
+    restore_p = sub.add_parser("restore", help="restore the original input link")
+    _add_target_args(restore_p)
+    return parser
+
+
+def main(argv=None):
+    args = _build_parser().parse_args(argv)
+    mock = NvidiaBMCLeakageMock(leakage_root=args.root)
+    handlers = {"list": _cmd_list, "status": _cmd_status, "mock": _cmd_mock, "restore": _cmd_restore}
+    try:
+        return handlers[args.command](mock, args)
+    except LeakageMockError as exc:
+        print("ERROR: {}".format(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/common/helpers/sensor_control_test_helper.py
+++ b/tests/common/helpers/sensor_control_test_helper.py
@@ -95,6 +95,8 @@ def mocker_factory(localhost, duthosts, enum_rand_one_per_hwsku_hostname):
         mocker_object = None
 
         if 'mlnx' in platform or 'nvidia' in platform:
+            from tests.common.helpers.nvidia.nvidia_bmc_liquid_leakage_control_test_helper \
+                import LiquidLeakageMockerNvidiaBMC  # noqa: F401
             mocker_type = BaseMocker.get_mocker_type(mocker_name)
             if mocker_type:
                 mocker_object = mocker_type(dut)

--- a/tests/common/platform/bmc_utils.py
+++ b/tests/common/platform/bmc_utils.py
@@ -9,7 +9,7 @@ import pytest
 
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.sonic_db import STATE_DB, redis_hget, redis_hset
+from tests.common.helpers.sonic_db import STATE_DB, redis_hget, redis_hgetall, redis_hset
 from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
@@ -215,6 +215,20 @@ def bmc_log_zgrep(duthost, pattern, tail=20, files='/var/log/syslog*'):
 
 # --- Leak-sensor injection helpers ----------------------------------------
 
+LIQUID_COOLING_INFO_TABLE = 'LIQUID_COOLING_INFO'
+
+
+def get_sensor_data(duthost, sensor_name):
+    """
+    Return LIQUID_COOLING_INFO|<sensor_name> from STATE_DB as a field dict.
+
+    Reads via ``sonic-db-cli STATE_DB HGETALL`` and parses the result into a
+    Python dictionary (e.g. leaking, leak_severity, leak_sensor_status).
+    Returns an empty dict when the key is absent.
+    """
+    return redis_hgetall(duthost, STATE_DB, f'{LIQUID_COOLING_INFO_TABLE}|{sensor_name}')
+
+
 def inject_leak_sensor(duthost, sensor_name, leak_severity, leaking='Yes', leak_sensor_status='Good',
                        sensor_type=None, location=None):
     """HSET LIQUID_COOLING_INFO|<sensor_name> with thermalctld's wire schema."""
@@ -231,7 +245,7 @@ def inject_leak_sensor(duthost, sensor_name, leak_severity, leaking='Yes', leak_
         fields['type'] = sensor_type
     if location is not None:
         fields['location'] = location
-    redis_hset(duthost, STATE_DB, f'LIQUID_COOLING_INFO|{sensor_name}', **fields)
+    redis_hset(duthost, STATE_DB, f'{LIQUID_COOLING_INFO_TABLE}|{sensor_name}', **fields)
 
 
 def get_system_leak_status(duthost):

--- a/tests/platform_tests/daemon/test_thermalctld.py
+++ b/tests/platform_tests/daemon/test_thermalctld.py
@@ -11,7 +11,12 @@ Tests cover:
 
 import logging
 import pytest
+import random
+import re
 import time
+from tests.common.helpers.liquid_leakage_control_test_helper import get_liquid_cooling_update_interval
+from tests.common.helpers.sensor_control_test_helper import mocker_factory  # noqa: F401
+from tests.common.platform.bmc_utils import recover_switch_host_after_power_off
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.sonic_db import (
@@ -43,6 +48,93 @@ pytestmark = [
 SYSTEM_LEAK_STATUS_TABLE = 'SYSTEM_LEAK_STATUS'
 LIQUID_COOLING_INFO_TABLE = 'LIQUID_COOLING_INFO'
 LEAK_PROFILE_TABLE = 'LEAK_PROFILE'
+
+LEAK_SEVERITY_AGGREGATION_PARAMS = [
+    pytest.param(['CRITICAL'], 'CRITICAL', None, id='rule1_one_critical'),
+    pytest.param(['MINOR', 'MINOR'], 'CRITICAL', None, id='rule2_two_minor'),
+    pytest.param(['MINOR', 'CRITICAL'], 'CRITICAL', None, id='rule2_minor_critical'),
+    pytest.param(['CRITICAL', 'CRITICAL'], 'CRITICAL', None, id='rule2_two_critical'),
+    pytest.param(['MINOR'], 'MINOR', True, id='rule3_minor_escalation'),
+    pytest.param(['MINOR'], 'MINOR', False, id='rule4_minor_no_escalation')
+]
+# the time window to observe the escalation from MINOR to CRITICAL
+MIN_ESCALATION_TIMEOUT_SEC = 5  # 5 seconds is the minimum time window to observe the MINOR state
+MAX_ESCALATION_TIMEOUT_SEC = 120  # 120 seconds is the maximum time window to observe the CRITICAL state
+
+
+# https://github.com/sonic-net/sonic-platform-daemons/blob/master/sonic-thermalctld/scripts/thermalctld#L1438
+DEFAULT_LIQUID_COOLING_POLL_INTERVAL_SEC = 0.5
+
+
+def _is_eligible_leak_sensor_duration(max_minor_duration_sec, max_minor_duration_sec_lb, max_minor_duration_sec_ub):
+    """Return True if the sensor won't escalate MINOR during the test window."""
+    # No limits, always match
+    if max_minor_duration_sec_lb is None and max_minor_duration_sec_ub is None:
+        return True
+    # No max_minor_duration_sec only matches if no upper limit is specified
+    if max_minor_duration_sec is None or max_minor_duration_sec == 0:
+        return max_minor_duration_sec_ub is None
+
+    # Lower bound violation
+    if max_minor_duration_sec_lb is not None and max_minor_duration_sec_lb > max_minor_duration_sec:
+        return False
+
+    # Upper bound violation
+    if max_minor_duration_sec_ub is not None and max_minor_duration_sec_ub < max_minor_duration_sec:
+        return False
+
+    return True
+
+
+def _select_leak_sensor_indices(leak_mocker, num_sensors, max_minor_duration_sec_lb, max_minor_duration_sec_ub):
+    """Randomly pick sensor indices that won't escalate during the test window."""
+    candidates = [
+        index for index, name in enumerate(leak_mocker.sensor_names)
+        if _is_eligible_leak_sensor_duration(
+            leak_mocker.sensors[name]['max_minor_duration_sec'], max_minor_duration_sec_lb, max_minor_duration_sec_ub)
+    ]
+
+    if len(candidates) < num_sensors:
+        pytest.skip(
+            "Need {} leak sensor(s) with max_minor_duration_sec in bounds"
+            "[{}, {}], but only {} candidate(s) available".format(
+                num_sensors, max_minor_duration_sec_lb, max_minor_duration_sec_ub, len(candidates)))
+
+    selected_indices = random.sample(candidates, num_sensors)
+    selected_sensors = []
+    for index in selected_indices:
+        name = leak_mocker.get_sensor_name(index)
+        selected_sensors.append({
+            'index': index,
+            'name': name,
+            'max_minor_duration_sec': leak_mocker.sensors[name]['max_minor_duration_sec'],
+        })
+    logger.info("Selected %d leak sensor(s): %s", num_sensors, selected_sensors)
+    return selected_indices
+
+
+def _leak_reported_syslog_regex(sensor_name):
+    """Regex for thermalctld leak syslog: 'Liquid cooling leakage sensor <name> reported leaking'."""
+    return r".*Liquid cooling leakage sensor {} reported leaking.*".format(
+        re.escape(sensor_name))
+
+
+def _leak_recovered_syslog_regex(sensor_name, is_critical):
+    """Regex for thermalctld recovery syslog after clearing a mocked leak."""
+    if is_critical:
+        recovery_message = "recovered from CRITICAL leak"
+    else:
+        recovery_message = "recovered from leaking"
+    return r".*Liquid cooling leakage sensor {} {}.*".format(
+        re.escape(sensor_name), recovery_message)
+
+
+def _wait_for_system_leak_status(leak_mocker, expected_status, timeout_sec, poll_interval_sec):
+    """Wait until SYSTEM_LEAK_STATUS matches the expected aggregated severity."""
+    def status_matches():
+        return leak_mocker.get_device_leak_status() == expected_status
+
+    return wait_until(timeout_sec, poll_interval_sec, 0, status_matches)
 
 
 class TestThermalctldDaemon:
@@ -280,14 +372,91 @@ class TestThermalctldDaemon:
         else:
             logger.info("SYSTEM_LEAK_STATUS not populated - liquid cooling not active on this platform")
 
-    def test_thermalctld_leak_severity_aggregation(self):
-        """Verify is_leak() → LIQUID_COOLING_INFO → SYSTEM_LEAK_STATUS aggregation
+    @pytest.mark.parametrize(
+        'leak_severities,expected_system_leak_status,escalation',
+        LEAK_SEVERITY_AGGREGATION_PARAMS,
+    )
+    def test_thermalctld_leak_severity_aggregation(
+            self, mocker_factory, leak_severities, expected_system_leak_status, escalation):  # noqa: F811
+        """Verify is_leak() → LIQUID_COOLING_INFO → SYSTEM_LEAK_STATUS aggregation."""
+        if get_system_leak_status(self.duthost) == 'CRITICAL':
+            pytest.skip("System leak status is already CRITICAL")
 
-        Deferred: requires a vendor LiquidLeakageMocker (or equivalent generic
-        leak-injection mechanism) to flip is_leak() on real sensor objects.
-        STATE_DB-only injection cannot drive thermalctld's in-memory aggregator.
-        """
-        pytest.skip("Not supported until generic leak injection is available")
+        leak_mocker = mocker_factory(self.duthost, 'LiquidLeakageMockerBMC')
+        if leak_mocker is None:
+            pytest.skip("No LiquidLeakageMockerBMC available on this platform")
+
+        host = self.duthost.get_bmc_host()
+        poll_interval = get_liquid_cooling_update_interval(self.duthost) or DEFAULT_LIQUID_COOLING_POLL_INTERVAL_SEC
+
+        if escalation is None:
+            # aggregation cases, any sensors will work, as long as they do not escalate too quickly
+            sensor_indices = _select_leak_sensor_indices(
+                leak_mocker, len(leak_severities), None, None)
+        elif escalation is True:
+            # MINOR sensor will escalate to CRITICAL
+            sensor_indices = _select_leak_sensor_indices(
+                leak_mocker, len(leak_severities), MIN_ESCALATION_TIMEOUT_SEC, MAX_ESCALATION_TIMEOUT_SEC)
+        else:
+            # MINOR sensor will not escalate to CRITICAL
+            sensor_indices = _select_leak_sensor_indices(
+                leak_mocker, len(leak_severities), MIN_ESCALATION_TIMEOUT_SEC, None)
+
+        selected_sensor_names = [leak_mocker.get_sensor_name(index) for index in sensor_indices]
+        la = make_bmc_loganalyzer(self.duthost, "thermalctld_leak_severity_aggregation")
+        marker = la.init(log_target='syslog')
+
+        try:
+            for sensor_index, leak_severity in zip(sensor_indices, leak_severities):
+                leak_mocker.set_sensor_state(sensor_index, leak_severity)
+                leak, sensor_severity, leak_sensor_status = leak_mocker.get_sensor_status(sensor_index)
+                pytest_assert(
+                    leak and sensor_severity == leak_severity and leak_sensor_status == 'Good',
+                    "Sensor {} expected leak=True, severity {}, leak_sensor_status=Good; "
+                    "got leak={} severity {} leak_sensor_status={}".format(
+                        leak_mocker.get_sensor_name(sensor_index),
+                        leak_severity, leak, sensor_severity, leak_sensor_status))
+
+            time.sleep(2 * poll_interval)
+
+            status_reached = _wait_for_system_leak_status(
+                leak_mocker, expected_system_leak_status, 2 * poll_interval, poll_interval)
+            pytest_assert(
+                status_reached,
+                "Expected SYSTEM_LEAK_STATUS={}, got {}".format(
+                    expected_system_leak_status, leak_mocker.get_device_leak_status()))
+
+            for sensor_index, leak_severity in zip(sensor_indices, leak_severities):
+                leak, sensor_severity, leak_sensor_status = leak_mocker.get_sensor_status(sensor_index)
+                pytest_assert(
+                    leak and sensor_severity == leak_severity and leak_sensor_status == 'Good',
+                    "Sensor {} expected leak=True, severity {}, leak_sensor_status=Good; "
+                    "got leak={} severity {} leak_sensor_status={}".format(
+                        leak_mocker.get_sensor_name(sensor_index),
+                        leak_severity, leak, sensor_severity, leak_sensor_status))
+
+            # if escalation is True, wait for the sensor to escalate to CRITICAL
+            if escalation is True:
+                time.sleep(leak_mocker.sensors[selected_sensor_names[0]]["max_minor_duration_sec"])
+                _wait_for_system_leak_status(leak_mocker, 'CRITICAL', 2 * poll_interval, poll_interval)
+
+            syslog_la = la._get_syslog_analyzer()
+            syslog_la.expect_regex = [
+                _leak_reported_syslog_regex(name) for name in selected_sensor_names]
+            la.analyze(marker, fail=True, log_target='syslog')
+        finally:
+            recovery_marker = la.init(log_target='syslog')
+            for sensor_index in sensor_indices:
+                leak_mocker.set_sensor_state(sensor_index, 'None')
+            leak_mocker.restore_all_sensors()
+            _wait_for_system_leak_status(leak_mocker, 'None', 2 * poll_interval, poll_interval)
+            recover_switch_host_after_power_off(self.duthost, host)
+
+            recovery_syslog_la = la._get_syslog_analyzer()
+            recovery_syslog_la.expect_regex = [
+                _leak_recovered_syslog_regex(name, leak_severity == 'CRITICAL')
+                for name, leak_severity in zip(selected_sensor_names, leak_severities)]
+            la.analyze(recovery_marker, fail=True, log_target='syslog')
 
     def test_thermalctld_chassis_thermal_monitoring(self):
         """


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Summary:
Add BMC-based liquid leakage simulation and enable `thermalctld` leakage severity aggregation, escalation, recovery, and syslog validation on NVIDIA platforms.
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->



### Type of change
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.
If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A


### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A


### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
Tests passed.

### Approach
#### What is the motivation for this PR?
The existing `thermalctld` leakage aggregation test was skipped because STATE_DB injection cannot affect the daemon's in-memory sensor objects. A platform-level mechanism is required to simulate real leakage sensor readings and validate end-to-end behavior.

#### How did you do it?
- Added a generic BMC liquid leakage mocker that discovers sensors and profiles through the platform CLI and reads their state from STATE_DB.
- Added an NVIDIA BMC implementation that maps discovered sensor names to hw-management leakage channels.
- Added a DUT-side NVIDIA leakage mocker that redirects sensor input symlinks to generated values while preserving the original targets for restoration.
- Added support for synthesizing normal, MINOR, CRITICAL, and FAULT readings from each sensor's configured thresholds.
- Registered the NVIDIA leakage mocker with the existing mocker factory.
- Added a helper for reading complete `LIQUID_COOLING_INFO` sensor records from STATE_DB.
- Replaced the skipped aggregation test with parameterized coverage for:
  - One CRITICAL sensor.
  - Two MINOR sensors.
  - Mixed MINOR and CRITICAL sensors.
  - Two CRITICAL sensors.
  - MINOR-to-CRITICAL timeout escalation.
  - A MINOR sensor that does not escalate.
- Added validation of per-sensor state, aggregated system severity, leakage and recovery syslog messages, and cleanup of mocked sensors.
- 
#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
The test performs end-to-end validation by changing the underlying BMC sensor input, waiting for `thermalctld` polling, and checking:
- `LIQUID_COOLING_INFO` per-sensor leakage state and severity.
- `SYSTEM_LEAK_STATUS` aggregation and escalation.
- Leakage detection and recovery syslog messages.
- Restoration of original sensor input links and system leak status during cleanup.
Execution evidence and image version should be added to the Test result section.

#### Any platform specific information?
The concrete mocker implementation targets NVIDIA platforms using the hw-management leakage hierarchy under `/var/run/hw-management/leakage`. Unsupported platforms are skipped when no `LiquidLeakageMockerBMC` implementation is registered.

#### Supported testbed topology if it's a new test case?
A physical NVIDIA testbed with BMC-managed liquid leakage sensors exposed through the SONiC platform leak CLI and hw-management leakage interfaces.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A. No documentation changes are included in this commit.