### PR TITLE
[dhcp_server][test] Verify grouped process alerts after CACL rebuild

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -1423,3 +1423,119 @@ def test_caclmgrd_syslog(duthosts, enum_rand_one_per_hwsku_hostname,):
     match = re.search(r'(caclmgrd.*?iptables)', systemctl_output)
     mux_match = re.search(r'(caclmgrd.*?mux)', systemctl_output)
     pytest_assert(match or mux_match, "iptables rules are not applied after restarting caclmgrd")
+
+
+@pytest.fixture
+def restore_dhcp_server_feature_state(duthosts, enum_rand_one_per_hwsku_hostname):
+    """Snapshot FEATURE|dhcp_server state and restore it after the test.
+
+    The teardown waits for CONFIG_DB to converge back to the original state so a
+    test that toggles the feature cannot leak a mid-transition state into the
+    next test. This lives in a fixture (not an in-test ``finally``) so the
+    convergence wait can be asserted without swallowing the test-body exception.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    orig_state = duthost.shell(
+        "sonic-db-cli CONFIG_DB HGET 'FEATURE|dhcp_server' state")["stdout"].strip()
+
+    yield orig_state
+
+    cur_state = duthost.shell(
+        "sonic-db-cli CONFIG_DB HGET 'FEATURE|dhcp_server' state",
+        module_ignore_errors=True)["stdout"].strip()
+    if cur_state != orig_state:
+        duthost.shell("sudo config feature state dhcp_server {}".format(orig_state),
+                      module_ignore_errors=True)
+
+    dhcp_syslog_rule = ("-A INPUT -i docker0 -p tcp -m tcp --dport 2514"
+                        " -m comment --comment dhcp_server_syslog -j ACCEPT")
+
+    def _converged():
+        state = duthost.shell(
+            "sonic-db-cli CONFIG_DB HGET 'FEATURE|dhcp_server' state",
+            module_ignore_errors=True)["stdout"].strip()
+        rule_present = dhcp_syslog_rule in duthost.command(
+            "iptables -S INPUT")["stdout"].split("\n")
+        return state == orig_state and rule_present == (orig_state == "enabled")
+
+    # Always wait for convergence (state + rule presence), even when the DB state
+    # already matches, so a still-transitioning feature is not leaked to the next
+    # test. The restore command above stays conditional.
+    pytest_assert(
+        wait_until(60, 5, 0, _converged),
+        "dhcp_server feature state did not converge back to {} during teardown"
+        .format(orig_state))
+
+
+def test_caclmgrd_dhcp_server_syslog(duthosts, enum_rand_one_per_hwsku_hostname,
+                                     dummy_acl_rules, restore_dhcp_server_feature_state):
+    """
+    Verify caclmgrd owns the dhcp_server docker0 syslog (RELP tcp/2514) INPUT
+    exception (sonic-net/sonic-buildimage#27584 and the ownership move in
+    sonic-net/sonic-buildimage#28328, sonic-net/sonic-host-services#412 and
+    sonic-net/sonic-buildimage#28580):
+
+      * the rule is programmed above caclmgrd's control-plane catch-all DROP
+        while FEATURE|dhcp_server is enabled,
+      * it survives a control-plane ACL flush-and-rebuild (dummy_acl_rules forces
+        one via acl-loader), and
+      * it is removed when the feature is disabled and restored when re-enabled.
+
+    dhcp_server uses bridge networking, so the exception only exists on the host
+    namespace where the feature is enabled (e.g. mx); the test skips otherwise.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    orig_state = restore_dhcp_server_feature_state
+    if orig_state != "enabled":
+        pytest.skip("dhcp_server feature is not enabled on this DUT; caclmgrd does "
+                    "not program the docker0 syslog exception")
+
+    dhcp_syslog_rule = ("-A INPUT -i docker0 -p tcp -m tcp --dport 2514"
+                        " -m comment --comment dhcp_server_syslog -j ACCEPT")
+    catch_all_drop = "-A INPUT -j DROP"
+
+    def _input_rules():
+        return duthost.command("iptables -S INPUT")["stdout"].split("\n")
+
+    def _rule_present():
+        return dhcp_syslog_rule in _input_rules()
+
+    # dummy_acl_rules has applied control-plane ACLs, forcing caclmgrd to flush
+    # and rebuild the INPUT chain and append the catch-all DROP. The
+    # caclmgrd-owned syslog exception must be re-emitted by that rebuild.
+    pytest_assert(
+        wait_until(60, 5, 0, _rule_present),
+        "caclmgrd did not program the dhcp_server docker0 syslog rule after a "
+        "control-plane ACL rebuild while the feature is enabled")
+
+    rules = _input_rules()
+    pytest_assert(
+        catch_all_drop in rules,
+        "Expected caclmgrd catch-all INPUT DROP is not present; cannot verify ordering")
+    pytest_assert(
+        rules.index(dhcp_syslog_rule) < rules.index(catch_all_drop),
+        "dhcp_server docker0 syslog rule is not ordered above the catch-all DROP")
+
+    # Disable the feature -> caclmgrd removes the rule on the next rebuild.
+    duthost.shell("sudo config feature state dhcp_server disabled")
+    pytest_assert(
+        wait_until(60, 5, 0, lambda: not _rule_present()),
+        "caclmgrd did not remove the dhcp_server docker0 syslog rule after "
+        "disabling the feature")
+
+    # Re-enable -> caclmgrd re-programs the rule, still above the catch-all DROP.
+    duthost.shell("sudo config feature state dhcp_server enabled")
+    pytest_assert(
+        wait_until(60, 5, 0, _rule_present),
+        "caclmgrd did not re-program the dhcp_server docker0 syslog rule after "
+        "re-enabling the feature")
+    rules = _input_rules()
+    pytest_assert(
+        catch_all_drop in rules,
+        "Expected caclmgrd catch-all INPUT DROP is not present after re-enabling "
+        "the feature; cannot verify ordering")
+    pytest_assert(
+        rules.index(dhcp_syslog_rule) < rules.index(catch_all_drop),
+        "dhcp_server docker0 syslog rule is not ordered above the catch-all DROP "
+        "after re-enabling the feature")


### PR DESCRIPTION
### Description of PR

Add black-box DHCP-server coverage for process-monitor alerts transported through the caclmgrd-owned `docker0` RELP `tcp/2514` syslog path.

The new `tests/dhcp_server/test_dhcp_server_syslog.py` test:

1. preserves the DUT's existing DHCP-server configuration;
2. temporarily disables `dhcp_server` container autorestart, matching the existing process-monitoring test setup;
3. discovers the real `dhcp-server-ipv4` Supervisor group and SIGKILLs `dhcpservd` and `kea-dhcp4`;
4. verifies through `LogAnalyzer` that both `Process '<name>' is not running in namespace 'host'.` alerts arrive in host syslog;
5. restores the processes and original autorestart state in teardown; and
6. repeats the same delivery check after restarting `caclmgrd`, which rebuilds its CACL-owned INPUT rules without reloading CONFIG_DB.

This deliberately validates externally visible behavior. It does not inspect iptables rules, depend on rule ordering, toggle the DHCP-server feature, or emit synthetic logger messages.

The product ownership changes required by this test are already merged on master:
- sonic-net/sonic-buildimage#28328
- sonic-net/sonic-host-services#412

The separate fresh-boot rsyslog listener race is tracked by sonic-net/sonic-buildimage#29661. This test intentionally detects that delivery failure if the host RELP listener is unavailable.

Related: sonic-net/sonic-buildimage#27584  
ADO: 38902700 (parent PBI 38699922)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

This PR is master-only.

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Exact PR tree at head `2e1157a5a1b0f6d0af04fcf1ead0ce44a8623728` was validated on physical `testbed-bjw-can-720dt-2` (`mx`, Arista 720DT) running `SONiC.20260510.16`. The validation ran before a patch-identical DCO-only history rewrite from `801532c5d9b44ffd6685a93468587552c90d6c78`; both heads have tree `e0b1f6dc46ec7f40ee8f7759f1b43be8d90f9381`.

- `deploy-mg`: passed, `failed=0`;
- `dhcp_server/test_dhcp_server_syslog.py`: **1 passed** in 276.48 seconds;
- both real grouped-process alerts were observed before and after the `caclmgrd` restart;
- `dhcpservd` and `kea-dhcp4` recovered;
- `dhcp_server` autorestart was restored to enabled;
- existing DHCP CONFIG_DB state was preserved with no post-test config-drift warning;
- `caclmgrd` and the `dhcp_server` container were healthy after the run.

Repository pre-commit checks, including Python AST and flake8, pass for the changed files.

### Approach

#### What is the motivation for this PR?

The previous test inspected CACL implementation details. This replacement covers the actual customer-visible contract: real `dhcp_server` process failures must produce alerts in host syslog, including after caclmgrd reconstructs the INPUT rules it owns.

#### How did you do it?

The test reuses the existing process-monitoring helpers and alert format, limits disruption to the two grouped DHCP-server processes, and restarts only `caclmgrd` between delivery checks.

#### How did you verify/test it?

The exact-head physical result and final DUT health are recorded above.

#### Any platform specific information?

The test requires the `dhcp_server` feature and uses the `mx` topology marker.

#### Supported testbed topology if it's a new test case?

`mx`

### Documentation

N/A.
