### PR TITLE
Remove dash_metering skip mark

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1005,12 +1005,6 @@ dash/test_dash_eni_counter.py::TestEniCounter::test_outbound_pkt_pass_eni_counte
     conditions:
       - "hwsku in ['Mellanox-SN4280-O8C40', 'Mellanox-SN4280-O28']"
 
-dash/test_dash_metering.py:
-  skip:
-    reason: "Metering w/ FNIC not supported on Nvidia yet"
-    conditions:
-      - "hwsku in ['Mellanox-SN4280-O8C40', 'Mellanox-SN4280-O28']"
-
 dash/test_dash_privatelink.py:
   skip:
     conditions_logical_operator: or


### PR DESCRIPTION
### Description of PR
Summary:
Remove skip mark for `dash/test_dash_metering.py` on Nvidia SmartSwitch platforms.
The DASH metering with FNIC feature is now supported after the NASA/SAI update to 26.4-RC8/SAIBuild0.0.56.0 (https://github.com/sonic-net/sonic-buildimage/pull/28544).

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
- master: pass

### Approach
#### What is the motivation for this PR?
The metering test was skipped because the feature was not supported. With NASA SDK 26.4-RC8, this feature is now available on Nvidia Bluefield DPU.
#### How did you do it?
Removed the skip condition from `tests_mark_conditions.yaml`.
#### How did you verify/test it?
Verified the test passes on SmartSwitch with the latest NASA SDK.

#### Any platform specific information?
SmartSwitch
#### Supported testbed topology if it's a new test case?
Any
### Documentation
N/A
