### PR TITLE
[cacl][test] Expect dhcp_server docker0 syslog rule on tcp/2514

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -578,9 +578,7 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
                                    .format(v['IPv6Address'],
                                            docker_network['bridge']['IPv6Address']))
 
-        # Only dhcp_server forwards rsyslog to the host over docker0 (RELP
-        # tcp/2514); caclmgrd re-adds this INPUT ACCEPT on every rebuild while
-        # FEATURE|dhcp_server is enabled. Gate on that feature state.
+        # dhcp_server forwards rsyslog to the host over docker0 (tcp/2514); caclmgrd adds this ACCEPT when enabled
         feature_status, _ = duthost.get_feature_status()
         if feature_status.get("dhcp_server") == "enabled":
             iptables_rules.append(

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -578,17 +578,11 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
                                    .format(v['IPv6Address'],
                                            docker_network['bridge']['IPv6Address']))
 
-        # dhcp_server and redfish both run in bridge mode, but only
-        # dhcp_server's rsyslog reaches the host over docker0 via RELP
-        # (tcp/2514). caclmgrd owns the INPUT ACCEPT
-        # exception for that traffic and re-emits it on every control-plane ACL
-        # flush-and-rebuild while FEATURE|dhcp_server is enabled, so the rule
-        # survives the rebuild. Gate the expectation on the feature state that
-        # caclmgrd keys on, not merely on the container being present.
-        dhcp_server_feature_state = duthost.shell(
-            "sonic-db-cli CONFIG_DB HGET 'FEATURE|dhcp_server' state",
-            module_ignore_errors=True)['stdout'].strip()
-        if dhcp_server_feature_state == "enabled":
+        # Only dhcp_server forwards rsyslog to the host over docker0 (RELP
+        # tcp/2514); caclmgrd re-adds this INPUT ACCEPT on every rebuild while
+        # FEATURE|dhcp_server is enabled. Gate on that feature state.
+        feature_status, _ = duthost.get_feature_status()
+        if feature_status.get("dhcp_server") == "enabled":
             iptables_rules.append(
                 "-A INPUT -i docker0 -p tcp -m tcp --dport 2514"
                 " -m comment --comment dhcp_server_syslog -j ACCEPT")

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -578,11 +578,19 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
                                    .format(v['IPv6Address'],
                                            docker_network['bridge']['IPv6Address']))
 
-        # dhcp_server uses bridge networking; its startup script adds an iptables
-        # rule to allow syslog (UDP 514) past caclmgrd's catch-all DROP.
-        if "dhcp_server" in docker_network['container']:
+        # dhcp_server and redfish both run in bridge mode, but only
+        # dhcp_server's rsyslog reaches the host over docker0 via RELP
+        # (tcp/2514). caclmgrd owns the INPUT ACCEPT
+        # exception for that traffic and re-emits it on every control-plane ACL
+        # flush-and-rebuild while FEATURE|dhcp_server is enabled, so the rule
+        # survives the rebuild. Gate the expectation on the feature state that
+        # caclmgrd keys on, not merely on the container being present.
+        dhcp_server_feature_state = duthost.shell(
+            "sonic-db-cli CONFIG_DB HGET 'FEATURE|dhcp_server' state",
+            module_ignore_errors=True)['stdout'].strip()
+        if dhcp_server_feature_state == "enabled":
             iptables_rules.append(
-                "-A INPUT -i docker0 -p udp -m udp --dport 514"
+                "-A INPUT -i docker0 -p tcp -m tcp --dport 2514"
                 " -m comment --comment dhcp_server_syslog -j ACCEPT")
 
     else:


### PR DESCRIPTION
### Description of PR

Summary:
`caclmgrd`'s control-plane ACL rebuild appends a catch-all `INPUT ... -j DROP`. The `dhcp_server` container forwards its rsyslog to the host over `docker0` (it is the only container that does so; other containers, including bridge-mode `redfish`, log to `127.0.0.1`), and that traffic now uses **RELP over tcp/2514** (not the old udp/514). Ownership of the `docker0` `ACCEPT` exception moved from the container start/stop script to `caclmgrd`, which re-installs it on every rebuild keyed on `FEATURE|dhcp_server` — so it survives the flush-and-rebuild (root cause of sonic-net/sonic-buildimage#27584).

This updates `generate_expected_rules()` in `tests/cacl/test_cacl_application.py` to assert the new **tcp/2514** exception instead of the stale **udp/514** rule and to gate that expectation on the `FEATURE|dhcp_server` state (what `caclmgrd` keys on) rather than container presence, so the CACL test matches the shipped behavior.

Product changes this test requires (merged on master):
- sonic-net/sonic-buildimage#28328 — remove the container-side add/del.
- sonic-net/sonic-host-services#412 — `caclmgrd` owns the rule.

Complementary follow-up sonic-net/sonic-buildimage#28580 adds container-side feature-gated waits; it does not change the rule asserted by this test.

Fixes # (issue)
ADO: 38902699 (parent PBI 38699922). Underlying bug: sonic-net/sonic-buildimage#27584.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): Microsoft ADO 38902699
Failure type: day-one issue (the container-owned docker0 syslog rule never survived a caclmgrd control-plane ACL rebuild; the test expectation must move to tcp/2514 in lockstep with the product change on each branch it is backported to)

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

202605 hardware validation passed on `bjw-can-720dt-2` (720dt, `mx`) running `SONiC.20260510.07`. The complete PR series was cherry-picked onto `internal-202605` and run with:

`run_tests.sh -n testbed-bjw-can-720dt-2 -c cacl/test_cacl_application.py -i ../ansible/veos,../ansible/bjw -u -x -a False`

Result: **5 passed, 4 topology skips** in 25:51. Post-teardown, `FEATURE|dhcp_server` remained enabled, the container was running, and the canonical tcp/2514 rule remained at INPUT position 3 above the catch-all DROP at position 46.

### Approach
#### What is the motivation for this PR?
Keep the CACL regression test aligned with the product: the `dhcp_server` `docker0` syslog exception is now a caclmgrd-owned tcp/2514 rule, not a container-owned udp/514 rule.

#### How did you do it?
In `generate_expected_rules()` (host / `asic_index is None` branch), changed the expected `dhcp_server_syslog` rule from `-p udp -m udp --dport 514` to `-p tcp -m tcp --dport 2514`, updated the comment to describe the new caclmgrd ownership, and changed the gate from mere container presence to the `FEATURE|dhcp_server` state returned by `duthost.get_feature_status()` that `caclmgrd` itself keys on.

#### How did you verify/test it?
`python3 -m py_compile` + repo pre-commit (flake8) pass. The full 202605 hardware run passed as recorded in Test result; the expected rule matches the live `iptables -S INPUT` output after test teardown.

#### Any platform specific information?
None — host-namespace IPv4 INPUT rule; applies to all platforms running the `dhcp_server` feature.

#### Supported testbed topology if it's a new test case?
N/A (existing test).

### Documentation
N/A.



