### PR TITLE
[merge-queue-test] PR1

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -11,7 +11,6 @@ from tests.common.utilities import (
     group_interfaces_by_asic
 )
 from tests.common.helpers.assertions import pytest_assert
-import time
 
 logger = logging.getLogger(__name__)
 
@@ -368,7 +367,12 @@ def test_lldp_entry_table_content(
 
 
 # Test case 2: Verify LLDP_ENTRY_TABLE after restart syncd and orchagent
+# This test deliberately restarts swss/syncd, which cascades to a bgp container
+# restart. The memory_utilization fixture's before/after snapshots become
+# meaningless across such a restart (bgpd RSS drops to ~0 then warms back up),
+# so disable memory monitoring for this test.
 @pytest.mark.disable_loganalyzer
+@pytest.mark.disable_memory_utilization
 def test_lldp_entry_table_after_syncd_orchagent(
     duthosts, enum_rand_one_per_hwsku_frontend_hostname, db_instance
 ):
@@ -394,7 +398,14 @@ def test_lldp_entry_table_after_syncd_orchagent(
         duthost.shell("sudo systemctl restart swss")
     assert wait_until(600, 5, 120, duthost.critical_services_fully_started), \
         "Not all critical services are fully started"
-    time.sleep(60)
+    # Wait for BGP sessions to reach Established state instead of a fixed sleep,
+    # to avoid a downstream memory-alarm false positive caused by bgpd warming up
+    # in the next test case.
+    bgp_neighbors = list(duthost.get_bgp_neighbors().keys())
+    pytest_assert(
+        wait_until(300, 10, 30, duthost.check_bgp_session_state, bgp_neighbors),
+        "BGP sessions did not reach Established state after swss restart",
+    )
     # Wait until all interfaces are up and lldp entries are populated
     for interface in lldp_entry_keys:
         result = wait_until(300, 2, 0, verify_lldp_entry, db_instance, [interface])


### PR DESCRIPTION
### Description of PR

Summary:
This PR makes two related fixes to
`tests/lldp/test_lldp_syncd.py::test_lldp_entry_table_after_syncd_orchagent`, which deliberately restarts `swss`/`syncd` and cascades to a `bgp` container restart.

#### Commit 1 — Replace `time.sleep(60)` with a BGP convergence wait After restarting `swss`/`syncd`, the test currently waits a hardcoded `time.sleep(60)` before proceeding. On a DUT with many BGP neighbors (e.g., T1/T2 with 7050CX3), 60 seconds is **not enough** for bgpd to fully re-converge after the cascade restart.

This leaves bgpd in a warming-up state by the time the test ends. The **next test** (e.g. `test_lldp_entry_table_after_cont_flap`) then takes its memory baseline snapshot while bgpd RSS is still low. When bgpd subsequently reaches its normal post-init RSS during the next test, the framework&#39;s memory monitor reports a large increase (e.g. +139 MB &gt; 128 MB threshold) and fails the next test with a **false-positive memory alarm**.

Replace `time.sleep(60)` with
`wait_until(duthost.check_bgp_session_state, ...)` so the test deterministically waits for all BGP sessions to reach `Established` state before exiting.

#### Commit 2 — Disable `memory_utilization` check for this test This test deliberately restarts swss/syncd, which cascades to a `bgp` container restart. The `memory_utilization` fixture takes before/after snapshots that become meaningless across such a restart (bgpd RSS drops to ~0 then warms back up over several minutes), so the in-test memory delta has no signal.

Add `@pytest.mark.disable_memory_utilization` to make the test intent explicit and prevent future framework changes (e.g. alarming on volatility or absolute decreases) from flagging this test on a meaningless measurement. This is consistent with other restart-style tests (e.g. `test_advanced_reboot`, `test_warm_reboot`, `test_container_autorestart`).

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38230412

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?
Observed in plan `6a1b270895e3f84fd1e9ace9` (7050cx3.m1-128.202603 NightlyTest, branch `20260310.11`) on `testbed-bjw3-can-7050c-6`:

- `test_lldp_entry_table_after_syncd_orchagent` restarted swss/syncd (which cascades to bgp container)
- `time.sleep(60)` returned while bgpd RSS was still 67.9 MB (mid-convergence)
- Next test `test_lldp_entry_table_after_cont_flap` took its &#34;before&#34; snapshot: bgpd = 67.9 MB
- 16 minutes later, bgpd had warmed up to its normal 207.1 MB
- Framework reported `+139.2 MB &gt; 128 MB threshold` → ALARM → next test FAILED

`vtysh show memory bgp` (FRR internal allocator counter) showed a consistent 204 MB both before and after the next test — proving bgpd did not actually leak memory. Only `top` RSS appeared to grow because the baseline was taken too early.

#### How did you do it?

**Commit 1 — wait for BGP convergence instead of sleep(60):**
```python
bgp_neighbors = list(duthost.get_bgp_neighbors().keys())
pytest_assert(
    wait_until(300, 10, 30, duthost.check_bgp_session_state, bgp_neighbors),
    &#34;BGP sessions did not reach Established state after swss restart&#34;,
)
```
- Uses existing `duthost.get_bgp_neighbors()` to dynamically fetch the neighbor list (works on all topologies)
- Uses existing `duthost.check_bgp_session_state()` (default expected state = `&#34;established&#34;`)
- Parameters: `timeout=300s`, `interval=10s`, `delay=30s`

**Commit 2 — disable memory check on this test:**
```python
@pytest.mark.disable_loganalyzer
@pytest.mark.disable_memory_utilization     # NEW
def test_lldp_entry_table_after_syncd_orchagent(...):
```

The two changes are complementary:
- **Commit 1** prevents pollution of the next test (wait for BGP convergence before exit)
- **Commit 2** disables the meaningless measurement on this test itself

#### How did you verify/test it?
Logic review against existing helpers (`get_bgp_neighbors`, `check_bgp_session_state`, `wait_until`, `disable_memory_utilization` marker) — all are widely used elsewhere in sonic-mgmt.

Behavior change matrix for Commit 1:
- Healthy fast DUT (T0): exits in ~20–30 s (faster than old 60s sleep)
- Slow DUT (T1 with many neighbors): waits up to 300 s for actual convergence (vs. silently returning after insufficient 60s)

A real run on testbed-bjw3-can-7050c-7 / 7050c-6 will be needed to confirm the next-test memory alarm cascade no longer fires.

#### Any platform specific information?
None — both changes are platform-agnostic. The helpers used are standard sonic-mgmt helpers.

#### Supported testbed topology if it&#39;s a new test case? N/A — not a new test case. The existing test continues to run on all topologies where it currently runs.

### Documentation
N/A

### Elastic Test Jobs
- testbed-bjw3-can-7050c-7: https://elastictest.org/scheduler/testplan/6a20dc922047c3c4a9f91c7c
- testbed-bjw3-can-7050c-8: https://elastictest.org/scheduler/testplan/6a20dc94729d944bd21c92e0
- testbed-bjw3-can-7050c-11: https://elastictest.org/scheduler/testplan/6a20dc962296f2ad62e47dbc

---------

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
