### PR TITLE
[console] Accept updated picocom termination message

### DIFF
--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -130,6 +130,7 @@ def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts, co
         "Target line {} is busy before reverse SSH session start".format(target_line))
 
     ressh_user = "{}:{}".format(dutuser, target_line)
+    client = None
     try:
         client = console_session(duthost, dutip, ressh_user, dutpass, target_line)
         pytest_assert(

--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -150,7 +150,7 @@ def test_console_reversessh_force_interrupt(duthost, creds, conn_graph_facts, co
         error_msg="Target line {} not toggle to IDLE state after force clear command sent".format(target_line))
 
     try:
-        client.expect("Picocom was killed")
+        client.expect_exact(["Picocom was killed", "Thanks for using picocom"])
     except Exception as e:
         pytest.fail("Console session not exit correctly: {}".format(e))
 


### PR DESCRIPTION
### Description of PR

Summary:

Update the reverse-SSH force-interrupt test for the console session behavior introduced by [sonic-utilities PR 4658](https://github.com/sonic-net/sonic-utilities/pull/4658).

That change replaced the previous console session implementation and changed the successful termination output from `Picocom was killed` to `Thanks for using picocom`. The console line still returned to `IDLE` and the SSH process exited successfully, but the test failed because it only accepted the legacy message.

This PR accepts either termination message so the test remains compatible with images from before and after the sonic-utilities change. It also explicitly initializes the console client variable to satisfy static analysis.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: compatibility with updated console termination output

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

- Affected SONiC image on a physical `c0` topology: `10 passed` in the full `console/test_console_reversessh.py` module.
- Static validation: Python syntax validation passed.

### Approach
#### What is the motivation for this PR?

The force-interrupt test assumed one specific console termination message. After sonic-utilities PR 4658 changed the console session implementation, successful termination produced a different message and caused a false test failure.

#### How did you do it?

Use `pexpect.expect_exact()` with the legacy and current termination messages as alternatives. This preserves compatibility across image versions while still validating that the client observes a successful console-session termination message.

Explicitly initialize `client` before the session-creation block so static analysis can determine that the local variable is initialized.

#### How did you verify/test it?

Ran the complete `console/test_console_reversessh.py` module on a physical `c0` topology with the affected SONiC image. All 10 cases passed, including `test_console_reversessh_force_interrupt` and all custom escape-character variants.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

N/A; this is not a new test case.

### Documentation

N/A; test-only compatibility update.
