### PR TITLE
[platform] Ignore recovered Redis EOF log

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -81,7 +81,8 @@ SKIP_ERROR_LOG_PSU_ABSENCE = [
     r'.*ERR pmon#thermalctld: Failed to read from file.*\/var\/run\/hw-management\/thermal\/psu.*ValueError.*',
     r'.*PSU power thresholds become invalid: threshold (\d+\.\d+|N/A) critical threshold N/A.*',
     r'.*ERR pmon#sensord: Error getting sensor data: pmbus\/#\d: Can\'t read',
-    r'.*ERR pmon#sensord: Error getting sensor data: dps\d+\/#\d: Kernel interface error']
+    r'.*ERR pmon#sensord: Error getting sensor data: dps\d+\/#\d: Kernel interface error',
+    r'.*ERR python3.*~RedisPipeline:.*flush in destructor:.*err=3:.*Server closed the connection, Database: STATE_DB.*']
 
 SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP.extend(SKIP_ERROR_LOG_COMMON)
 SKIP_ERROR_LOG_PSU_ABSENCE.extend(SKIP_ERROR_LOG_COMMON)


### PR DESCRIPTION
### Description of PR

Summary:
Ignore the recoverable RedisPipeline destructor EOF emitted during the PSU power-cycle test.

### Motivation

On Cisco 8000 platforms, the platform fault monitor can temporarily retain a stale STATE_DB connection after the database service restarts. The first fault write detects the closed connection, reconnects, and retries successfully, but the old RedisPipeline emits an ERR while being destroyed. LogAnalyzer treats this recovered transient error as a test failure.

The regex is limited to the destructor flush, hiredis EOF (`err=3`), closed STATE_DB connection signature, and is only used by the PSU power-cycle test.

### Verification

- Confirmed the regex matches the captured syslog message.
- `python3 -m py_compile tests/platform_tests/test_platform_info.py`
- Pre-commit Python AST and flake8 hooks passed.