### PR TITLE
test(macsec): xfail test_per_interface_profile on VS pending harness fix

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3836,6 +3836,12 @@ macsec/test_interop_protocol.py::TestInteropProtocol::test_snmp:
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/18273"
 
+macsec/test_per_interface_profile.py:
+  xfail:
+    reason: "Setup aborts on VS with \"SonicHost object has no attribute 'sonic_basic_facts'\" (parallel thread worker); build team is working on a fix"
+    conditions:
+      - "asic_type in ['vs']"
+
 #######################################
 #####           mclag             #####
 #######################################


### PR DESCRIPTION
### Description of PR

Summary:

Mark the `macsec/test_per_interface_profile.py` module as an expected failure on VS while the build team fixes the underlying harness/image issue. Physical (non-VS) coverage remains enabled.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: regression

### Approach
#### What is the motivation for this PR?

On VS (`t0-64-32`, master KVM images), every non-skipped run of this module aborts in **setup**, not in the test body, with:

```
failed on setup with "RuntimeError: Thread worker aborted: AttributeError("'<class 'tests.common.devices.sonic.SonicHost'>' object has no attribute 'sonic_basic_facts'")"
```

This is a harness issue (the parallel thread worker fails resolving the `sonic_basic_facts` Ansible module on `SonicHost` during fact gathering), not a MACsec product defect. Because it aborts in setup, it surfaces as `error` and lands as a sev0 signal in baseline and as a flaky signal in PR (MACsec runs in only a minority of plans, so the aggregate failure rate looks intermittent). The build team is working on a fix; quarantine on VS until then.

#### How did you do it?

Added a conditional, non-strict xfail for the `macsec/test_per_interface_profile.py` module when `asic_type` is `vs`. 
