### PR TITLE
[snappi] Added support for GCU on DNX platform

### DIFF
--- a/tests/common/helpers/xml_utils.py
+++ b/tests/common/helpers/xml_utils.py
@@ -1,7 +1,27 @@
 import xml.etree.ElementTree as ET
 import os
 import logging
+import ipaddress
 logger = logging.getLogger(__name__)
+
+
+def _is_ip_address(text):
+    try:
+        ipaddress.ip_address(text.split('/')[0])
+        return True
+    except ValueError:
+        return False
+
+
+def _text_matches(search_text, elem_text):
+    """Match element text; use case-insensitive compare for IP addresses."""
+    if not elem_text:
+        return False
+    if search_text in elem_text:
+        return True
+    if _is_ip_address(search_text):
+        return search_text.lower() in elem_text.lower()
+    return False
 
 
 def remove_xml_entries(file_path, text_to_remove, element_tag_to_check=None, remove_parent_if_matched=True):
@@ -41,7 +61,7 @@ def remove_xml_entries(file_path, text_to_remove, element_tag_to_check=None, rem
         tag_matches_criteria = (element_tag_to_check is None) or (elem.tag == element_tag_to_check)
 
         # Check if the element's text contains the string to remove
-        if tag_matches_criteria and elem.text and text_to_remove in elem.text:
+        if tag_matches_criteria and _text_matches(text_to_remove, elem.text):
             if elem == root:
                 # Special handling for root: we can't remove the root itself from a parent.
                 # If root matches and we're not removing its parent, we'll clear its content.
@@ -93,7 +113,7 @@ def remove_xml_entries(file_path, text_to_remove, element_tag_to_check=None, rem
     return removed_count
 
 
-def modify_minigraph(minigraph_file, minigraph_data, rsb_mode):
+def modify_minigraph(minigraph_file, minigraph_data, rsb_mode, platform_asic=None):
     if "minigraph_interfaces" not in minigraph_data:
         raise RuntimeError("Couldnot find any interface data in minigraph_data")
 
@@ -113,52 +133,113 @@ def modify_minigraph(minigraph_file, minigraph_data, rsb_mode):
             interfaces_not_to_remove = [all_active_fp_ports[0]]
 
     remove_count = 0
-    for entry in interfaces_to_remove:
-        remove_count += remove_xml_entries(
-            minigraph_file,
-            text_to_remove=entry,
-            element_tag_to_check=None,
-            remove_parent_if_matched=True)
-        remove_count += remove_xml_entries(
-            minigraph_file,
-            text_to_remove=minigraph_data['minigraph_port_name_to_alias_map'][entry],
-            element_tag_to_check=None,
-            remove_parent_if_matched=True)
+    is_broadcom_dnx = platform_asic == "broadcom-dnx"
+    if not is_broadcom_dnx:
+        for entry in interfaces_to_remove:
+            remove_count += remove_xml_entries(
+                minigraph_file,
+                text_to_remove=entry,
+                element_tag_to_check=None,
+                remove_parent_if_matched=True)
+            remove_count += remove_xml_entries(
+                minigraph_file,
+                text_to_remove=minigraph_data['minigraph_port_name_to_alias_map'][entry],
+                element_tag_to_check=None,
+                remove_parent_if_matched=True)
 
-        # TODO: take care of vlan members
+            # TODO: take care of vlan members
 
-        for pc, data in minigraph_data['minigraph_portchannels'].items():
-            for member in data['members']:
-                if "-BP" not in member and member not in interfaces_not_to_remove:
+            for pc, data in minigraph_data['minigraph_portchannels'].items():
+                for member in data['members']:
+                    if "-BP" not in member and member not in interfaces_not_to_remove:
+                        remove_count += remove_xml_entries(
+                            minigraph_file,
+                            text_to_remove=member,
+                            element_tag_to_check=None,
+                            remove_parent_if_matched=False)
+
+            for entry in minigraph_data['minigraph_neighbors']:
+                if "-BP" not in entry and entry not in interfaces_not_to_remove:
                     remove_count += remove_xml_entries(
                         minigraph_file,
-                        text_to_remove=member,
+                        text_to_remove=entry,
                         element_tag_to_check=None,
-                        remove_parent_if_matched=False)
+                        remove_parent_if_matched=True)
 
-        for entry in minigraph_data['minigraph_neighbors']:
-            if "-BP" not in entry and entry not in interfaces_not_to_remove:
-                remove_count += remove_xml_entries(
-                    minigraph_file,
-                    text_to_remove=entry,
-                    element_tag_to_check=None,
-                    remove_parent_if_matched=True)
+            for entry, value in minigraph_data['minigraph_ports'].items():
+                if "-BP" not in entry and entry not in interfaces_not_to_remove:
+                    remove_count += remove_xml_entries(
+                        minigraph_file,
+                        text_to_remove=value['name'],
+                        element_tag_to_check=None,
+                        remove_parent_if_matched=True)
+                    remove_count += remove_xml_entries(
+                        minigraph_file,
+                        text_to_remove=value['alias'],
+                        element_tag_to_check=None,
+                        remove_parent_if_matched=True)
+                    remove_count += remove_xml_entries(
+                        minigraph_file,
+                        text_to_remove=minigraph_data['minigraph_port_name_to_alias_map'][entry],
+                        element_tag_to_check=None,
+                        remove_parent_if_matched=True)
+    else:
+        for pc, data in minigraph_data['minigraph_portchannels'].items():
+            for member in data['members']:
+                if (member in interfaces_to_remove):
+                    remove_count += remove_xml_entries(
+                        minigraph_file,
+                        text_to_remove=pc,
+                        element_tag_to_check=None,
+                        remove_parent_if_matched=True)
 
-        for entry, value in minigraph_data['minigraph_ports'].items():
-            if "-BP" not in entry and entry not in interfaces_not_to_remove:
+        bgp_peer_not_to_remove = ''
+        bgp_peer_to_remove = []
+        for key, value in minigraph_data['minigraph_neighbors'].items():
+            if key in interfaces_to_remove:
+                logger.info('To remove BGP neighbor:{}'.format(value['name']))
+                bgp_peer_to_remove.append(value['name'])
                 remove_count += remove_xml_entries(
                     minigraph_file,
                     text_to_remove=value['name'],
                     element_tag_to_check=None,
                     remove_parent_if_matched=True)
-                remove_count += remove_xml_entries(
-                    minigraph_file,
-                    text_to_remove=value['alias'],
-                    element_tag_to_check=None,
-                    remove_parent_if_matched=True)
-                remove_count += remove_xml_entries(
-                    minigraph_file,
-                    text_to_remove=minigraph_data['minigraph_port_name_to_alias_map'][entry],
-                    element_tag_to_check=None,
-                    remove_parent_if_matched=True)
+            else:
+                bgp_peer_not_to_remove = value['name']
+                logger.info('BGP peer that will not be removed in test:{}'.format(bgp_peer_not_to_remove))
+
+        bgp_peers = [
+            x for x in minigraph_data['minigraph_bgp']
+            if (
+                ("ASIC" not in x['name'])
+                and (x['name'] != bgp_peer_not_to_remove)
+                and (x['name'] in bgp_peer_to_remove)
+            )
+        ]
+
+        addr_list = []
+        peer_list = []
+        for peer in bgp_peers:
+            addr_list.append(peer['addr'])
+            peer_list.append(peer['peer_addr'])
+
+        addr_list = list(set(addr_list))
+        peer_list = list(set(peer_list))
+
+        for addr in addr_list:
+            logger.info('To remove addr:{} from minigraph'.format(addr))
+            remove_count += remove_xml_entries(
+                minigraph_file,
+                text_to_remove=addr,
+                element_tag_to_check=None,
+                remove_parent_if_matched=True)
+
+        for peer in peer_list:
+            logger.info('To remove peer addr:{} from minigraph'.format(peer))
+            remove_count += remove_xml_entries(
+                minigraph_file,
+                text_to_remove=peer,
+                element_tag_to_check=None,
+                remove_parent_if_matched=True)
+
     return remove_count

--- a/tests/snappi_tests/GCU_README.md
+++ b/tests/snappi_tests/GCU_README.md
@@ -1,0 +1,369 @@
+# Snappi GCU (Generic Configuration Updater) Tests
+
+This document describes how GCU-based Reduced-Set-Base (RSB) configuration works for
+Snappi tests, how to run those tests, and how to troubleshoot common issues.
+
+## Overview
+
+When `--test_gcu_snappi` is enabled, the test harness:
+
+1. Modifies a copy of `minigraph.xml` to remove front-panel ports (RSB minigraph).
+2. Loads that minigraph on the DUT and saves the resulting **RSB** `config_db` snapshot
+   (`rsb_configs/`).
+3. **Builds** JSON patch files under `gcu_patches/` using `jsondiff` and `jq` (this step
+   does **not** run `config apply-patch`). Patches capture the difference between
+   `rsb_configs` (reduced) and `full_configs` (original).
+4. Restores the **original** `minigraph.xml` on the DUT disk from `full_configs/`
+   (`copy_minigraph_back`). The running `config_db` at this point is still the RSB
+   snapshot from step 2 until patches are applied.
+5. At the **start of each test module**, runs `sudo config apply-patch` on the generated
+   patch file(s) to bring the DUT to the **test runtime configuration** (original baseline
+   plus the changes encoded in the patch).
+6. At **session teardown** (after all modules finish), runs `config_reload` from the
+   restored original minigraph and `config save` to return the DUT to its original
+   configuration.
+
+Primary implementation files:
+
+| File | Role |
+|------|------|
+| `snappi_tests/conftest.py` | GCU fixtures, patch prepare/apply/archive |
+| `common/helpers/xml_utils.py` | Minigraph XML modification (`modify_minigraph`) |
+
+---
+
+## Prerequisites
+
+**Run `test_pretest.py` before GCU Snappi tests** on a testbed (especially after testbed
+changes, failed runs, or cache issues). Pretest helps ensure:
+
+- Local test cache is cleaned (`test_cleanup_cache`)
+- DUT feature/service state is valid
+- Testbed metadata and golden configs are refreshed
+
+Without pretest, the DUT may retain stale portchannel/LAG state and RSB conversion may
+not remove `PORTCHANNEL` / `PORTCHANNEL_MEMBER` from `rsb_configs` as expected.
+
+Example:
+
+```bash
+pytest test_pretest.py \
+  --inventory ../ansible/<inventory> \
+  --host-pattern <dut-hostname> \
+  --testbed <testbed-name> \
+  --testbed_file ../ansible/testbed.csv \
+  --topology util
+```
+
+Then run Snappi GCU tests (see [Running tests](#running-tests)).
+
+---
+
+## GCU modes: `--test_gcu_snappi`
+
+| Value | Description |
+|-------|-------------|
+| *(empty, default)* | GCU disabled; fixtures are no-ops |
+| `no_front_panel_ports` | Remove **all** front-panel ports from the RSB minigraph |
+| `one_front_panel_port` | Keep **one** front-panel port; remove the rest |
+
+### How ports are selected
+
+In `modify_minigraph()` (`common/helpers/xml_utils.py`):
+
+- Front-panel ports = keys in `minigraph_ports` whose names do not contain `-BP`.
+- `no_front_panel_ports`: all front-panel ports are removed.
+- `one_front_panel_port`: the first front-panel port (per ASIC minigraph facts pass)
+  is kept; all others are removed. If only one front-panel port exists, minigraph
+  modification is a no-op for that ASIC.
+
+On multi-ASIC DUTs, `modify_minigraph()` is called **once per ASIC** using that ASIC's
+`duts_minigraph_facts` entry, but always edits the **same** fetched minigraph file.
+
+---
+
+## Session flow (high level)
+
+```
+test_pretest.py (recommended)
+        │
+        ▼
+pytest snappi_tests/... --test_gcu_snappi=<mode>
+        │
+        ├─► convert_to_rsb (session, autouse) — setup
+        │     • fetch /etc/sonic/minigraph.xml
+        │     • modify_minigraph() per ASIC
+        │     • backup full_configs (original config + minigraph)
+        │     • load modified minigraph → config_reload → config save  [RSB on DUT]
+        │     • backup rsb_configs (RSB config snapshot)
+        │     • prepare_gcu_patches() — jsondiff/jq only → gcu_patches/
+        │     • copy_minigraph_back() — restore original minigraph.xml on disk
+        │
+        ├─► load_gcu_config (module, autouse) — per test module
+        │     • setup: sudo config apply-patch  [test runtime config on DUT]
+        │     • teardown: archive patch JSON to gcu_patches_archive/
+        │
+        └─► convert_to_rsb finally (session teardown)
+              • config_reload from original minigraph  [restore original config]
+              • config save
+```
+
+---
+
+## Minigraph modification
+
+### Fetch and edit
+
+1. Minigraph is fetched from the DUT to the test host (`/tmp/...`).
+2. `modify_minigraph(minigraph_file, minigraph_data, rsb_mode, platform_asic=...)`
+   edits that file in place using `remove_xml_entries()`.
+
+### Non–Broadcom-DNX platforms
+
+Removes interface names, aliases, neighbors, portchannel members (when
+`minigraph_portchannels` is populated in facts), and related XML entries using a
+broad minigraph scrubbing path.
+
+### Broadcom-DNX platforms (`platform_asic == "broadcom-dnx"`)
+
+Uses a targeted path:
+
+1. **Portchannels** — For each portchannel whose member is in `interfaces_to_remove`,
+   remove the portchannel name from the minigraph (when `minigraph_portchannels` is
+   available in minigraph facts).
+2. **BGP neighbors** — Remove neighbor names tied to removed interfaces.
+3. **BGP addresses** — Remove `addr` / `peer_addr` only for BGP peers associated with
+   removed neighbors (not all BGP entries).
+
+Platform detection uses `node.facts.get("platform_asic")` passed from
+`convert_to_rsb`; it is not hardcoded in the helper.
+
+### Load RSB minigraph
+
+If any XML was modified, the edited file is copied to `/etc/sonic/minigraph.xml` on
+the DUT and `config_reload(config_source="minigraph")` is run, followed by
+`config save`.
+
+### Minigraph handling
+
+After RSB backup and patch generation, **`copy_minigraph_back()` restores the original
+minigraph file** from `full_configs/minigraph.xml` onto the DUT (`/etc/sonic/minigraph.xml`).
+This does **not** by itself change the running `config_db`; it prepares the DUT so that
+**session teardown** can reload the original configuration from minigraph.
+
+**During the test:** runtime configuration comes from **`config apply-patch`** (module
+setup), not from the on-disk minigraph file.
+
+**After all tests:** session `finally` runs `config_reload(config_source="minigraph")` using
+the restored original minigraph, returning the DUT to its pre-test configuration.
+
+---
+
+## GCU patch generation (`prepare_gcu_patches`)
+
+Patch **generation** uses `jsondiff` and `jq` on the DUT. It does **not** invoke
+`config apply-patch`. Application happens later in `load_gcu_config`.
+
+For each ASIC ID from `duthost.get_asic_ids()`:
+
+1. `jsondiff` between `rsb_configs/config_db{asic}.json` and
+   `full_configs/config_db{asic}.json`.
+2. Filter out `remove`, `move`, and `BUFFER_*` operations.
+3. Prefix paths with `/asic{N}` for multi-ASIC.
+4. Split `INTERFACE` operations into `INTERFACES_{asic}.json`.
+5. Change remaining operations to `"add"`.
+
+### Per-ASIC patch files (non-DNX apply path)
+
+| File | Contents |
+|------|----------|
+| `patch{asic}.json` | Main patch (non-INTERFACE ops), e.g. `patch0.json`, `patchNone.json` |
+| `INTERFACES_{asic}.json` | INTERFACE-related ops only |
+
+On a pizza-box (single ASIC), `asic` may be `None` → filenames like `patchNone.json`.
+
+---
+
+## Broadcom-DNX variant
+
+### Combined patch
+
+On `platform_asic == "broadcom-dnx"`, after individual per-ASIC files are generated,
+`combine_gcu_patches()`:
+
+1. Collects `patch{asic}.json` and `INTERFACES_{asic}.json` that **exist and are
+   non-empty** (in deterministic order: all `patch*` first, then all `INTERFACES_*`).
+2. Merges them with `jq -s 'add'` into **`gcu_patches/combined_patch.json`**.
+
+### Applying patches on DNX
+
+In `load_gcu_config`:
+
+- **DNX:** Apply `gcu_patches/combined_patch.json` once.
+  - If combined patch is missing or empty, fall back to applying each `*.json` file
+    individually (same as non-DNX).
+- **Non-DNX:** Apply each `*.json` file under `gcu_patches/` via `dut.find()`.
+
+Supervisor nodes are skipped for both apply and archive.
+
+---
+
+## Patch apply (`load_gcu_config`)
+
+- **Scope:** `module` (setup applies patches; teardown archives them).
+- **Command:** `sudo config apply-patch <patch-file>`
+- **When:** Start of each test module, after session setup has built patches and
+  restored the original minigraph on disk.
+- **Purpose:** Apply the generated JSON patch to bring the DUT to the **test runtime
+  configuration** for that module.
+- **Success check:** Last line of stdout must be `Patch applied successfully.`
+- **Empty files:** Skipped (`size == 0`).
+
+After the module finishes, applied patch JSON files are moved to a timestamped archive
+under `gcu_patches_archive/` so the next module does not re-apply stale patches.
+
+**Session teardown** (not module teardown) restores the original DUT configuration via
+`config_reload` from the original minigraph — see [Session flow](#session-flow-high-level).
+
+---
+
+## Directories on the DUT
+
+All paths are relative to the DUT user home directory (typically `admin@<dut>:~`).
+
+| Directory / path | When created | Contents |
+|------------------|--------------|----------|
+| `full_configs/` | Session setup (`convert_to_rsb`) | Snapshot **before** RSB minigraph load: `config_db*.json`, `minigraph.xml` (original full config) |
+| `rsb_configs/` | Session setup, after RSB load | Snapshot **after** RSB minigraph load: RSB `config_db*.json`, modified minigraph |
+| `gcu_patches/` | `prepare_gcu_patches` | JSON patches for `config apply-patch`; cleared and regenerated each session prepare |
+| `gcu_patches_archive/<UTC-timestamp>/` | Module teardown after successful apply | Archived `*.json` from `gcu_patches/` (debug/history) |
+
+### Example `gcu_patches/` layout (multi-ASIC, non-DNX)
+
+```
+gcu_patches/
+  patch0.json
+  patch1.json
+  INTERFACES_0.json
+  INTERFACES_1.json
+```
+
+### Example with Broadcom-DNX
+
+```
+gcu_patches/
+  patch0.json
+  patch1.json
+  INTERFACES_0.json
+  INTERFACES_1.json
+  combined_patch.json          # used for apply on DNX
+```
+
+After module teardown:
+
+```
+gcu_patches/                   # empty
+gcu_patches_archive/
+  20260721_221530/
+    combined_patch.json
+    patch0.json
+    ...
+```
+
+---
+
+## Running tests
+
+### Enable GCU
+
+Add `--test_gcu_snappi` to your pytest command:
+
+```bash
+pytest snappi_tests/pfc/test_m2o_oversubscribe_lossless.py \
+  --inventory ../ansible/<inventory> \
+  --host-pattern <dut-hostname> \
+  --testbed <testbed-name> \
+  --testbed_file ../ansible/testbed.csv \
+  --topology multidut-tgen \
+  --test_gcu_snappi=no_front_panel_ports
+```
+
+Or keep one front-panel port:
+
+```bash
+  --test_gcu_snappi=one_front_panel_port
+```
+
+### Recommended full workflow
+
+```bash
+# 1. Pretest (once per testbed session / after issues)
+pytest test_pretest.py --inventory ... --host-pattern ... --testbed ... --topology util
+
+# 2. Snappi test with GCU
+pytest snappi_tests/<suite>/test_<name>.py \
+  --inventory ... \
+  --host-pattern ... \
+  --testbed ... \
+  --topology multidut-tgen \
+  --test_gcu_snappi=no_front_panel_ports \
+  ...
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | What to do |
+|---------|--------------|------------|
+| `PORTCHANNEL` in both `full_configs` and `rsb_configs` | Pretest not run; stale DUT/cache state | Run `test_pretest.py`; re-run GCU session |
+| Portchannels still in `show interface` before patch apply | RSB minigraph reload did not strip LAGs | Re-run pretest; inspect modified minigraph on test host during debug |
+| GCU apply fails / `Patch applied successfully` missing | Invalid patch, timeout, or YANG validation | Inspect patch file in `gcu_patches/` or `gcu_patches_archive/`; check `config apply-patch` manually |
+| Patches applied twice / stale behavior | Old JSON left in `gcu_patches/` | Archive logic should move files after each module; check `gcu_patches_archive/` and ensure module teardown ran |
+| DNX apply issues with many patch files | Ordering / multiple applies | DNX uses `combined_patch.json`; confirm `platform_asic` is `broadcom-dnx` and combined file exists |
+| Supervisor node errors | GCU skipped on supervisor by design | Expected; only linecard/front-end nodes are converted |
+| Empty `minigraph_portchannels` on T2 chassis | Per-ASIC minigraph facts may not populate portchannels | RSB still works via minigraph reload + config_db diff when pretest was run; portchannel removal in XML may rely on BGP path on DNX |
+
+### Inspect patches on DUT
+
+```bash
+ls -la gcu_patches/
+ls -la gcu_patches_archive/*/
+grep -i portchannel gcu_patches/*.json
+```
+
+### Compare config backups
+
+```bash
+diff <(jq -S '.PORTCHANNEL' full_configs/config_db0.json) \
+     <(jq -S '.PORTCHANNEL' rsb_configs/config_db0.json)
+```
+
+### Session cleanup
+
+Session `finally` in `convert_to_rsb` runs `config_reload` from minigraph and
+`config save` to restore a consistent state after all tests complete.
+
+---
+
+## Related pytest options
+
+| Option | Purpose |
+|--------|---------|
+| `--test_gcu_snappi` | Enable GCU RSB mode (`no_front_panel_ports`, `one_front_panel_port`, or empty) |
+| `--topology multidut-tgen` | Typical topology for Snappi/Ixia tests |
+
+---
+
+## Summary
+
+- **Pretest first** — required for reliable RSB/portchannel behavior on chassis testbeds.
+- **RSB snapshot** — created temporarily by loading a modified minigraph; saved as
+  `rsb_configs/` and used with `full_configs/` to **build** patch files (`jsondiff`/`jq`).
+- **Patch build ≠ patch apply** — `prepare_gcu_patches` only writes JSON files;
+  `load_gcu_config` runs `sudo config apply-patch` at module start.
+- **During tests** — DUT runtime config comes from applied GCU patches.
+- **After all tests** — session teardown reloads the **original minigraph** to restore
+  the DUT to its original configuration.
+- **Broadcom-DNX** merges patches into `combined_patch.json` and applies it once.
+- **On-DUT folders:** `full_configs`, `rsb_configs`, `gcu_patches`, `gcu_patches_archive`.

--- a/tests/snappi_tests/conftest.py
+++ b/tests/snappi_tests/conftest.py
@@ -1,10 +1,17 @@
 import pytest
+import logging
 import random
+from datetime import datetime, timezone
 from tests.common.snappi_tests.common_helpers import enable_packet_aging, start_pfcwd
 from tests.conftest import generate_priority_lists
 from tests.common.helpers.parallel import parallel_run
 from tests.common.helpers.xml_utils import modify_minigraph
 from tests.common.config_reload import config_reload
+
+logger = logging.getLogger(__name__)
+
+GCU_PATCHES_DIR = "gcu_patches"
+GCU_PATCHES_ARCHIVE_ROOT = "gcu_patches_archive"
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -121,8 +128,10 @@ def convert_to_rsb(duthosts, duts_minigraph_facts, gcu_mode_enabled):
         node.shell("rm /etc/sonic/running_golden*", module_ignore_errors=True)
         filename = node.fetch(src=minigraph_xml, dest="/tmp")['dest']
         modified = 0
+        platform_asic = node.facts.get("platform_asic")
         for entry in duts_minigraph_facts[node.hostname]:
-            modified += modify_minigraph(filename, entry[1], rsb_mode)
+            modified += modify_minigraph(
+                 filename, entry[1], rsb_mode, platform_asic=platform_asic)
         backup_config_files(node, "full_configs")
         if modified:
             copy_and_load_minigraph_to_dut(node, filename)
@@ -156,18 +165,70 @@ def convert_to_rsb(duthosts, duts_minigraph_facts, gcu_mode_enabled):
 
 
 def backup_config_files(dut, path):
+    logger.info('GCU: Taking backup of config_dbs and minigraphs')
     dut.shell(cmd=f"mkdir {path}", module_ignore_errors=True)
     dut.shell(cmd=f"cp /etc/sonic/config_db*json {path}")
     dut.shell(cmd=f"cp /etc/sonic/minigraph.xml {path}")
 
 
 def copy_and_load_minigraph_to_dut(dut, path):
+    logger.info('GCU: Loading new test minigraph on DUT:{}'.format(dut.hostname))
     dut.copy(src=path, dest="/etc/sonic/minigraph.xml")
     config_reload(dut, config_source="minigraph", start_bgp=True)
     dut.shell("config save -y")
 
 
+def _collect_gcu_patch_files(duthost, gcu_patches):
+    """Return patch files in deterministic apply order (patches first, then interfaces)."""
+    patch_files = []
+    for asic in duthost.get_asic_ids():
+        for name in (f"patch{asic}.json", f"INTERFACES_{asic}.json"):
+            path = f"{gcu_patches}/{name}"
+            stat = duthost.stat(path=path)['stat']
+            if stat['exists'] and stat['size'] != 0:
+                patch_files.append(path)
+    return patch_files
+
+
+def combine_gcu_patches(duthost, gcu_patches=GCU_PATCHES_DIR):
+    patch_files = _collect_gcu_patch_files(duthost, gcu_patches)
+    if not patch_files:
+        logger.info('GCU: No patch files to combine for DUT:{}'.format(duthost.hostname))
+        return False
+
+    combined = f"{gcu_patches}/combined_patch.json"
+    files_arg = ' '.join(patch_files)
+    duthost.shell(f"jq -s 'add' {files_arg} > {combined}")
+    logger.info('GCU: Combined {} patch file(s) into {} on DUT:{}'.format(
+        len(patch_files), combined, duthost.hostname))
+    return True
+
+
+def archive_gcu_patches(duthost, gcu_patches=GCU_PATCHES_DIR,
+                        archive_root=GCU_PATCHES_ARCHIVE_ROOT):
+    """Move JSON patch files into a timestamped archive directory on the DUT."""
+    if not duthost.stat(path=gcu_patches)['stat']['exists']:
+        return None
+
+    json_files = duthost.find(paths=gcu_patches, pattern="*.json")['files']
+    if not json_files:
+        logger.info('GCU: No patch files to archive on DUT:{}'.format(duthost.hostname))
+        return None
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    archive_dir = f"{archive_root}/{timestamp}"
+    duthost.shell(f"mkdir -p {archive_dir}", module_ignore_errors=True)
+    duthost.shell(
+        f"mv {gcu_patches}/*.json {archive_dir}/",
+        module_ignore_errors=True)
+    logger.info(
+        'GCU: Archived {} patch file(s) from {} to {} on DUT:{}'.format(
+            len(json_files), gcu_patches, archive_dir, duthost.hostname))
+    return archive_dir
+
+
 def prepare_gcu_patches(duthost, full_configs, rsb_configs, gcu_patches="gcu_patches"):
+    logger.info('GCU: Preparing GCU patches for DUT:{}'.format(duthost.hostname))
     duthost.shell(f"mkdir {gcu_patches}", module_ignore_errors=True)
     duthost.shell(f'''rm {gcu_patches}/*.json''', module_ignore_errors=True)
     for asic in duthost.get_asic_ids():
@@ -188,6 +249,9 @@ def prepare_gcu_patches(duthost, full_configs, rsb_configs, gcu_patches="gcu_pat
         for cmd in cmds:
             duthost.shell(cmd=cmd)
 
+    if duthost.facts.get("platform_asic") == "broadcom-dnx":
+        combine_gcu_patches(duthost, gcu_patches)
+
 
 def copy_minigraph_back(duthost, source):
     duthost.shell(f"cp {source}/minigraph.xml /etc/sonic/minigraph.xml")
@@ -203,17 +267,48 @@ def load_gcu_config(duthosts, gcu_mode_enabled):
     def load_file(dut, filename):
         stats = dut.stat(path=filename)['stat']
         if stats['exists'] and stats['size'] != 0:
+            logger.info('GCU: Applying JSON patch:{} on DUT:{}'.format(filename, dut.hostname))
             result = dut.shell(f"config apply-patch {filename}")
             if result['stdout_lines'][-1] != 'Patch applied successfully.':
                 raise RuntimeError(f"GCU patch{filename} was not applied successfully: Result: {result}")
             return True
+        return False
+
+    patches_applied = {}
 
     for dut in duthosts:
-        path = "gcu_patches"
-        if dut.stat(path=path)['stat']['exists']:
-            file_list = [x['path'] for x in dut.find(paths=path, pattern="*.json")['files']]
+        patches_applied[dut.hostname] = False
+
+        if dut.is_supervisor_node():
+            continue
+
+        path = GCU_PATCHES_DIR
+        if not dut.stat(path=path)['stat']['exists']:
+            continue
+
+        if dut.facts.get("platform_asic") == "broadcom-dnx":
+            combined = f"{path}/combined_patch.json"
+            if not load_file(dut, combined):
+                file_list = [
+                    x['path'] for x in dut.find(paths=path, pattern="*.json")['files']
+                ]
+                for filename in file_list:
+                    if load_file(dut, filename):
+                        patches_applied[dut.hostname] = True
+            else:
+                patches_applied[dut.hostname] = True
+        else:
+            file_list = [
+                x['path'] for x in dut.find(paths=path, pattern="*.json")['files']
+            ]
             for filename in file_list:
-                load_file(dut, filename)
+                if load_file(dut, filename):
+                    patches_applied[dut.hostname] = True
 
     yield
-    return
+
+    for dut in duthosts:
+        if dut.is_supervisor_node():
+            continue
+        if patches_applied.get(dut.hostname):
+            archive_gcu_patches(dut)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Added support for GCU on DNX platform.

- Using broadcom_dnx flag to separate the DNX vs non-DNX  code.
- DNX code removes portchannels, IP-interfaces etc.
- Instead of multiple GCU patches, it combines all patches in one single patch - combined_patch.json.
- Added GCU_README.md file documenting details of implementation and how-to for using GCU along with regular test.

Summary:
Fixes #22080 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [X] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
The GCU support on SNAPPI was added for packet-based chassis. This was extended to DNX platform based chassis.

#### How did you do it?
Created a flag based out of node-platform and passed on that flag to '_modify_minigraph_' function. If DUT is DNX platform, then code will remove all necessary parameters to create RSB config.

Additionally, if this flag is present, instead of loading individual patches, all patches are combined into one single patch.

Added support for archiving the patches instead of deleting them. For every test, a folder with date-timestamp is created in '_gcu_archive_' folder. The GCU patches are stored in them. Currently, all the patches are deleted at the start of the test. Archiving will help for referencing/storing and debugging issues.

Created a GCU_README.md file for documentation pertaining to this feature.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran the test against Broadcom-DNX based platform and ensured that patch(es) are created, applied and archived. Test ran on the DUT after patch-application and original minigraph is restored in the end.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
