### PR TITLE
[Smartswitch] Fix a test issue in get_dpu_link_status

### DIFF
--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -457,7 +457,7 @@ def get_dpu_link_status(duthost, num_dpu_modules,
 
     for index in range(num_dpu_modules):
         dpu_name = module.get_name(platform_api_conn, index)
-        if configured_dpus and dpu_name.lower() not in configured_dpus:
+        if configured_dpus and not any(dpu.endswith(dpu_name.lower()) for dpu in configured_dpus):
             logging.info("Skipping unconfigured module %s (index=%d)", dpu_name, index)
             continue
         ip_address = module.get_midplane_ip(platform_api_conn, index)
@@ -605,6 +605,7 @@ def pre_test_check(duthost,
     ip_address_list, dpu_on_list, dpu_off_list = get_dpu_link_status(
                                                  duthost, num_dpu_modules,
                                                  platform_api_conn)
+    pytest_assert(dpu_on_list and ip_address_list, "No DPUs are ON or IP address list is empty")
 
     logging.info("Checking DPU connectivity before the operation")
     pytest_assert(wait_until(PING_TIMEOUT, PING_TIME_INT, 0,


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (https://github.com/sonic-net/sonic-mgmt/issues/26338)
The DPU key in NPU DPU table config_db was recently changed from "dpu" to "<npu_hostname>-dpu" in PR: https://github.com/sonic-net/sonic-mgmt/pull/25466. Which is causing an issue in:
https://github.com/sonic-net/sonic-mgmt/blob/e7daa983434f021fa2e521ed9b158f2b702a780e/tests/smartswitch/common/device_utils_dpu.py#L460

As a result, we have failures a false positive results in test_reload_dpu.py. For details please check the issue.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
master: tested and passed
202605: tested and passed
Before the fix:
<img width="605" height="138" alt="image" src="https://github.com/user-attachments/assets/8eb32dbc-3995-4dd4-8af0-b11dcc741425" />
The post switch cases falsely passed(there is another issue, these 2 cases should fail), the post dpu cases falsely failed.

After the fix:
<img width="623" height="138" alt="image" src="https://github.com/user-attachments/assets/1d102464-8a51-4a77-9ea8-edfc322589d3" />
The results are as expected.

### Approach
#### What is the motivation for this PR?
Fix a test issue in get_dpu_link_status
#### How did you do it?
1. Instead of matching the exact dpu names, using endswith() to ignore the NPU hostname.
2. Add an assertion in pre_test_check, if no DPUs are on, fail the test.
#### How did you verify/test it?
Run the test on SN4280 smartswitch testbed.
#### Any platform specific information?
Change is only for smartswitch
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
