### PR TITLE
[gnmi] Port poll_mode_no_table_or_key test from telemetry to gnmi suite

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -384,6 +384,40 @@ def gnmi_subscribe_polling(duthost, ptfhost, path_list, interval_ms, count, ip=N
     return output['stdout'], output['stderr']
 
 
+def gnmi_subscribe_polling_py(duthost, ptfhost, path_list, polling_interval, update_count,
+                              max_sync_count, timeout, ip=None):
+    """
+    Send a POLL-mode GNMI subscribe request via py_gnmicli.
+
+    Unlike gnmi_subscribe_polling (gnmi_cli), this uses py_gnmicli so callers can
+    bound the run with max_sync_count / timeout and inspect the raw response
+    stream (sync_response, json_ietf_val, delete markers). Used by the ported
+    telemetry POLL edge-case tests.
+
+    Returns the ptfhost.shell result dict (rc / stdout / stderr).
+    """
+    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    ip = ip or duthost.mgmt_ip
+    port = env.gnmi_port
+    cmd = '/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py '
+    cmd += '-t %s -p %u ' % (ip, port)
+    cmd += '-xo sonic-db '
+    cmd += '-rcert /root/gnmiCA.pem '
+    cmd += '-pkey /root/gnmiclient.key '
+    cmd += '-cchain /root/gnmiclient.crt '
+    cmd += '--encoding 4 '
+    cmd += '-m subscribe '
+    cmd += '--subscribe_mode 2 '  # POLL
+    cmd += '--polling_interval %u ' % polling_interval
+    cmd += '--update_count %u ' % update_count
+    cmd += '--max_sync_count %u ' % max_sync_count
+    cmd += '--timeout %u ' % timeout
+    cmd += '--xpath '
+    for path in path_list:
+        cmd += " " + path.replace('sonic-db:', '')
+    return ptfhost.shell(cmd, module_ignore_errors=True)
+
+
 def gnmi_subscribe_streaming_sample(duthost, ptfhost, path_list, interval_ms, count, origin=None, target=None,
                                     ip=None):
     """

--- a/tests/gnmi/test_gnmi_appldb.py
+++ b/tests/gnmi/test_gnmi_appldb.py
@@ -1,7 +1,8 @@
 import logging
 import pytest
+import re
 
-from .helper import gnmi_set, gnmi_get
+from .helper import gnmi_set, gnmi_get, gnmi_subscribe_polling_py, get_namespace
 
 logger = logging.getLogger(__name__)
 
@@ -63,3 +64,21 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
         logger.info("Failed to read path2: " + str(e))
     else:
         pytest.fail("Remove DASH_VNET_TABLE failed: " + msg_list2[0])
+
+
+def test_poll_mode_no_table_or_key(duthosts, rand_one_dut_hostname, ptfhost):
+    '''
+    POLL mode from APPL_DB querying a non-existent table and key returns sync
+    responses and no error. Ported from tests/telemetry test_poll_mode_no_table_or_key.
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    namespace_name = get_namespace(duthost)
+    path_list = ["/sonic-db:APPL_DB/{}/FAKE_APPL_DB_TABLE_0".format(namespace_name),
+                 "/sonic-db:APPL_DB/{}/FAKE_APPL_DB_TABLE_1/fake_key1".format(namespace_name)]
+    result = gnmi_subscribe_polling_py(duthost, ptfhost, path_list, polling_interval=5,
+                                       update_count=0, max_sync_count=5, timeout=30)
+    assert result['rc'] == 0, "ptf poll command failed: {}".format(result)
+    out = str(result['stdout'])
+    sync_responses = re.findall("sync_response: true", out)
+    assert len(sync_responses) == 5, (
+        "Expected 5 sync responses, got {}: {}".format(len(sync_responses), out))

--- a/tests/telemetry/test_telemetry_poll.py
+++ b/tests/telemetry/test_telemetry_poll.py
@@ -44,30 +44,6 @@ def modify_fake_appdb_table(duthost, add=True, entries=1, namespace=""):
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_poll_mode_no_table_or_key(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                                   setup_streaming_telemetry, gnxi_path,
-                                   enum_rand_one_asic_index):
-    """
-    Test poll mode from APPL_DB and query a non existing table and key, ensure no errors
-    """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    logger.info('Start telemetry poll mode testing')
-    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
-    cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
-                              subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=5,
-                              xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
-                              max_sync_count=5, update_count=0, timeout=30, namespace=namespace)
-    ptf_result = ptfhost.shell(cmd)
-    pytest_assert(ptf_result['rc'] == 0, "ptf cmd command {} failed".format(cmd))
-    show_gnmi_out = ptf_result['stdout']
-    logger.info("GNMI Server output")
-    logger.info(show_gnmi_out)
-    result = str(show_gnmi_out)
-    sync_responses_match = re.findall("sync_response: true", result)
-    pytest_assert(len(sync_responses_match) == 5, "Missing sync responses")
-
-
-@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_poll_mode_present_table_delayed_key(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
                                              setup_streaming_telemetry, gnxi_path,
                                              enum_rand_one_asic_index):


### PR DESCRIPTION
### Description of PR

Summary:
The `telemetry` container is deprecated in favor of the `gnmi` container, which runs the same sonic-gnmi server. POLL is a generic gNMI subscribe mode that server serves (client_subscribe.go handles POLL for DB targets), so this coverage belongs on the gnmi container. This **ports** `test_poll_mode_no_table_or_key` from `tests/telemetry/test_telemetry_poll.py` to the gnmi suite and removes the telemetry copy. It is the first of the `test_telemetry_poll.py` group; the remaining (more involved) POLL tests will stack on the helper this PR adds.

The test issues a POLL-mode subscribe to a non-existent APPL_DB table and key and asserts it returns the expected number of `sync_response: true` messages with no error.

The gnmi suite's existing `gnmi_subscribe_polling` uses the `gnmi_cli` binary, which cannot bound a run by `max_sync_count` or surface the raw `sync_response` stream these POLL edge-case tests assert on. So this PR adds a py_gnmicli-based POLL helper (`gnmi_subscribe_polling_py`) alongside it.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: N/A

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

`gnmi/test_gnmi_appldb.py` is listed in `.azure-pipelines/pr_test_scripts.yaml` (t0 / t1-lag / onboarding-multi-asic), so this PR's Elastictest kvmtest jobs run `test_poll_mode_no_table_or_key` on KVM virtual testbeds — see the `Azure.sonic-mgmt ... kvmtest` checks for the pass/skip signal. Additional grounding:

- `pre-commit run` (flake8) and `pyflakes` are clean on all changed files.
- POLL over DB targets is served by the same sonic-gnmi server the gnmi container runs (`gnmi_server/client_subscribe.go`), so this is generic-server coverage, not telemetry-container-specific.
- Open item: the exact py_gnmicli POLL flag set (`--subscribe_mode 2 --polling_interval / --update_count / --max_sync_count / --timeout`) is mirrored from the telemetry client's proven POLL command, but py_gnmicli lives on the ptfhost image (not this repo), so the kvmtest run is what confirms it.

### Approach
#### What is the motivation for this PR?

Migrate generic gNMI-server test coverage off the deprecated telemetry container onto the gnmi container, one test per PR for clean review.

#### How did you do it?

Added `gnmi_subscribe_polling_py` (py_gnmicli POLL subscribe supporting `max_sync_count` / `timeout`) to `tests/gnmi/helper.py`, added `test_poll_mode_no_table_or_key` to `tests/gnmi/test_gnmi_appldb.py`, and removed the telemetry copy.

#### How did you verify/test it?

See Test result above.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

`topology('any')` — same as the source test.

### Documentation

No documentation changes required.
