### PR TITLE
[dualtor] Skip unsupported VxLAN scale tests on dualtor

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5985,6 +5985,12 @@ vrf/test_vrf_attr.py::TestVrfAttrSrcMac::test_vrf1_neigh_with_default_router_mac
 #######################################
 #####           vxlan            #####
 #######################################
+vxlan/test_scale_ecmp.py:
+  skip:
+    reason: "test_scale_ecmp is not supported on dualtor topologies"
+    conditions:
+      - "'dualtor' in topo_name"
+
 vxlan/test_vnet_bgp_route_precedence.py:
   skip:
     reason: "test_vnet_bgp_route_precedence can only run on cisco, mnlx and VPP platforms. Also skip in 202411"
@@ -6260,6 +6266,12 @@ vxlan/test_vxlan_route_advertisement.py::Test_VxLAN_route_Advertisement::test_sc
     reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20725"
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/20725 and '-v6-' in topo_name"
+
+vxlan/test_vxlan_tunnel_route_scale.py:
+  skip:
+    reason: "test_vxlan_tunnel_route_scale is not supported on dualtor topologies"
+    conditions:
+      - "'dualtor' in topo_name"
 
 vxlan/test_vxlan_underlay_ecmp.py:
   skip:


### PR DESCRIPTION
### Description of PR

Skip two VxLAN scale tests on dualtor topologies where they are not supported:
- `vxlan/test_vxlan_tunnel_route_scale.py`
- `vxlan/test_scale_ecmp.py`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Approach
#### What is the motivation for this PR?
On dualtor testbeds, these two VxLAN scale tests are not supported and can generate non-actionable failures/noise in PR validation.

#### How did you do it?
Updated `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` to add dualtor skip rules:
- `vxlan/test_scale_ecmp.py` -> skip when `'dualtor' in topo_name`
- `vxlan/test_vxlan_tunnel_route_scale.py` -> skip when `'dualtor' in topo_name`

#### How did you verify/test it?
- Parsed the updated YAML with `yaml.safe_load(...)`.
- Verified the diff is scoped to one file only:
  - `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`

#### Any platform specific information?
- Dualtor topology specific skip for the two tests above.
