### PR TITLE
[pfcwd] Increase restore-phase timeout for high port-count SKUs

### DIFF
--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -236,12 +236,20 @@ class TestPfcwdAllPortStorm(object):
             logger.info(f"Waiting for {threshold}% of {port_type} to reach {action} state")
 
             # Scale timeout with port count to allow sufficient time on high port-count platforms.
+            # Restore needs materially more time than detection: once the storm stops, PFCWD must
+            # poll each queue, clear the storm state, and emit the "storm restored" syslog for every
+            # stormed port, and these do not all complete at once. On high port-count SKUs (e.g. 48+
+            # stormed ports) a detection-sized budget is too short for a strict 100% restore bar, so
+            # give the restore phase a larger per-port budget and floor.
             num_ports = len(stormed_ports_list) if stormed_ports_list else len(selected_test_ports)
-            timeout = max(60, num_ports * 3)
-            # LT2/FT2 topologies need at least 120s because the traffic generator
+            if action == "restore":
+                timeout = max(120, num_ports * 6)
+            else:
+                timeout = max(60, num_ports * 3)
+            # LT2/FT2 topologies need extra headroom because the traffic generator
             # takes longer to spin up on those setups.
             if tbinfo and tbinfo['topo']['type'] in ["lt2", "ft2"]:
-                timeout = max(timeout, 120)
+                timeout = max(timeout, 240 if action == "restore" else 120)
             pytest_assert(
                 wait_until(timeout, 2, 5, verify_all_ports_pfc_storm_in_expected_state, duthost,
                            storm_hndle, action, selected_test_ports,


### PR DESCRIPTION
### Description of PR

Summary:
`pfcwd/test_pfcwd_all_port_storm.py::test_all_port_storm_restore` fails consistently on high port-count 7060x6 SKUs (e.g. `Arista-7060X6-64PE-P64`, `ft2-64`) with **"Not enough ports reached restore state (threshold: 100%)"**. The storm and detect phases pass; only the **restore** phase fails.

Root cause is a too-short restore timeout, not a product bug. When the storm stops, PFCWD must poll each queue, clear the storm state, and emit the `storm restored` syslog for **every** stormed port, and the last few ports lag. On ~49-50 stormed ports the restore phase genuinely takes ~200s (measured on the DUT), but the old restore budget was `max(max(60, num_ports*3), 120)` = ~150s and timed out before the final ports cleared.

This change increases the restore-phase timeout while keeping the strict 100% restore threshold (we intentionally do **not** lower the threshold, which would mask real restore failures).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue (restore budget too short for high port-count SKUs)

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
- master / 202511 (code identical): `SONiC.20251110.40`
  - ft2 (`Arista-7060X6-64PE-P64`, 49 stormed ports): IPv4 restore reaches 100% at ~203s — fails the old 150s budget, passes the new 300s budget.
  - 64PE lt2 sibling: `test_all_port_storm_restore` — **2 passed** (IPv4 + IPv6) with the strict 100% threshold; IPv6 restores cleanly 8.3% -> 100% (no separate IPv6 defect, no regression).

### Approach
#### What is the motivation for this PR?

`test_all_port_storm_restore` fails every nightly on 64-port 7060x6 SKUs because the restore phase is given a detection-sized time budget. Restore is inherently slower than detection: after the storm stops, PFCWD clears each queue and emits a per-port `storm restored` syslog, and these do not all complete at once, so the last handful of ports need materially more time.

#### How did you do it?

In `TestPfcwdAllPortStorm.run_test`, scale the restore timeout separately from detection and raise the lt2/ft2 floor, keeping the 100% restore bar:

- restore: `timeout = max(120, num_ports * 6)` (was `max(60, num_ports * 3)`)
- lt2/ft2 floor: `240s` for restore (was a flat `120s`)
- detection unchanged: `max(60, num_ports * 3)` / `120s`

#### How did you verify/test it?

Ran `test_all_port_storm_restore` against the DUT and captured the per-iteration restore curve:

- ft2 (49 stormed ports): IPv4 restore climbs to 100% at ~203s -> fails old 150s budget, passes new 300s budget.
- 64PE lt2 sibling: both IPv4 and IPv6 pass; IPv6 (run first) restores cleanly 8.3% -> 100%, confirming the previously observed IPv6 "stuck" behavior was an ordering artifact, not a product defect.

#### Any platform specific information?

Affects high port-count SKUs where a large number of ports storm simultaneously (e.g. `Arista-7060X6-64PE-P64`, ft2-64). The scaling is generic (`num_ports * 6`) so lower port-count platforms are unaffected in practice.

#### Supported testbed topology if it's a new test case?

N/A — existing test, no topology change.

### Documentation

N/A