### PR TITLE
[gnmi] Drop telemetry-container branch from test_mimic_hwproxy_cert_rotation

### DIFF
--- a/tests/gnmi/test_mimic_hwproxy_cert_rotation.py
+++ b/tests/gnmi/test_mimic_hwproxy_cert_rotation.py
@@ -24,19 +24,17 @@ def check_gnmi_status(duthost):
     return "RUNNING" in output['stdout']
 
 
-def check_telemetry_status(duthost):
-    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
-    dut_command = "docker exec %s supervisorctl status %s" % (env.gnmi_container, env.gnmi_program)
-    output = duthost.shell(dut_command, module_ignore_errors=True)
-    return "RUNNING" in output['stdout']
-
-
 def test_mimic_hwproxy_cert_rotation(duthosts, rand_one_dut_hostname, localhost, ptfhost):
+    """Verify gnmi cert rotation across a feature restart: disable the gnmi feature,
+    rotate the server cert and rewrite the GNMI cert config, re-enable the feature,
+    and confirm the server comes back and serves (gnmi capabilities succeed).
+    Complements test_gnmi_cert_rotation.py::test_gnmi_cert_rotate, which hot-rotates
+    certs on a running server (no feature restart) and checks a data GET."""
     duthost = duthosts[rand_one_dut_hostname]
 
     # Use bash -c to run the pipeline properly
     cmd_feature = (
-        'bash -c "show feature status | awk \'$1==\\"gnmi\\" || $1==\\"telemetry\\" {print $1, $2}\'"'
+        'bash -c "show feature status | awk \'$1==\\"gnmi\\" {print $1, $2}\'"'
     )
     logging.debug("show feature status command is: {}".format(cmd_feature))
 
@@ -44,7 +42,6 @@ def test_mimic_hwproxy_cert_rotation(duthosts, rand_one_dut_hostname, localhost,
     output = result["stdout"]
 
     gnmi_enabled = False
-    telemetry_enabled = False
 
     for line in output.splitlines():
         parts = line.split()
@@ -52,13 +49,11 @@ def test_mimic_hwproxy_cert_rotation(duthosts, rand_one_dut_hostname, localhost,
             feature, state = parts
             if feature == "gnmi" and state == "enabled":
                 gnmi_enabled = True
-            elif feature == "telemetry" and state == "enabled":
-                telemetry_enabled = True
 
     if get_image_type(duthost) != "public":
         pytest_assert(
-            gnmi_enabled or telemetry_enabled,
-            "Internal image has neither gnmi nor telemetry feature enabled"
+            gnmi_enabled,
+            "Internal image does not have the gnmi feature enabled"
         )
 
     if gnmi_enabled:
@@ -93,32 +88,3 @@ def test_mimic_hwproxy_cert_rotation(duthosts, rand_one_dut_hostname, localhost,
             assert ret == 0, msg
             assert "sonic-db" in msg, msg
             assert "JSON_IETF" in msg, msg
-
-    if telemetry_enabled:
-        cmd_feature = "docker images | grep 'docker-sonic-telemetry'"
-        result = duthost.command(cmd_feature, module_ignore_errors=True)
-        if result["stdout"].strip():
-            # disable feature
-            disable_feature = 'sudo config feature state telemetry disabled'
-            duthost.command(disable_feature, module_ignore_errors=True)
-            # rotate telemetry cert
-            setup_gnmi_rotated_server(duthosts, rand_one_dut_hostname, localhost, ptfhost)
-            # set telemetry table
-            env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
-            port = env.gnmi_port
-            set_table = (
-                f'sonic-db-cli CONFIG_DB hset "TELEMETRY|gnmi" '
-                f'client_auth "true" '
-                f'log_level "2" '
-                f'port "{port}"'
-            )
-            duthost.command(set_table, module_ignore_errors=True)
-            set_table_cert = 'sonic-db-cli CONFIG_DB hset "TELEMETRY|certs"   \
-                    ca_crt "/etc/sonic/telemetry/gnmiCA.pem"   \
-                    server_crt "/etc/sonic/telemetry/gnmiserver.crt"   \
-                    server_key "/etc/sonic/telemetry/gnmiserver.key"'
-            duthost.command(set_table_cert, module_ignore_errors=True)
-            # enable feature
-            enable_feature = 'sudo config feature state telemetry enabled'
-            duthost.command(enable_feature, module_ignore_errors=True)
-            assert wait_until(60, 3, 0, check_telemetry_status, duthost), "TELEMETRY service failed to start"

--- a/tests/gnmi/test_mimic_hwproxy_cert_rotation.py
+++ b/tests/gnmi/test_mimic_hwproxy_cert_rotation.py
@@ -1,11 +1,22 @@
 import pytest
 import logging
 
-from tests.gnmi.conftest import setup_gnmi_rotated_server
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from tests.common.helpers.gnmi_utils import GNMIEnvironment, gnmi_capabilities
+from tests.common.helpers.gnmi_utils import GNMIEnvironment, gnmi_capabilities, \
+    prepare_root_cert, prepare_server_cert, prepare_client_cert, copy_certificate_to_ptf, \
+    create_revoked_cert_and_crl, copy_certificate_to_dut
 from tests.common.utilities import get_image_type
+
+
+def _rotate_gnmi_certs(duthost, localhost, ptfhost):
+    """Regenerate the GNMI PKI and push the fresh certs to the DUT and ptf."""
+    prepare_root_cert(localhost)
+    prepare_server_cert(duthost, localhost)
+    prepare_client_cert(localhost)
+    copy_certificate_to_ptf(ptfhost)
+    create_revoked_cert_and_crl(localhost, ptfhost)
+    copy_certificate_to_dut(duthost)
 
 
 logger = logging.getLogger(__name__)
@@ -64,7 +75,7 @@ def test_mimic_hwproxy_cert_rotation(duthosts, rand_one_dut_hostname, localhost,
             disable_feature = 'sudo config feature state gnmi disabled'
             duthost.command(disable_feature, module_ignore_errors=True)
             # rotate gnmi cert
-            setup_gnmi_rotated_server(duthosts, rand_one_dut_hostname, localhost, ptfhost)
+            _rotate_gnmi_certs(duthost, localhost, ptfhost)
             # set gnmi table
             env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
             port = env.gnmi_port


### PR DESCRIPTION
### Description of PR

Summary:
The `telemetry` container is deprecated in favor of the `gnmi` container. `test_mimic_hwproxy_cert_rotation` previously rotated certs against whichever of the two containers was enabled; the telemetry path is now dead weight and is removed.

- Remove the `if telemetry_enabled:` branch (telemetry cert rotation, `TELEMETRY|gnmi` / `TELEMETRY|certs` writes, telemetry feature toggle) and the `check_telemetry_status` helper.
- Simplify the feature gate to require only the `gnmi` feature.

The gnmi cert-rotation path (`GNMI_MODE`) is unchanged.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: N/A

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Validated on a hardware testbed: `test_mimic_hwproxy_cert_rotation` passes against the gnmi container with the telemetry branch removed. `pre-commit` (flake8) and `pyflakes` are clean.

### Approach
#### What is the motivation for this PR?

Remove deprecated telemetry-container plumbing from the gnmi test suite.

#### How did you do it?

Deleted the telemetry cert-rotation branch and its helper, and narrowed the feature check to gnmi only.

#### How did you verify/test it?

See Test result above.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation changes required.

