### PR TITLE
Enable SYSTEM_DEFAULTS decap_qos_map via golden config

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -1092,6 +1092,17 @@ class GenerateGoldenConfigDBModule(object):
             ori_config_db["DEVICE_METADATA"]["localhost"]["zebra_nexthop"] = zebra_nexthop
         return json.dumps(ori_config_db, indent=4)
 
+    def update_decap_qos_map_config(self, config):
+        if self.hwsku not in {'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16'}:
+            return config
+        ori_config_db = json.loads(config)
+        if multi_asic.is_multi_asic():
+            for key, value in ori_config_db.items():
+                value.setdefault("SYSTEM_DEFAULTS", {})["decap_qos_map"] = {"status": "enabled"}
+        else:
+            ori_config_db.setdefault("SYSTEM_DEFAULTS", {})["decap_qos_map"] = {"status": "enabled"}
+        return json.dumps(ori_config_db, indent=4)
+
     def generate_drh_golden_config_db(self):
         """
         Generate golden_config for disaggregated Regional Hub (LRH/URH) topologies.
@@ -1298,6 +1309,8 @@ class GenerateGoldenConfigDBModule(object):
 
         # update zebra_nexthop config from minigraph
         config = self.update_zebra_nexthop_config(config)
+
+        config = self.update_decap_qos_map_config(config)
 
         # Rebuild PORT table from port_speeds + platform.json when port override is active
         if self.port_override_from_links:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Arista-7060X6-64PE-B-C448O16/C512S2 use generate_port_qos_map_per_sku in qos.json.j2, which prevents the global dscp_to_tc_map from being set in config_db.json. Without it, Broadcom ipinip decap falls through to SAI's built-in default instead of the intended decap_dscp_to_tc_map from ipinip.json.

Setting SYSTEM_DEFAULTS decap_qos_map status to 'enabled' lets ipinip.json.j2 use the SYSTEM_DEFAULTS attribute instead of hardcoded platform checks.
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
With golden config enabling decap_qos_map:
```shell
admin@qspf201:~$ sonic-cfggen -d -v "SYSTEM_DEFAULTS"
{'decap_qos_map': {'status': 'enabled'}, 'mux_tunnel_egress_acl': {'status': 'disabled'}}

admin@qspf201:~$ sonic-db-cli APPL_DB HGETALL "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL"
{'decap_dscp_to_tc_map': 'AZURE', 'dscp_mode': 'uniform', 'ecn_mode': 'copy_from_outer', 'ttl_mode': 'pipe', 'tunnel_type': 'IPINIP'}

admin@qspf201:~$ sonic-db-cli APPL_DB HGETALL "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL"
{'decap_dscp_to_tc_map': 'AZURE', 'dscp_mode': 'uniform', 'ecn_mode': 'copy_from_outer', 'ttl_mode': 'pipe', 'tunnel_type': 'IPINIP'}

```

### Approach
#### What is the motivation for this PR?
Currently ipinip.json.j2 is having platform checks for enabling/disabling decap entries. We want to prevent having platform checks for simple enable/disable scenarios.

#### How did you do it?
SYSTEM_DEFAULTS['decap_qos_map']['status'] is added in https://github.com/sonic-net/sonic-buildimage/pull/28588, and enable it for Arista-7060X6-64PE-B-C448O16/C512S2 in sonic-mgmt generate_golden_config_db.py.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Check config generated from the golden config and ipinip.json

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
