### PR TITLE
[dhcp_relay]: Model external and internal relay readiness

### DIFF
--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -563,7 +563,8 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
         if not succeeded:
             raise RuntimeError("Failed to determine dhcp_server feature state")
-        relay_type = 'isc-internal' if features_state.get('dhcp_server') == 'enabled' else 'isc'
+        relay_type = ('isc-internal' if features_state.get('dhcp_server') in ('enabled', 'always_enabled')
+                      else 'isc')
 
     if dhcpv4_config_flag:
         duthost.shell('sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" "has_sonic_dhcpv4_relay" "True"',

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -553,6 +553,18 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
     """
     Enable or disable the SONiC DHCPv4 feature flag and restart the DHCP service on the DUT.
     """
+    relay_type = 'sonic'
+    if not dhcpv4_config_flag:
+        try:
+            features_state, _ = duthost.get_feature_status()
+        except Exception as error:
+            raise RuntimeError("Failed to determine dhcp_server feature state") from error
+
+        dhcp_server_state = features_state.get('dhcp_server')
+        if dhcp_server_state is None:
+            raise RuntimeError("dhcp_server feature is unavailable; cannot select DHCP relay mode")
+        relay_type = 'isc-internal' if dhcp_server_state == 'enabled' else 'isc'
+
     if dhcpv4_config_flag:
         duthost.shell('sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" "has_sonic_dhcpv4_relay" "True"',
                       module_ignore_errors=True)
@@ -562,7 +574,7 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
     # Save the config and restart DHCP relay service
     duthost.shell('sudo config save -y', module_ignore_errors=True)
-    restart_dhcp_service(duthost, ['sonic'] if dhcpv4_config_flag else ['isc'])
+    restart_dhcp_service(duthost, [relay_type])
 
 
 @pytest.fixture()

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -557,14 +557,13 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
     relay_type = 'sonic'
     if not dhcpv4_config_flag:
         try:
-            features_state, _ = duthost.get_feature_status()
+            features_state, succeeded = duthost.get_feature_status()
         except Exception as error:
             raise RuntimeError("Failed to determine dhcp_server feature state") from error
 
-        dhcp_server_state = features_state.get('dhcp_server')
-        if dhcp_server_state is None:
-            raise RuntimeError("dhcp_server feature is unavailable; cannot select DHCP relay mode")
-        relay_type = 'isc-internal' if dhcp_server_state == 'enabled' else 'isc'
+        if not succeeded:
+            raise RuntimeError("Failed to determine dhcp_server feature state")
+        relay_type = 'isc-internal' if features_state.get('dhcp_server') == 'enabled' else 'isc'
 
     if dhcpv4_config_flag:
         duthost.shell('sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" "has_sonic_dhcpv4_relay" "True"',

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -550,21 +550,30 @@ def merge_counters(source_counter, merge_counter, is_v6=False):
                                                                     merge_counter.get(dir, {}).get(dhcp_type, 0)
 
 
+def get_dhcp_relay_type(duthost):
+    """Return the IPv4 DHCP relay layout required by the current DHCP server configuration."""
+    try:
+        features_state, succeeded = duthost.get_feature_status()
+    except Exception as error:
+        raise RuntimeError("Failed to determine dhcp_server feature state") from error
+
+    if not succeeded:
+        raise RuntimeError("Failed to determine dhcp_server feature state")
+    if features_state.get('dhcp_server') not in ('enabled', 'always_enabled'):
+        return 'isc'
+
+    config_facts = duthost.config_facts(host=duthost.hostname, source='running')['ansible_facts']
+    dhcp_server_ipv4 = config_facts.get('DHCP_SERVER_IPV4', {})
+    if any(config.get('state') == 'enabled' for config in dhcp_server_ipv4.values()):
+        return 'isc-internal'
+    return 'isc'
+
+
 def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
     """
     Enable or disable the SONiC DHCPv4 feature flag and restart the DHCP service on the DUT.
     """
-    relay_type = 'sonic'
-    if not dhcpv4_config_flag:
-        try:
-            features_state, succeeded = duthost.get_feature_status()
-        except Exception as error:
-            raise RuntimeError("Failed to determine dhcp_server feature state") from error
-
-        if not succeeded:
-            raise RuntimeError("Failed to determine dhcp_server feature state")
-        relay_type = ('isc-internal' if features_state.get('dhcp_server') in ('enabled', 'always_enabled')
-                      else 'isc')
+    relay_type = 'sonic' if dhcpv4_config_flag else get_dhcp_relay_type(duthost)
 
     if dhcpv4_config_flag:
         duthost.shell('sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" "has_sonic_dhcpv4_relay" "True"',

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -31,15 +31,18 @@ def _validate_relay_types(caller, relay_types):
     if not relay_types:
         raise ValueError("%s: relay_types must be a non-empty iterable" % caller)
     relay_types = list(relay_types)
-    valid = {'isc', 'isc-internal', 'sonic', 'v6'}
+    valid = {'isc', 'isc-internal', 'isc-internal-idle', 'sonic', 'v6'}
     bad = [t for t in relay_types if t not in valid]
     if bad:
         raise ValueError("%s: invalid relay_types %s; allowed %s"
                          % (caller, bad, sorted(valid)))
-    v4_modes = [t for t in relay_types if t in {'isc', 'isc-internal', 'sonic'}]
+    v4_modes = [
+        t for t in relay_types
+        if t in {'isc', 'isc-internal', 'isc-internal-idle', 'sonic'}
+    ]
     if len(v4_modes) > 1:
         raise ValueError(
-            "%s: at most one of {'isc', 'isc-internal', 'sonic'} "
+            "%s: at most one of {'isc', 'isc-internal', 'isc-internal-idle', 'sonic'} "
             "may be requested per call (mutually exclusive in the relay container); got %s"
             % (caller, v4_modes))
     return relay_types
@@ -94,6 +97,13 @@ def restart_dhcp_service(duthost, relay_types):
                           proc); at that point we should require dhcpmon
                           RUNNING here too, mirroring the 'isc' check.
 
+        'isc-internal-idle'
+                        -> mx internal mode with the dhcp_server feature enabled
+                          but no enabled DHCP_SERVER_IPV4 interface. dhcprelayd
+                          owns the v4 relay lifecycle, so the external ISC and
+                          dhcpmon supervisord entries stay STOPPED, while no
+                          internal `/usr/sbin/dhcrelay` process is expected.
+
         'sonic'        -> Consolidated v4 relay layout
                           (dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2).
                           One `/usr/sbin/dhcp4relay` proc handles all v4 VLANs.
@@ -117,9 +127,10 @@ def restart_dhcp_service(duthost, relay_types):
     The orchestrator (`dhcprelayd`) is always required RUNNING. There is intentionally
     no default; each caller must declare which agent(s) it expects to be active.
 
-    At most one of {'isc', 'isc-internal', 'sonic'} may appear in relay_types: the
-    container layout makes them mutually exclusive (driven by has_sonic_dhcpv4_relay
-    + mx internal mode), so any combination is unsatisfiable and is rejected up front.
+    At most one of {'isc', 'isc-internal', 'isc-internal-idle', 'sonic'} may
+    appear in relay_types: the container layout makes them mutually exclusive
+    (driven by has_sonic_dhcpv4_relay + mx internal mode), so any combination
+    is unsatisfiable and is rejected up front.
     """
     relay_types = _validate_relay_types('restart_dhcp_service', relay_types)
 
@@ -141,7 +152,7 @@ def wait_dhcp_relay_ready(duthost, relay_types):
     """
     relay_types = _validate_relay_types('wait_dhcp_relay_ready', relay_types)
 
-    last_state = {'states': {}, 'relay_procs': []}
+    last_state = {'states': {}, 'relay_procs': [], 'sonic_procs': []}
 
     def _supervisor_status_map():
         # supervisorctl returns rc != 0 if ANY entry is not RUNNING (e.g. the one-shot
@@ -176,19 +187,35 @@ def wait_dhcp_relay_ready(duthost, relay_types):
             # Same layout-driven rule for dhcpmon-Vlan*: each entry is paired
             # 1:1 with isc-dhcpv4-relay-<Vlan> in the same supervisord conf
             # and must be RUNNING. Intentionally NOT checked in 'isc-internal'
-            # / 'sonic' / 'v6' modes - see the docstring for the per-mode
-            # rationale (and the v6 TODO for the upcoming dhcpv6mon).
+            # / 'isc-internal-idle' / 'sonic' / 'v6' modes - see the
+            # docstring for the per-mode rationale (and the v6 TODO for the
+            # upcoming dhcpv6mon).
             for name, state in states.items():
                 if name.startswith('dhcpmon-') and state != 'RUNNING':
                     return False
-        if 'isc-internal' in relay_types:
+        if 'isc-internal' in relay_types or 'isc-internal-idle' in relay_types:
             relay_procs = duthost.shell(
                 "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcrelay' || true"
             )['stdout_lines']
             relay_procs = [line for line in relay_procs if line.strip()]
             last_state['relay_procs'] = relay_procs
-            if len(relay_procs) != 1 or '-iu docker0' not in relay_procs[0]:
-                return False
+            if 'isc-internal' in relay_types:
+                if len(relay_procs) != 1 or '-iu docker0' not in relay_procs[0]:
+                    return False
+            else:
+                if relay_procs:
+                    return False
+                for name, state in states.items():
+                    if (name.startswith('isc-dhcpv4-relay-') or name.startswith('dhcpmon-')) \
+                            and state != 'STOPPED':
+                        return False
+                sonic_procs = duthost.shell(
+                    "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcp4relay' || true"
+                )['stdout_lines']
+                sonic_procs = [line for line in sonic_procs if line.strip()]
+                last_state['sonic_procs'] = sonic_procs
+                if sonic_procs or states.get('dhcp4relay') not in (None, 'STOPPED'):
+                    return False
         if 'sonic' in relay_types:
             if states.get('dhcp4relay') != 'RUNNING':
                 return False
@@ -196,8 +223,9 @@ def wait_dhcp_relay_ready(duthost, relay_types):
 
     pytest_assert(
         wait_until(240, 5, 10, _is_dhcp_relay_ready),
-        "dhcp_relay is not ready (relay_types=%s last_supervisor_states=%s relay_procs=%s)"
-        % (relay_types, last_state['states'], last_state['relay_procs']))
+        "dhcp_relay is not ready "
+        "(relay_types=%s last_supervisor_states=%s relay_procs=%s sonic_procs=%s)"
+        % (relay_types, last_state['states'], last_state['relay_procs'], last_state['sonic_procs']))
 
 
 def init_dhcpmon_counters(duthost, is_v6=False):
@@ -551,7 +579,7 @@ def merge_counters(source_counter, merge_counter, is_v6=False):
 
 
 def get_dhcp_relay_type(duthost):
-    """Return the IPv4 DHCP relay layout required by the current DHCP server configuration."""
+    """Return the non-Sonic IPv4 layout required by the current DHCP server configuration."""
     try:
         features_state, succeeded = duthost.get_feature_status()
     except Exception as error:
@@ -566,7 +594,7 @@ def get_dhcp_relay_type(duthost):
     dhcp_server_ipv4 = config_facts.get('DHCP_SERVER_IPV4', {})
     if any(config.get('state') == 'enabled' for config in dhcp_server_ipv4.values()):
         return 'isc-internal'
-    return 'isc'
+    return 'isc-internal-idle'
 
 
 def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -78,7 +78,8 @@ def restart_dhcp_service(duthost, relay_types):
                           into a single `dhcrelay -iu docker0 ...` proc
                           (not a supervisord entry).
                           Required:
-                            - exactly one such dhcrelay proc
+                            - exactly one /usr/sbin/dhcrelay proc, which includes
+                              -iu docker0
                           Not checked:
                             - isc-dhcpv4-relay-<Vlan> supervisord entries
                               (stay STOPPED by design in this mode)
@@ -140,7 +141,7 @@ def wait_dhcp_relay_ready(duthost, relay_types):
     """
     relay_types = _validate_relay_types('wait_dhcp_relay_ready', relay_types)
 
-    last_state = {'states': {}, 'internal_procs': []}
+    last_state = {'states': {}, 'relay_procs': []}
 
     def _supervisor_status_map():
         # supervisorctl returns rc != 0 if ANY entry is not RUNNING (e.g. the one-shot
@@ -181,12 +182,12 @@ def wait_dhcp_relay_ready(duthost, relay_types):
                 if name.startswith('dhcpmon-') and state != 'RUNNING':
                     return False
         if 'isc-internal' in relay_types:
-            internal = duthost.shell(
-                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcrelay.*-iu docker0' || true"
+            relay_procs = duthost.shell(
+                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcrelay' || true"
             )['stdout_lines']
-            internal = [line for line in internal if line.strip()]
-            last_state['internal_procs'] = internal
-            if len(internal) != 1:
+            relay_procs = [line for line in relay_procs if line.strip()]
+            last_state['relay_procs'] = relay_procs
+            if len(relay_procs) != 1 or '-iu docker0' not in relay_procs[0]:
                 return False
         if 'sonic' in relay_types:
             if states.get('dhcp4relay') != 'RUNNING':
@@ -195,8 +196,8 @@ def wait_dhcp_relay_ready(duthost, relay_types):
 
     pytest_assert(
         wait_until(240, 5, 10, _is_dhcp_relay_ready),
-        "dhcp_relay is not ready (relay_types=%s last_supervisor_states=%s isc_internal_procs=%s)"
-        % (relay_types, last_state['states'], last_state['internal_procs']))
+        "dhcp_relay is not ready (relay_types=%s last_supervisor_states=%s relay_procs=%s)"
+        % (relay_types, last_state['states'], last_state['relay_procs']))
 
 
 def init_dhcpmon_counters(duthost, is_v6=False):

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -59,7 +59,7 @@ def _validate_relay_types(caller, relay_types):
     if not relay_types:
         raise ValueError("%s: relay_types must be a non-empty iterable" % caller)
     relay_types = list(relay_types)
-    valid = {'isc', 'isc-internal', 'sonic', 'v6', 'orchestrator'}
+    valid = {'isc', 'isc-internal', 'sonic', 'v6'}
     bad = [t for t in relay_types if t not in valid]
     if bad:
         raise ValueError("%s: invalid relay_types %s; allowed %s"
@@ -140,11 +140,6 @@ def restart_dhcp_service(duthost, relay_types):
                               will need to be extended to mirror the 'isc'
                               dhcpmon-<Vlan> check above.
                           TODO: revisit when dhcpv6mon ships.
-
-        'orchestrator' -> Only the dhcprelayd orchestrator is required RUNNING.
-                          Use after dhcp_server teardown or when the relay
-                          container has no v4/v6 helper programs in supervisord
-                          (e.g. multi_vlan tests that reshape VLAN relay layout).
 
     The orchestrator (`dhcprelayd`) is always required RUNNING. There is intentionally
     no default; each caller must declare which agent(s) it expects to be active.
@@ -582,25 +577,6 @@ def merge_counters(source_counter, merge_counter, is_v6=False):
                                                                     merge_counter.get(dir, {}).get(dhcp_type, 0)
 
 
-def _dhcp_server_feature_enabled(duthost):
-    features_state, _ = duthost.get_feature_status()
-    return 'enabled' in features_state.get('dhcp_server', '')
-
-
-def _relay_types_after_sonic_disable(duthost):
-    """
-    Readiness contract after removing has_sonic_dhcpv4_relay.
-
-    When the dhcp_server feature is enabled, dhcprelayd keeps supervisord
-    isc-dhcpv4-relay-* / dhcpmon-* STOPPED and manages v4 relay itself (or
-    none at all once DHCP_SERVER_IPV4 config is cleaned). Waiting for
-    relay_types=['isc'] is unsatisfiable in that mode.
-    """
-    if _dhcp_server_feature_enabled(duthost):
-        return ['orchestrator']
-    return ['isc']
-
-
 def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
     """
     Enable or disable the SONiC DHCPv4 feature flag and restart the DHCP service on the DUT.
@@ -614,11 +590,7 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
     # Save the config and restart DHCP relay service
     duthost.shell('sudo config save -y', module_ignore_errors=True)
-    if dhcpv4_config_flag:
-        relay_types = ['sonic']
-    else:
-        relay_types = _relay_types_after_sonic_disable(duthost)
-    restart_dhcp_service(duthost, relay_types)
+    restart_dhcp_service(duthost, ['sonic'] if dhcpv4_config_flag else ['isc'])
 
 
 @pytest.fixture()

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -59,15 +59,18 @@ def _validate_relay_types(caller, relay_types):
     if not relay_types:
         raise ValueError("%s: relay_types must be a non-empty iterable" % caller)
     relay_types = list(relay_types)
-    valid = {'isc', 'isc-internal', 'sonic', 'v6'}
+    valid = {'isc', 'isc-internal', 'isc-internal-idle', 'sonic', 'v6'}
     bad = [t for t in relay_types if t not in valid]
     if bad:
         raise ValueError("%s: invalid relay_types %s; allowed %s"
                          % (caller, bad, sorted(valid)))
-    v4_modes = [t for t in relay_types if t in {'isc', 'isc-internal', 'sonic'}]
+    v4_modes = [
+        t for t in relay_types
+        if t in {'isc', 'isc-internal', 'isc-internal-idle', 'sonic'}
+    ]
     if len(v4_modes) > 1:
         raise ValueError(
-            "%s: at most one of {'isc', 'isc-internal', 'sonic'} "
+            "%s: at most one of {'isc', 'isc-internal', 'isc-internal-idle', 'sonic'} "
             "may be requested per call (mutually exclusive in the relay container); got %s"
             % (caller, v4_modes))
     return relay_types
@@ -85,6 +88,8 @@ def restart_dhcp_service(duthost, relay_types):
                             - every dhcpmon-<Vlan> supervisord entry (paired
                               1:1 with the isc helpers via
                               dhcp-relay.monitors.j2)
+                            - the supervisor-owned `dhcp4relay` entry is
+                              STOPPED or absent
                           Notes:
                             - The expected per-Vlan entries are read from
                               supervisord at poll time (parsed from
@@ -97,39 +102,45 @@ def restart_dhcp_service(duthost, relay_types):
                               we wait on.
                             - If no Vlan has v4 dhcp_servers defined, the
                               matching set of isc-dhcpv4-relay-<Vlan> /
-                              dhcpmon-<Vlan> entries is empty, the loops
-                              iterate over nothing, and the 'isc' check
-                              passes immediately. This is intentional:
-                              there is genuinely nothing to wait for.
+                              dhcpmon-<Vlan> entries is empty. Readiness then
+                              requires no stale `dhcrelay` process.
 
         'isc-internal' -> mx internal mode. dhcprelayd consolidates v4 relay
                           into a single `dhcrelay -iu docker0 ...` proc
                           (not a supervisord entry).
                           Required:
-                            - exactly one such dhcrelay proc
+                            - exactly one `dhcrelay` process, which includes
+                              -iu docker0
+                            - external ISC and supervisor-owned SONiC v4 relay
+                              entries are STOPPED or absent
                           Not checked:
-                            - isc-dhcpv4-relay-<Vlan> supervisord entries
-                              (stay STOPPED by design in this mode)
-                            - dhcpmon-<Vlan> supervisord entries (also stay
-                              STOPPED today: dhcpmon does not yet support
-                              the mx/isc-internal layout, so when dhcprelayd
-                              takes over the v4 relay it does not (re)spawn
-                              dhcpmon)
-                          TODO: extend this check once dhcpmon supports the
-                          mx/isc-internal layout (when a single dhcpmon can
-                          monitor the consolidated `dhcrelay -iu docker0`
-                          proc); at that point we should require dhcpmon
-                          RUNNING here too, mirroring the 'isc' check.
+                            - dhcpmon-<Vlan> entries; monitor lifecycle is
+                              orthogonal to the active IPv4 relay mode
+
+        'isc-internal-idle'
+                        -> mx internal ISC mode with no enabled local DHCP
+                           server interface. dhcprelayd stops the external ISC
+                           relay entries and starts no dynamic `dhcrelay`.
+                           Required:
+                             - no `dhcrelay` process exists
+                             - every `isc-dhcpv4-relay-*` supervisor entry is
+                               STOPPED or absent
+                             - the supervisor-owned `dhcp4relay` entry is
+                               STOPPED or absent
+                           Not checked:
+                             - dhcpmon-<Vlan> entries; monitor lifecycle is
+                               orthogonal to the idle IPv4 relay mode
 
         'sonic'        -> Consolidated v4 relay layout
                           (dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2).
-                          One `/usr/sbin/dhcp4relay` proc handles all v4 VLANs.
-                          Required RUNNING:
-                            - the single `dhcp4relay` supervisord entry
+                          The SONiC DHCPv4 relay flag renders and starts the
+                          `dhcp4relay` supervisor program even when no
+                          DHCPV4_RELAY server configuration exists.
+                          Required:
+                            - the `dhcp4relay` supervisord entry is RUNNING
                           Not checked:
-                            - dhcpmon-<Vlan> supervisord entries (dhcp4relay
-                              publishes its own counters, so per-Vlan dhcpmon
-                              is not part of this layout)
+                            - dhcpmon-<Vlan> supervisord entries; monitor
+                              lifecycle is orthogonal to the active v4 relay
 
         'v6'           -> IPv6 relay.
                           Required RUNNING:
@@ -144,9 +155,9 @@ def restart_dhcp_service(duthost, relay_types):
     The orchestrator (`dhcprelayd`) is always required RUNNING. There is intentionally
     no default; each caller must declare which agent(s) it expects to be active.
 
-    At most one of {'isc', 'isc-internal', 'sonic'} may appear in relay_types: the
-    container layout makes them mutually exclusive (driven by has_sonic_dhcpv4_relay
-    + mx internal mode), so any combination is unsatisfiable and is rejected up front.
+    At most one IPv4 mode may appear in relay_types: the container layout makes
+    them mutually exclusive, so any combination is unsatisfiable and is rejected
+    up front.
     """
     relay_types = _validate_relay_types('restart_dhcp_service', relay_types)
 
@@ -168,8 +179,6 @@ def wait_dhcp_relay_ready(duthost, relay_types):
     """
     relay_types = _validate_relay_types('wait_dhcp_relay_ready', relay_types)
 
-    last_state = {'states': {}, 'internal_procs': []}
-
     def _supervisor_status_map():
         # supervisorctl returns rc != 0 if ANY entry is not RUNNING (e.g. the one-shot
         # 'start' / 'dependent-startup' entries are EXITED by design). Ignore the rc and
@@ -186,11 +195,22 @@ def wait_dhcp_relay_ready(duthost, relay_types):
 
     def _is_dhcp_relay_ready():
         states = _supervisor_status_map()
-        last_state['states'] = states
         if states.get('dhcprelayd') != 'RUNNING':
             return False
         if 'v6' in relay_types and states.get('dhcp6relay') != 'RUNNING':
             return False
+        v4_modes = {'isc', 'isc-internal', 'isc-internal-idle', 'sonic'}
+        if any(mode in relay_types for mode in v4_modes):
+            isc_relay_processes = duthost.shell(
+                "docker exec dhcp_relay sh -c "
+                "'pgrep -a -x dhcrelay || [ $? -eq 1 ]'"
+            )['stdout_lines']
+
+        isc_supervisor_states = [
+            state for name, state in states.items()
+            if name.startswith('isc-dhcpv4-relay-')
+        ]
+
         if 'isc' in relay_types:
             # Drive from supervisord's actual layout: every isc-dhcpv4-relay-*
             # entry currently present must be RUNNING. If none are present,
@@ -202,29 +222,42 @@ def wait_dhcp_relay_ready(duthost, relay_types):
                     return False
             # Same layout-driven rule for dhcpmon-Vlan*: each entry is paired
             # 1:1 with isc-dhcpv4-relay-<Vlan> in the same supervisord conf
-            # and must be RUNNING. Intentionally NOT checked in 'isc-internal'
-            # / 'sonic' / 'v6' modes - see the docstring for the per-mode
-            # rationale (and the v6 TODO for the upcoming dhcpv6mon).
+            # and must be RUNNING. Intentionally NOT checked in internal,
+            # SONiC, or v6-only modes; see the per-mode docstrings.
             for name, state in states.items():
                 if name.startswith('dhcpmon-') and state != 'RUNNING':
                     return False
+            if not isc_supervisor_states and isc_relay_processes:
+                return False
+            if any('-iu docker0' in process for process in isc_relay_processes):
+                return False
+            if states.get('dhcp4relay') not in (None, 'STOPPED'):
+                return False
         if 'isc-internal' in relay_types:
-            internal = duthost.shell(
-                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcrelay.*-iu docker0' || true"
-            )['stdout_lines']
-            internal = [line for line in internal if line.strip()]
-            last_state['internal_procs'] = internal
-            if len(internal) != 1:
+            if len(isc_relay_processes) != 1 or '-iu docker0' not in isc_relay_processes[0]:
+                return False
+            if any(state != 'STOPPED' for state in isc_supervisor_states):
+                return False
+            if states.get('dhcp4relay') not in (None, 'STOPPED'):
+                return False
+        if 'isc-internal-idle' in relay_types:
+            if isc_relay_processes:
+                return False
+            if any(state != 'STOPPED' for state in isc_supervisor_states):
+                return False
+            if states.get('dhcp4relay') not in (None, 'STOPPED'):
                 return False
         if 'sonic' in relay_types:
+            if isc_relay_processes:
+                return False
             if states.get('dhcp4relay') != 'RUNNING':
                 return False
         return True
 
     pytest_assert(
-        wait_until(240, 5, 10, _is_dhcp_relay_ready),
-        "dhcp_relay is not ready (relay_types=%s last_supervisor_states=%s isc_internal_procs=%s)"
-        % (relay_types, last_state['states'], last_state['internal_procs']))
+        wait_until(240, 5, 0, _is_dhcp_relay_ready),
+        "dhcp_relay is not ready (relay_types=%s)" % relay_types
+    )
 
 
 def init_dhcpmon_counters(duthost, is_v6=False):

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -610,9 +610,9 @@ def merge_counters(source_counter, merge_counter, is_v6=False):
                                                                     merge_counter.get(dir, {}).get(dhcp_type, 0)
 
 
-def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
+def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag, relay_type):
     """
-    Enable or disable the SONiC DHCPv4 feature flag and restart the DHCP service on the DUT.
+    Set the SONiC DHCPv4 feature flag and restart for the caller's explicit relay mode.
     """
     if dhcpv4_config_flag:
         duthost.shell('sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" "has_sonic_dhcpv4_relay" "True"',
@@ -623,7 +623,20 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
     # Save the config and restart DHCP relay service
     duthost.shell('sudo config save -y', module_ignore_errors=True)
-    restart_dhcp_service(duthost, ['sonic'] if dhcpv4_config_flag else ['isc'])
+    restart_dhcp_service(duthost, [relay_type])
+
+
+def get_isc_relay_type(duthost):
+    """Return the external, active internal, or idle internal ISC layout."""
+    features_state, _ = duthost.get_feature_status()
+    if 'enabled' not in features_state.get('dhcp_server', ''):
+        return 'isc'
+
+    config_facts = duthost.config_facts(host=duthost.hostname, source='running')['ansible_facts']
+    dhcp_server_ipv4 = config_facts.get('DHCP_SERVER_IPV4', {})
+    if any(config.get('state') == 'enabled' for config in dhcp_server_ipv4.values()):
+        return 'isc-internal'
+    return 'isc-internal-idle'
 
 
 @pytest.fixture()
@@ -644,14 +657,15 @@ def enable_sonic_dhcpv4_relay_agent(rand_selected_dut, request):
 
     try:
         if request.getfixturevalue("relay_agent") == "sonic-relay-agent":
-            sonic_dhcpv4_flag_config_and_unconfig(duthost, True)
+            sonic_dhcpv4_flag_config_and_unconfig(duthost, True, 'sonic')
             sonic_dhcp_relay_config(duthost, dut_dhcp_relay_data, True)
         yield
     finally:
-        # Cleanup: disable the feature flag
         if request.getfixturevalue("relay_agent") == "sonic-relay-agent":
-            sonic_dhcpv4_flag_config_and_unconfig(duthost, False)
             sonic_dhcp_relay_unconfig(duthost, dut_dhcp_relay_data)
+            # Resolve live state so teardown is independent of DHCP-server cleanup fixture ordering.
+            target_relay_type = get_isc_relay_type(duthost)
+            sonic_dhcpv4_flag_config_and_unconfig(duthost, False, target_relay_type)
 
 
 def check_dhcpv4_socket_status(duthost, dut_dhcp_relay_data=None, process_and_socket_check=None):

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -97,7 +97,7 @@ def restart_dhcp_service(duthost, relay_types):
                             - exactly one `dhcp4relay` process exists
                           Without external relay-server configuration:
                             - the supervisord entry is absent
-                            - no `/usr/sbin/dhcp4relay` process exists
+                            - no `dhcp4relay` process exists
                           Not checked:
                             - dhcpmon-<Vlan> supervisord entries; monitor
                               lifecycle is orthogonal to the active v4 relay

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -31,18 +31,18 @@ def _validate_relay_types(caller, relay_types):
     if not relay_types:
         raise ValueError("%s: relay_types must be a non-empty iterable" % caller)
     relay_types = list(relay_types)
-    valid = {'internal-idle', 'isc', 'isc-internal', 'sonic', 'sonic-internal', 'v6'}
+    valid = {'isc', 'isc-internal', 'isc-internal-idle', 'sonic', 'sonic-internal', 'v6'}
     bad = [t for t in relay_types if t not in valid]
     if bad:
         raise ValueError("%s: invalid relay_types %s; allowed %s"
                          % (caller, bad, sorted(valid)))
     v4_modes = [
         t for t in relay_types
-        if t in {'internal-idle', 'isc', 'isc-internal', 'sonic', 'sonic-internal'}
+        if t in {'isc', 'isc-internal', 'isc-internal-idle', 'sonic', 'sonic-internal'}
     ]
     if len(v4_modes) > 1:
         raise ValueError(
-            "%s: at most one of {'internal-idle', 'isc', 'isc-internal', "
+            "%s: at most one of {'isc', 'isc-internal', 'isc-internal-idle', "
             "'sonic', 'sonic-internal'} "
             "may be requested per call (mutually exclusive in the relay container); got %s"
             % (caller, v4_modes))
@@ -90,6 +90,15 @@ def restart_dhcp_service(duthost, relay_types):
                             - dhcpmon-<Vlan> entries; monitor lifecycle is
                               orthogonal to the active IPv4 relay mode
 
+        'isc-internal-idle'
+                        -> mx internal ISC mode with no enabled local DHCP
+                           server interface. dhcprelayd stops the external ISC
+                           relay entries and starts no dynamic `dhcrelay`.
+                           Required:
+                             - no `dhcrelay` or `dhcp4relay` process exists
+                             - every IPv4 relay supervisor entry is STOPPED or
+                               absent
+
         'sonic'        -> Consolidated v4 relay layout
                           (dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2).
                           The SONiC DHCPv4 relay flag renders and starts the
@@ -103,16 +112,11 @@ def restart_dhcp_service(duthost, relay_types):
                               lifecycle is orthogonal to the active v4 relay
 
         'sonic-internal'
-                        -> mx internal SONiC mode. dhcprelayd dynamically owns
-                          exactly one `dhcp4relay` process, while
-                          external ISC and supervisor-owned SONiC v4 relay
-                          entries stay STOPPED or absent.
-
-        'internal-idle'
-                        -> mx internal lifecycle with no enabled local DHCP
-                          server interface. dhcprelayd remains RUNNING, no
-                          `dhcrelay` or `dhcp4relay` process exists, and every
-                          IPv4 relay supervisor entry is STOPPED or absent.
+                        -> mx internal SONiC mode. The same supervisor-owned
+                          `dhcp4relay` process remains RUNNING and switches
+                          internally from DHCPV4_RELAY to DHCP_SERVER_IPV4
+                          configuration. Its process-layout requirements are
+                          therefore identical to `sonic`.
 
         'v6'           -> IPv6 relay.
                           Required RUNNING:
@@ -174,7 +178,7 @@ def wait_dhcp_relay_ready(duthost, relay_types):
             return False
         if 'v6' in relay_types and states.get('dhcp6relay') != 'RUNNING':
             return False
-        v4_modes = {'internal-idle', 'isc', 'isc-internal', 'sonic', 'sonic-internal'}
+        v4_modes = {'isc', 'isc-internal', 'isc-internal-idle', 'sonic', 'sonic-internal'}
         if any(mode in relay_types for mode in v4_modes):
             isc_relay_processes = duthost.shell(
                 "docker exec dhcp_relay pgrep -a -x dhcrelay || true"
@@ -223,26 +227,19 @@ def wait_dhcp_relay_ready(duthost, relay_types):
                 return False
             if states.get('dhcp4relay') not in (None, 'STOPPED'):
                 return False
-        if 'sonic' in relay_types:
-            if isc_relay_processes:
-                return False
-            if states.get('dhcp4relay') != 'RUNNING':
-                return False
-            if len(sonic_relay_processes) != 1:
-                return False
-        if 'sonic-internal' in relay_types:
-            if isc_relay_processes or len(sonic_relay_processes) != 1:
-                return False
-            if any(state != 'STOPPED' for state in isc_supervisor_states):
-                return False
-            if states.get('dhcp4relay') not in (None, 'STOPPED'):
-                return False
-        if 'internal-idle' in relay_types:
+        if 'isc-internal-idle' in relay_types:
             if isc_relay_processes or sonic_relay_processes:
                 return False
             if any(state != 'STOPPED' for state in isc_supervisor_states):
                 return False
             if states.get('dhcp4relay') not in (None, 'STOPPED'):
+                return False
+        if 'sonic' in relay_types or 'sonic-internal' in relay_types:
+            if isc_relay_processes:
+                return False
+            if states.get('dhcp4relay') != 'RUNNING':
+                return False
+            if len(sonic_relay_processes) != 1:
                 return False
         return True
 
@@ -619,21 +616,13 @@ def get_dhcp_relay_type(duthost):
     if features_state.get('dhcp_server') not in ('enabled', 'always_enabled'):
         return 'sonic' if has_sonic_dhcpv4_relay else 'isc'
 
+    if has_sonic_dhcpv4_relay:
+        return 'sonic-internal'
+
     dhcp_server_ipv4 = config_facts.get('DHCP_SERVER_IPV4', {})
     if any(config.get('state') == 'enabled' for config in dhcp_server_ipv4.values()):
-        return 'sonic-internal' if has_sonic_dhcpv4_relay else 'isc-internal'
-
-    if has_sonic_dhcpv4_relay:
-        vlan_interfaces = config_facts.get('VLAN_INTERFACE', {})
-        dhcpv4_relay = config_facts.get('DHCPV4_RELAY', {})
-        external_sonic_relay_configured = any(
-            vlan_name in vlan_interfaces
-            and any(str(server).strip() for server in config.get('dhcpv4_servers', []))
-            for vlan_name, config in dhcpv4_relay.items()
-        )
-        if external_sonic_relay_configured:
-            return 'sonic'
-    return 'internal-idle'
+        return 'isc-internal'
+    return 'isc-internal-idle'
 
 
 def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -96,8 +96,13 @@ def restart_dhcp_service(duthost, relay_types):
                            relay entries and starts no dynamic `dhcrelay`.
                            Required:
                              - no `dhcrelay` or `dhcp4relay` process exists
-                             - every IPv4 relay supervisor entry is STOPPED or
-                               absent
+                             - every `isc-dhcpv4-relay-*` supervisor entry is
+                               STOPPED or absent
+                             - the supervisor-owned `dhcp4relay` entry is
+                               STOPPED or absent
+                           Not checked:
+                             - dhcpmon-<Vlan> entries; monitor lifecycle is
+                               orthogonal to the idle IPv4 relay mode
 
         'sonic'        -> Consolidated v4 relay layout
                           (dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2).

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -609,26 +609,6 @@ def merge_counters(source_counter, merge_counter, is_v6=False):
                                                                     merge_counter.get(dir, {}).get(dhcp_type, 0)
 
 
-def get_dhcp_relay_type(duthost):
-    """Return the IPv4 relay layout required by the current configuration."""
-    features_state, succeeded = duthost.get_feature_status()
-    pytest_assert(succeeded, "Failed to get feature status")
-
-    config_facts = duthost.config_facts(host=duthost.hostname, source='running')['ansible_facts']
-    device_metadata = config_facts['DEVICE_METADATA']['localhost']
-    has_sonic_dhcpv4_relay = device_metadata.get('has_sonic_dhcpv4_relay', 'False') == 'True'
-    if features_state.get('dhcp_server') not in ('enabled', 'always_enabled'):
-        return 'sonic' if has_sonic_dhcpv4_relay else 'isc'
-
-    if has_sonic_dhcpv4_relay:
-        return 'sonic-internal'
-
-    dhcp_server_ipv4 = config_facts.get('DHCP_SERVER_IPV4', {})
-    if any(config.get('state') == 'enabled' for config in dhcp_server_ipv4.values()):
-        return 'isc-internal'
-    return 'isc-internal-idle'
-
-
 def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
     """
     Enable or disable the SONiC DHCPv4 feature flag and restart the DHCP service on the DUT.
@@ -642,8 +622,7 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
     # Save the config and restart DHCP relay service
     duthost.shell('sudo config save -y', module_ignore_errors=True)
-    relay_type = get_dhcp_relay_type(duthost)
-    restart_dhcp_service(duthost, [relay_type])
+    restart_dhcp_service(duthost, ['sonic'] if dhcpv4_config_flag else ['isc'])
 
 
 @pytest.fixture()

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -615,7 +615,7 @@ def get_dhcp_relay_type(duthost):
     pytest_assert(succeeded, "Failed to get feature status")
 
     config_facts = duthost.config_facts(host=duthost.hostname, source='running')['ansible_facts']
-    device_metadata = config_facts.get('DEVICE_METADATA', {}).get('localhost', {})
+    device_metadata = config_facts['DEVICE_METADATA']['localhost']
     has_sonic_dhcpv4_relay = device_metadata.get('has_sonic_dhcpv4_relay', 'False') == 'True'
     if features_state.get('dhcp_server') not in ('enabled', 'always_enabled'):
         return 'sonic' if has_sonic_dhcpv4_relay else 'isc'

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -76,8 +76,6 @@ def restart_dhcp_service(duthost, relay_types):
                               dhcpmon-<Vlan> entries is empty. Readiness then
                               requires no stale `dhcrelay` or `dhcp4relay`
                               process.
-                            - The supervisor-owned `dhcp4relay` entry must be
-                              STOPPED or absent.
 
         'isc-internal' -> mx internal mode. dhcprelayd consolidates v4 relay
                           into a single `dhcrelay -iu docker0 ...` proc
@@ -227,8 +225,6 @@ def wait_dhcp_relay_ready(duthost, relay_types):
             if any('-iu docker0' in process for process in isc_relay_processes):
                 return False
             if sonic_relay_processes:
-                return False
-            if states.get('dhcp4relay') not in (None, 'STOPPED'):
                 return False
         if 'isc-internal' in relay_types:
             if len(isc_relay_processes) != 1 or '-iu docker0' not in isc_relay_processes[0]:

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -31,18 +31,19 @@ def _validate_relay_types(caller, relay_types):
     if not relay_types:
         raise ValueError("%s: relay_types must be a non-empty iterable" % caller)
     relay_types = list(relay_types)
-    valid = {'isc', 'isc-internal', 'isc-internal-idle', 'sonic', 'v6'}
+    valid = {'internal-idle', 'isc', 'isc-internal', 'sonic', 'sonic-internal', 'v6'}
     bad = [t for t in relay_types if t not in valid]
     if bad:
         raise ValueError("%s: invalid relay_types %s; allowed %s"
                          % (caller, bad, sorted(valid)))
     v4_modes = [
         t for t in relay_types
-        if t in {'isc', 'isc-internal', 'isc-internal-idle', 'sonic'}
+        if t in {'internal-idle', 'isc', 'isc-internal', 'sonic', 'sonic-internal'}
     ]
     if len(v4_modes) > 1:
         raise ValueError(
-            "%s: at most one of {'isc', 'isc-internal', 'isc-internal-idle', 'sonic'} "
+            "%s: at most one of {'internal-idle', 'isc', 'isc-internal', "
+            "'sonic', 'sonic-internal'} "
             "may be requested per call (mutually exclusive in the relay container); got %s"
             % (caller, v4_modes))
     return relay_types
@@ -72,10 +73,9 @@ def restart_dhcp_service(duthost, relay_types):
                               we wait on.
                             - If no Vlan has v4 dhcp_servers defined, the
                               matching set of isc-dhcpv4-relay-<Vlan> /
-                              dhcpmon-<Vlan> entries is empty, the loops
-                              iterate over nothing, and the 'isc' check
-                              passes immediately. This is intentional:
-                              there is genuinely nothing to wait for.
+                              dhcpmon-<Vlan> entries is empty. Readiness then
+                              requires no stale `dhcrelay` or `dhcp4relay`
+                              process.
 
         'isc-internal' -> mx internal mode. dhcprelayd consolidates v4 relay
                           into a single `dhcrelay -iu docker0 ...` proc
@@ -83,36 +83,36 @@ def restart_dhcp_service(duthost, relay_types):
                           Required:
                             - exactly one /usr/sbin/dhcrelay proc, which includes
                               -iu docker0
+                            - external ISC and supervisor-owned SONiC v4 relay
+                              entries are STOPPED or absent
+                            - no `/usr/sbin/dhcp4relay` process exists
                           Not checked:
-                            - isc-dhcpv4-relay-<Vlan> supervisord entries
-                              (stay STOPPED by design in this mode)
-                            - dhcpmon-<Vlan> supervisord entries (also stay
-                              STOPPED today: dhcpmon does not yet support
-                              the mx/isc-internal layout, so when dhcprelayd
-                              takes over the v4 relay it does not (re)spawn
-                              dhcpmon)
-                          TODO: extend this check once dhcpmon supports the
-                          mx/isc-internal layout (when a single dhcpmon can
-                          monitor the consolidated `dhcrelay -iu docker0`
-                          proc); at that point we should require dhcpmon
-                          RUNNING here too, mirroring the 'isc' check.
-
-        'isc-internal-idle'
-                        -> mx internal mode with the dhcp_server feature enabled
-                          but no enabled DHCP_SERVER_IPV4 interface. dhcprelayd
-                          owns the v4 relay lifecycle, so the external ISC and
-                          dhcpmon supervisord entries stay STOPPED, while no
-                          internal `/usr/sbin/dhcrelay` process is expected.
+                            - dhcpmon-<Vlan> entries; monitor lifecycle is
+                              orthogonal to the active IPv4 relay mode
 
         'sonic'        -> Consolidated v4 relay layout
                           (dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2).
-                          One `/usr/sbin/dhcp4relay` proc handles all v4 VLANs.
-                          Required RUNNING:
-                            - the single `dhcp4relay` supervisord entry
+                          When external DHCPV4_RELAY configuration exists:
+                            - the single `dhcp4relay` supervisord entry is RUNNING
+                            - exactly one `/usr/sbin/dhcp4relay` process exists
+                          With no external v4 configuration:
+                            - the supervisord entry is absent or STOPPED
+                            - no `/usr/sbin/dhcp4relay` process exists
                           Not checked:
-                            - dhcpmon-<Vlan> supervisord entries (dhcp4relay
-                              publishes its own counters, so per-Vlan dhcpmon
-                              is not part of this layout)
+                            - dhcpmon-<Vlan> supervisord entries; monitor
+                              lifecycle is orthogonal to the active v4 relay
+
+        'sonic-internal'
+                        -> mx internal SONiC mode. dhcprelayd dynamically owns
+                          exactly one `/usr/sbin/dhcp4relay` process, while
+                          external ISC and supervisor-owned SONiC v4 relay
+                          entries stay STOPPED or absent.
+
+        'internal-idle'
+                        -> mx internal lifecycle with no enabled local DHCP
+                          server interface. dhcprelayd remains RUNNING, no
+                          `dhcrelay` or `dhcp4relay` process exists, and every
+                          IPv4 relay supervisor entry is STOPPED or absent.
 
         'v6'           -> IPv6 relay.
                           Required RUNNING:
@@ -127,10 +127,9 @@ def restart_dhcp_service(duthost, relay_types):
     The orchestrator (`dhcprelayd`) is always required RUNNING. There is intentionally
     no default; each caller must declare which agent(s) it expects to be active.
 
-    At most one of {'isc', 'isc-internal', 'isc-internal-idle', 'sonic'} may
-    appear in relay_types: the container layout makes them mutually exclusive
-    (driven by has_sonic_dhcpv4_relay + mx internal mode), so any combination
-    is unsatisfiable and is rejected up front.
+    At most one IPv4 mode may appear in relay_types: the container layout makes
+    them mutually exclusive, so any combination is unsatisfiable and is rejected
+    up front.
     """
     relay_types = _validate_relay_types('restart_dhcp_service', relay_types)
 
@@ -175,6 +174,24 @@ def wait_dhcp_relay_ready(duthost, relay_types):
             return False
         if 'v6' in relay_types and states.get('dhcp6relay') != 'RUNNING':
             return False
+        v4_modes = {'internal-idle', 'isc', 'isc-internal', 'sonic', 'sonic-internal'}
+        if any(mode in relay_types for mode in v4_modes):
+            relay_procs = duthost.shell(
+                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcrelay' || true"
+            )['stdout_lines']
+            relay_procs = [line for line in relay_procs if line.strip()]
+            sonic_procs = duthost.shell(
+                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcp4relay' || true"
+            )['stdout_lines']
+            sonic_procs = [line for line in sonic_procs if line.strip()]
+            last_state['relay_procs'] = relay_procs
+            last_state['sonic_procs'] = sonic_procs
+
+        isc_supervisor_states = [
+            state for name, state in states.items()
+            if name.startswith('isc-dhcpv4-relay-')
+        ]
+
         if 'isc' in relay_types:
             # Drive from supervisord's actual layout: every isc-dhcpv4-relay-*
             # entry currently present must be RUNNING. If none are present,
@@ -186,38 +203,49 @@ def wait_dhcp_relay_ready(duthost, relay_types):
                     return False
             # Same layout-driven rule for dhcpmon-Vlan*: each entry is paired
             # 1:1 with isc-dhcpv4-relay-<Vlan> in the same supervisord conf
-            # and must be RUNNING. Intentionally NOT checked in 'isc-internal'
-            # / 'isc-internal-idle' / 'sonic' / 'v6' modes - see the
-            # docstring for the per-mode rationale (and the v6 TODO for the
-            # upcoming dhcpv6mon).
+            # and must be RUNNING. Intentionally NOT checked in internal,
+            # SONiC, or v6-only modes; see the per-mode docstrings.
             for name, state in states.items():
                 if name.startswith('dhcpmon-') and state != 'RUNNING':
                     return False
-        if 'isc-internal' in relay_types or 'isc-internal-idle' in relay_types:
-            relay_procs = duthost.shell(
-                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcrelay' || true"
-            )['stdout_lines']
-            relay_procs = [line for line in relay_procs if line.strip()]
-            last_state['relay_procs'] = relay_procs
-            if 'isc-internal' in relay_types:
-                if len(relay_procs) != 1 or '-iu docker0' not in relay_procs[0]:
+            if not isc_supervisor_states and relay_procs:
+                return False
+            if sonic_procs:
+                return False
+        if 'isc-internal' in relay_types:
+            if len(relay_procs) != 1 or '-iu docker0' not in relay_procs[0]:
+                return False
+            if sonic_procs:
+                return False
+            if any(state != 'STOPPED' for state in isc_supervisor_states):
+                return False
+            if states.get('dhcp4relay') not in (None, 'STOPPED'):
+                return False
+        if 'sonic' in relay_types:
+            if relay_procs:
+                return False
+            sonic_state = states.get('dhcp4relay')
+            if sonic_state == 'RUNNING':
+                if len(sonic_procs) != 1:
+                    return False
+            elif sonic_state in (None, 'STOPPED'):
+                if sonic_procs:
                     return False
             else:
-                if relay_procs:
-                    return False
-                for name, state in states.items():
-                    if (name.startswith('isc-dhcpv4-relay-') or name.startswith('dhcpmon-')) \
-                            and state != 'STOPPED':
-                        return False
-                sonic_procs = duthost.shell(
-                    "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcp4relay' || true"
-                )['stdout_lines']
-                sonic_procs = [line for line in sonic_procs if line.strip()]
-                last_state['sonic_procs'] = sonic_procs
-                if sonic_procs or states.get('dhcp4relay') not in (None, 'STOPPED'):
-                    return False
-        if 'sonic' in relay_types:
-            if states.get('dhcp4relay') != 'RUNNING':
+                return False
+        if 'sonic-internal' in relay_types:
+            if relay_procs or len(sonic_procs) != 1:
+                return False
+            if any(state != 'STOPPED' for state in isc_supervisor_states):
+                return False
+            if states.get('dhcp4relay') not in (None, 'STOPPED'):
+                return False
+        if 'internal-idle' in relay_types:
+            if relay_procs or sonic_procs:
+                return False
+            if any(state != 'STOPPED' for state in isc_supervisor_states):
+                return False
+            if states.get('dhcp4relay') not in (None, 'STOPPED'):
                 return False
         return True
 
@@ -579,7 +607,7 @@ def merge_counters(source_counter, merge_counter, is_v6=False):
 
 
 def get_dhcp_relay_type(duthost):
-    """Return the non-Sonic IPv4 layout required by the current DHCP server configuration."""
+    """Return the IPv4 relay layout required by the current configuration."""
     try:
         features_state, succeeded = duthost.get_feature_status()
     except Exception as error:
@@ -587,22 +615,33 @@ def get_dhcp_relay_type(duthost):
 
     if not succeeded:
         raise RuntimeError("Failed to determine dhcp_server feature state")
-    if features_state.get('dhcp_server') not in ('enabled', 'always_enabled'):
-        return 'isc'
-
     config_facts = duthost.config_facts(host=duthost.hostname, source='running')['ansible_facts']
+    device_metadata = config_facts.get('DEVICE_METADATA', {}).get('localhost', {})
+    has_sonic_dhcpv4_relay = str(device_metadata.get('has_sonic_dhcpv4_relay', 'False')).lower() == 'true'
+    if features_state.get('dhcp_server') not in ('enabled', 'always_enabled'):
+        return 'sonic' if has_sonic_dhcpv4_relay else 'isc'
+
     dhcp_server_ipv4 = config_facts.get('DHCP_SERVER_IPV4', {})
     if any(config.get('state') == 'enabled' for config in dhcp_server_ipv4.values()):
-        return 'isc-internal'
-    return 'isc-internal-idle'
+        return 'sonic-internal' if has_sonic_dhcpv4_relay else 'isc-internal'
+
+    if has_sonic_dhcpv4_relay:
+        vlan_interfaces = config_facts.get('VLAN_INTERFACE', {})
+        dhcpv4_relay = config_facts.get('DHCPV4_RELAY', {})
+        external_sonic_relay_configured = any(
+            vlan_name in vlan_interfaces
+            and any(str(server).strip() for server in config.get('dhcpv4_servers', []))
+            for vlan_name, config in dhcpv4_relay.items()
+        )
+        if external_sonic_relay_configured:
+            return 'sonic'
+    return 'internal-idle'
 
 
 def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
     """
     Enable or disable the SONiC DHCPv4 feature flag and restart the DHCP service on the DUT.
     """
-    relay_type = 'sonic' if dhcpv4_config_flag else get_dhcp_relay_type(duthost)
-
     if dhcpv4_config_flag:
         duthost.shell('sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" "has_sonic_dhcpv4_relay" "True"',
                       module_ignore_errors=True)
@@ -612,6 +651,7 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
     # Save the config and restart DHCP relay service
     duthost.shell('sudo config save -y', module_ignore_errors=True)
+    relay_type = get_dhcp_relay_type(duthost)
     restart_dhcp_service(duthost, [relay_type])
 
 

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -96,7 +96,7 @@ def restart_dhcp_service(duthost, relay_types):
                             - the single `dhcp4relay` supervisord entry is RUNNING
                             - exactly one `/usr/sbin/dhcp4relay` process exists
                           With no external v4 configuration:
-                            - the supervisord entry is absent or STOPPED
+                            - the supervisord entry is absent
                             - no `/usr/sbin/dhcp4relay` process exists
                           Not checked:
                             - dhcpmon-<Vlan> supervisord entries; monitor
@@ -228,7 +228,7 @@ def wait_dhcp_relay_ready(duthost, relay_types):
             if sonic_state == 'RUNNING':
                 if len(sonic_procs) != 1:
                     return False
-            elif sonic_state in (None, 'STOPPED'):
+            elif sonic_state is None:
                 if sonic_procs:
                     return False
             else:

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -92,12 +92,12 @@ def restart_dhcp_service(duthost, relay_types):
 
         'sonic'        -> Consolidated v4 relay layout
                           (dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2).
-                          With external relay-server configuration:
+                          The SONiC DHCPv4 relay flag renders and starts the
+                          `dhcp4relay` supervisor program even when no
+                          DHCPV4_RELAY server configuration exists.
+                          Required:
                             - the `dhcp4relay` supervisord entry is RUNNING
                             - exactly one `dhcp4relay` process exists
-                          Without external relay-server configuration:
-                            - the supervisord entry is absent
-                            - no `dhcp4relay` process exists
                           Not checked:
                             - dhcpmon-<Vlan> supervisord entries; monitor
                               lifecycle is orthogonal to the active v4 relay
@@ -226,14 +226,9 @@ def wait_dhcp_relay_ready(duthost, relay_types):
         if 'sonic' in relay_types:
             if isc_relay_processes:
                 return False
-            sonic_state = states.get('dhcp4relay')
-            if sonic_state == 'RUNNING':
-                if len(sonic_relay_processes) != 1:
-                    return False
-            elif sonic_state is None:
-                if sonic_relay_processes:
-                    return False
-            else:
+            if states.get('dhcp4relay') != 'RUNNING':
+                return False
+            if len(sonic_relay_processes) != 1:
                 return False
         if 'sonic-internal' in relay_types:
             if isc_relay_processes or len(sonic_relay_processes) != 1:

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -81,11 +81,11 @@ def restart_dhcp_service(duthost, relay_types):
                           into a single `dhcrelay -iu docker0 ...` proc
                           (not a supervisord entry).
                           Required:
-                            - exactly one /usr/sbin/dhcrelay proc, which includes
+                            - exactly one `dhcrelay` process, which includes
                               -iu docker0
                             - external ISC and supervisor-owned SONiC v4 relay
                               entries are STOPPED or absent
-                            - no `/usr/sbin/dhcp4relay` process exists
+                            - no `dhcp4relay` process exists
                           Not checked:
                             - dhcpmon-<Vlan> entries; monitor lifecycle is
                               orthogonal to the active IPv4 relay mode
@@ -94,7 +94,7 @@ def restart_dhcp_service(duthost, relay_types):
                           (dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2).
                           With external relay-server configuration:
                             - the `dhcp4relay` supervisord entry is RUNNING
-                            - exactly one `/usr/sbin/dhcp4relay` process exists
+                            - exactly one `dhcp4relay` process exists
                           Without external relay-server configuration:
                             - the supervisord entry is absent
                             - no `/usr/sbin/dhcp4relay` process exists
@@ -104,7 +104,7 @@ def restart_dhcp_service(duthost, relay_types):
 
         'sonic-internal'
                         -> mx internal SONiC mode. dhcprelayd dynamically owns
-                          exactly one `/usr/sbin/dhcp4relay` process, while
+                          exactly one `dhcp4relay` process, while
                           external ISC and supervisor-owned SONiC v4 relay
                           entries stay STOPPED or absent.
 

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -116,7 +116,10 @@ def restart_dhcp_service(duthost, relay_types):
                           `dhcp4relay` process remains RUNNING and switches
                           internally from DHCPV4_RELAY to DHCP_SERVER_IPV4
                           configuration. Its process-layout requirements are
-                          therefore identical to `sonic`.
+                          therefore identical to `sonic`. This mode encompasses
+                          both an enabled local DHCP-server interface and the
+                          no-interface idle state, so no separate SONiC
+                          internal-idle mode is needed.
 
         'v6'           -> IPv6 relay.
                           Required RUNNING:

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -92,12 +92,13 @@ def restart_dhcp_service(duthost, relay_types):
 
         'sonic'        -> Consolidated v4 relay layout
                           (dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2).
-                          When external DHCPV4_RELAY configuration exists:
-                            - the single `dhcp4relay` supervisord entry is RUNNING
+                          Current behavior always renders the single
+                          supervisor-owned `dhcp4relay` when
+                          has_sonic_dhcpv4_relay is True, even with no external
+                          relay-server configuration.
+                          Required:
+                            - the `dhcp4relay` supervisord entry is RUNNING
                             - exactly one `/usr/sbin/dhcp4relay` process exists
-                          With no external v4 configuration:
-                            - the supervisord entry is absent
-                            - no `/usr/sbin/dhcp4relay` process exists
                           Not checked:
                             - dhcpmon-<Vlan> supervisord entries; monitor
                               lifecycle is orthogonal to the active v4 relay
@@ -151,7 +152,7 @@ def wait_dhcp_relay_ready(duthost, relay_types):
     """
     relay_types = _validate_relay_types('wait_dhcp_relay_ready', relay_types)
 
-    last_state = {'states': {}, 'relay_procs': [], 'sonic_procs': []}
+    last_state = {'states': {}, 'dhcrelay_processes': [], 'dhcp4relay_processes': []}
 
     def _supervisor_status_map():
         # supervisorctl returns rc != 0 if ANY entry is not RUNNING (e.g. the one-shot
@@ -176,16 +177,16 @@ def wait_dhcp_relay_ready(duthost, relay_types):
             return False
         v4_modes = {'internal-idle', 'isc', 'isc-internal', 'sonic', 'sonic-internal'}
         if any(mode in relay_types for mode in v4_modes):
-            relay_procs = duthost.shell(
+            dhcrelay_processes = duthost.shell(
                 "docker exec dhcp_relay pgrep -af '/usr/sbin/dhc[r]elay' || true"
             )['stdout_lines']
-            relay_procs = [line for line in relay_procs if line.strip()]
-            sonic_procs = duthost.shell(
+            dhcrelay_processes = [line for line in dhcrelay_processes if line.strip()]
+            dhcp4relay_processes = duthost.shell(
                 "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcp4[r]elay' || true"
             )['stdout_lines']
-            sonic_procs = [line for line in sonic_procs if line.strip()]
-            last_state['relay_procs'] = relay_procs
-            last_state['sonic_procs'] = sonic_procs
+            dhcp4relay_processes = [line for line in dhcp4relay_processes if line.strip()]
+            last_state['dhcrelay_processes'] = dhcrelay_processes
+            last_state['dhcp4relay_processes'] = dhcp4relay_processes
 
         isc_supervisor_states = [
             state for name, state in states.items()
@@ -208,40 +209,37 @@ def wait_dhcp_relay_ready(duthost, relay_types):
             for name, state in states.items():
                 if name.startswith('dhcpmon-') and state != 'RUNNING':
                     return False
-            if not isc_supervisor_states and relay_procs:
+            if not isc_supervisor_states and dhcrelay_processes:
                 return False
-            if sonic_procs:
+            if any('-iu docker0' in process for process in dhcrelay_processes):
+                return False
+            if dhcp4relay_processes:
                 return False
         if 'isc-internal' in relay_types:
-            if len(relay_procs) != 1 or '-iu docker0' not in relay_procs[0]:
+            if len(dhcrelay_processes) != 1 or '-iu docker0' not in dhcrelay_processes[0]:
                 return False
-            if sonic_procs:
+            if dhcp4relay_processes:
                 return False
             if any(state != 'STOPPED' for state in isc_supervisor_states):
                 return False
             if states.get('dhcp4relay') not in (None, 'STOPPED'):
                 return False
         if 'sonic' in relay_types:
-            if relay_procs:
+            if dhcrelay_processes:
                 return False
-            sonic_state = states.get('dhcp4relay')
-            if sonic_state == 'RUNNING':
-                if len(sonic_procs) != 1:
-                    return False
-            elif sonic_state is None:
-                if sonic_procs:
-                    return False
-            else:
+            if states.get('dhcp4relay') != 'RUNNING':
+                return False
+            if len(dhcp4relay_processes) != 1:
                 return False
         if 'sonic-internal' in relay_types:
-            if relay_procs or len(sonic_procs) != 1:
+            if dhcrelay_processes or len(dhcp4relay_processes) != 1:
                 return False
             if any(state != 'STOPPED' for state in isc_supervisor_states):
                 return False
             if states.get('dhcp4relay') not in (None, 'STOPPED'):
                 return False
         if 'internal-idle' in relay_types:
-            if relay_procs or sonic_procs:
+            if dhcrelay_processes or dhcp4relay_processes:
                 return False
             if any(state != 'STOPPED' for state in isc_supervisor_states):
                 return False
@@ -252,8 +250,9 @@ def wait_dhcp_relay_ready(duthost, relay_types):
     pytest_assert(
         wait_until(240, 5, 0, _is_dhcp_relay_ready),
         "dhcp_relay is not ready "
-        "(relay_types=%s last_supervisor_states=%s relay_procs=%s sonic_procs=%s)"
-        % (relay_types, last_state['states'], last_state['relay_procs'], last_state['sonic_procs']))
+        "(relay_types=%s last_supervisor_states=%s dhcrelay_processes=%s dhcp4relay_processes=%s)"
+        % (relay_types, last_state['states'],
+           last_state['dhcrelay_processes'], last_state['dhcp4relay_processes']))
 
 
 def init_dhcpmon_counters(duthost, is_v6=False):
@@ -626,15 +625,7 @@ def get_dhcp_relay_type(duthost):
         return 'sonic-internal' if has_sonic_dhcpv4_relay else 'isc-internal'
 
     if has_sonic_dhcpv4_relay:
-        vlan_interfaces = config_facts.get('VLAN_INTERFACE', {})
-        dhcpv4_relay = config_facts.get('DHCPV4_RELAY', {})
-        external_sonic_relay_configured = any(
-            vlan_name in vlan_interfaces
-            and any(str(server).strip() for server in config.get('dhcpv4_servers', []))
-            for vlan_name, config in dhcpv4_relay.items()
-        )
-        if external_sonic_relay_configured:
-            return 'sonic'
+        return 'sonic'
     return 'internal-idle'
 
 

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -177,11 +177,11 @@ def wait_dhcp_relay_ready(duthost, relay_types):
         v4_modes = {'internal-idle', 'isc', 'isc-internal', 'sonic', 'sonic-internal'}
         if any(mode in relay_types for mode in v4_modes):
             relay_procs = duthost.shell(
-                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcrelay' || true"
+                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhc[r]elay' || true"
             )['stdout_lines']
             relay_procs = [line for line in relay_procs if line.strip()]
             sonic_procs = duthost.shell(
-                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcp4relay' || true"
+                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcp4[r]elay' || true"
             )['stdout_lines']
             sonic_procs = [line for line in sonic_procs if line.strip()]
             last_state['relay_procs'] = relay_procs
@@ -250,7 +250,7 @@ def wait_dhcp_relay_ready(duthost, relay_types):
         return True
 
     pytest_assert(
-        wait_until(240, 5, 10, _is_dhcp_relay_ready),
+        wait_until(240, 5, 0, _is_dhcp_relay_ready),
         "dhcp_relay is not ready "
         "(relay_types=%s last_supervisor_states=%s relay_procs=%s sonic_procs=%s)"
         % (relay_types, last_state['states'], last_state['relay_procs'], last_state['sonic_procs']))

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -92,13 +92,12 @@ def restart_dhcp_service(duthost, relay_types):
 
         'sonic'        -> Consolidated v4 relay layout
                           (dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2).
-                          Current behavior always renders the single
-                          supervisor-owned `dhcp4relay` when
-                          has_sonic_dhcpv4_relay is True, even with no external
-                          relay-server configuration.
-                          Required:
+                          With external relay-server configuration:
                             - the `dhcp4relay` supervisord entry is RUNNING
                             - exactly one `/usr/sbin/dhcp4relay` process exists
+                          Without external relay-server configuration:
+                            - the supervisord entry is absent
+                            - no `/usr/sbin/dhcp4relay` process exists
                           Not checked:
                             - dhcpmon-<Vlan> supervisord entries; monitor
                               lifecycle is orthogonal to the active v4 relay
@@ -152,7 +151,7 @@ def wait_dhcp_relay_ready(duthost, relay_types):
     """
     relay_types = _validate_relay_types('wait_dhcp_relay_ready', relay_types)
 
-    last_state = {'states': {}, 'dhcrelay_processes': [], 'dhcp4relay_processes': []}
+    last_state = {'states': {}, 'isc_relay_processes': [], 'sonic_relay_processes': []}
 
     def _supervisor_status_map():
         # supervisorctl returns rc != 0 if ANY entry is not RUNNING (e.g. the one-shot
@@ -177,16 +176,16 @@ def wait_dhcp_relay_ready(duthost, relay_types):
             return False
         v4_modes = {'internal-idle', 'isc', 'isc-internal', 'sonic', 'sonic-internal'}
         if any(mode in relay_types for mode in v4_modes):
-            dhcrelay_processes = duthost.shell(
-                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhc[r]elay' || true"
+            isc_relay_processes = duthost.shell(
+                "docker exec dhcp_relay pgrep -a -x dhcrelay || true"
             )['stdout_lines']
-            dhcrelay_processes = [line for line in dhcrelay_processes if line.strip()]
-            dhcp4relay_processes = duthost.shell(
-                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcp4[r]elay' || true"
+            isc_relay_processes = [line for line in isc_relay_processes if line.strip()]
+            sonic_relay_processes = duthost.shell(
+                "docker exec dhcp_relay pgrep -a -x dhcp4relay || true"
             )['stdout_lines']
-            dhcp4relay_processes = [line for line in dhcp4relay_processes if line.strip()]
-            last_state['dhcrelay_processes'] = dhcrelay_processes
-            last_state['dhcp4relay_processes'] = dhcp4relay_processes
+            sonic_relay_processes = [line for line in sonic_relay_processes if line.strip()]
+            last_state['isc_relay_processes'] = isc_relay_processes
+            last_state['sonic_relay_processes'] = sonic_relay_processes
 
         isc_supervisor_states = [
             state for name, state in states.items()
@@ -209,37 +208,42 @@ def wait_dhcp_relay_ready(duthost, relay_types):
             for name, state in states.items():
                 if name.startswith('dhcpmon-') and state != 'RUNNING':
                     return False
-            if not isc_supervisor_states and dhcrelay_processes:
+            if not isc_supervisor_states and isc_relay_processes:
                 return False
-            if any('-iu docker0' in process for process in dhcrelay_processes):
+            if any('-iu docker0' in process for process in isc_relay_processes):
                 return False
-            if dhcp4relay_processes:
+            if sonic_relay_processes:
                 return False
         if 'isc-internal' in relay_types:
-            if len(dhcrelay_processes) != 1 or '-iu docker0' not in dhcrelay_processes[0]:
+            if len(isc_relay_processes) != 1 or '-iu docker0' not in isc_relay_processes[0]:
                 return False
-            if dhcp4relay_processes:
+            if sonic_relay_processes:
                 return False
             if any(state != 'STOPPED' for state in isc_supervisor_states):
                 return False
             if states.get('dhcp4relay') not in (None, 'STOPPED'):
                 return False
         if 'sonic' in relay_types:
-            if dhcrelay_processes:
+            if isc_relay_processes:
                 return False
-            if states.get('dhcp4relay') != 'RUNNING':
-                return False
-            if len(dhcp4relay_processes) != 1:
+            sonic_state = states.get('dhcp4relay')
+            if sonic_state == 'RUNNING':
+                if len(sonic_relay_processes) != 1:
+                    return False
+            elif sonic_state is None:
+                if sonic_relay_processes:
+                    return False
+            else:
                 return False
         if 'sonic-internal' in relay_types:
-            if dhcrelay_processes or len(dhcp4relay_processes) != 1:
+            if isc_relay_processes or len(sonic_relay_processes) != 1:
                 return False
             if any(state != 'STOPPED' for state in isc_supervisor_states):
                 return False
             if states.get('dhcp4relay') not in (None, 'STOPPED'):
                 return False
         if 'internal-idle' in relay_types:
-            if dhcrelay_processes or dhcp4relay_processes:
+            if isc_relay_processes or sonic_relay_processes:
                 return False
             if any(state != 'STOPPED' for state in isc_supervisor_states):
                 return False
@@ -250,9 +254,9 @@ def wait_dhcp_relay_ready(duthost, relay_types):
     pytest_assert(
         wait_until(240, 5, 0, _is_dhcp_relay_ready),
         "dhcp_relay is not ready "
-        "(relay_types=%s last_supervisor_states=%s dhcrelay_processes=%s dhcp4relay_processes=%s)"
+        "(relay_types=%s last_supervisor_states=%s isc_relay_processes=%s sonic_relay_processes=%s)"
         % (relay_types, last_state['states'],
-           last_state['dhcrelay_processes'], last_state['dhcp4relay_processes']))
+           last_state['isc_relay_processes'], last_state['sonic_relay_processes']))
 
 
 def init_dhcpmon_counters(duthost, is_v6=False):
@@ -625,7 +629,15 @@ def get_dhcp_relay_type(duthost):
         return 'sonic-internal' if has_sonic_dhcpv4_relay else 'isc-internal'
 
     if has_sonic_dhcpv4_relay:
-        return 'sonic'
+        vlan_interfaces = config_facts.get('VLAN_INTERFACE', {})
+        dhcpv4_relay = config_facts.get('DHCPV4_RELAY', {})
+        external_sonic_relay_configured = any(
+            vlan_name in vlan_interfaces
+            and any(str(server).strip() for server in config.get('dhcpv4_servers', []))
+            for vlan_name, config in dhcpv4_relay.items()
+        )
+        if external_sonic_relay_configured:
+            return 'sonic'
     return 'internal-idle'
 
 

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -617,7 +617,7 @@ def get_dhcp_relay_type(duthost):
         raise RuntimeError("Failed to determine dhcp_server feature state")
     config_facts = duthost.config_facts(host=duthost.hostname, source='running')['ansible_facts']
     device_metadata = config_facts.get('DEVICE_METADATA', {}).get('localhost', {})
-    has_sonic_dhcpv4_relay = str(device_metadata.get('has_sonic_dhcpv4_relay', 'False')).lower() == 'true'
+    has_sonic_dhcpv4_relay = device_metadata.get('has_sonic_dhcpv4_relay', 'False') == 'True'
     if features_state.get('dhcp_server') not in ('enabled', 'always_enabled'):
         return 'sonic' if has_sonic_dhcpv4_relay else 'isc'
 

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -611,13 +611,9 @@ def merge_counters(source_counter, merge_counter, is_v6=False):
 
 def get_dhcp_relay_type(duthost):
     """Return the IPv4 relay layout required by the current configuration."""
-    try:
-        features_state, succeeded = duthost.get_feature_status()
-    except Exception as error:
-        raise RuntimeError("Failed to determine dhcp_server feature state") from error
+    features_state, succeeded = duthost.get_feature_status()
+    pytest_assert(succeeded, "Failed to get feature status")
 
-    if not succeeded:
-        raise RuntimeError("Failed to determine dhcp_server feature state")
     config_facts = duthost.config_facts(host=duthost.hostname, source='running')['ansible_facts']
     device_metadata = config_facts.get('DEVICE_METADATA', {}).get('localhost', {})
     has_sonic_dhcpv4_relay = device_metadata.get('has_sonic_dhcpv4_relay', 'False') == 'True'

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -76,6 +76,8 @@ def restart_dhcp_service(duthost, relay_types):
                               dhcpmon-<Vlan> entries is empty. Readiness then
                               requires no stale `dhcrelay` or `dhcp4relay`
                               process.
+                            - The supervisor-owned `dhcp4relay` entry must be
+                              STOPPED or absent.
 
         'isc-internal' -> mx internal mode. dhcprelayd consolidates v4 relay
                           into a single `dhcrelay -iu docker0 ...` proc
@@ -225,6 +227,8 @@ def wait_dhcp_relay_ready(duthost, relay_types):
             if any('-iu docker0' in process for process in isc_relay_processes):
                 return False
             if sonic_relay_processes:
+                return False
+            if states.get('dhcp4relay') not in (None, 'STOPPED'):
                 return False
         if 'isc-internal' in relay_types:
             if len(isc_relay_processes) != 1 or '-iu docker0' not in isc_relay_processes[0]:

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -628,7 +628,8 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag, relay_typ
 
 def get_isc_relay_type(duthost):
     """Return the external, active internal, or idle internal ISC layout."""
-    features_state, _ = duthost.get_feature_status()
+    features_state, succeeded = duthost.get_feature_status()
+    pytest_assert(succeeded, "Failed to determine dhcp_server feature state")
     if 'enabled' not in features_state.get('dhcp_server', ''):
         return 'isc'
 

--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -201,7 +201,7 @@ def test_dhcpv4_feature_flag_validation(duthosts, rand_one_dut_hostname, dut_dhc
 
     # Apply valid relay config and enable feature flag
     sonic_dhcp_relay_config(duthost, dut_dhcp_relay_data, False)
-    sonic_dhcpv4_flag_config_and_unconfig(duthost, True)
+    sonic_dhcpv4_flag_config_and_unconfig(duthost, True, 'sonic')
 
     # Verify sonic-dhcpv4 socket are active
     pytest_assert(wait_until(40, 5, 0, check_dhcpv4_socket_status, duthost, dut_dhcp_relay_data,
@@ -209,7 +209,7 @@ def test_dhcpv4_feature_flag_validation(duthosts, rand_one_dut_hostname, dut_dhc
 
     # Cleanup config and disable feature flag
     sonic_dhcp_relay_unconfig(duthost, dut_dhcp_relay_data)
-    sonic_dhcpv4_flag_config_and_unconfig(duthost, False)
+    sonic_dhcpv4_flag_config_and_unconfig(duthost, False, 'isc')
 
 
 @pytest.mark.skip_config_dhcpv4_relay_agent

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -62,6 +62,7 @@ def dhcp_server_setup_teardown(duthost):
         restore_state_flag = True
         duthost.shell("config feature state dhcp_server enabled")
         duthost.shell("sudo systemctl restart dhcp_relay.service")
+        duthost.critical_services_tracking_list()
 
     def is_supervisor_subprocess_running(duthost, container_name, app_name):
         return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}")["stdout"]
@@ -86,6 +87,7 @@ def dhcp_server_setup_teardown(duthost):
     if restore_state_flag:
         duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)
         duthost.shell("sudo systemctl restart dhcp_relay.service")
+        duthost.critical_services_tracking_list()
         duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
 
 

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -57,11 +57,11 @@ def is_dhcprelayd_running(duthost):
 def dhcp_server_setup_teardown(duthost):
     features_state, _ = duthost.get_feature_status()
     py_require(DHCP_SERVER_FEATRUE_NAME in features_state, "Skip on vs testbed without dhcp server feature")
-    was_enabled_at_start = "enabled" in features_state.get(DHCP_SERVER_FEATRUE_NAME, "")
-    if not was_enabled_at_start:
+    restore_state_flag = False
+    if "enabled" not in features_state.get(DHCP_SERVER_FEATRUE_NAME, ""):
+        restore_state_flag = True
         duthost.shell("config feature state dhcp_server enabled")
         duthost.shell("sudo systemctl restart dhcp_relay.service")
-        duthost.critical_services_tracking_list()
 
     def is_supervisor_subprocess_running(duthost, container_name, app_name):
         return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}")["stdout"]
@@ -83,23 +83,15 @@ def dhcp_server_setup_teardown(duthost):
 
     yield
 
-    if not was_enabled_at_start:
-        # Leave dhcp_server enabled on platforms that ship the feature. Disabling
-        # it here persists disabled state in config while pytest may still track
-        # dhcp_server as critical (stale list from when the module enabled it),
-        # so later config_reload waits for a container that will not start.
-        duthost.shell("config feature state dhcp_server enabled", module_ignore_errors=True)
-        duthost.shell("sudo systemctl restart dhcp_relay.service", module_ignore_errors=True)
-        duthost.critical_services_tracking_list()
+    if restore_state_flag:
+        duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)
+        duthost.shell("sudo systemctl restart dhcp_relay.service")
+        duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
 
 
 @pytest.fixture(scope="function", autouse=True)
-def clean_dhcp_server_config_after_test(duthost, request):
+def clean_dhcp_server_config_after_test(duthost):
     clean_dhcp_server_config(duthost)
-
-    if "enable_sonic_dhcpv4_relay_agent" in request.fixturenames:
-        # Make relay restoration run after DHCP server configuration cleanup.
-        request.getfixturevalue("enable_sonic_dhcpv4_relay_agent")
 
     yield
 


### PR DESCRIPTION
### Description of PR

Summary:

Replace merged https://github.com/sonic-net/sonic-mgmt/pull/27228 with precise, observable DHCP relay readiness contracts while retaining every required regression fix and restoring the DUT's original `dhcp_server` feature state.

This PR deliberately keeps four commits so reviewers can see the replacement structure:

1. `737c312c2` — exact revert of #27228.
2. `9989ac881` — explicit external ISC, active/idle internal ISC, SONiC, and IPv6 readiness contracts.
3. `cf75da58a` — the separately reviewed https://github.com/sonic-net/sonic-mgmt/pull/26658 fixture fix, preserved as one patch-identical commit.
4. `5182a573c` — the focused two-line critical-service synchronization split from https://github.com/sonic-net/sonic-mgmt/pull/26526.

The commit separation is intentional. A normal root PR contributes one commit, but the exact revert and each independently reviewed replacement unit remain visible here to show that #27228 is removed before its behavior is rebuilt without a regression window.

ADO records remain separate and are retained:

- Root readiness replacement: https://msazure.visualstudio.com/One/_workitems/edit/39301045
- Fixture restoration originally reviewed in #26658: https://msazure.visualstudio.com/One/_workitems/edit/39301044
- Broader transition hardening that remains in #26526: https://msazure.visualstudio.com/One/_workitems/edit/39301051

#### Why revert #27228?

#27228 fixed the immediate SONiC-relay teardown error by introducing an `orchestrator` readiness mode. When `dhcp_server` was enabled, that mode required only `dhcprelayd` to be RUNNING.

That proxy is too weak. `dhcprelayd` can already be RUNNING while the actual IPv4 layout is still wrong or stale. It does not distinguish:

- external per-VLAN ISC relay processes;
- one active internal `dhcrelay -iu docker0` process;
- the intentional internal-idle state with no IPv4 relay process;
- the supervisor-owned SONiC `dhcp4relay` process.

#27228 also forced DHCP-server cleanup to precede relay restoration and, when the feature started disabled, left `dhcp_server` enabled after the module. The first dependency is unnecessary when teardown selects the live state; the second fails to restore the DUT's original feature state.

#### How is regression avoided?

| #27228 behavior | Replacement in this PR |
|---|---|
| Avoid false external-ISC readiness after disabling SONiC | Explicit readiness modes plus the #26658 fixture commit select the live ISC target. |
| Ensure relay restoration sees a valid DHCP-server state | `get_isc_relay_type()` handles external, active-internal, and idle-internal states, so restoration is independent of cleanup ordering. |
| Prevent stale `dhcp_server` critical-service tracking | Refresh the tracking list after temporarily enabling the feature and again after restoring disabled state. |
| Keep later suites from waiting for a disabled service | The post-disable refresh removes `dhcp_server` from pytest's expected critical services before container removal. |
| Preserve the original DUT state | Initially enabled remains enabled; initially disabled is enabled only for this module and restored disabled afterward. |

The remaining #26526 code is intentionally not included. Its per-transition waits, failure-preserving cleanup, force-removal checks, and five-file helper plumbing are broader hardening rather than requirements for replacing #27228 without regression. #26526 remains a separate draft PR on top of this combined head.

The originally captured regression was:

`tests/dhcp_server/test_dhcp_server.py::test_dhcp_server_port_based_assignment_single_ip_tc1[gcu-sonic-relay-agent]`

The test body passed; fixture teardown failed while waiting for an incompatible external ISC supervisor layout. The same shared fixture path serves 16 DHCP-server test functions across:

- `tests/dhcp_server/test_dhcp_server.py` — 13 functions;
- `tests/dhcp_server/test_dhcp_server_multi_vlans.py` — 2 functions;
- `tests/dhcp_server/test_dhcp_server_stress.py` — 1 function.

The explicit flag-helper contract also updates `tests/dhcp_relay/test_dhcpv4_relay.py::test_dhcpv4_feature_flag_validation`.

Fixes https://github.com/sonic-net/sonic-mgmt/issues/27036

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39301045
Failure type: regression

Public 202605 does not contain the exact #27228 commit, so the leading revert is intentionally empty in the public backport and the three replacement commits are the release payload. The branch-matched internal-202605 validation base already carries equivalent generic `orchestrator` and leave-enabled lifecycle behavior through downstream content; the validation-only conflict resolution removes that equivalent behavior before applying the replacements. This distinction does not add the revert to the public 202605 payload.

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- Current combined head: `5182a573cacd011277b0152131d09a6e3da5cffa`.
- Static validation passed for the four-commit stack: `git diff --check`, Python compilation, targeted pre-commit, exact #27228 revert verification, #26658 tree/patch equality, and focused critical-service transition probes.
- Fresh 202605 MX validation passed: pretest 11 passed/3 expected skips; five isolated DHCP-server invocations passed 20/20 parameterizations; an initially-disabled lifecycle invocation passed 4/4 and verified disabled-state restoration. [Detailed evidence](https://github.com/sonic-net/sonic-mgmt/pull/26525#issuecomment-5483903442).\n- Fresh master MX validation passed: pretest 11 passed/4 expected skips; five forced-disabled DHCP-server invocations passed 20/20 parameterizations with a successful disabled-state/container-absent assertion after every teardown. [Detailed evidence](https://github.com/sonic-net/sonic-mgmt/pull/26525#issuecomment-5485840640).\n- Exact-head CI is fully classified across identical-input builds `1207991` and `1208099`: every impacted-area lane has an exact-merge-SHA pass. The remaining red aggregate check is an environment-wide t0 BGP link-local failure seen across unrelated plans; the original identical-input build passed t0. [Detailed CI evidence](https://github.com/sonic-net/sonic-mgmt/pull/26525#issuecomment-5486664536).

### Approach
#### What is the motivation for this PR?

Readiness must prove the relay process layout selected by the test, not infer intent from one feature flag or accept orchestrator liveness as a substitute. The replacement must also preserve the teardown fixes that users already rely on without leaking a changed `dhcp_server` feature state into later modules.

#### How did you do it?

- Revert the generic #27228 implementation exactly.
- Add strict readiness modes for `isc`, `isc-internal`, `isc-internal-idle`, `sonic`, and `v6`.
- Require flag-switch callers to provide the expected readiness mode.
- During shared SONiC fixture teardown, remove SONiC relay configuration, derive the live ISC target from feature and `DHCP_SERVER_IPV4` state, then clear the flag.
- Keep that restoration independent of DHCP-server cleanup fixture ordering.
- Refresh pytest's critical-service list after both temporary feature enablement and restoration to disabled.

#### How did you verify/test it?

Static validation and fresh branch-matched physical validation on both master and 202605 passed and are linked above. Two identical-input exact-head Azure runs provide a pass for every impacted-area lane; the sole remaining red aggregate result is the classified environment-wide t0 BGP link-local failure linked above.

#### Any platform specific information?

The internal active/idle layouts apply to MX DHCP-server tests. External ISC and SONiC readiness remain shared across supported DHCP-relay topologies.

#### Supported testbed topology if it's a new test case?

N/A — no new test case.

### Xichen review

The explicit readiness implementation was reviewed through #26525 `v4.3`. The fixture replacement was reviewed separately through #26658 `v2.6` and then squashed tree-identically into commit `cf75da58a`. Xichen approved splitting the focused two-line critical-service synchronization from #26526 and directed the combined PR to proceed through validation and 202605 backport preparation.

### Documentation

No external documentation update is required; the PR description records the readiness state model and replacement rationale.