### PR TITLE
Wait for ASIC_DB ACL entry count to stabilize before CRM validation

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -92,6 +92,30 @@ def handle_default_acl_rules(duthost, tbinfo):
         RESTORE_CMDS["test_acl_counter"].append({"data_acl": data_acl})
 
 
+def wait_for_acl_entry_count_stable(asichost, timeout=30, interval=3):
+    """
+    Wait until ASIC_DB ACL_ENTRY count stabilizes (two consecutive reads match).
+    This ensures orchagent has finished processing ACL deletions/additions.
+    """
+    cmd = "{} ASIC_DB KEYS \"*SAI_OBJECT_TYPE_ACL_ENTRY*\"".format(asichost.sonic_db_cli)
+    previous_count = None
+
+    def _count_stable():
+        nonlocal previous_count
+        keys = asichost.shell(cmd)["stdout"].split()
+        current_count = len(keys) if keys != [''] else 0
+
+        if previous_count is not None and current_count == previous_count:
+            logger.info(f"ACL entry count stabilized at {current_count}")
+            return True
+
+        logger.info(f"ACL entry count: {current_count} (previous: {previous_count})")
+        previous_count = current_count
+        return False
+
+    return wait_until(timeout, interval, 0, _count_stable)
+
+
 def apply_acl_config(duthost, asichost, test_name, collector, entry_num=1):
     """ Create acl rule defined in config file. Return ACL table key. """
     base_dir = os.path.dirname(os.path.realpath(__file__))
@@ -143,6 +167,8 @@ def apply_acl_config(duthost, asichost, test_name, collector, entry_num=1):
         except BaseException:
             acl_tbl_key = None
             return False
+
+    wait_for_acl_entry_count_stable(asichost, timeout=30, interval=3)
 
     pytest_assert(wait_until(CONFIG_UPDATE_TIME * 3, CRM_POLLING_INTERVAL, 0, _acl_config_applied),
                   "ACL configuration did not propagate within timeout")


### PR DESCRIPTION
### Description of PR

Summary:
Fix race condition in CRM ACL tests by waiting for ASIC_DB ACL entry count to stabilize before proceeding.
The test was proceeding immediately after detecting ACL table key, but orchagent may still be processing ACL entries. This causes flaky test failures.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
Test passed on master and 202605.

### Approach
#### What is the motivation for this PR?
Race condition between CONFIG_DB ACL loading and ASIC_DB synchronization causes intermittent CRM test failures. The test proceeds immediately after detecting the ACL table key in ASIC_DB, but orchagent may still be processing ACL entries asynchronously, leading to flaky assertion failures.

#### How did you do it?
Added `wait_for_acl_entry_count_stable()` helper that waits for two consecutive ASIC_DB reads to return the same ACL entry count, ensuring orchagent has finished processing before the test proceeds.

#### How did you verify/test it?
Test passed on master and 202605.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A