### PR TITLE
[generic_config_updater]: Remove test_bgp_prefix_tc1_suite xfail (GCU libyang3 regression fixed)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2686,10 +2686,6 @@ generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite:
       - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/18445"
       - "'isolated' in topo_name"
-  xfail:
-    reason: "BGP allowed-prefix GCU validation fails across platforms, tracked by https://github.com/sonic-net/sonic-buildimage/issues/27818"
-    conditions:
-      - "https://github.com/sonic-net/sonic-buildimage/issues/27818"
 
 generic_config_updater/test_bgp_speaker.py::test_bgp_speaker_tc1_test_config:
   xfail:


### PR DESCRIPTION
### Description of PR
Removes the `xfail` on `generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite`. The underlying libyang3 GCU regression is fixed and merged.

Relates to https://github.com/sonic-net/sonic-mgmt/issues/25549 (removes the `master` xfail; the 202605 half is https://github.com/sonic-net/sonic-mgmt/pull/26494 — close #25549 once both merge)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

_The 202605 branch carries its own xfail entry for this test (keyed on #25549, distinct from this master entry keyed on sonic-buildimage#27818); it is removed in the companion PR https://github.com/sonic-net/sonic-mgmt/pull/26494. Older release branches (<=202511) are libyang1 and never had the regression, so no xfail there._

### Approach
#### What is the motivation for this PR?
The xfail was added because `config apply-patch` on an empty `BGP_ALLOWED_PREFIXES` leaf-list returned rc!=0 after the libyang3 migration ([sonic-buildimage#26584](https://github.com/sonic-net/sonic-buildimage/pull/26584)) — tracked by https://github.com/sonic-net/sonic-mgmt/issues/25549 and [sonic-buildimage#27818](https://github.com/sonic-net/sonic-buildimage/issues/27818).

The read-side fix has landed in `sonic-yang-mgmt` and is merged to both affected branches:
- master: [sonic-buildimage#28248](https://github.com/sonic-net/sonic-buildimage/pull/28248)
- 202605: [sonic-buildimage#28308](https://github.com/sonic-net/sonic-buildimage/pull/28308)

With the fix in the image, the test passes, so the xfail now masks a passing test.

#### How did you do it?
Removed only the `xfail:` block for `test_bgp_prefix_tc1_suite` in `tests_mark_conditions.yaml`. The existing `skip:` block (Cisco 8122 / VS / isolated topo) is retained unchanged.

#### How did you verify/test it?
Matched A/B on a KVM t1 testbed (vlab-03) using the real sonic-mgmt test with `--runxfail` to see through the mask, on both libyang3 branches with the fix hot-deployed:

| Branch (libyang3) | Unpatched baseline | With read-side fix |
|---|---|---|
| master `1145536` (post-#26584) | 2 failed / 2 errored | **2 passed** |
| 202605 `1157773` | 2 failed / 2 errored | **2 passed / 0 errored** |

Both parametrizations (`[None-empty]`, `[None-1010:1010]`) pass. Kusto `V2TestCases` after the master merge (2026-07-09) shows zero failures on master/202605 (all currently masked by this xfail).

Note: the remaining write-side item ([sonic-buildimage#27818](https://github.com/sonic-net/sonic-buildimage/issues/27818)) is a separate GCU-core defect that this test does not exercise — the test removes the whole `/BGP_ALLOWED_PREFIXES` table and never empties a single leaf-list.

#### Any platform specific information?
The fix is at the pure-Python YANG validation layer (platform-independent), so all platforms are covered.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case.

### Documentation
N/A
