### PR TITLE
[Mellanox][Smartswitch] Fix a test issue in mellanox_dpu_shutdown_check

### DIFF
--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -51,7 +51,7 @@ def mellanox_dpu_shutdown_check(duthost, dpu_on_list):
     yield
 
     dpu_down_log_pattern = r"dpuctl_plat.*(dpu\d).*Total time taken = (\d+\.\d+) for going down"
-    syslog = duthost.shell(f"grep -E '{dpu_down_log_pattern}' /var/log/syslog")['stdout']
+    syslog = duthost.shell(f"grep -P '{dpu_down_log_pattern}' /var/log/syslog")['stdout']
     matches = re.findall(dpu_down_log_pattern, syslog)
     logging.info(f"Found {len(matches)} DPU down logs")
     logging.info(f"Time taken for DPUs to shutdown: {matches}")


### PR DESCRIPTION
### Description of PR

Summary:
Recently a new check mellanox_dpu_shutdown_check was introduced to test case test_reload_dpu.py::test_cold_reboot_dpus in https://github.com/sonic-net/sonic-mgmt/pull/25265

But there is a bug which happens only on Nvidia smartswitch:
The "grep -E" doesn't recognize the regex pattern "\d"
Use "grep -P" instead.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

The backport should happen only after  https://github.com/sonic-net/sonic-mgmt/pull/25265 is backported.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<img width="907" height="218" alt="image" src="https://github.com/user-attachments/assets/b745479e-61c0-4416-8067-87fe741e3368" />

### Approach
#### What is the motivation for this PR?
Fix a test issue in mellanox_dpu_shutdown_check
#### How did you do it?
Use "grep -P" instead of "grep -E".
#### How did you verify/test it?
Run the test test_cold_reboot_dpus on SN4280 testbed.

#### Any platform specific information?
Only for smartswitch
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
