### PR TITLE
test(dualtor): xfail flaky multivlan mux port iptables test

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1430,6 +1430,12 @@ dualtor/test_ipinip.py::test_encap_with_mirror_session:
        - https://github.com/sonic-net/sonic-mgmt/issues/8577
        - "'dualtor-aa' in topo_name and asic_type in ['mellanox']"
 
+dualtor/test_mux_port_iptables_entries.py::test_multivlan_mux_port_iptables_entries:
+  xfail:
+    reason: "Docker IPv6 NAT rules are intermittently missing on VS: https://github.com/sonic-net/sonic-mgmt/issues/26179"
+    conditions:
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/26179"
+
 dualtor/test_mux_port_iptables_entries.py::test_mux_port_iptables_entries:
   xfail:
     reason: "Docker IPv6 NAT rules are intermittently missing on VS: https://github.com/sonic-net/sonic-mgmt/issues/26179"


### PR DESCRIPTION
### Description of PR

Summary:

Mark `dualtor/test_mux_port_iptables_entries.py::test_multivlan_mux_port_iptables_entries` as an expected failure on VS while the intermittent Docker IPv6 NAT rule issue is investigated. Physical dualtor coverage remains enabled.

Related to #26179

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: regression

### Approach
#### What is the motivation for this PR?

The test entered a new failure episode on 2026-07-11. It failed in 58 of 173 master dualtor KVM PR plans through 2026-07-14, and every affected plan failed the initial attempt and both retries. The recurring signature is the absence of the expected Trixie `DOCKER` IPv6 NAT chain and jump rules.

#### How did you do it?

Added a conditional, non-strict xfail for the exact test node when `asic_type` is `vs` and tracking issue #26179 remains open. The mark does not apply to physical ASICs.

#### How did you verify/test it?

Loaded the conditions YAML and exercised the conditional mark matcher with VS and Broadcom facts. The exact node receives the xfail for VS and remains unmarked for Broadcom.

#### Any platform specific information?

The quarantine is limited to the VS platform used by dualtor KVM PR tests.

#### Supported testbed topology if it's a new test case?

N/A. This changes an existing dualtor test.

### Documentation

N/A.
 