### PR TITLE
Skip BGP VNET tests on topologies on unsupported topos

### DIFF
--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -144,6 +144,28 @@ def setup_vnet(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, localhost,
               skip_test_module_over_backend_topologies):        # noqa F811
     duthost = duthosts[rand_one_dut_hostname]
 
+    # This test suite splits the DUT's uplink PortChannels into two VNETs and
+    # verifies traffic between them.  The vnet_config_db.j2 template only tags
+    # PORTCHANNEL_INTERFACE entries with vnet_name (not physical INTERFACE
+    # entries), and the data-plane checks look up PTF ports through
+    # PORTCHANNEL_MEMBER.  On t0 variants where T1 uplinks are configured as
+    # routed subinterfaces directly on physical Ethernet ports,
+    # there are no PortChannels at all and every test in this module would fail with
+    # "No PTF ports found for Vnet1".  Skip the entire module in that case.
+    pre_cfg = get_cfg_facts(duthost)
+    pc_intfs = [pc for pc in pre_cfg.get('PORTCHANNEL_INTERFACE', {}) if '|' not in pc]
+    # Need at least 4 PortChannels: 2 for Vnet1 + 2 for Vnet2 (see
+    # setup_vnet_cfg above, which uses vnet1_num = 2 and expects an
+    # ARISTA03/04T1 dynamic peer group in the remainder).
+    if len(pc_intfs) < 4:
+        pytest.skip(
+            f"test_bgp_vnet requires a t0 topology with >= 4 PortChannel uplinks."
+            f"This DUT is running a "
+            f"topology without PortChannels (found {len(pc_intfs)} PortChannel "
+            f"interfaces); vnet_name tagging only works on PORTCHANNEL_INTERFACE "
+            f"entries."
+        )
+
     # backup config_db.json
     duthost.shell("cp /etc/sonic/config_db.json /etc/sonic/config_db.json.bak")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip BGP VNET tests on topologies with fewer than 4 PortChannel uplinks

Added a check in the BGP VNET test suite to skip tests if the DUT's configuration lacks the required number of PortChannel interfaces. This ensures that tests do not fail due to unsupported topologies

Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
