### PR TITLE
[QoS] Skip ECN queue toggle test on lossy only devices

### DIFF
--- a/tests/qos/test_ecn_config.py
+++ b/tests/qos/test_ecn_config.py
@@ -304,6 +304,9 @@ def test_ecn_config_utility(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
 
     # Verify ecnconfig status on lossless queue
     test_prio_list = lossless_prio_list
+    if not test_prio_list:
+        pytest.skip("Skipping ECN queue toggle test: no lossless priorities found "
+                    "pfc_enable not set on device. ")
     for prio in test_prio_list:
         cmd = 'sudo ecnconfig {} -q {}'.format(asic, prio)
         result = duthost.command(cmd)

--- a/tests/qos/test_ecn_config.py
+++ b/tests/qos/test_ecn_config.py
@@ -304,8 +304,8 @@ def test_ecn_config_utility(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
 
     # Verify ecnconfig status on lossless queue
     test_prio_list = lossless_prio_list
-    if not test_prio_list:
-        pytest.skip("Skipping ECN queue toggle test: no lossless priorities found "
+    if test_prio_list is None:
+        pytest.skip("Skipping ECN queue toggle test: no lossless priorities found, "
                     "pfc_enable not set on device. ")
     for prio in test_prio_list:
         cmd = 'sudo ecnconfig {} -q {}'.format(asic, prio)


### PR DESCRIPTION
### Description of PR

Fix `TypeError: 'NoneType' object is not iterable` crash in `test_ecn_config_utility` when running on lossy-only HWSKUs where `pfc_enable` is not configured in PORT_QOS_MAP.

The `lossless_prio_list` fixture returns `None` on devices without lossless priorities. The test was not handling this case before iterating.

### Root Cause

On lossy-only platforms (listed in `LOSSY_ONLY_HWSKUS` in `broadcom_data.py`), PFC is intentionally disabled and `pfc_enable` is absent from PORT_QOS_MAP. The `lossless_prio_list` fixture correctly returns `None`, but `test_ecn_config_utility` did not guard against it.

### Fix

Add a `pytest.skip()` when `lossless_prio_list` is `None`, since the ECN queue toggle portion of the test requires lossless priorities to operate on.

### Type of change

- [x] Bug fix (test code)

### Affected test

- `tests/qos/test_ecn_config.py::test_ecn_config_utility`

### Testbed topology

Any (marker: `pytest.mark.topology('any')`)