### PR TITLE
[ipfwd] Fix NHOP group capacity assertion

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -456,26 +456,22 @@ def test_nhop_group_member_count(duthost, tbinfo, loganalyzer):
             "crm config polling interval {}".format(crm_before["polling"])
         )
 
-    # verify the test used up all the NHOP group resources
-    # skip this check on Mellanox as ASIC resources are shared
-    if is_cisco_device(duthost) or is_high_scale_platform(duthost):
-        pytest_assert(
-            crm_after["available_nhop_grp"] + nhop_group_count == crm_before["available_nhop_grp"],
-            "Unused NHOP group resource:{}, used:{}, nhop_group_count:{}, Unused NHOP group resource before:{}".format(
-                crm_after["available_nhop_grp"], crm_after["used_nhop_grp"], nhop_group_count,
-                crm_before["available_nhop_grp"]
-
-            )
-        )
-    elif is_mellanox_device(duthost):
+    # verify the test used the expected NHOP group resources
+    if is_mellanox_device(duthost):
         logger.info("skip this check on Mellanox as ASIC resources are shared")
     elif is_vs_device(duthost):
         logger.info("skip this check on VS as no real ASIC")
     else:
+        expected_available_nhop_grp = max(
+            crm_before["available_nhop_grp"] - nhop_group_count, 0
+        )
         pytest_assert(
-            crm_after["available_nhop_grp"] == 0,
-            "Unused NHOP group resource:{}, used_nhop_grp:{}".format(
-                crm_after["available_nhop_grp"], crm_after["used_nhop_grp"]
+            crm_after["available_nhop_grp"] == expected_available_nhop_grp,
+            "Unexpected available NHOP group resources:{}, expected:{}, used:{}, "
+            "nhop_group_count:{}, available before:{}".format(
+                crm_after["available_nhop_grp"], expected_available_nhop_grp,
+                crm_after["used_nhop_grp"], nhop_group_count,
+                crm_before["available_nhop_grp"]
             )
         )
 


### PR DESCRIPTION
### Description of PR

Summary:
Fix the `test_nhop_group_member_count` regression introduced by #24524 without reverting its extended timeout for large NHOP workloads. The CRM assertion now derives the expected remaining capacity from the pre-test availability and requested group count instead of coupling correctness to the number of front-panel interfaces.

Related fix attempt: #26212

Fixes https://github.com/aristanetworks/sonic-qual.msft/issues/1349

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/aristanetworks/sonic-qual.msft/issues/1349
Failure type: regression

Intended backports after target-branch test evidence is attached: 202511 and msft-202603. The public 202605 branch does not currently contain #24524.

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

- Local master static validation: `python -m py_compile tests/ipfwd/test_nhop_group.py` passed.
- Local master static validation: `pre-commit run flake8 --files tests/ipfwd/test_nhop_group.py` passed.
- 202511 applicability: the commit cherry-picked cleanly and passed Python compilation and flake8 with the repository's 120-character limit.
- Capacity scenarios validated: `(before=253, requested=265) -> 0`, `(4095, 1034) -> 3061`, and `(1000, 920) -> 80`.
- Existing physical Broadcom validation for the same capacity calculation is documented in #26212. Direct target-branch device validation is still required before requesting backports.

### Approach
#### What is the motivation for this PR?

PR #24524 used `is_high_scale_platform()` for two independent decisions: selecting a longer programming wait and selecting a TH5/Cisco-specific CRM assertion. The affected Arista 7050CX3-32C-S128 exposes 128 logical interfaces and therefore entered the special assertion path even though its NHOP group capacity was already saturated successfully.

The reported values were:

```text
available before: 253
requested groups: 265
available after: 0
```

The current assertion evaluates `0 + 265 == 253`, so the test fails despite consuming all available resources. Reverting #24524 would also restore the original timeout failure on 7060X6/7060XE7.

#### How did you do it?

For platforms with deterministic CRM accounting, calculate the expected available NHOP groups as:

```python
max(available_before - requested_group_count, 0)
```

Compare the post-programming CRM value directly with this result. Mellanox is checked first and remains excluded because its ASIC resources are shared; VS remains excluded because it has no real ASIC. The timeout selection from #24524 is unchanged.

This handles both cases generically:

- Capacity below the requested count: expected availability is zero.
- Capacity above the test cap: expected availability is the unused remainder.

#### How did you verify/test it?

Ran Python compilation, the configured flake8 pre-commit hook, explicit capacity calculations, and a clean 202511 cherry-pick validation. Physical target-branch testing is pending and will be attached before requesting backports.

#### Any platform specific information?

The observed regression is on Arista 7050CX3-32C-S128. The calculation also preserves the intended behavior for Broadcom TH5 and Cisco platforms. Mellanox shared-resource platforms and VS continue to skip the strict CRM assertion.

#### Supported testbed topology if it's a new test case?

N/A. This PR fixes an existing test used on t1, t2, lrh, urh, m1, lt2, and ft2 topologies.

### Documentation

N/A. No documentation changes are required.