### PR TITLE
[Mellanox] Configure CT aging interval to 1s in ENI counter test

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -970,20 +970,6 @@ dash/test_dash_eni_counter.py:
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16407"
 
-dash/test_dash_eni_counter.py::TestEniCounter::test_inbound_pkt_eni_counter:
-  regex: true
-  xfail:
-    reason: "SAI_ENI_STAT_FLOW_AGED does not increment within the counter poll window on the Nvidia Bluefield DPU (flows do not idle-age)"
-    conditions:
-      - "hwsku in ['Mellanox-SN4280-O8C40', 'Mellanox-SN4280-O28']"
-
-dash/test_dash_eni_counter.py::TestEniCounter::test_outbound_pkt_pass_eni_counter:
-  regex: true
-  xfail:
-    reason: "SAI_ENI_STAT_FLOW_AGED does not increment within the counter poll window on the Nvidia Bluefield DPU (flows do not idle-age)"
-    conditions:
-      - "hwsku in ['Mellanox-SN4280-O8C40', 'Mellanox-SN4280-O28']"
-
 dash/test_dash_metering.py:
   skip:
     reason: "Metering w/ FNIC not supported on Nvidia yet"

--- a/tests/dash/dash_eni_counter_utils.py
+++ b/tests/dash/dash_eni_counter_utils.py
@@ -8,6 +8,7 @@ import re
 logger = logging.getLogger(__name__)
 ENI_COUNTER_POLL_INTERVAL = 1000  # 1 second
 ENI_COUNTER_READY_MAX_TIME = 10  # 10 seconds
+CT_AGING_TEST_INTERVAL = 1  # 1 second aging interval for ENI counter test
 
 
 def get_eni_counter_status(dpuhost):
@@ -43,6 +44,45 @@ def get_eni_counters(dpuhost, eni_counter_oid):
     dash_counter_dict = dpuhost.shell(cmd_get_eni_counter)['stdout']
     dash_counter_dict = ast.literal_eval(dash_counter_dict)
     return dash_counter_dict
+
+
+def get_ct_aging_interval(dpuhost, use_udp=False):
+    """Get the current CT aging interval from sai.profile via nasa-cli-helper. Bluefield only.
+
+    Args:
+        dpuhost: DPU host object
+        use_udp: If True, get UDP aging interval; otherwise get TCP aging interval
+
+    Returns:
+        int: Current aging interval in seconds, or None if not supported
+    """
+    if 'bluefield' not in dpuhost.facts['asic_type']:
+        return None
+    cmd = "nasa-cli-helper.py get_aging_interval"
+    if use_udp:
+        cmd += " -u"
+    result = dpuhost.shell(cmd)
+    return int(result['stdout'].strip())
+
+
+def set_ct_aging_interval(dpuhost, seconds, use_udp=False):
+    """Set the CT aging interval in sai.profile via nasa-cli-helper. Bluefield only.
+
+    Note: Requires syncd restart or config reload to take effect.
+
+    Args:
+        dpuhost: DPU host object
+        seconds: Aging interval in seconds
+        use_udp: If True, set UDP aging interval; otherwise set TCP aging interval
+    """
+    if 'bluefield' not in dpuhost.facts['asic_type']:
+        return
+    cmd = f"nasa-cli-helper.py set_aging_interval {seconds}"
+    if use_udp:
+        cmd += " -u"
+    protocol = "UDP" if use_udp else "TCP"
+    logger.info(f"Setting CT {protocol} aging interval to {seconds}s")
+    dpuhost.shell(cmd)
 
 
 def verify_eni_counter(eni_counter_check_point_dict, eni_counter_before_sending_pkt, eni_counter_after_sending_pkt):

--- a/tests/dash/test_dash_eni_counter.py
+++ b/tests/dash/test_dash_eni_counter.py
@@ -16,6 +16,7 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.common.dash_utils import apply_dash_configs, apply_swssconfig_file
 from dash_eni_counter_utils import get_eni_counters, get_eni_counter_oid, verify_eni_counter, \
+    get_ct_aging_interval, set_ct_aging_interval, CT_AGING_TEST_INTERVAL, \
     eni_counter_setup, partition_supported_counters, ENI_COUNTER_READY_MAX_TIME  # noqa: F401
 
 
@@ -43,7 +44,7 @@ def _get_interface_ip(duthost, interface):
 
 
 @pytest.fixture(scope="module")
-def module_set_vxlan_udp_sport_range(dpuhosts, dpu_index):
+def module_set_vxlan_udp_sport_range(dpuhosts, dpu_index, module_set_ct_aging):
     """Module-scoped equivalent of the shared ``set_vxlan_udp_sport_range`` fixture.
 
     Programs the DPU's VXLAN UDP source-port range / security once per module (instead of
@@ -69,7 +70,39 @@ def module_set_vxlan_udp_sport_range(dpuhosts, dpu_index):
 
 
 @pytest.fixture(scope="module")
-def module_setup_npu_dpu(duthost, dpuhosts, dpu_index, dash_pl_config, skip_config, skip_cleanup):
+def module_set_ct_aging(dpuhosts, dpu_index, skip_config, skip_cleanup):
+    dpuhost = dpuhosts[dpu_index]
+    """
+    Programs the DPU's CT aging interval. Performs config_reload as part of setup and teardown.
+
+    This fixture should come before others because it performs config_reloads,
+    which will wipe out config changes applied by earlier fixtures.
+    """
+    dpuhost = dpuhosts[dpu_index]
+    if not skip_config and 'bluefield' in dpuhost.facts['asic_type']:
+        original_tcp_aging = get_ct_aging_interval(dpuhost, use_udp=False)
+        original_udp_aging = get_ct_aging_interval(dpuhost, use_udp=True)
+        logger.info(f"Original CT aging intervals - TCP: {original_tcp_aging}s, UDP: {original_udp_aging}s")
+
+        set_ct_aging_interval(dpuhost, CT_AGING_TEST_INTERVAL, use_udp=False)
+        set_ct_aging_interval(dpuhost, CT_AGING_TEST_INTERVAL, use_udp=True)
+        logger.info(f"Set CT aging intervals to {CT_AGING_TEST_INTERVAL}s, restarting syncd to apply")
+
+        config_reload(dpuhost, safe_reload=True)
+
+    yield
+
+    if not skip_config and not skip_cleanup and 'bluefield' in dpuhost.facts['asic_type']:
+        logger.info(f"Restoring CT aging intervals - TCP: {original_tcp_aging}s, UDP: {original_udp_aging}s")
+        set_ct_aging_interval(dpuhost, original_tcp_aging, use_udp=False)
+        set_ct_aging_interval(dpuhost, original_udp_aging, use_udp=True)
+        config_reload(dpuhost, safe_reload=True)
+
+
+@pytest.fixture(scope="module")
+def module_setup_npu_dpu(
+    duthost, dpuhosts, dpu_index, dash_pl_config, skip_config, skip_cleanup, module_set_ct_aging
+):
     """Module-scoped equivalent of the shared ``setup_npu_dpu`` fixture.
 
     Programs the DPU loopback and the NPU static routes once per module (instead of per

--- a/tests/dash/test_dash_eni_counter.py
+++ b/tests/dash/test_dash_eni_counter.py
@@ -71,7 +71,6 @@ def module_set_vxlan_udp_sport_range(dpuhosts, dpu_index, module_set_ct_aging):
 
 @pytest.fixture(scope="module")
 def module_set_ct_aging(dpuhosts, dpu_index, skip_config, skip_cleanup):
-    dpuhost = dpuhosts[dpu_index]
     """
     Programs the DPU's CT aging interval. Performs config_reload as part of setup and teardown.
 


### PR DESCRIPTION
### Description of PR

Summary:
The default CT aging interval in the Nvidia smartswitch DPU has been changed from 1s to TCP: 300s, UDP 120s.
This causes ENI counter test failures in SAI_ENI_STAT_FLOW_AGED counter because the test flow is not aged.

Configure the intervals to 1s in the test setup phase and restore them back to the default, so the failing cases test_inbound_pkt_eni_counter, test_outbound_pkt_pass_eni_counter can pass again.


### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression, cause by a behavior change in Nvidia smartswitch DPU per customer request.

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<img width="907" height="1253" alt="image" src="https://github.com/user-attachments/assets/a8a9db27-e00b-47a2-8df7-10b202ca4356" />

### Approach
#### What is the motivation for this PR?
Fix the tests/dash/test_dash_eni_counter.py for Nvidia smartswitch.
#### How did you do it?
1. Configuring CT aging interval to 1s in ENI counter test when it's Nvidia smartswitch: Adding a fixture to set the intervals and reload config. Adding the fixture to the param list of other setup fixtures to make sure the config reload happens at the beginning so the following configurations are not wiped out.
2. Remove the SN4280 skip conditions.
#### How did you verify/test it?
Run the test tests/dash/test_dash_eni_counter.py on SN4280 smartswitch testbed.
#### Any platform specific information?
Change is only for Nvidia smartswitch 
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
