### PR TITLE
Skip bgp/test_bgp_vnet.py on t0-isolated-d32u32s2-mix due to issue #26523

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -703,9 +703,11 @@ bgp/test_bgp_update_replication.py:
 
 bgp/test_bgp_vnet.py:
   skip:
-    reason: "Test is only enabled for VS, Cisco and Nvidia mellanox platforms"
+    reason: "Test is only enabled for VS, Cisco and Nvidia mellanox platforms. Also not supported on topologies without PortChannel uplinks due to GH issue https://github.com/sonic-net/sonic-mgmt/issues/26523"
+    conditions_logical_operator: or
     conditions:
       - "asic_type not in ['vs', 'cisco-8000', 'mellanox']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/26523 and topo_name == 't0-isolated-d32u32s2-mix'"
 
 bgp/test_bgp_vnet_scale.py:
   skip:


### PR DESCRIPTION

The t0-isolated-d32u32s2-mix topology has no PortChannel uplinks, which test_bgp_vnet does not support (see
https://github.com/sonic-net/sonic-mgmt/issues/26523). Skip by bug so the tests are re-enabled automatically once the issue is fixed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

The t0-isolated-d32u32s2-mix topology has no PortChannel uplinks, which test_bgp_vnet does not support (see
https://github.com/sonic-net/sonic-mgmt/issues/26523). Skip by bug so the tests are re-enabled automatically once the issue is fixed.

### Description of PR

Summary: Skip bgp/test_bgp_vnet.py on the t0-isolated-d32u32s2-mix topology via conditional mark, gated on GitHub issue #26523.

The BGP VNET test suite assumes the DUT's T1 uplinks are PortChannels: the vnet_config_db.j2 template only tags PORTCHANNEL_INTERFACE entries with vnet_name, and the data-plane checks derive PTF ports from PORTCHANNEL_MEMBER. On t0-isolated-d32u32s2-mix the uplinks are routed physical ports (no PortChannels), so every test in the module fails (e.g. "No PTF ports found for Vnet1"). 


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/sonic-net/sonic-mgmt/issues/26523
Failure type: day-one issue (the test never supported PortChannel-less topologies; first exposed when the suite was enabled on t0-isolated-d32u32s2-mix)

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result


### Approach
#### What is the motivation for this PR?

bgp/test_bgp_vnet.py fails on every run on t0-isolated-d32u32s2-mix because the topology has no PortChannel uplinks (#26523). These constant failures generate noise in regression reports; the module should be skipped until the suite supports routed-port topologies.

#### How did you do it?

Extended the existing `bgp/test_bgp_vnet.py` skip entry in tests_mark_conditions.yaml with `conditions_logical_operator: or`, preserving the current asic_type condition and adding an issue-gated topology condition:
`https://github.com/sonic-net/sonic-mgmt/issues/26523 and topo_name == 't0-isolated-d32u32s2-mix'`.

#### How did you verify/test it?

#### Any platform specific information?

Observed on SN6600_LD (x86_64-nvidia_sn6600_ld-r0), but the root cause is topology-specific (no PortChannels), not platform-specific — hence the topo_name condition.

#### Supported testbed topology if it's a new test case?

### Documentation

