### PR TITLE
[smartswitch] Harden DPU pre-upgrade image cleanup and install

### DIFF
--- a/ansible/library/upgrade_dpu_sonic_image.py
+++ b/ansible/library/upgrade_dpu_sonic_image.py
@@ -65,6 +65,10 @@ SHORT_CMD_TIMEOUT = 120
 REBOOT_TIMEOUT = 600
 # Poll interval while waiting for DPU reboot
 REBOOT_POLL_INTERVAL = 30
+# Extra /host headroom (MB) required beyond the image size before a DPU install
+DPU_INSTALL_MARGIN_MB = 500
+# Minimum plausible initrd size (bytes); anything smaller means a corrupt image
+DPU_MIN_INITRD_BYTES = 1024 * 1024
 
 
 class UpgradeDpuSonicImageModule(object):
@@ -163,7 +167,7 @@ class UpgradeDpuSonicImageModule(object):
             return False, "", str(e)
 
     def reduce_installed_images(self, ssh, dpu_ip):
-        """Clean up old SONiC images on the DPU, keeping only the current image."""
+        """Free disk space by cleaning up old DPU images, always attempting cleanup even if listing fails."""
         self.log("[DPU {}] Step: Reducing installed images".format(dpu_ip))
 
         ok = False
@@ -176,31 +180,38 @@ class UpgradeDpuSonicImageModule(object):
                 dpu_ip, attempt + 1))
             time.sleep(20)
 
-        if not ok:
-            self.log("WARNING: [DPU {}] Failed to list images after 3 attempts. Continuing anyway.".format(dpu_ip))
-            return
+        if ok:
+            curr_image = ""
+            next_image = ""
+            for line in out.split('\n'):
+                if 'Current:' in line:
+                    curr_image = line.split(':')[1].strip()
+                elif 'Next:' in line:
+                    next_image = line.split(':')[1].strip()
 
-        curr_image = ""
-        next_image = ""
-        for line in out.split('\n'):
-            if 'Current:' in line:
-                curr_image = line.split(':')[1].strip()
-            elif 'Next:' in line:
-                next_image = line.split(':')[1].strip()
+            self.log("[DPU {}] Current image: '{}', Next image: '{}'".format(
+                dpu_ip, curr_image, next_image))
 
-        self.log("[DPU {}] Current image: '{}', Next image: '{}'".format(
-            dpu_ip, curr_image, next_image))
+            if curr_image and next_image and curr_image != next_image:
+                self.log("[DPU {}] Setting next-boot to current image".format(dpu_ip))
+                self.execute_command(ssh, dpu_ip,
+                                     "sudo sonic-installer set-next-boot {}".format(curr_image))
+        else:
+            self.log("WARNING: [DPU {}] Could not list images after 3 attempts; "
+                     "attempting cleanup anyway".format(dpu_ip))
 
-        if not curr_image:
-            self.log("WARNING: [DPU {}] Could not determine current image".format(dpu_ip))
-            return
+        # Always attempt cleanup (safe: keeps Current and Next), retrying transient failures
+        cleaned = False
+        for attempt in range(3):
+            cleaned, _, err = self.execute_command(ssh, dpu_ip, "sudo sonic-installer cleanup -y")
+            if cleaned:
+                break
+            self.log("[DPU {}] sonic-installer cleanup failed (attempt {}/3), retrying in 20s: {}".format(
+                dpu_ip, attempt + 1, err.strip()))
+            time.sleep(20)
 
-        if curr_image != next_image and next_image:
-            self.log("[DPU {}] Setting next-boot to current image".format(dpu_ip))
-            self.execute_command(ssh, dpu_ip,
-                                 "sudo sonic-installer set-next-boot {}".format(curr_image))
-
-        self.execute_command(ssh, dpu_ip, "sudo sonic-installer cleanup -y")
+        if not cleaned:
+            self.log("WARNING: [DPU {}] sonic-installer cleanup did not succeed after 3 attempts".format(dpu_ip))
         self.log("[DPU {}] Done reducing images".format(dpu_ip))
 
     def free_up_disk_space(self, ssh, dpu_ip):
@@ -294,6 +305,29 @@ class UpgradeDpuSonicImageModule(object):
         if not self.scp_image_to_dpu(dpu_ip):
             return False
 
+        # Skip install if /host lacks room to extract, failing cleanly instead of bricking the DPU
+        img_mb = 0
+        sz_ok, sz_out, _ = self.execute_command(ssh, dpu_ip, "stat -c %s {}".format(DPU_IMAGE_PATH))
+        if sz_ok:
+            try:
+                img_mb = int(sz_out.strip()) // (1024 * 1024)
+            except ValueError:
+                img_mb = 0
+        if img_mb:
+            required_mb = img_mb + DPU_INSTALL_MARGIN_MB
+            avail_ok, avail_out, _ = self.execute_command(ssh, dpu_ip, "df -BM --output=avail /host")
+            try:
+                avail_mb = int(avail_out.splitlines()[-1].strip().rstrip('M')) if avail_ok else required_mb
+            except (ValueError, IndexError):
+                avail_mb = required_mb
+            if avail_mb < required_mb:
+                self.log("WARNING: [DPU {}] Insufficient /host space: {}M free < {}M required "
+                         "({}M image + {}M margin); skipping install to avoid a corrupt image".format(
+                             dpu_ip, avail_mb, required_mb, img_mb, DPU_INSTALL_MARGIN_MB))
+                self.execute_command(ssh, dpu_ip, "sudo rm -f {}".format(DPU_IMAGE_PATH))
+                return False
+            self.log("[DPU {}] /host free {}M >= required {}M".format(dpu_ip, avail_mb, required_mb))
+
         # Check for --skip-package-migration support
         skip_param = ""
         ok, help_out, _ = self.execute_command(ssh, dpu_ip, "sudo sonic-installer install --help")
@@ -317,6 +351,39 @@ class UpgradeDpuSonicImageModule(object):
         if not ok:
             self.log("WARNING: [DPU {}] Image installation FAILED: {}".format(dpu_ip, err.strip()))
             return False
+
+        # Flush to eMMC and verify the new image's initrd is intact before allowing a reboot
+        self.execute_command(ssh, dpu_ip, "sudo sync")
+        list_ok, list_out, _ = self.execute_command(ssh, dpu_ip, "sudo sonic-installer list")
+        curr_image = ""
+        next_image = ""
+        if list_ok:
+            for line in list_out.split('\n'):
+                if 'Current:' in line:
+                    curr_image = line.split(':')[1].strip()
+                elif 'Next:' in line:
+                    next_image = line.split(':')[1].strip()
+        if next_image:
+            img_dir = "/host/image-{}".format(next_image.replace("SONiC-OS-", ""))
+            _, initrd_out, _ = self.execute_command(
+                ssh, dpu_ip,
+                "sudo sh -c 'stat -c %s {}/boot/initrd.img-* 2>/dev/null | sort -n | tail -1'".format(img_dir))
+            try:
+                initrd_bytes = int(initrd_out.strip() or "0")
+            except ValueError:
+                initrd_bytes = 0
+            if initrd_bytes < DPU_MIN_INITRD_BYTES:
+                self.log("WARNING: [DPU {}] Post-install check FAILED for '{}': initrd missing/truncated "
+                         "({} bytes); not rebooting into a corrupt image".format(dpu_ip, next_image, initrd_bytes))
+                if curr_image and curr_image != next_image:
+                    self.execute_command(ssh, dpu_ip,
+                                         "sudo sonic-installer set-next-boot {}".format(curr_image))
+                return False
+            self.log("[DPU {}] Post-install check OK for '{}': initrd {} bytes".format(
+                dpu_ip, next_image, initrd_bytes))
+        else:
+            self.log("WARNING: [DPU {}] Could not read image list after install; skipping integrity check".format(
+                dpu_ip))
 
         self.log("[DPU {}] Image installed successfully".format(dpu_ip))
         return True

--- a/ansible/library/upgrade_dpu_sonic_image.py
+++ b/ansible/library/upgrade_dpu_sonic_image.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import shlex
 import time
 import paramiko
 from ansible.module_utils.basic import AnsibleModule
@@ -197,10 +198,12 @@ class UpgradeDpuSonicImageModule(object):
 
     def get_host_path_size_mb(self, ssh, dpu_ip, path):
         """Return du -sm size (MB) of a /host path, or None if it cannot be read/parsed."""
-        ok, out, _ = self.execute_command(ssh, dpu_ip, "sudo du -sm {} 2>/dev/null | cut -f1".format(path))
+        ok, out, _ = self.execute_command(ssh, dpu_ip, "sudo du -sm -- {}".format(shlex.quote(path)))
+        if not ok:
+            return None
         try:
-            return int(out.strip())
-        except ValueError:
+            return int(out.split()[0])
+        except (ValueError, IndexError):
             return None
 
     def reduce_installed_images(self, ssh, dpu_ip):
@@ -313,6 +316,14 @@ class UpgradeDpuSonicImageModule(object):
         finally:
             ssh.close()
 
+    def restore_boot_to_current(self, ssh, dpu_ip, curr_image, next_image):
+        """Point default and next-boot back at the current image so a reboot can't land on a bad image."""
+        if curr_image and curr_image != next_image:
+            self.log("[DPU {}] Restoring default and next boot to current image '{}'".format(
+                dpu_ip, curr_image))
+            self.execute_command(ssh, dpu_ip, "sudo sonic-installer set-default {}".format(curr_image))
+            self.execute_command(ssh, dpu_ip, "sudo sonic-installer set-next-boot {}".format(curr_image))
+
     def install_image_on_dpu(self, ssh, dpu_ip):
         """Transfer the image from NPU to DPU via SCP and install it."""
         self.log("[DPU {}] Step: Install image".format(dpu_ip))
@@ -367,12 +378,17 @@ class UpgradeDpuSonicImageModule(object):
             self.log("WARNING: [DPU {}] Image installation FAILED: {}".format(dpu_ip, err.strip()))
             return False
 
-        # Persist writes and verify the new image's initrd is intact before allowing a reboot
-        self.execute_command(ssh, dpu_ip, "sudo sync")
+        # Persist writes before verifying/rebooting; a failed sync means writes may not be durable
+        sync_ok, _, sync_err = self.execute_command(ssh, dpu_ip, "sudo sync")
         list_ok, curr_image, next_image = self.get_installed_images(ssh, dpu_ip)
         if not (list_ok and next_image):
             self.log("WARNING: [DPU {}] Could not read image list after install; "
                      "failing safe (not rebooting into an unverified image)".format(dpu_ip))
+            return False
+        if not sync_ok:
+            self.log("WARNING: [DPU {}] Post-install sync FAILED: {}; writes may not be persisted, "
+                     "not rebooting into a potentially corrupt image".format(dpu_ip, sync_err.strip()))
+            self.restore_boot_to_current(ssh, dpu_ip, curr_image, next_image)
             return False
         img_dir = "/host/image-{}".format(next_image.replace("SONiC-OS-", ""))
         _, initrd_out, _ = self.execute_command(
@@ -385,11 +401,7 @@ class UpgradeDpuSonicImageModule(object):
         if initrd_bytes < DPU_MIN_INITRD_BYTES:
             self.log("WARNING: [DPU {}] Post-install check FAILED for '{}': initrd missing/truncated "
                      "({} bytes); not rebooting into a corrupt image".format(dpu_ip, next_image, initrd_bytes))
-            if curr_image and curr_image != next_image:
-                self.log("[DPU {}] Restoring default and next boot to current image '{}'".format(
-                    dpu_ip, curr_image))
-                self.execute_command(ssh, dpu_ip, "sudo sonic-installer set-default {}".format(curr_image))
-                self.execute_command(ssh, dpu_ip, "sudo sonic-installer set-next-boot {}".format(curr_image))
+            self.restore_boot_to_current(ssh, dpu_ip, curr_image, next_image)
             return False
         self.log("[DPU {}] Post-install check OK for '{}': initrd {} bytes".format(
             dpu_ip, next_image, initrd_bytes))

--- a/ansible/library/upgrade_dpu_sonic_image.py
+++ b/ansible/library/upgrade_dpu_sonic_image.py
@@ -166,38 +166,57 @@ class UpgradeDpuSonicImageModule(object):
             self.log("WARNING: [DPU {}] Exception running '{}': {}".format(dpu_ip, command, str(e)))
             return False, "", str(e)
 
+    def get_installed_images(self, ssh, dpu_ip, attempts=3):
+        """Return (ok, current, next) from sonic-installer list, retrying transient failures."""
+        ok = False
+        out = ""
+        for attempt in range(attempts):
+            ok, out, _ = self.execute_command(ssh, dpu_ip, "sudo sonic-installer list")
+            if ok:
+                break
+            self.log("[DPU {}] sonic-installer list failed (attempt {}/{}), retrying in 20s".format(
+                dpu_ip, attempt + 1, attempts))
+            time.sleep(20)
+        curr = nxt = ""
+        for line in out.split('\n'):
+            if 'Current:' in line:
+                curr = line.split(':')[1].strip()
+            elif 'Next:' in line:
+                nxt = line.split(':')[1].strip()
+        return ok, curr, nxt
+
+    def get_host_avail_mb(self, ssh, dpu_ip):
+        """Return free MB on /host, or None if it cannot be read/parsed."""
+        ok, out, _ = self.execute_command(ssh, dpu_ip, "df -BM --output=avail /host")
+        if not ok:
+            return None
+        try:
+            return int(out.splitlines()[-1].strip().rstrip('M'))
+        except (ValueError, IndexError):
+            return None
+
+    def get_host_path_size_mb(self, ssh, dpu_ip, path):
+        """Return du -sm size (MB) of a /host path, or None if it cannot be read/parsed."""
+        ok, out, _ = self.execute_command(ssh, dpu_ip, "sudo du -sm {} 2>/dev/null | cut -f1".format(path))
+        try:
+            return int(out.strip())
+        except ValueError:
+            return None
+
     def reduce_installed_images(self, ssh, dpu_ip):
         """Free disk space by cleaning up old DPU images, always attempting cleanup even if listing fails."""
         self.log("[DPU {}] Step: Reducing installed images".format(dpu_ip))
 
-        ok = False
-        out = ""
-        for attempt in range(3):
-            ok, out, _ = self.execute_command(ssh, dpu_ip, "sudo sonic-installer list")
-            if ok:
-                break
-            self.log("[DPU {}] sonic-installer list failed (attempt {}/3), retrying in 20s".format(
-                dpu_ip, attempt + 1))
-            time.sleep(20)
-
-        if ok:
-            curr_image = ""
-            next_image = ""
-            for line in out.split('\n'):
-                if 'Current:' in line:
-                    curr_image = line.split(':')[1].strip()
-                elif 'Next:' in line:
-                    next_image = line.split(':')[1].strip()
-
+        list_ok, curr_image, next_image = self.get_installed_images(ssh, dpu_ip)
+        if list_ok:
             self.log("[DPU {}] Current image: '{}', Next image: '{}'".format(
                 dpu_ip, curr_image, next_image))
-
             if curr_image and next_image and curr_image != next_image:
                 self.log("[DPU {}] Setting next-boot to current image".format(dpu_ip))
                 self.execute_command(ssh, dpu_ip,
                                      "sudo sonic-installer set-next-boot {}".format(curr_image))
         else:
-            self.log("WARNING: [DPU {}] Could not list images after 3 attempts; "
+            self.log("WARNING: [DPU {}] Could not list images after retries; "
                      "attempting cleanup anyway".format(dpu_ip))
 
         # Always attempt cleanup (safe: keeps Current and Next), retrying transient failures
@@ -305,28 +324,24 @@ class UpgradeDpuSonicImageModule(object):
         if not self.scp_image_to_dpu(dpu_ip):
             return False
 
-        # Skip install if /host lacks room to extract, failing cleanly instead of bricking the DPU
-        img_mb = 0
-        sz_ok, sz_out, _ = self.execute_command(ssh, dpu_ip, "stat -c %s {}".format(DPU_IMAGE_PATH))
-        if sz_ok:
-            try:
-                img_mb = int(sz_out.strip()) // (1024 * 1024)
-            except ValueError:
-                img_mb = 0
-        if img_mb:
-            required_mb = img_mb + DPU_INSTALL_MARGIN_MB
-            avail_ok, avail_out, _ = self.execute_command(ssh, dpu_ip, "df -BM --output=avail /host")
-            try:
-                avail_mb = int(avail_out.splitlines()[-1].strip().rstrip('M')) if avail_ok else required_mb
-            except (ValueError, IndexError):
-                avail_mb = required_mb
-            if avail_mb < required_mb:
-                self.log("WARNING: [DPU {}] Insufficient /host space: {}M free < {}M required "
-                         "({}M image + {}M margin); skipping install to avoid a corrupt image".format(
-                             dpu_ip, avail_mb, required_mb, img_mb, DPU_INSTALL_MARGIN_MB))
-                self.execute_command(ssh, dpu_ip, "sudo rm -f {}".format(DPU_IMAGE_PATH))
-                return False
-            self.log("[DPU {}] /host free {}M >= required {}M".format(dpu_ip, avail_mb, required_mb))
+        # Skip install if /host lacks room for the extracted image, failing safe instead of bricking the DPU
+        _, curr_image, _ = self.get_installed_images(ssh, dpu_ip)
+        cur_dir = "/host/image-{}".format(curr_image.replace("SONiC-OS-", "")) if curr_image else ""
+        proxy_mb = self.get_host_path_size_mb(ssh, dpu_ip, cur_dir) if cur_dir else None
+        avail_mb = self.get_host_avail_mb(ssh, dpu_ip)
+        if proxy_mb is None or avail_mb is None:
+            self.log("WARNING: [DPU {}] Could not determine /host free space or image footprint; "
+                     "skipping install to avoid a corrupt image".format(dpu_ip))
+            self.execute_command(ssh, dpu_ip, "sudo rm -f {}".format(DPU_IMAGE_PATH))
+            return False
+        required_mb = proxy_mb + DPU_INSTALL_MARGIN_MB
+        if avail_mb < required_mb:
+            self.log("WARNING: [DPU {}] Insufficient /host space: {}M free < {}M required "
+                     "({}M image + {}M margin); skipping install to avoid a corrupt image".format(
+                         dpu_ip, avail_mb, required_mb, proxy_mb, DPU_INSTALL_MARGIN_MB))
+            self.execute_command(ssh, dpu_ip, "sudo rm -f {}".format(DPU_IMAGE_PATH))
+            return False
+        self.log("[DPU {}] /host free {}M >= required {}M".format(dpu_ip, avail_mb, required_mb))
 
         # Check for --skip-package-migration support
         skip_param = ""
@@ -352,38 +367,32 @@ class UpgradeDpuSonicImageModule(object):
             self.log("WARNING: [DPU {}] Image installation FAILED: {}".format(dpu_ip, err.strip()))
             return False
 
-        # Flush to eMMC and verify the new image's initrd is intact before allowing a reboot
+        # Persist writes and verify the new image's initrd is intact before allowing a reboot
         self.execute_command(ssh, dpu_ip, "sudo sync")
-        list_ok, list_out, _ = self.execute_command(ssh, dpu_ip, "sudo sonic-installer list")
-        curr_image = ""
-        next_image = ""
-        if list_ok:
-            for line in list_out.split('\n'):
-                if 'Current:' in line:
-                    curr_image = line.split(':')[1].strip()
-                elif 'Next:' in line:
-                    next_image = line.split(':')[1].strip()
-        if next_image:
-            img_dir = "/host/image-{}".format(next_image.replace("SONiC-OS-", ""))
-            _, initrd_out, _ = self.execute_command(
-                ssh, dpu_ip,
-                "sudo sh -c 'stat -c %s {}/boot/initrd.img-* 2>/dev/null | sort -n | tail -1'".format(img_dir))
-            try:
-                initrd_bytes = int(initrd_out.strip() or "0")
-            except ValueError:
-                initrd_bytes = 0
-            if initrd_bytes < DPU_MIN_INITRD_BYTES:
-                self.log("WARNING: [DPU {}] Post-install check FAILED for '{}': initrd missing/truncated "
-                         "({} bytes); not rebooting into a corrupt image".format(dpu_ip, next_image, initrd_bytes))
-                if curr_image and curr_image != next_image:
-                    self.execute_command(ssh, dpu_ip,
-                                         "sudo sonic-installer set-next-boot {}".format(curr_image))
-                return False
-            self.log("[DPU {}] Post-install check OK for '{}': initrd {} bytes".format(
-                dpu_ip, next_image, initrd_bytes))
-        else:
-            self.log("WARNING: [DPU {}] Could not read image list after install; skipping integrity check".format(
-                dpu_ip))
+        list_ok, curr_image, next_image = self.get_installed_images(ssh, dpu_ip)
+        if not (list_ok and next_image):
+            self.log("WARNING: [DPU {}] Could not read image list after install; "
+                     "failing safe (not rebooting into an unverified image)".format(dpu_ip))
+            return False
+        img_dir = "/host/image-{}".format(next_image.replace("SONiC-OS-", ""))
+        _, initrd_out, _ = self.execute_command(
+            ssh, dpu_ip,
+            "sudo sh -c 'stat -c %s {}/boot/initrd.img-* 2>/dev/null | sort -n | tail -1'".format(img_dir))
+        try:
+            initrd_bytes = int(initrd_out.strip() or "0")
+        except ValueError:
+            initrd_bytes = 0
+        if initrd_bytes < DPU_MIN_INITRD_BYTES:
+            self.log("WARNING: [DPU {}] Post-install check FAILED for '{}': initrd missing/truncated "
+                     "({} bytes); not rebooting into a corrupt image".format(dpu_ip, next_image, initrd_bytes))
+            if curr_image and curr_image != next_image:
+                self.log("[DPU {}] Restoring default and next boot to current image '{}'".format(
+                    dpu_ip, curr_image))
+                self.execute_command(ssh, dpu_ip, "sudo sonic-installer set-default {}".format(curr_image))
+                self.execute_command(ssh, dpu_ip, "sudo sonic-installer set-next-boot {}".format(curr_image))
+            return False
+        self.log("[DPU {}] Post-install check OK for '{}': initrd {} bytes".format(
+            dpu_ip, next_image, initrd_bytes))
 
         self.log("[DPU {}] Image installed successfully".format(dpu_ip))
         return True


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #26436

Harden the SmartSwitch DPU pre-upgrade image handling so that a low-disk-space (or interrupted) `sonic-installer install` can no longer silently produce a corrupt image and leave the DPU stuck at U-Boot with a missing/truncated `initrd` (which previously required a re-flash). On these DPUs the `/host` free space barely exceeds a single image, so without guaranteed cleanup a second image does not fit.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #26436
Failure type: day-one issue (missing robustness in the DPU image-upgrade module)

### Tested branch
- [x] master
- [x] 202605

### Test result
- master: identical, branch-agnostic shell commands; verified via the checks in "How did you verify/test it?".
- 202605: 20260510.04 - all new code paths verified on a live SmartSwitch DPU (see "How did you verify/test it?").

### Approach
#### What is the motivation for this PR?
During SmartSwitch nightly image-upgrade runs, a DPU upgrade could report success (`sonic-installer install` returns 0) while actually writing a corrupt/truncated image when `/host` was low on free space: the boot config was written but the `initrd` was missing, so on the next boot the DPU was stuck at U-Boot (`Failed to load .../initrd.img... Skipping main for failure retrieving initrd`) and required a re-flash. The underlying failure was also easily masked at the harness level, because the DPU upgrade runs as an Ansible async job on the NPU: an NPU reboot loses the async state file and the job fails with `could not find job`, hiding the real space/corruption problem.

#### How did you do it?
In `ansible/library/upgrade_dpu_sonic_image.py`:
- `reduce_installed_images`: always run `sonic-installer cleanup -y` (with retry) before install, even when `sonic-installer list` fails, so old images are reclaimed instead of being skipped on a transient list/parse error.
- `install_image_on_dpu`: add a pre-install `/host` free-space guard that fails cleanly (leaving the DPU on its working image) when there is not enough room to extract the new image, instead of writing a truncated one.
- `install_image_on_dpu`: after install, `sync` to persist writes and verify the new image's `initrd` is present and non-trivial in size before rebooting; on failure, restore next-boot to the current image.

#### How did you verify/test it?
Verified all three new code paths against a live SmartSwitch DPU by exercising the exact shell commands and parsing the module uses; all checks passed:
- `sonic-installer list` parsing of Current/Next.
- `df -BM --output=avail /host` parsing used by the space guard.
- Space guard, both directions: proceeds when free space is ample; blocks (skips the install) when the required size exceeds free space.
- Post-install integrity check, both directions: a valid image (real `initrd` present, tens of MB) passes; a missing/truncated `initrd` (0 bytes) is detected and would fail the install and roll back next-boot - reproducing the exact boot-loop symptom this PR prevents.
- `sync` succeeds.
- `flake8 --max-line-length=120` and `py_compile` pass.

#### Any platform specific information?
Applies to SmartSwitch DPU image upgrades (the `upgrade_dpu_sonic_image` Ansible module used in the prepare stage). No NPU/host-side behavior change.

#### Supported testbed topology if it's a new test case?
N/A (not a new test case).

### Documentation
N/A
