### PR TITLE
[bgp/test_bgp_router_id.py] Fix assumption that VoQ is multi asic

### DIFF
--- a/tests/bgp/test_bgp_router_id.py
+++ b/tests/bgp/test_bgp_router_id.py
@@ -137,7 +137,7 @@ def default_bgp_router_id(duthosts, enum_frontend_dut_hostname, enum_frontend_as
     cfg_facts = get_asic_config_facts(duthost, enum_frontend_asic_index)
     dev_meta = cfg_facts.get('DEVICE_METADATA', {}).get('localhost', {})
 
-    if dev_meta.get('switch_type') in ['voq', 'chassis-packet']:
+    if dev_meta.get('switch_type') in ['voq', 'chassis-packet'] and duthost.is_multi_asic:
         host_vars = get_host_visible_vars(duthost.host.options['inventory'], duthost.hostname)
         loopback4096_ips = host_vars.get('loopback4096_ip', [])
         if len(loopback4096_ips) > enum_frontend_asic_index:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #26520
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: Regression by https://github.com/sonic-net/sonic-mgmt/pull/25683, tracked: https://msazure.visualstudio.com/One/_workitems/edit/38914444

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
- master: 20251110.36 - locally tested

### Approach
#### What is the motivation for this PR?
Prevent failures from regression on single-asic VoQ
#### How did you do it?
Add gate to check for multi-asic before performing multi-asic specific part of test, specifically assuming `enum_frontend_asic_index` is not None
#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A