### PR TITLE
Add cdb background mode stress test _followup eeprom case

### DIFF
--- a/tests/transceiver/common/dmesg_helpers.py
+++ b/tests/transceiver/common/dmesg_helpers.py
@@ -1,0 +1,128 @@
+r"""Shared dmesg (kernel ring-buffer) scanning helpers for transceiver tests.
+
+Several tests need to watch the kernel log for errors emitted *during* an
+operation — e.g. the CDB background-mode stress test watches for I2C errors
+while it hammers the bus, and the CDB firmware-upgrade tests will watch for the
+same class of errors during firmware writes.  The watermark + cumulative-dedup
+scan implemented here is the reusable primitive for that; callers supply their
+own ``grep -iE`` pattern so the module stays error-class agnostic.  Its first
+consumer is the CDB background-mode stress test in this package; the upcoming
+process-restart / CDB firmware-upgrade categories can build on it too.
+
+The scan is anchored on a *seconds-since-boot* watermark (from ``/proc/uptime``)
+rather than a dmesg line number, which keeps it robust against ring-buffer wraps
+and concurrent ``dmesg -c`` invocations (both of which would invalidate a
+line-number cursor).  We use the kernel's own monotonic timestamp (the default
+``dmesg`` ``[<seconds-since-boot>]`` format) as the per-line clock so the window
+can be filtered in plain Python — no ``awk``/``date`` timestamp gymnastics — and
+so the comparison is immune to a test-runner-vs-DUT timezone mismatch or an NTP
+step that wall-clock (``dmesg -T``) timestamps would be subject to.
+
+Why a dedicated scanner instead of the autouse loganalyzer framework?
+  This is a natural "isn't this redundant?" question — it is not, for four
+  reasons.  loganalyzer structurally cannot serve as the I2C-error gate here:
+
+  1. loganalyzer actively *ignores* I2C errors.  Its common-ignore set filters
+     exactly this class of message (e.g. ``loganalyzer_common_ignore.txt``
+     ``".* ERR kernel:.*ltc2497.*i2c transfer failed: -EFAULT"`` and the SCD
+     I2C ack-error warnings), so even an ERR-severity I2C fault that reaches
+     syslog is dropped as known noise.  This scanner is not subject to those
+     ignores.
+  2. Severity gap.  ``loganalyzer_common_match.txt`` is crash/ERR-centric
+     (``\.ERR``, ``kernel:.*panic`` …) with no i2c/nack/timeout pattern and no
+     warning-level catch-all, so bus faults emitted at warn/notice via
+     ``dev_warn`` slip through.  This scanner covers emerg..warn with an
+     I2C-specific regex.
+  3. Source gap.  loganalyzer reads ``/var/log/syslog``; this reads the kernel
+     ring buffer directly, so rate-limited / below-forwarding-threshold lines
+     that never reach rsyslog (dmesg-only) are still caught.
+  4. Granularity/ownership.  loganalyzer is whole-test, post-hoc, binary, and
+     ``--disable_loganalyzer``-able; this runs per iteration for per-port
+     attribution + early abort, making "no I2C errors during the loop" an
+     assertion the test itself owns.
+
+  There is partial overlap only for ERR-severity I2C lines that reach syslog
+  and aren't in the ignore list — not enough to drop this helper.
+"""
+import re
+
+
+# Default dmesg lines start with a kernel-monotonic timestamp in brackets:
+#     [   123.456789] i2c i2c-1: error -110
+# group(1) is seconds-since-boot, compared against the /proc/uptime watermark.
+_DMESG_MONOTONIC_TS_RE = re.compile(r'^\[\s*(\d+(?:\.\d+)?)\]')
+
+# Severity levels worth scanning. Genuine I2C hardware faults (bus errors,
+# timeouts, NACKs) are emitted via dev_err/dev_warn and friends, never at
+# info/notice/debug -- which is the bulk of ring-buffer volume. Bounding dmesg
+# to these levels shrinks the input grep has to scan on each stress iteration
+# (the scan is O(iterations x buffer) otherwise) without weakening the
+# timestamp-window + seen_errors correctness guarantees below.
+_DMESG_ERROR_LEVELS = "emerg,alert,crit,err,warn"
+
+
+def capture_dmesg_uptime_watermark(duthost):
+    """Read seconds-since-boot from ``/proc/uptime`` and return it as a float.
+
+    This is the lower bound a subsequent :func:`scan_new_dmesg_errors` call
+    filters on.  Returns 0.0 on any parse failure — 0.0 means "include
+    everything in dmesg", which is safer than silently truncating the scan
+    window.  ``/proc/uptime`` is the same monotonic clock dmesg stamps its lines
+    with, so the watermark and the per-line timestamps are directly comparable
+    regardless of the DUT's wall-clock timezone.
+    """
+    res = duthost.shell("cat /proc/uptime", module_ignore_errors=True)
+    try:
+        return float(res.get('stdout_lines', ['0'])[0].split()[0])
+    except (ValueError, IndexError):
+        return 0.0
+
+
+def scan_new_dmesg_errors(duthost, start_uptime, seen_errors, grep_pattern):
+    """Scan dmesg for lines matching ``grep_pattern`` stamped at-or-after
+    ``start_uptime`` (seconds since boot), return only the lines not already in
+    ``seen_errors``, and mutate ``seen_errors`` to include them.
+
+    Only ``dmesg`` + ``grep`` run on the DUT; the timestamp-window filtering is
+    done here in Python (matching the leading ``[<seconds-since-boot>]``) rather
+    than in an ``awk`` + ``date`` pipeline — both more readable and timezone-safe.
+
+    ``grep_pattern`` is a ``grep -iE`` (extended, case-insensitive) regex
+    embedded into a single-quoted shell argument, so it must not itself contain
+    a single quote.  Callers pass the error class they care about, e.g.
+    ``i2c.*(error|fail|timeout|nack)|(error|fail).*i2c``.  ``|| true`` keeps the
+    command at rc 0 so grep's exit-1-on-no-match is not mistaken for a failure
+    under ``module_ignore_errors=True``.
+
+    The de-dup matters: each scan is cumulative since the watermark, not
+    iteration-delta.  Without the ``seen_errors`` filter the same error would be
+    counted on every scan and a threshold would trip almost immediately on a
+    single transient error.  The set also makes the count robust against a dmesg
+    ring-buffer wrap mid-test: even if old errors fall out of dmesg, the set
+    retains them so the cumulative count never shrinks.
+
+    A matching line whose leading ``[<seconds>]`` timestamp can't be parsed is
+    conservatively kept (not dropped), so an unrecognized format never silently
+    hides an error.
+
+    ``dmesg --level`` bounds the scan to error/warning-class lines
+    (:data:`_DMESG_ERROR_LEVELS`) so each iteration only greps the relevant
+    slice of the ring buffer rather than the full info/debug-dominated buffer.
+    """
+    result = duthost.shell(
+        "sudo dmesg --level=" + _DMESG_ERROR_LEVELS
+        + " | grep -iE '" + grep_pattern + "' || true",
+        module_ignore_errors=True,
+    )
+    truly_new = []
+    for line in result.get('stdout_lines', []):
+        line = line.strip()
+        if not line:
+            continue
+        m = _DMESG_MONOTONIC_TS_RE.match(line)
+        if m is not None and float(m.group(1)) < start_uptime:
+            continue   # emitted before the watermark
+        if line not in seen_errors:
+            seen_errors.add(line)
+            truly_new.append(line)
+    return truly_new

--- a/tests/transceiver/common/test_dmesg_helpers.py
+++ b/tests/transceiver/common/test_dmesg_helpers.py
@@ -1,0 +1,91 @@
+"""Unit tests for ``tests/transceiver/common/dmesg_helpers.py``.
+
+Pure logic tests: they drive the scanner against a fake duthost whose ``shell``
+returns canned dmesg output, so no DUT / network is required.  They cover the
+three behaviors that make the scanner correct as the reusable kernel-log-scan
+primitive: the seconds-since-boot watermark filtering, the ``seen_errors``
+cumulative de-dup, and the "unparseable timestamp is kept" fail-open rule.
+"""
+from tests.transceiver.common import dmesg_helpers
+
+# Same error class the transceiver stress/firmware tests scan for.
+I2C_PATTERN = r"i2c.*(error|fail|timeout|nack)|(error|fail).*i2c"
+
+
+class _FakeDut(object):
+    """Minimal duthost stand-in whose ``shell`` returns a fixed stdout_lines."""
+
+    def __init__(self, stdout_lines):
+        self._stdout_lines = list(stdout_lines)
+        self.last_cmd = None
+
+    def shell(self, cmd, module_ignore_errors=False):
+        self.last_cmd = cmd
+        return {"stdout_lines": list(self._stdout_lines)}
+
+
+def test_scan_drops_lines_before_watermark():
+    dut = _FakeDut([
+        "[  100.000000] i2c i2c-1: error -110",
+        "[  200.000000] i2c i2c-2: error -110",
+    ])
+    new = dmesg_helpers.scan_new_dmesg_errors(dut, 150.0, set(), I2C_PATTERN)
+    assert new == ["[  200.000000] i2c i2c-2: error -110"]
+
+
+def test_scan_keeps_lines_at_or_after_watermark():
+    dut = _FakeDut([
+        "[  150.000000] i2c i2c-1: error -110",
+        "[  151.500000] i2c i2c-2: timeout",
+    ])
+    new = dmesg_helpers.scan_new_dmesg_errors(dut, 150.0, set(), I2C_PATTERN)
+    assert len(new) == 2
+
+
+def test_scan_dedups_via_seen_errors():
+    line = "[  200.000000] i2c i2c-1: error -110"
+    dut = _FakeDut([line])
+    seen = set()
+
+    first = dmesg_helpers.scan_new_dmesg_errors(dut, 0.0, seen, I2C_PATTERN)
+    assert first == [line]
+    assert line in seen
+
+    # A second scan of the identical dmesg output yields nothing new, because
+    # the cumulative de-dup remembers the already-reported line.
+    second = dmesg_helpers.scan_new_dmesg_errors(dut, 0.0, seen, I2C_PATTERN)
+    assert second == []
+
+
+def test_scan_keeps_line_with_unparseable_timestamp():
+    # No leading [<seconds>] stamp -> cannot be placed relative to the watermark,
+    # so it is conservatively kept (fail open) even with a watermark far ahead.
+    line = "i2c i2c-1: error -110 (no leading timestamp)"
+    new = dmesg_helpers.scan_new_dmesg_errors(_FakeDut([line]), 99999.0, set(), I2C_PATTERN)
+    assert new == [line]
+
+
+def test_scan_skips_blank_lines():
+    dut = _FakeDut(["", "   ", "[  200.000000] i2c i2c-1: error -110"])
+    new = dmesg_helpers.scan_new_dmesg_errors(dut, 0.0, set(), I2C_PATTERN)
+    assert new == ["[  200.000000] i2c i2c-1: error -110"]
+
+
+def test_scan_command_bounds_severity_and_uses_pattern():
+    dut = _FakeDut([])
+    dmesg_helpers.scan_new_dmesg_errors(dut, 0.0, set(), I2C_PATTERN)
+    assert "--level=" in dut.last_cmd
+    assert I2C_PATTERN in dut.last_cmd
+
+
+def test_capture_watermark_parses_first_field():
+    # /proc/uptime is "<uptime> <idle>"; only the first field is the watermark.
+    assert dmesg_helpers.capture_dmesg_uptime_watermark(_FakeDut(["12345.67 89.01"])) == 12345.67
+
+
+def test_capture_watermark_falls_back_to_zero_on_empty_output():
+    assert dmesg_helpers.capture_dmesg_uptime_watermark(_FakeDut([])) == 0.0
+
+
+def test_capture_watermark_falls_back_to_zero_on_garbage():
+    assert dmesg_helpers.capture_dmesg_uptime_watermark(_FakeDut(["not-a-number"])) == 0.0

--- a/tests/transceiver/eeprom/cmis/_constants.py
+++ b/tests/transceiver/eeprom/cmis/_constants.py
@@ -1,0 +1,19 @@
+"""Shared constants for the CMIS test package.
+
+Kept in a standalone module (rather than in a test module) so that
+``conftest.py`` and ``test_cdb_background_mode.py`` can both import them
+without ``conftest`` importing from a test module -- an anti-pattern that
+couples conftest import to test-module collection.
+"""
+
+# Stem for the /tmp counter/PGID file names written on the DUT by the CDB
+# background-mode stress test's ``_RemoteBgReader``.  The test appends
+# per-run suffixes; the session-scoped cleanup fixture in this package's
+# conftest.py globs ``<prefix>_*`` to sweep anything a SIGKILL'd run leaks.
+BG_READER_TMP_PREFIX = "/tmp/test_cmis_bg"
+
+# Inter-read delay (seconds) for the background EEPROM reader loop. Default 0
+# runs the loop at maximum rate, which is the intended I2C bus contention for
+# the CDB background-mode stress test; raise it (fractional allowed) on a
+# platform that needs the background load throttled.
+BG_READER_READ_INTERVAL_SEC = 0

--- a/tests/transceiver/eeprom/cmis/conftest.py
+++ b/tests/transceiver/eeprom/cmis/conftest.py
@@ -1,0 +1,39 @@
+"""CMIS test-category conftest.
+
+Houses fixtures that only apply to the CMIS-specific tests under
+``tests/transceiver/eeprom/cmis/``.
+
+Currently provides a single defensive cleanup fixture for the CDB
+background-mode stress test.  That test launches a long-lived bash loop on
+the DUT (under ``setsid``) that writes counter and PGID files to ``/tmp``;
+when pytest exits normally those files are removed by
+``_RemoteBgReader.join()``, but when pytest is SIGKILL'd (CI timeout,
+operator ^C^C, OOM) the loop's EXIT trap may not run and the temp files
+leak.  This fixture sweeps any leftovers before the session starts and
+again on teardown so a subsequent run cannot pick up stale counters.
+"""
+import logging
+
+import pytest
+
+# Pull the shared prefix from the package constants module (not a test module)
+# so the cleanup pattern tracks any future rename of the temp-file stem without
+# conftest importing from a test module.
+from tests.transceiver.eeprom.cmis._constants import BG_READER_TMP_PREFIX
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _cleanup_stale_cdb_bg_tmpfiles(duthost):
+    """Remove any ``/tmp/test_cmis_bg_*`` files on the DUT before and after the
+    session, so a previously-aborted pytest run can't contaminate this one.
+
+    Idempotent and cheap (``rm -f`` of a glob with no matches is a no-op).
+    """
+    cleanup_cmd = f"rm -f {BG_READER_TMP_PREFIX}_*"
+    logger.debug("Pre-session cleanup of stale CDB bg-reader temp files: %s", cleanup_cmd)
+    duthost.shell(cleanup_cmd, module_ignore_errors=True)
+    yield
+    logger.debug("Post-session cleanup of CDB bg-reader temp files: %s", cleanup_cmd)
+    duthost.shell(cleanup_cmd, module_ignore_errors=True)

--- a/tests/transceiver/eeprom/cmis/scripts/bg_eeprom_reader.sh
+++ b/tests/transceiver/eeprom/cmis/scripts/bg_eeprom_reader.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Background EEPROM reader for the CMIS CDB background mode stress test.
+#
+# Launched under `setsid` by _RemoteBgReader.start() in
+# tests/transceiver/eeprom/cmis/test_cdb_background_mode.py, so this shell is
+# its own session / process-group leader (PGID == this shell's PID). The shell
+# writes its own PID to the pgid file immediately; the Python side reads that to
+# learn the PGID and later signals the whole group (`kill -- -<pgid>`) so any
+# in-flight read-eeprom child dies with the loop instead of orphaning on the
+# I2C bus.
+#
+# Usage:
+#   setsid bash bg_eeprom_reader.sh <port> <fail_file> <total_file> \
+#                                   <pgid_file> <read_eeprom_cmd> [read_interval]
+#
+# Loops running "<read_eeprom_cmd> -p <port> -n 0 -o 0 -s 1", counting total
+# attempts and failures, and flushes the running counts to <total_file> /
+# <fail_file> on TERM/INT/EXIT. <read_eeprom_cmd> is passed in (not hardcoded)
+# so the command spelling stays single-sourced from
+# cli_helpers.SFPUTIL_READ_EEPROM on the Python side.
+#
+# [read_interval] (optional, default 0) is the delay in seconds between reads
+# (fractional allowed). 0 runs the loop at maximum rate -- the intended I2C bus
+# contention for the stress test; a non-zero value throttles the load rate.
+set -u
+
+port="$1"
+fail_file="$2"
+total_file="$3"
+pgid_file="$4"
+read_eeprom_cmd="$5"
+# Optional inter-read delay in seconds (fractional ok). Default 0 = max rate.
+read_interval="${6:-0}"
+
+# Record this shell's PID so the launcher can capture the PGID. setsid forks
+# before exec, so the launcher's own $! would point at the setsid wrapper, not
+# this shell -- hence we publish $$ here rather than relying on $!.
+echo "$$" > "$pgid_file"
+
+fail_count=0
+total_count=0
+
+write_counts() {
+    echo "$fail_count" > "$fail_file"
+    echo "$total_count" > "$total_file"
+}
+
+# Flush the final counts on any orderly stop (SIGTERM from join(), SIGINT, or
+# normal EXIT) so the Python side can read accurate totals.  Note bash defers a
+# trap until the in-flight foreground command (sfputil) returns, and a SIGKILL
+# bypasses the trap entirely -- so the per-iteration write_counts below, not
+# this trap, is what makes the totals durable across an abrupt kill.
+trap 'write_counts; exit 0' TERM INT EXIT
+
+# Publish an initial 0/0 so the counter files always exist for join() to read,
+# even if the reader is killed before the first iteration completes.
+write_counts
+
+while true; do
+    # read_eeprom_cmd is intentionally left unquoted so a multi-word command
+    # ("sfputil read-eeprom") word-splits into separate argv entries.
+    if ! $read_eeprom_cmd -p "$port" -n 0 -o 0 -s 1 >/dev/null 2>&1; then
+        fail_count=$((fail_count + 1))
+    fi
+    # Increment total_count only after the read returns so the counters move
+    # together. If the process group is SIGKILL'd mid-read, that in-flight
+    # attempt is counted in neither total nor fail, keeping the fail-rate exact
+    # rather than counting an attempt that could never be marked as a failure.
+    total_count=$((total_count + 1))
+    # Flush counts every iteration so a SIGKILL (which bypasses the trap) or a
+    # trap deferred behind a stuck sfputil loses at most the in-flight update,
+    # not the whole running total.  Each iteration already forks sfputil (tens
+    # of ms), so two tiny tmpfs writes are negligible.
+    write_counts
+    # Optional rate control. Skip the sleep fork entirely at the default rate 0
+    # so the max-rate stress keeps its current behavior.
+    if [ "$read_interval" != "0" ]; then
+        sleep "$read_interval"
+    fi
+done

--- a/tests/transceiver/eeprom/cmis/test_cdb_background_mode.py
+++ b/tests/transceiver/eeprom/cmis/test_cdb_background_mode.py
@@ -1,10 +1,19 @@
 import logging
+import os
+import re
+import shlex
+import uuid
 
 import pytest
 
 from tests.common.platform.interface_utils import is_first_subport
 from tests.transceiver.attribute_parser.attribute_keys import EEPROM_ATTRIBUTES_KEY
-from tests.transceiver.common import cli_helpers
+from tests.transceiver.common import cli_helpers, dmesg_helpers
+from tests.transceiver.eeprom.cmis._constants import (
+    BG_READER_READ_INTERVAL_SEC,
+    BG_READER_TMP_PREFIX,
+)
+from tests.transceiver.common.cli_parser_helper import RC_FAILURE
 from tests.transceiver.common.cmis_helper import (
     CMIS_PAGE_01_CDB_CAP_PAGE,
     CMIS_PAGE_01_CDB_CAP_OFFSET,
@@ -12,6 +21,243 @@ from tests.transceiver.common.cmis_helper import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Maximum tolerated background EEPROM read failure rate during the CDB stress
+# test.  The HLD's expected result is that the reads "complete successfully", so
+# this is zero-tolerance: any background-read failure fails the port.  The
+# observed rate is always logged in the pass line so an operator can confirm 0%.
+STRESS_EEPROM_MAX_FAIL_RATE = 0
+
+# Number of I2C kernel-log errors tolerated before failing a stress-test
+# iteration loop.  The HLD's expected result is "without I2C errors in kernel
+# logs", so this is zero — the loop fails on the first I2C error.  The observed
+# count is always reported in the result line.
+#
+# Note: there is intentionally NO loganalyzer ignore_regex suppression for the
+# I2C / "Failed to read EEPROM" strings.  The HLD says those must not appear, so
+# framework-level loganalyzer is left free to catch them too; suppressing them
+# would mask exactly the failures this test exists to detect (and would weaken
+# the sibling capability test via autouse over-reach).
+STRESS_TEST_I2C_ERROR_THRESHOLD = 0
+
+# dmesg ``grep -iE`` pattern for kernel I2C errors, passed to
+# dmesg_helpers.scan_new_dmesg_errors().  Embedded in a single-quoted grep
+# argument there, so it must not contain a single quote.
+I2C_ERROR_PATTERN = r"i2c.*(error|fail|timeout|nack)|(error|fail).*i2c"
+
+# Absolute path to the background-reader bash script shipped to the DUT by
+# _RemoteBgReader.start().  Resolved from this module's location so it works
+# regardless of the pytest invocation directory.
+_BG_READER_SCRIPT = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "scripts", "bg_eeprom_reader.sh"
+)
+
+
+class _RemoteBgReader(object):
+    """Manage a background EEPROM polling loop running on the DUT.
+
+    The bash loop is launched under ``setsid`` so it (and any in-flight
+    ``sfputil`` child) form a dedicated process group; join() signals the
+    whole group via ``kill -- -<pgid>`` instead of just SIGTERM-ing bash and
+    leaving an orphan ``sfputil read-eeprom`` in flight on the I2C bus.
+
+    Temp-file names include a short UUID fragment so concurrent test runs
+    (e.g. parallel tox invocations) cannot collide on the same DUT files.
+    All temp files share the ``BG_READER_TMP_PREFIX`` so the session-scoped
+    cleanup fixture in conftest.py can ``rm -f`` everything left behind
+    after a SIGKILL'd pytest run.
+    """
+
+    def __init__(self, host, sfp_port):
+        safe_port = re.sub(r"[^A-Za-z0-9_.-]", "_", str(sfp_port))
+        run_id = uuid.uuid4().hex[:8]
+        self.host = host
+        self.port = sfp_port
+        # Process-group ID of the bash loop.  Equal to bash's own PID because
+        # ``setsid`` makes bash the leader of a freshly-minted session/group.
+        self.pgid = None
+        # Final counters; populated by join() from the bash loop's EXIT trap.
+        self.fail_count = 0
+        self.total_count = 0
+        # /tmp paths used by the bash loop and torn down at join() time.
+        stem = f"{BG_READER_TMP_PREFIX}_{safe_port}_{run_id}"
+        self.fail_file = f"{stem}_fail"
+        self.total_file = f"{stem}_total"
+        self.pgid_file = f"{stem}_pgid"
+        # Per-run copy of the reader script on the DUT.  Shares the prefix so
+        # the conftest cleanup fixture sweeps it after a SIGKILL'd run.
+        self.script_file = f"{stem}_reader.sh"
+
+    def start(self):
+        """Ship the reader script to the DUT, launch it, and capture its PGID."""
+        # 1. Copy the reader script to the DUT (auditable on disk rather than
+        #    embedded as escaped inline bash).
+        copy_result = self.host.copy(
+            src=_BG_READER_SCRIPT, dest=self.script_file, mode="0644",
+            module_ignore_errors=True,
+        )
+        if copy_result.get("failed"):
+            logger.error(
+                "Port %s: failed to copy bg reader script to DUT: %s",
+                self.port, copy_result.get("msg"),
+            )
+            self.pgid = None
+            return
+
+        # 2. Launch under ``setsid`` so the script becomes a new session leader
+        #    (PGID == its own PID), detached from the test runner's job-control
+        #    group so 'kill -- -<pgid>' in join() is safe.  The script writes
+        #    its own PID ($$) to pgid_file — the launcher's ``$!`` would point
+        #    at the setsid wrapper, not the script, since setsid forks before
+        #    exec.  The read-eeprom command is passed in so its spelling stays
+        #    single-sourced from cli_helpers.
+        # 3. Poll pgid_file for up to ~2 s and echo its contents; that value
+        #    (the script's PID) is the PGID used for signal delivery in join().
+        # Built via str.format (not an f-string) so the embedded shell syntax
+        # (``[ ]`` test brackets, ``;`` separators) lives in plain string
+        # literals rather than tokenized f-string text.
+        cmd = (
+            "setsid bash '{script}' "
+            "'{port}' '{fail}' '{total}' "
+            "'{pgid}' '{read_cmd}' "
+            "'{interval}' "
+            "</dev/null >/dev/null 2>&1 & "
+            "for _ in $(seq 1 20); do "
+            "if [ -s \"{pgid}\" ]; then "
+            "cat \"{pgid}\"; exit 0; "
+            "fi; "
+            "sleep 0.1; "
+            "done; "
+            "echo \"\"; exit 1"
+        ).format(
+            script=self.script_file,
+            port=self.port,
+            fail=self.fail_file,
+            total=self.total_file,
+            pgid=self.pgid_file,
+            read_cmd=cli_helpers.SFPUTIL_READ_EEPROM,
+            interval=BG_READER_READ_INTERVAL_SEC,
+        )
+        result = self.host.shell(cmd, module_ignore_errors=True)
+        pgid_str = (result.get('stdout') or '').strip()
+        if result.get('rc', RC_FAILURE) == 0 and pgid_str:
+            try:
+                self.pgid = int(pgid_str)
+                if self.pgid <= 0:
+                    raise ValueError(f"non-positive PGID: {pgid_str!r}")
+                return                                   # PGID captured — success
+            except (TypeError, ValueError) as exc:
+                logger.error(
+                    "Port %s: failed to parse background reader PGID: %s",
+                    self.port, exc,
+                )
+        # Capture failed (non-zero rc, empty pgid file, or unparseable PID), but
+        # the detached reader launched above may already be looping on the I2C
+        # bus.  Without a PGID, join() can't signal it, and the conftest cleanup
+        # only rm's the temp files — it never stops the process.  Kill it by its
+        # unique per-run script path so it can't outlive start().
+        self.pgid = None
+        self._pkill_by_script_path()
+
+    def _pkill_by_script_path(self):
+        """Best-effort kill of this reader by its unique per-run script path.
+
+        ``script_file`` is UUID-stamped, so ``pkill -f`` matches only THIS
+        reader (safe under xdist / parallel-port runs).  Needed because the
+        conftest cleanup ``rm -f``'s the temp files but never stops the process,
+        and a reader whose PGID we failed to capture is otherwise unkillable for
+        the rest of the session — it would keep polling the I2C bus.  ``pkill``
+        excludes its own PID, so matching its own command line is not a concern.
+        """
+        quoted = shlex.quote(self.script_file)
+        self.host.shell(
+            (
+                "pkill -TERM -f {q} 2>/dev/null; sleep 0.5; "
+                "pkill -KILL -f {q} 2>/dev/null || true"
+            ).format(q=quoted),
+            module_ignore_errors=True,
+        )
+
+    def join(self, timeout=10):
+        """Stop the background process group and retrieve the final counters.
+
+        Sends SIGTERM to the whole process group (``-<pgid>``), polls every
+        100 ms for up to ``timeout`` seconds, then escalates to SIGKILL on
+        the group as a fallback.  Both signals target ``-<pgid>`` so any
+        in-flight ``sfputil`` child dies with bash — no orphans.
+
+        Liveness is probed at the GROUP level (``pgrep -g <pgid>``), not the
+        leader PID: a slow ``sfputil`` child can outlive the bash leader, so a
+        leader-PID probe would prematurely declare the group gone and skip the
+        SIGKILL escalation.
+
+        Args:
+            timeout: maximum seconds to wait for the remote process group to
+                     exit after receiving SIGTERM (default 10 s).
+        """
+        # 0.1s poll interval below → 10 polls per second.
+        wait_iterations = max(1, int(timeout) * 10)
+        if self.pgid is not None:
+            # kill -- -<PGID> targets the whole process group.
+            self.host.shell(f"kill -- -{self.pgid}", module_ignore_errors=True)
+            # SIGTERM wait loop — break as soon as the whole group is empty.
+            # Probe the GROUP (pgrep -g), not the leader PID: the bash leader can
+            # exit its EXIT trap while a slow sfputil child is still mid-I2C, and
+            # a leader-PID probe (kill -0 <pid>) would then wrongly report "gone"
+            # and skip the SIGKILL escalation below — orphaning that child (and
+            # risking a kill on a reused PID once the leader's PID is freed).
+            self.host.shell(
+                (
+                    "for _ in $(seq 1 {n}); do "
+                    "pgrep -g {pgid} >/dev/null 2>&1 || break; "
+                    "sleep 0.1; "
+                    "done"
+                ).format(n=wait_iterations, pgid=self.pgid),
+                module_ignore_errors=True,
+            )
+            # SIGKILL fallback — gate on whether the GROUP still has any member
+            # (pgrep -g), so a lingering sfputil child that outlived the bash
+            # leader still triggers the kill -9 on the group.  Emit a sentinel so
+            # the warning below knows whether the escalation actually fired.
+            kill_check = self.host.shell(
+                (
+                    "if pgrep -g {pgid} >/dev/null 2>&1; then "
+                    "  kill -9 -- -{pgid} 2>/dev/null; echo killed; "
+                    "else "
+                    "  echo exited; "
+                    "fi"
+                ).format(pgid=self.pgid),
+                module_ignore_errors=True,
+            )
+            if "killed" in (kill_check.get("stdout") or ""):
+                logger.warning(
+                    "Port %s: background EEPROM reader PGID %d ignored "
+                    "SIGTERM for %.1fs; escalated to SIGKILL",
+                    self.port, self.pgid, timeout,
+                )
+        fail_result = self.host.shell(
+            f"cat {self.fail_file} 2>/dev/null || echo 0",
+            module_ignore_errors=True,
+        )
+        total_result = self.host.shell(
+            f"cat {self.total_file} 2>/dev/null || echo 0",
+            module_ignore_errors=True,
+        )
+        # Best-effort cleanup of this reader's /tmp files.  The session-scoped
+        # cleanup fixture in conftest.py picks up anything we miss (e.g. when
+        # pytest is SIGKILL'd before we reach join()).
+        self.host.shell(
+            f"rm -f {self.fail_file} {self.total_file} {self.pgid_file} {self.script_file}",
+            module_ignore_errors=True,
+        )
+        try:
+            self.fail_count = int((fail_result.get('stdout') or '0').strip())
+        except (TypeError, ValueError):
+            self.fail_count = 0
+        try:
+            self.total_count = int((total_result.get('stdout') or '0').strip())
+        except (TypeError, ValueError):
+            self.total_count = 0
 
 
 def test_cdb_background_mode_support_test(
@@ -122,3 +368,234 @@ def test_cdb_background_mode_support_test(
 
     if all_failures:
         pytest.fail("CDB background mode verification failures:\n" + "\n".join(all_failures))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Private helpers for the CDB background-mode stress test .
+# The orchestrator (test_cdb_background_mode_stress_test) below is a
+# thin loop that delegates each phase to one of these helpers.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _stress_port_in_scope(port, port_attrs, lport_to_first_subport):
+    """Return True iff ``port`` qualifies for the CDB stress test.
+
+    Encapsulates the four skip gates (first sub-port, non-empty attrs,
+    cmis_active_optical, cdb_background_mode_supported); logs the reason at
+    DEBUG level for every port that is filtered out, so a single grep of
+    the run log explains why any port was skipped.
+    """
+    if not is_first_subport(port, lport_to_first_subport):
+        logger.debug("Port %s is not the first breakout sub-port, skipping stress test", port)
+        return False
+    if not port_attrs:
+        logger.debug("Port %s has no attributes, skipping", port)
+        return False
+    eeprom_attrs = port_attrs.get(EEPROM_ATTRIBUTES_KEY, {})
+    if not eeprom_attrs.get("cmis_active_optical"):
+        logger.debug("Port %s: cmis_active_optical is not True, skipping", port)
+        return False
+    if not eeprom_attrs.get("cdb_background_mode_supported"):
+        logger.debug(
+            "Port %s: cdb_background_mode_supported is not True, skipping", port
+        )
+        return False
+    return True
+
+
+def _run_cdb_fwversion_stress_loop(duthost, port, iterations, start_uptime):
+    """Run the per-iteration ``sfputil show fwversion`` loop with I2C error
+    monitoring.
+
+    Returns ``(iteration_failures, cumulative_i2c_errors)``.  The loop
+    aborts early once ``cumulative_i2c_errors`` exceeds
+    ``STRESS_TEST_I2C_ERROR_THRESHOLD``; that abort itself appears as a
+    failure entry in ``iteration_failures`` so the caller's aggregated
+    report explains why the loop short-circuited.
+    """
+    iteration_failures = []
+    cumulative_i2c_errors = []
+    seen_i2c_errors = set()
+
+    for iteration in range(1, iterations + 1):
+        logger.debug("Port %s: CDB stress iteration %d/%d", port, iteration, iterations)
+
+        _, err = cli_helpers.sfputil_show_fwversion(duthost, port)
+        if err:
+            iteration_failures.append(f"Iteration {iteration}/{iterations}: {err}")
+
+        truly_new = dmesg_helpers.scan_new_dmesg_errors(
+            duthost, start_uptime, seen_i2c_errors, I2C_ERROR_PATTERN
+        )
+        if not truly_new:
+            continue
+
+        cumulative_i2c_errors.extend(truly_new)
+        logger.warning(
+            "Port %s: %d new I2C error(s) after iteration %d "
+            "(%d cumulative, threshold=%d)",
+            port, len(truly_new), iteration,
+            len(cumulative_i2c_errors), STRESS_TEST_I2C_ERROR_THRESHOLD,
+        )
+        if len(cumulative_i2c_errors) > STRESS_TEST_I2C_ERROR_THRESHOLD:
+            iteration_failures.append(
+                f"I2C kernel errors exceeded threshold "
+                f"({len(cumulative_i2c_errors)} > {STRESS_TEST_I2C_ERROR_THRESHOLD}) "
+                f"after iteration {iteration}/{iterations}" ":\n    "
+                + "\n    ".join(cumulative_i2c_errors[:10])
+            )
+            logger.warning(
+                "Port %s: I2C error threshold exceeded — aborting stress loop", port,
+            )
+            break
+
+    return iteration_failures, cumulative_i2c_errors
+
+
+def _evaluate_bg_reader_results(port, bg_reader):
+    """Compute the background-EEPROM-reader stats and emit per-port logging.
+
+    Returns ``(failures, total, failed, fail_rate)``.  ``failures`` is a
+    list with a single string entry iff ``fail_rate`` exceeded
+    ``STRESS_EEPROM_MAX_FAIL_RATE``; otherwise empty.  ``total`` /
+    ``failed`` / ``fail_rate`` are returned so the orchestrator can
+    include them in the per-port pass line.
+    """
+    total = bg_reader.total_count
+    failed = bg_reader.fail_count
+    fail_rate = (failed / total) if total > 0 else 0.0
+
+    failures = []
+    if total > 0:
+        logger.info(
+            "Port %s: background EEPROM reads — %d total, %d failed (%.2f%%)",
+            port, total, failed, fail_rate * 100,
+        )
+        if fail_rate > STRESS_EEPROM_MAX_FAIL_RATE:
+            failures.append(
+                f"Background EEPROM read failure rate too high: "
+                f"{failed}/{total} ({format(fail_rate * 100, '.2f')}%) reads failed "
+                f"(threshold: {format(STRESS_EEPROM_MAX_FAIL_RATE * 100, '.2f')}%)"
+            )
+    else:
+        logger.warning("Port %s: background EEPROM reader made no attempts", port)
+
+    return failures, total, failed, fail_rate
+
+
+def _run_cdb_stress_for_port(duthost, port, port_attrs):
+    """Drive the full per-port stress sequence: epoch capture → start
+    background reader → stress loop → stop background reader → evaluate
+    results.
+
+    Returns a list of per-port failure strings (empty on success).  The
+    bg-reader join always runs (via ``finally``) so a mid-loop exception
+    cannot leave a stray bash process group on the DUT.
+    """
+    eeprom_attrs = port_attrs.get(EEPROM_ATTRIBUTES_KEY, {})
+    # Per-port iteration count comes from the EEPROM inventory attribute; its
+    # default (10) lives in eeprom.json's ``defaults`` block, not in this test
+    # (see the "CDB background mode stress test" case in eeprom_test_plan.md). A
+    # port that reaches the stress test without it is an inventory
+    # misconfiguration, so fail rather than silently substituting a count.
+    iterations = eeprom_attrs.get("cdb_stress_iteration_count")
+    if iterations is None:
+        return [
+            "EEPROM_ATTRIBUTES.cdb_stress_iteration_count is not defined in the "
+            "inventory for this port; it is required for the CDB background-mode "
+            "stress test (set it in eeprom.json defaults or per-PN)"
+        ]
+    logger.info(
+        "Port %s: starting CDB background mode stress test (%d iterations)",
+        port, iterations,
+    )
+
+    # Step 1 – dmesg uptime (seconds-since-boot) watermark
+    start_uptime = dmesg_helpers.capture_dmesg_uptime_watermark(duthost)
+
+    # Step 2 – background EEPROM reader (concurrent I2C load)
+    bg_reader = _RemoteBgReader(duthost, port)
+    bg_reader.start()
+    if bg_reader.pgid is None:
+        # If start() never captured a PGID, the stress loop would run with
+        # zero background load — defeating the test's purpose.  Treat as a
+        # per-port failure and move on.
+        return [
+            "failed to start background EEPROM reader "
+            "(no PGID captured); stress traffic would be absent — skipping port"
+        ]
+
+    port_failures = []
+    cumulative_i2c_errors = []
+    try:
+        # Steps 3 + 4 – CDB fwversion read loop with I2C error monitoring
+        port_failures, cumulative_i2c_errors = _run_cdb_fwversion_stress_loop(
+            duthost, port, iterations, start_uptime,
+        )
+    finally:
+        # Step 5 – stop background process group unconditionally
+        bg_reader.join(timeout=10)
+
+    # Step 6 – evaluate background EEPROM reader stats
+    bg_failures, total, failed, fail_rate = _evaluate_bg_reader_results(port, bg_reader)
+    port_failures.extend(bg_failures)
+
+    if not port_failures:
+        # Surface the observed fail-rate in the pass line too so drift below
+        # the threshold is still visible at a glance.
+        logger.info(
+            "Port %s: CDB background mode stress test passed (%d iterations, "
+            "%d/%d background EEPROM reads succeeded, fail-rate %.2f%% ≤ %.2f%%, "
+            "I2C kernel errors observed: %d (≤ threshold %d))",
+            port, iterations, total - failed, total,
+            fail_rate * 100, STRESS_EEPROM_MAX_FAIL_RATE * 100,
+            len(cumulative_i2c_errors), STRESS_TEST_I2C_ERROR_THRESHOLD,
+        )
+
+    return port_failures
+
+
+def test_cdb_background_mode_stress_test(
+    duthost, port_attributes_dict, lport_to_first_subport_mapping
+):
+    """CDB background mode stress test for CMIS transceivers.
+
+    Prerequisites per port (silently skipped when not met):
+      - ``EEPROM_ATTRIBUTES.cmis_active_optical`` is True (non-DAC CMIS)
+      - ``EEPROM_ATTRIBUTES.cdb_background_mode_supported`` is True
+    Both gates plus the first-sub-port filter are evaluated by
+    ``_stress_port_in_scope``.
+
+    For each qualifying first sub-port the helper ``_run_cdb_stress_for_port``:
+      1. Records a seconds-since-boot watermark (``/proc/uptime`` on the DUT).
+      2. Starts a background EEPROM reader thread (concurrent I2C traffic).
+      3. Reads CDB firmware version for
+         ``EEPROM_ATTRIBUTES.cdb_stress_iteration_count`` iterations
+         (required per-port inventory attribute, see the "CDB background mode
+         stress test" case in eeprom_test_plan.md; the port fails if it is
+         undefined — its default of 10 is supplied by eeprom.json defaults).
+      4. After each iteration scans dmesg for new I2C errors; aborts early
+         on the first I2C error (``STRESS_TEST_I2C_ERROR_THRESHOLD`` is 0).
+      5. Stops the background reader (joined with a 10 s timeout, always).
+      6. Reports a failure if any background EEPROM read failed
+         (``STRESS_EEPROM_MAX_FAIL_RATE`` is 0).
+
+    Expected result (per the HLD): every configured iteration completes, zero
+    background-read failures, and zero I2C kernel errors in dmesg.  The per-port
+    pass line reports the observed counters (expected 0) so a clean run is
+    visible at a glance.  Per-port failures are aggregated into one
+    ``pytest.fail`` at the end so a single run surfaces every misbehaving
+    port.
+    """
+    all_failures = []
+    for port, port_attrs in port_attributes_dict.items():
+        if not _stress_port_in_scope(port, port_attrs, lport_to_first_subport_mapping):
+            continue
+        port_failures = _run_cdb_stress_for_port(duthost, port, port_attrs)
+        if port_failures:
+            all_failures.append(port + ":\n  " + "\n  ".join(port_failures))
+
+    if all_failures:
+        pytest.fail(
+            "CDB background mode stress test failures:\n" + "\n".join(all_failures)
+        )


### PR DESCRIPTION
 
Follow-up to https://github.com/sonic-net/sonic-mgmt/pull/23828. Adds the CDB background-mode stress test (TC2) for CMIS transceivers, together with the supporting files that were intentionally split out of https://github.com/sonic-net/sonic-mgmt/issues/23828 to keep that PR focused and reviewable. This PR implements the TC2 row already documented in docs/testplan/transceiver/eeprom_test_plan.md.

Summary: Fixes # N/A (follow-up to https://github.com/sonic-net/sonic-mgmt/pull/23828)

Type of change

not done
Bug fix
done
Testbed and Framework (new/improved test & test-infrastructure)
not done
New Test case
not done
Skipped for non-supported platforms
not done
Test case enhancement
Back port request

not done
202X
Approach

What is the motivation for this PR?

https://github.com/sonic-net/sonic-mgmt/issues/23828 landed the transceiver EEPROM test framework and TC1 (CDB background-mode capability check). The CDB background-mode stress test (TC2) was split into this follow-up because it is the highest-churn part (background-reader process lifecycle, dmesg-based I2C-error scanning, threshold semantics) and is cleanly decoupled from the rest. This PR adds it now that the framework has merged.

How did you do it?

Adds test_cdb_background_mode_stress_test and its machinery to tests/transceiver/eeprom/cmis/test_cdb_background_mode.py (TC1 is unchanged), plus the supporting files:

_RemoteBgReader + shipped scripts/bg_eeprom_reader.sh — launches a background EEPROM read loop on the DUT under setsid so the bash loop and any in-flight sfputil child form a dedicated process group. Teardown signals the whole group (kill -- -) so no sfputil read-eeprom is orphaned on the I2C bus; a session-scoped conftest.py cleanup fixture sweeps any temp files left by a SIGKILL'd run.
common/dmesg_helpers.py — reusable kernel-ring-buffer scanner (seconds-since-boot watermark + cumulative dedup, severity-bounded via dmesg --level), consumed here for the first time; the process-restart / CDB firmware-upgrade categories can build on it too.
common/test_dmesg_helpers.py — standalone unit test for the scanner (watermark filtering, seen_errors dedup, unparseable-timestamp-kept, watermark parse/fallbacks).
cmis/constants.py — BG_READER* constants shared between the test and its cleanup fixture.
Per-iteration the test reads the CMIS CDB firmware version while the background reader hammers EEPROM, and scans dmesg for new I2C errors. Per the HLD it is zero-tolerance: any I2C kernel error or background-read failure fails the port, and there is deliberately no loganalyzer suppression of I2C messages.

How did you verify/test it?

Ran the CDB background-mode stress test on real hardware — Arista 800G (SN7060x6) and Nvidia 800G (SN5640) — with CMIS active-optical modules; the loop completes all iterations with zero I2C kernel errors and zero background-read failures.
dmesg_helpers covered by the new unit tests (watermark/dedup/unparseable-timestamp behavior).
pre-commit / flake8 clean.
Any platform specific information?

The stress test auto-skips non-CMIS / DAC / flat-memory optics and virtual-switch testbeds; it runs only on CMIS active-optical modules that advertise cdb_background_mode_supported.

Documentation

done
Test plan already documents this case: docs/testplan/transceiver/eeprom_test_plan.md (TC row "CDB background mode stress test").

Result	Test	Duration	Links
Passed	tests/transceiver/eeprom/cmis/test_cdb_background_mode.py::test_cdb_background_mode_support_test	00:01:35	 
Passed	tests/transceiver/eeprom/cmis/test_cdb_background_mode.py::test_cdb_background_mode_stress_test	00:09:09