### PR TITLE
[202605][conditional_mark] Backport nodeid normalization for centralized marks

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -710,12 +710,16 @@ def pytest_collection_modifyitems(session, config, items):
         json.dumps(basic_facts, indent=2)))
     dynamic_update_skip_reason = session.config.option.dynamic_update_skip_reason
     basic_facts['constants'] = MARK_CONDITIONS_CONSTANTS
-    # Normalize nodeids: strip root directory prefix if present (pytest 9.0+ includes it)
+    # Normalize nodeids to match the tests/-relative condition keys. rootdir may
+    # float above tests/ (e.g. --inventory ../ansible/veos_vtb), so strip both
+    # basename(rootpath) and a leading "tests/" or all conditional skips no-op.
     root_prefix = os.path.basename(str(session.config.rootpath)) + "/"
     for item in items:
         nodeid = item.nodeid
         if nodeid.startswith(root_prefix):
             nodeid = nodeid[len(root_prefix):]
+        if nodeid.startswith("tests/"):
+            nodeid = nodeid[len("tests/"):]
         all_matches = find_all_matches(nodeid, conditions, session, dynamic_update_skip_reason, basic_facts)
 
         if all_matches:


### PR DESCRIPTION
### Description of PR

Summary:
Backport #25930 to `202605` so centralized conditional marks still match when pytest resolves `rootdir` above the `tests/` directory. This is a prerequisite for the warm-reboot conditional skips in #26417 to apply under the standard `run_tests.sh` invocation.

Related to #25929, #25930, and #26417.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38862000

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: `testbed-bjw-can-720dt-3` (m0, `Arista-720DT-G48S4`) on `SONiC.20260510.06`; with this normalization fix and the #26340 warm-reboot marks, targeted `tests/run_tests.sh` completed with **3 skipped**, 0 failures, exit 0 in 43.88 seconds. Each case reported `Warm reboot is not supported on dualtor, m0, m1, or mx topologies`.
- CI: all checks passed at head `8724ffec97851a6359cef16d64b94ebc8a106e32`, including every impacted Elastictest lane.

### Approach
#### What is the motivation for this PR?

The `202605` branch only strips `basename(rootpath)` from collected node IDs. Standard `run_tests.sh` arguments can make pytest resolve `rootdir` at the repository root, leaving node IDs prefixed with `tests/`. Conditional-mark keys are relative to `tests/`, so every centralized skip or xfail silently misses in that mode.

#26417 adds topology-based warm-reboot skips through the centralized conditional-mark file and therefore requires this normalization fix.

#### How did you do it?

Cherry-picked the functional change from #25930. After the existing root-directory normalization, the plugin now also strips a leading `tests/` before matching the node ID against conditional-mark keys.

#### How did you verify/test it?

`py_compile` and `git diff --check` passed on the `202605` backport branch. The backported patch matches #25930 apart from expected context offsets.

Physical validation on `testbed-bjw-can-720dt-3` used `SONiC.20260510.06` with this normalization fix and the #26340 warm-reboot marks. The standard test runner selected all three target cases as skips with zero failures.

#### Any platform specific information?

No. The fix applies to every platform when pytest reports node IDs with a leading `tests/`.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

Not applicable.
