### PR TITLE
Fix console stress test for conserver backend

### DIFF
--- a/tests/dut_console/test_console_stress.py
+++ b/tests/dut_console/test_console_stress.py
@@ -36,9 +36,8 @@ def test_console_stress_output(duthost_console):
     # Disable echo verification: the wrapped 9600-baud echo never matches and a half-typed command leaves a PS2 prompt.
     output = duthost_console.send_command(
         f"python3 -c \"for i in range({num_lines}): print(f'LINE_{{i:04d}}: ' + '0123456789' * 10)\"",  # noqa: E231
-        read_timeout=300,
+        max_loops=300,
         expect_string=PROMPT_PATTERN,
-        cmd_verify=False
     )
 
     # Parse output into lines


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Replace the Netmiko-style console arguments in
  dut_console/test_console_stress.py::test_console_stress_output with arguments
  supported by the shared console fixture path.

  On conserver-console testbeds, duthost_console can be backed by the
  pexpect-based ConserverConsoleConn backend. ConserverConsoleConn.send_command()
  does not accept Netmiko-specific arguments such as read_timeout or cmd_verify;
  it uses max_loops for timeout control.

  Passing unsupported console kwargs causes the test to fail with TypeError
  before the console stress command is executed.

Summary:
Fixes #26489 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
https://github.com/sonic-net/sonic-mgmt/issues/26489
Failure type: regression 

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202605:
**After  Fix** 
[test_console_stress.py::test_console_stress_output.log](https://github.com/user-attachments/files/30284300/test_console_stress.py.test_console_stress_output.log)
[test_console_stress.py::test_console_stress_output.xml](https://github.com/user-attachments/files/30284301/test_console_stress.py.test_console_stress_output.xml)


### Approach

#### What is the motivation for this PR?
`test_console_stress_output` used Netmiko-style arguments with
  `duthost_console.send_command()`. On conserver-console testbeds, the console
  fixture can return the pexpect-based `ConserverConsoleConn` backend, whose
  `send_command()` API does not accept `read_timeout` or `cmd_verify`.
  This causes the test to fail with `TypeError` before the console stress
  command is executed.

#### How did you do it?
Replaced `read_timeout=300` with `max_loops=300` and removed the unsupported
  `cmd_verify` argument from `test_console_stress_output`.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
```
 sudo ./run_tests.sh -n dtAA -m individual -r -p logs_bug1908390_pass \
    -t any,util,dualtor,t0 \
    -f ../ansible/testbed.yaml \
    -u \
    -c "dut_console/test_console_stress.py::test_console_stress_output"

```

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A