### PR TITLE
[bgp] Fix VNET interface bindings

### DIFF
--- a/tests/bgp/templates/vnet_config_db.j2
+++ b/tests/bgp/templates/vnet_config_db.j2
@@ -43,6 +43,15 @@
         "Loopback2|10.1.0.32/32": {},
         "Loopback2|FC00:1::32/128": {}
     },
+{%     elif k == 'INTERFACE' %}
+    "INTERFACE": {
+{%         for interface, data in cfg_t0['INTERFACE'].items() | sort %}
+{%             if '|' not in interface and interface in vnet_interface_bindings %}
+{%                 set data = data | combine({'vnet_name': vnet_interface_bindings[interface]}) %}
+{%             endif %}
+        "{{ interface }}": {{ data | to_nice_json | indent(width=8) }}{% if not loop.last %},{% endif %}
+{%         endfor %}
+    },
 {%     elif k == 'PORTCHANNEL_INTERFACE' %}
     "PORTCHANNEL_INTERFACE": {
 {%        for pc in cfg_t0['PORTCHANNEL_INTERFACE'] | sort %}

--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -78,6 +78,40 @@ def get_cfg_facts(duthost):
     return tmp_facts
 
 
+def get_vnet_interface_bindings(cfg_t0, vnet1_neighbor_names):
+    """Map routed interfaces to the VNET containing their BGP neighbors."""
+    local_addr_to_interface = {}
+    for key in cfg_t0.get('INTERFACE', {}):
+        interface, separator, prefix = key.partition('|')
+        if not separator:
+            continue
+        try:
+            local_addr = str(ipaddress.ip_interface(prefix).ip)
+        except ValueError:
+            continue
+        local_addr_to_interface[local_addr] = interface
+
+    bindings = {}
+    for attrs in cfg_t0.get('BGP_NEIGHBOR', {}).values():
+        name = attrs.get('name')
+        local_addr = attrs.get('local_addr')
+        try:
+            local_addr = str(ipaddress.ip_address(local_addr))
+        except ValueError:
+            continue
+        interface = local_addr_to_interface.get(local_addr)
+        if not name or not interface:
+            continue
+
+        vnet = 'Vnet1' if name in vnet1_neighbor_names else 'Vnet2'
+        if interface in bindings and bindings[interface] != vnet:
+            raise ValueError(
+                "Interface {} maps to multiple VNETs".format(interface))
+        bindings[interface] = vnet
+
+    return bindings
+
+
 def setup_vnet_cfg(duthost, localhost, cfg_facts):
     '''
     setup vrf configuration on dut before test suite
@@ -93,8 +127,12 @@ def setup_vnet_cfg(duthost, localhost, cfg_facts):
     vlan_ports = {'Vlan1000': ports[:len(ports)//2],
                   'Vlan2000': ports[len(ports)//2:]}
 
+    vnet1_neighbor_names = ['ARISTA01T1', 'ARISTA02T1']
+
     extra_vars = {'cfg_t0': cfg_t0,
-                  'vlan_ports': vlan_ports}
+                  'vlan_ports': vlan_ports,
+                  'vnet_interface_bindings': get_vnet_interface_bindings(
+                      cfg_t0, vnet1_neighbor_names)}
 
     duthost.host.options['variable_manager'].extra_vars.update(extra_vars)
 
@@ -364,13 +402,19 @@ def _check_vnet_bgp_peers_established(duthost, cfg_facts, route_count):
             summary_str = duthost.shell(
                 "vtysh -c 'show bgp vrf {} summary json'".format(vnet))['stdout']
             bgp_summary = json.loads(summary_str)
+            if not bgp_summary:
+                return False
+            peers_found = False
             for info, info_data in bgp_summary.items():
                 for peer, attr in info_data.get('peers', {}).items():
                     if ((info == "ipv4Unicast" and attr.get('idType') == 'ipv6') or
                             (info == "ipv6Unicast" and attr.get('idType') == 'ipv4')):
                         continue
+                    peers_found = True
                     if int(attr.get('pfxRcd', 0)) < route_count:
                         return False
+            if not peers_found:
+                return False
         return True
     except Exception:
         return False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: sonic-buildimage [PR #27981](https://github.com/sonic-net/sonic-buildimage/pull/27981) makes bgpcfgd resolve BGP local addresses within the peer VRF and requires the interface vrf_name or vnet_name to match.

The VNET test template left routed physical interfaces unbound, so bgpcfgd deferred all VRF peers and show bgp vrf returned an empty summary. Derive interface bindings from each neighbor local_addr, render the matching vnet_name, and treat an empty summary as not ready.

Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

- master: bgp.test_bgp_vnet#test_dynamic_peer_vnet PASS

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
