### PR TITLE
[platform_tests]: skip tests that are not available on BMC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -111,6 +111,12 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_status_led:
 #######################################
 #####   api/test_chassis_fans.py  #####
 #######################################
+platform_tests/api/test_chassis_fans.py:
+  skip:
+    reason: "Chassis fans API tests are not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_direction:
   xfail:
     reason: "Testcase consistently fails, raised issue to track"
@@ -184,6 +190,12 @@ platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_speed:
 #######################################
 #####    api/test_component.py    #####
 #######################################
+platform_tests/api/test_component.py:
+  skip:
+    reason: "Component API tests are not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 platform_tests/api/test_component.py::TestComponentApi::test_get_available_firmware_version:
   skip:
     reason: "Unsupported platform API"
@@ -291,6 +303,12 @@ platform_tests/api/test_component.py::TestComponentApi::test_update_firmware:
 #######################################
 #####   api/test_fan_drawer.py    #####
 #######################################
+platform_tests/api/test_fan_drawer.py:
+  skip:
+    reason: "Fan drawer API tests are not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_maximum_consumed_power:
   skip:
     reason: "Unsupported platform API"
@@ -341,6 +359,12 @@ platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_le
 #######################################
 ##### api/test_fan_drawer_fans.py #####
 #######################################
+
+platform_tests/api/test_fan_drawer_fans.py:
+  skip:
+    reason: "Fan drawer fans API tests are not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_model:
   skip:
@@ -430,6 +454,12 @@ platform_tests/api/test_module.py::TestModuleApi::test_reboot:
 #######################################
 #####        api/test_psu.py      #####
 #######################################
+platform_tests/api/test_psu.py:
+  skip:
+    reason: "PSU API tests are not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 platform_tests/api/test_psu.py::TestPsuApi::test_fans:
   skip:
     reason: "Unsupported platform API"
@@ -512,6 +542,12 @@ platform_tests/api/test_psu.py::test_temperature:
     conditions:
       - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
+
+platform_tests/api/test_psu_fans.py:
+  skip:
+    reason: "PSU fans API tests are not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
 
 platform_tests/api/test_psu_fans.py::TestPsuFans::test_get_error_description:
   xfail:
@@ -1072,6 +1108,19 @@ platform_tests/daemon/test_chassisd.py:
     conditions:
       - "release in ['201811', '201911', '202012']"
       - "asic_type in ['vs']"
+      - "'bmc' in topo_type"
+
+platform_tests/daemon/test_fancontrol.py:
+  skip:
+    reason: "Not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
+platform_tests/daemon/test_ledd.py:
+  skip:
+    reason: "Not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
 
 
 platform_tests/daemon/test_ledd.py::test_pmon_ledd_kill_and_start_status:
@@ -1085,8 +1134,16 @@ platform_tests/daemon/test_ledd.py::test_pmon_ledd_kill_and_start_status:
 platform_tests/daemon/test_pcied.py:
   skip:
     reason: "Not supported, AMD DPU Pcie link bringup sequence is handled differently"
+    conditions_logical_operator: or
     conditions:
       - "platform in ['arm64-elba-asic-flash128-r0']"
+      - "'bmc' in topo_type"
+
+platform_tests/daemon/test_psud.py:
+  skip:
+    reason: "Not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
 
 #######################################
 #####    fwutil/test_fwutil.py    #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1139,6 +1139,19 @@ platform_tests/daemon/test_chassisd.py:
     conditions:
       - "release in ['201811', '201911', '202012']"
       - "asic_type in ['vs']"
+      - "'bmc' in topo_type"
+
+platform_tests/daemon/test_fancontrol.py:
+  skip:
+    reason: "Not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
+platform_tests/daemon/test_ledd.py:
+  skip:
+    reason: "Not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
 
 
 platform_tests/daemon/test_ledd.py::test_pmon_ledd_kill_and_start_status:
@@ -1152,8 +1165,16 @@ platform_tests/daemon/test_ledd.py::test_pmon_ledd_kill_and_start_status:
 platform_tests/daemon/test_pcied.py:
   skip:
     reason: "Not supported, AMD DPU Pcie link bringup sequence is handled differently"
+    conditions_logical_operator: or
     conditions:
       - "platform in ['arm64-elba-asic-flash128-r0']"
+      - "'bmc' in topo_type"
+
+platform_tests/daemon/test_psud.py:
+  skip:
+    reason: "Not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
 
 #######################################
 #####    fwutil/test_fwutil.py    #####

--- a/tests/platform_tests/api/test_bmc.py
+++ b/tests/platform_tests/api/test_bmc.py
@@ -83,9 +83,13 @@ class TestBMCApi(PlatformApiTestBase):
     """Platform and Host API test cases for the BMC class"""
 
     @pytest.fixture(scope="class", autouse=True)
-    def skip_if_no_bmc(self, duthosts, enum_rand_one_per_hwsku_hostname):
-        """Skip tests if BMC is not present - these tests require BMC"""
+    def skip_if_no_bmc(self, duthosts, enum_rand_one_per_hwsku_hostname, tbinfo):
+        """Skip tests if BMC is not present or if running on a BMC topology."""
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        topo_type = (tbinfo.get("topo", {}).get("type") or "").lower()
+        if "bmc" in topo_type:
+            pytest.skip("Skipping BMC platform API tests on BMC topology")
+
         if not bmc.is_bmc_exists(duthost):
             pytest.skip("BMC is not present, skipping BMC platform API tests")
 

--- a/tests/platform_tests/api/test_bmc.py
+++ b/tests/platform_tests/api/test_bmc.py
@@ -84,9 +84,13 @@ class TestBMCApi(PlatformApiTestBase):
     """Platform and Host API test cases for the BMC class"""
 
     @pytest.fixture(scope="class", autouse=True)
-    def skip_if_no_bmc(self, duthosts, enum_rand_one_per_hwsku_hostname):
-        """Skip tests if BMC is not present - these tests require BMC"""
+    def skip_if_no_bmc(self, duthosts, enum_rand_one_per_hwsku_hostname, tbinfo):
+        """Skip tests if BMC is not present or if running on a BMC topology."""
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        topo_type = (tbinfo.get("topo", {}).get("type") or "").lower()
+        if "bmc" in topo_type:
+            pytest.skip("Skipping BMC platform API tests on BMC topology")
+
         if not bmc.is_bmc_exists(duthost):
             pytest.skip("BMC is not present, skipping BMC platform API tests")
 

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -35,6 +35,20 @@ pytestmark = [
 REGEX_MAC_ADDRESS = r'^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$'
 REGEX_SERIAL_NUMBER = r'^[A-Za-z0-9\-]+$'
 
+BMC_SKIPPED_CHASSIS_TESTS = {
+    "test_get_position_in_parent",
+    "test_is_replaceable",
+    "test_components",
+    "test_fans",
+    "test_fan_drawers",
+    "test_psus",
+    "test_thermals",
+    "test_sfps",
+    "test_status_led",
+    "test_get_supervisor_slot",
+    "test_get_my_slot",
+}
+
 # Valid OCP ONIE TlvInfo EEPROM type codes as defined here:
 # https://opencomputeproject.github.io/onie/design-spec/hw_requirements.html
 ONIE_TLVINFO_TYPE_CODE_PRODUCT_NAME = '0x21'    # Product Name
@@ -82,6 +96,16 @@ def gather_facts(request, duthosts):
 class TestChassisApi(PlatformApiTestBase):
     """Platform API test cases for the Chassis class"""
     inv_files = None
+
+    @pytest.fixture(autouse=True)
+    def skip_bmc_blocklisted_tests(self, request, tbinfo):
+        topo_type = (tbinfo.get("topo", {}).get("type") or "").lower()
+        if "bmc" not in topo_type:
+            return
+
+        test_name = request.function.__name__
+        if test_name in BMC_SKIPPED_CHASSIS_TESTS:
+            pytest.skip("Skipped on BMC: {} is in BMC skip list".format(test_name))
 
     #
     # Helper functions


### PR DESCRIPTION
### Description of PR
Summary:
Skip platform API and daemon tests that are not available on BMC topologies. This adds file-level BMC skips in the conditional mark rules for the affected platform tests, adds a BMC-only allowlist for chassis API coverage, and prevents `test_bmc.py` from running on BMC topologies.


### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
N/A
Failure type: other

### Test result
N/A

### Approach
#### What is the motivation for this PR?
BMC topologies do not support several platform API and daemon test paths that are valid on standard DUTs. Running those tests on BMC produces noise and avoidable failures.

#### How did you do it?
Added file-level BMC skip conditions in `tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml` for the affected platform test suites, updated `test_chassis.py` to only run a BMC allowlist on BMC topologies, and updated `test_bmc.py` to skip its BMC-specific API coverage when the DUT topology itself is BMC.

#### How did you verify/test it?
Reviewed the changed skip conditions and validated the updated test selection logic in the touched files. No runtime test pass was executed in this change set.

#### Any platform specific information?
This change targets BMC topologies only and leaves non-BMC DUT behavior unchanged.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A