### PR TITLE
[gnmi] Port poll_mode_present_table_delayed_key from telemetry to gnmi suite

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -384,6 +384,40 @@ def gnmi_subscribe_polling(duthost, ptfhost, path_list, interval_ms, count, ip=N
     return output['stdout'], output['stderr']
 
 
+def gnmi_subscribe_polling_py(duthost, ptfhost, path_list, polling_interval, update_count,
+                              max_sync_count, timeout, ip=None):
+    """
+    Send a POLL-mode GNMI subscribe request via py_gnmicli.
+
+    Unlike gnmi_subscribe_polling (gnmi_cli), this uses py_gnmicli so callers can
+    bound the run with max_sync_count / timeout and inspect the raw response
+    stream (sync_response, json_ietf_val, delete markers). Used by the ported
+    telemetry POLL edge-case tests.
+
+    Returns the ptfhost.shell result dict (rc / stdout / stderr).
+    """
+    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    ip = ip or duthost.mgmt_ip
+    port = env.gnmi_port
+    cmd = '/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py '
+    cmd += '-t %s -p %u ' % (ip, port)
+    cmd += '-xo sonic-db '
+    cmd += '-rcert /root/gnmiCA.pem '
+    cmd += '-pkey /root/gnmiclient.key '
+    cmd += '-cchain /root/gnmiclient.crt '
+    cmd += '--encoding 4 '
+    cmd += '-m subscribe '
+    cmd += '--subscribe_mode 2 '  # POLL
+    cmd += '--polling_interval %u ' % polling_interval
+    cmd += '--update_count %u ' % update_count
+    cmd += '--max_sync_count %u ' % max_sync_count
+    cmd += '--timeout %u ' % timeout
+    cmd += '--xpath '
+    for path in path_list:
+        cmd += " " + path.replace('sonic-db:', '')
+    return ptfhost.shell(cmd, module_ignore_errors=True)
+
+
 def gnmi_subscribe_streaming_sample(duthost, ptfhost, path_list, interval_ms, count, origin=None, target=None,
                                     ip=None):
     """

--- a/tests/gnmi/test_gnmi_appldb.py
+++ b/tests/gnmi/test_gnmi_appldb.py
@@ -1,7 +1,8 @@
 import logging
 import pytest
+import re
 
-from .helper import gnmi_set, gnmi_get
+from .helper import gnmi_set, gnmi_get, gnmi_subscribe_polling_py, get_namespace
 
 logger = logging.getLogger(__name__)
 
@@ -63,3 +64,21 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
         logger.info("Failed to read path2: " + str(e))
     else:
         pytest.fail("Remove DASH_VNET_TABLE failed: " + msg_list2[0])
+
+
+def test_poll_mode_no_table_or_key(duthosts, rand_one_dut_hostname, ptfhost):
+    '''
+    POLL mode from APPL_DB querying a non-existent table and key returns sync
+    responses and no error. Ported from tests/telemetry test_poll_mode_no_table_or_key.
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    namespace_name = get_namespace(duthost)
+    path_list = ["/sonic-db:APPL_DB/{}/FAKE_APPL_DB_TABLE_0".format(namespace_name),
+                 "/sonic-db:APPL_DB/{}/FAKE_APPL_DB_TABLE_1/fake_key1".format(namespace_name)]
+    result = gnmi_subscribe_polling_py(duthost, ptfhost, path_list, polling_interval=5,
+                                       update_count=0, max_sync_count=5, timeout=30)
+    assert result['rc'] == 0, "ptf poll command failed: {}".format(result)
+    out = str(result['stdout'])
+    sync_responses = re.findall("sync_response: true", out)
+    assert len(sync_responses) == 5, (
+        "Expected 5 sync responses, got {}: {}".format(len(sync_responses), out))

--- a/tests/gnmi/test_gnmi_appldb.py
+++ b/tests/gnmi/test_gnmi_appldb.py
@@ -1,10 +1,33 @@
 import logging
 import pytest
 import re
+import threading
 
 from .helper import gnmi_set, gnmi_get, gnmi_subscribe_polling_py, get_namespace
+from tests.common.helpers.gnmi_utils import GNMIEnvironment
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
+
+
+def _gnmi_client_connected(duthost, ptfhost):
+    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    res = ptfhost.shell('netstat -tn | grep ":{} .*ESTABLISHED"'.format(env.gnmi_port),
+                        module_ignore_errors=True)
+    return res["rc"] == 0
+
+
+def _modify_fake_appdb_table(duthost, namespace, add=True, entries=1):
+    cmd_prefix = "sonic-db-cli"
+    if duthost.is_multi_asic:
+        cmd_prefix = "sonic-db-cli -n {}".format(namespace)
+    for entry in range(entries):
+        if add:
+            cmd = cmd_prefix + " APPL_DB hset FAKE_APPL_DB_TABLE_{0}:fake_key{0} dummy{0} val".format(entry)
+        else:
+            cmd = cmd_prefix + " APPL_DB hdel FAKE_APPL_DB_TABLE_{0}:fake_key{0} dummy{0}".format(entry)
+        assert duthost.shell(cmd)['rc'] == 0, "Unable to modify FAKE_APPL_DB_TABLE_{}".format(entry)
+
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -82,3 +105,41 @@ def test_poll_mode_no_table_or_key(duthosts, rand_one_dut_hostname, ptfhost):
     sync_responses = re.findall("sync_response: true", out)
     assert len(sync_responses) == 5, (
         "Expected 5 sync responses, got {}: {}".format(len(sync_responses), out))
+
+
+def test_poll_mode_present_table_delayed_key(duthosts, rand_one_dut_hostname, ptfhost, enum_rand_one_asic_index):
+    '''
+    POLL an existing APPL_DB table returns data with no error; then re-poll while
+    inserting a key mid-stream and confirm the new data appears. Ported from
+    tests/telemetry test_poll_mode_present_table_delayed_key.
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
+    path_ns = namespace if namespace else "localhost"
+    path_list = ["/sonic-db:APPL_DB/{}/FAKE_APPL_DB_TABLE_0".format(path_ns),
+                 "/sonic-db:APPL_DB/{}/FAKE_APPL_DB_TABLE_1/fake_key1".format(path_ns)]
+
+    _modify_fake_appdb_table(duthost, namespace)  # add first table data
+    result = gnmi_subscribe_polling_py(duthost, ptfhost, path_list, polling_interval=2,
+                                       update_count=5, max_sync_count=-1, timeout=30)
+    assert result['rc'] == 0, "ptf poll command failed: {}".format(result)
+    updates = re.findall("json_ietf_val", str(result['stdout']))
+    assert len(updates) == 5, "Expected 5 update responses, got {}".format(len(updates))
+
+    holder = {}
+
+    def poll_worker():
+        holder['result'] = gnmi_subscribe_polling_py(duthost, ptfhost, path_list, polling_interval=2,
+                                                     update_count=20, max_sync_count=-1, timeout=60)
+
+    client_thread = threading.Thread(target=poll_worker)
+    client_thread.start()
+    try:
+        wait_until(5, 1, 0, _gnmi_client_connected, duthost, ptfhost)
+        _modify_fake_appdb_table(duthost, namespace, add=True, entries=2)  # add second table data
+        client_thread.join(60)
+    finally:
+        _modify_fake_appdb_table(duthost, namespace, add=False, entries=2)  # remove added tables
+
+    out = str(holder.get('result', {}).get('stdout', ''))
+    assert re.findall("dummy1", out), "Missing update response for delayed key: {}".format(out)

--- a/tests/telemetry/test_telemetry_poll.py
+++ b/tests/telemetry/test_telemetry_poll.py
@@ -44,53 +44,6 @@ def modify_fake_appdb_table(duthost, add=True, entries=1, namespace=""):
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_poll_mode_present_table_delayed_key(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                                             setup_streaming_telemetry, gnxi_path,
-                                             enum_rand_one_asic_index):
-    """
-    Test poll mode from APPL_DB and query an existing table and missing key, ensure no errors and present data
-    After that, begin querying again and put the key and ensure no errors and new data
-    """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    logger.info('Start telemetry poll mode testing')
-    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
-    cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
-                              subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
-                              xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
-                              max_sync_count=-1, update_count=5, timeout=30, namespace=namespace)
-    modify_fake_appdb_table(duthost, namespace=namespace)  # Add first table data
-    ptf_result = ptfhost.shell(cmd)
-    pytest_assert(ptf_result['rc'] == 0, "ptf cmd command {} failed".format(cmd))
-    show_gnmi_out = ptf_result['stdout']
-    logger.info("GNMI Server output")
-    logger.info(show_gnmi_out)
-    result = str(show_gnmi_out)
-    update_responses_match = re.findall("json_ietf_val", result)
-    pytest_assert(len(update_responses_match) == 5, "Missing update responses")
-
-    cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
-                              subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
-                              xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
-                              max_sync_count=-1, update_count=20, timeout=60, namespace=namespace)
-
-    def callback(show_gnmi_out):
-        result = str(show_gnmi_out)
-        logger.info(result)
-        update_responses_match = re.findall("dummy1", result)
-        assert len(update_responses_match) != 0, "Missing update response"
-
-    client_thread = InterruptableThread(target=invoke_py_cli_from_ptf, args=(ptfhost, cmd, callback,))
-    client_thread.start()
-
-    wait_until(5, 1, 0, check_gnmi_cli_running, duthost, ptfhost)
-
-    modify_fake_appdb_table(duthost, True, 2, namespace)  # Add second table data
-    client_thread.join(60)
-
-    modify_fake_appdb_table(duthost, False, 2, namespace)  # Remove all added tables
-
-
-@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_poll_mode_delete(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
                           setup_streaming_telemetry, gnxi_path,
                           enum_rand_one_asic_index):

--- a/tests/telemetry/test_telemetry_poll.py
+++ b/tests/telemetry/test_telemetry_poll.py
@@ -44,30 +44,6 @@ def modify_fake_appdb_table(duthost, add=True, entries=1, namespace=""):
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_poll_mode_no_table_or_key(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                                   setup_streaming_telemetry, gnxi_path,
-                                   enum_rand_one_asic_index):
-    """
-    Test poll mode from APPL_DB and query a non existing table and key, ensure no errors
-    """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    logger.info('Start telemetry poll mode testing')
-    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
-    cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
-                              subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=5,
-                              xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
-                              max_sync_count=5, update_count=0, timeout=30, namespace=namespace)
-    ptf_result = ptfhost.shell(cmd)
-    pytest_assert(ptf_result['rc'] == 0, "ptf cmd command {} failed".format(cmd))
-    show_gnmi_out = ptf_result['stdout']
-    logger.info("GNMI Server output")
-    logger.info(show_gnmi_out)
-    result = str(show_gnmi_out)
-    sync_responses_match = re.findall("sync_response: true", result)
-    pytest_assert(len(sync_responses_match) == 5, "Missing sync responses")
-
-
-@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_poll_mode_present_table_delayed_key(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
                                              setup_streaming_telemetry, gnxi_path,
                                              enum_rand_one_asic_index):


### PR DESCRIPTION
### Description of PR

Summary:
The `telemetry` container is deprecated in favor of the `gnmi` container, which runs the same sonic-gnmi server; POLL is a generic subscribe mode it serves. This **ports** `test_poll_mode_present_table_delayed_key` from `tests/telemetry/test_telemetry_poll.py` to the gnmi suite and removes the telemetry copy.

The test POLLs an existing APPL_DB table, then re-polls while a key is inserted mid-stream, and confirms the new data appears in the stream.

> **Stacked on #26471** (the `poll_mode_no_table_or_key` port), which adds the `gnmi_subscribe_polling_py` helper this test reuses. Until that merges, this PR's diff also shows #26471's commit; review the "present_table_delayed_key" commit here.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: N/A

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Validated on a t1 testbed (gold208): `test_poll_mode_present_table_delayed_key` passes against the gnmi container. `gnmi/test_gnmi_appldb.py` is also in `.azure-pipelines/pr_test_scripts.yaml`, so the Elastictest kvmtest jobs exercise it on KVM. `pre-commit` (flake8) and `pyflakes` are clean.

### Approach
#### What is the motivation for this PR?

Migrate generic gNMI-server test coverage off the deprecated telemetry container onto the gnmi container, one test per PR for clean review.

#### How did you do it?

Added `_modify_fake_appdb_table` / `_gnmi_client_connected` helpers and `test_poll_mode_present_table_delayed_key` to `tests/gnmi/test_gnmi_appldb.py`, running the second POLL in a worker thread while the fake APPL_DB key is inserted mid-stream, and removed the telemetry copy.

#### How did you verify/test it?

See Test result above.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

`topology('any')` — same as the source test.

### Documentation

No documentation changes required.
