### PR TITLE
[Dash] Use the new apply_dash_configs in pl redirect test

### DIFF
--- a/tests/dash/test_dash_privatelink_redirect.py
+++ b/tests/dash/test_dash_privatelink_redirect.py
@@ -17,8 +17,7 @@ from constants import (
 from tests.dash.conftest import get_interface_ip
 from configs.privatelink_config import TUNNEL1_ENDPOINT_IP
 import configs.privatelink_config as pl
-from tests.common.dash_utils import apply_swssconfig_file
-from gnmi_utils import apply_messages
+from tests.common.dash_utils import apply_swssconfig_file, apply_dash_configs
 from packets import (
     get_pl_overlay_dip,
     get_overlay_pkt_details,
@@ -465,74 +464,53 @@ def privatelink_redirect_fnic_config(
         yield
         return
     dpuhost = dpuhosts[dpu_index]
-    logger.info(pl.ROUTING_TYPE_PL_CONFIG)
 
     tunnel_config = pl.TUNNEL1_CONFIG
 
-    base_config_messages = {
-        **pl.APPLIANCE_FNIC_CONFIG,
-        **pl.ROUTING_TYPE_PL_CONFIG,
-        **pl.ROUTING_TYPE_VNET_CONFIG,
-        **pl.VNET_CONFIG,
-        **pl.VNET2_CONFIG,
-        **pl.ROUTE_GROUP1_CONFIG,
-        **pl.METER_POLICY_V4_CONFIG,
-        **pl.RD_PORTMAP_CONFIG,
-        **pl.RD_PORTMAP_RANGE_CONFIG,
-        **tunnel_config
-    }
-    logger.info(base_config_messages)
-
-    apply_messages(
-        localhost, duthost, ptfhost,
-        base_config_messages, dpuhost.dpu_index
-    )
-
-    route_and_mapping_messages = {
-        **pl.PL_REDIRECT_PE_VNET_MAPPING_CONFIG,
-        **pl.PE_SUBNET_ROUTE_CONFIG,
-        **pl.VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT
-    }
-    logger.info(route_and_mapping_messages)
-    apply_messages(
-        localhost, duthost, ptfhost,
-        route_and_mapping_messages, dpuhost.dpu_index
-    )
+    route_and_mapping_messages = [
+        pl.PL_REDIRECT_PE_VNET_MAPPING_CONFIG,
+        pl.PE_SUBNET_ROUTE_CONFIG,
+        pl.VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT
+    ]
 
     # inbound routing not implemented in Pensando SAI yet
+    route_rule_messages = []
     if 'pensando' not in dpuhost.facts['asic_type']:
-        route_rule_messages = {
-            **pl.VM_VNI_ROUTE_RULE_CONFIG,
-            **pl.PL_REDIRECT_BACKEND_IP_ROUTE_RULE_CONFIG,
-            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
-            **pl.TRUSTED_VNI_ROUTE_RULE_CONFIG
-        }
-        logger.info(route_rule_messages)
-        apply_messages(
-            localhost, duthost, ptfhost,
-            route_rule_messages, dpuhost.dpu_index
-        )
+        route_rule_messages = [
+            pl.VM_VNI_ROUTE_RULE_CONFIG,
+            pl.PL_REDIRECT_BACKEND_IP_ROUTE_RULE_CONFIG,
+            pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
+            pl.TRUSTED_VNI_ROUTE_RULE_CONFIG
+        ]
 
-    meter_rule_messages = {
-        **pl.METER_RULE1_V4_CONFIG,
-        **pl.METER_RULE2_V4_CONFIG,
-    }
-    logger.info(meter_rule_messages)
-    apply_messages(
-        localhost, duthost, ptfhost,
-        meter_rule_messages, dpuhost.dpu_index
-    )
+    meter_rule_messages = [
+        pl.METER_RULE1_V4_CONFIG,
+        pl.METER_RULE2_V4_CONFIG,
+    ]
 
-    logger.info(pl.ENI_FNIC_CONFIG)
-    apply_messages(
-        localhost, duthost, ptfhost,
-        pl.ENI_FNIC_CONFIG, dpuhost.dpu_index
-    )
+    config_messages = [
+        pl.APPLIANCE_FNIC_CONFIG,
+        pl.ROUTING_TYPE_PL_CONFIG,
+        pl.ROUTING_TYPE_VNET_CONFIG,
+        pl.VNET_CONFIG,
+        pl.VNET2_CONFIG,
+        pl.ROUTE_GROUP1_CONFIG,
+        pl.METER_POLICY_V4_CONFIG,
+        pl.RD_PORTMAP_CONFIG,
+        pl.RD_PORTMAP_RANGE_CONFIG,
+        tunnel_config,
+        *route_and_mapping_messages,
+        *route_rule_messages,
+        *meter_rule_messages,
+        pl.ENI_FNIC_CONFIG,
+        pl.ENI_ROUTE_GROUP1_CONFIG
+    ]
 
-    logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
-    apply_messages(
+    logger.info(f"config_messages: {config_messages}")
+
+    apply_dash_configs(
         localhost, duthost, ptfhost,
-        pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index
+        dpuhost.dpu_index, *config_messages
     )
 
     yield
@@ -555,72 +533,50 @@ def privatelink_redirect_nsg_config(
         yield
         return
     dpuhost = dpuhosts[dpu_index]
-    logger.info(pl.ROUTING_TYPE_PL_CONFIG)
 
     tunnel_config = pl.TUNNEL3_CONFIG
 
-    base_config_messages = {
-        **pl.APPLIANCE_CONFIG,
-        **pl.ROUTING_TYPE_PL_CONFIG,
-        **pl.ROUTING_TYPE_VNET_CONFIG,
-        **pl.VNET_CONFIG,
-        **pl.VNET2_CONFIG,
-        **pl.ROUTE_GROUP1_CONFIG,
-        **pl.METER_POLICY_V4_CONFIG,
-        **pl.RD_PORTMAP_CONFIG,
-        **pl.RD_PORTMAP_RANGE_CONFIG,
-        **tunnel_config,
-    }
-    logger.info(base_config_messages)
+    route_and_mapping_messages = [
+        pl.PL_REDIRECT_PE_PLNSG_SINGLE_ENDPOINT_VNET_MAPPING_CONFIG,
+        pl.PE_SUBNET_ROUTE_CONFIG,
+        pl.VM_SUBNET_ROUTE_CONFIG,
+    ]
 
-    apply_messages(
-        localhost, duthost, ptfhost,
-        base_config_messages, dpuhost.dpu_index
-    )
-
-    route_and_mapping_messages = {
-        **pl.PL_REDIRECT_PE_PLNSG_SINGLE_ENDPOINT_VNET_MAPPING_CONFIG,
-        **pl.PE_SUBNET_ROUTE_CONFIG,
-        **pl.VM_SUBNET_ROUTE_CONFIG,
-    }
-    logger.info(route_and_mapping_messages)
-    apply_messages(
-        localhost, duthost, ptfhost,
-        route_and_mapping_messages, dpuhost.dpu_index
-    )
-
+    route_rule_messages = []
     if 'pensando' not in dpuhost.facts['asic_type']:
-        route_rule_messages = {
-            **pl.VM_VNI_ROUTE_RULE_CONFIG,
-            **pl.PL_REDIRECT_BACKEND_IP_ROUTE_RULE_CONFIG,
-            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
-        }
-        logger.info(route_rule_messages)
-        apply_messages(
-            localhost, duthost, ptfhost,
-            route_rule_messages, dpuhost.dpu_index
-        )
+        route_rule_messages = [
+            pl.VM_VNI_ROUTE_RULE_CONFIG,
+            pl.PL_REDIRECT_BACKEND_IP_ROUTE_RULE_CONFIG,
+            pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
+        ]
 
-    meter_rule_messages = {
-        **pl.METER_RULE1_V4_CONFIG,
-        **pl.METER_RULE2_V4_CONFIG,
-    }
-    logger.info(meter_rule_messages)
-    apply_messages(
-        localhost, duthost, ptfhost,
-        meter_rule_messages, dpuhost.dpu_index
-    )
+    meter_rule_messages = [
+        pl.METER_RULE1_V4_CONFIG,
+        pl.METER_RULE2_V4_CONFIG,
+    ]
 
-    logger.info(pl.ENI_CONFIG)
-    apply_messages(
-        localhost, duthost, ptfhost,
-        pl.ENI_CONFIG, dpuhost.dpu_index
-    )
+    config_messages = [
+        pl.APPLIANCE_CONFIG,
+        pl.ROUTING_TYPE_PL_CONFIG,
+        pl.ROUTING_TYPE_VNET_CONFIG,
+        pl.VNET_CONFIG,
+        pl.VNET2_CONFIG,
+        pl.ROUTE_GROUP1_CONFIG,
+        pl.METER_POLICY_V4_CONFIG,
+        pl.RD_PORTMAP_CONFIG,
+        pl.RD_PORTMAP_RANGE_CONFIG,
+        tunnel_config,
+        *route_and_mapping_messages,
+        *route_rule_messages,
+        *meter_rule_messages,
+        pl.ENI_CONFIG,
+        pl.ENI_ROUTE_GROUP1_CONFIG
+    ]
+    logger.info(f"config_messages: {config_messages}")
 
-    logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
-    apply_messages(
+    apply_dash_configs(
         localhost, duthost, ptfhost,
-        pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index
+        dpuhost.dpu_index, *config_messages
     )
 
     yield


### PR DESCRIPTION
### Description of PR
Summary:
The apply_dash_configs(https://github.com/sonic-net/sonic-mgmt/pull/25252) handles the dash config dependencies and apply them in correct order.
The pl redirect test now is failing because it still uses the old apply_messages method.
```
AssertionError: Did not receive expected packet on any of ports [25, 24] for device 0.
========== EXPECTED ==========
Mask:

packet status: OK
packet:
0000  2A 28 23 82 72 2B 28 01 CD 0B 06 00 08 00 45 00  *(#.r+(.......E.
0010  00 94 00 00 00 00 40 2F F7 F8 0A 01 00 05 3C 3C  ......@/......<<
0020  3C 01 20 00 65 58 00 00 64 00 43 BE 65 25 FA 67  <. .eX..d.C.e%.g
0030  F4 93 9F EF C4 7E 86 DD 60 00 00 00 00 42 06 40  .....~..`....B.@
0040  FD 40 01 08 00 20 D1 07 00 64 FF 71 0A 00 00 0B  .@... ...d.q....
0050  26 03 10 E1 01 00 00 02 00 00 00 00 3C 3C 3C 01  &...........<<<.
0060  30 39 A4 11 00 00 00 00 00 00 00 00 50 02 20 00  09..........P. .
0070  E4 57 00 00 74 65 73 74 5F 64 61 73 68 5F 70 72  .W..test_dash_pr
0080  69 76 61 74 65 6C 69 6E 6B 5F 72 65 64 69 72 65  ivatelink_redire
0090  63 74 20 74 65 73 74 5F 64 61 73 68 5F 70 72 69  ct test_dash_pri
00a0  76 61                                            va

packet's mask:
0000  00 00 00 00 00 00 00 00 00 00 00 00 FF FF FF FF  ................
0010  FF FF FF FF FF FF 00 FF 00 00 FF FF FF FF FF FF  ................
0020  FF FF FF FF FF FF FF FF FF FF 00 00 00 00 00 00  ................
0030  FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF  ................
0040  FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF  ................
0050  FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF  ................
0060  FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF  ................
0070  FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF  ................
0080  FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF  ................
0090  FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF  ................
00a0  FF FF                                            ..

========== RECEIVED ==========
137 total packets. Displaying most recent 3 packets:
------------------------------
0000  62 82 2F 7F BB 3A 28 01 CD 0B 06 00 08 00 45 C0  b./..:(.......E.
0010  00 47 AB 51 40 00 01 06 B9 2B 0A 00 00 3A 0A 00  .G.Q@....+...:..
0020  00 3B AA 42 00 B3 1F 6B 1A A3 E9 9D C5 94 80 18  .;.B...k........
0030  00 7C F6 E0 00 00 01 01 08 0A 0C 07 96 F2 7A 22  .|............z"
0040  B5 6B FF FF FF FF FF FF FF FF FF FF FF FF FF FF  .k..............
0050  FF FF 00 13 04                                   .....
------------------------------
0000  12 EA 39 94 22 DE 28 01 CD 0B 06 00 86 DD 6C 08  ..9.".(.......l.
0010  B2 A0 00 33 06 01 FC 00 00 00 00 00 00 00 00 00  ...3............
0020  00 00 00 00 00 85 FC 00 00 00 00 00 00 00 00 00  ................
0030  00 00 00 00 00 86 9B 70 00 B3 5E 3C FE D2 DF 6A  .......p..^<...j
0040  62 C1 80 18 00 7C 66 B2 00 00 01 01 08 0A 22 AE  b....|f.......".
0050  32 E2 56 57 2B 0E FF FF FF FF FF FF FF FF FF FF  2.VW+...........
0060  FF FF FF FF FF FF 00 13 04                       .........
------------------------------
0000  4A 78 C4 EA 4E 1C 28 01 CD 0B 06 00 86 DD 6C 01  Jx..N.(.......l.
0010  EF 1E 00 33 06 01 FC 00 00 00 00 00 00 00 00 00  ...3............
0020  00 00 00 00 00 19 FC 00 00 00 00 00 00 00 00 00  ................
0030  00 00 00 00 00 1A 00 B3 95 61 21 B3 D2 6E 61 6E  .........a!..nan
0040  75 83 80 18 04 88 EC E9 00 00 01 01 08 0A 7D 2F  u.............}/
0050  C3 F0 56 86 90 1A FF FF FF FF FF FF FF FF FF FF  ..V.............
0060  FF FF FF FF FF FF 00 13 04                       .........
==============================
```



### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression, introduced by a sonic behavior change in https://github.com/sonic-net/sonic-swss/pull/4566

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
The above/below port range test cases are excluded because there is another issue, which is not relevant to this change.
<img width="911" height="658" alt="image" src="https://github.com/user-attachments/assets/0f0c8be3-9138-4737-b9cb-f7c6169e24eb" />


### Approach
#### What is the motivation for this PR?
Fix the test test_dash_privatelink_redirect.py
#### How did you do it?
Replace the apply_messages with the new apply_dash_configs in pl redirect test
#### How did you verify/test it?
Run the test on SN4280 smartswitch testbed.
#### Any platform specific information?
Change is only for smartswitch
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
