### PR TITLE
[dhcp_server]: Wait across relay mode transitions

### DIFF
--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -59,7 +59,7 @@ def _validate_relay_types(caller, relay_types):
     if not relay_types:
         raise ValueError("%s: relay_types must be a non-empty iterable" % caller)
     relay_types = list(relay_types)
-    valid = {'isc', 'isc-internal', 'sonic', 'v6', 'orchestrator'}
+    valid = {'isc', 'isc-internal', 'sonic', 'v6'}
     bad = [t for t in relay_types if t not in valid]
     if bad:
         raise ValueError("%s: invalid relay_types %s; allowed %s"
@@ -140,11 +140,6 @@ def restart_dhcp_service(duthost, relay_types):
                               will need to be extended to mirror the 'isc'
                               dhcpmon-<Vlan> check above.
                           TODO: revisit when dhcpv6mon ships.
-
-        'orchestrator' -> Only the dhcprelayd orchestrator is required RUNNING.
-                          Use after dhcp_server teardown or when the relay
-                          container has no v4/v6 helper programs in supervisord
-                          (e.g. multi_vlan tests that reshape VLAN relay layout).
 
     The orchestrator (`dhcprelayd`) is always required RUNNING. There is intentionally
     no default; each caller must declare which agent(s) it expects to be active.
@@ -582,25 +577,6 @@ def merge_counters(source_counter, merge_counter, is_v6=False):
                                                                     merge_counter.get(dir, {}).get(dhcp_type, 0)
 
 
-def _dhcp_server_feature_enabled(duthost):
-    features_state, _ = duthost.get_feature_status()
-    return 'enabled' in features_state.get('dhcp_server', '')
-
-
-def _relay_types_after_sonic_disable(duthost):
-    """
-    Readiness contract after removing has_sonic_dhcpv4_relay.
-
-    When the dhcp_server feature is enabled, dhcprelayd keeps supervisord
-    isc-dhcpv4-relay-* / dhcpmon-* STOPPED and manages v4 relay itself (or
-    none at all once DHCP_SERVER_IPV4 config is cleaned). Waiting for
-    relay_types=['isc'] is unsatisfiable in that mode.
-    """
-    if _dhcp_server_feature_enabled(duthost):
-        return ['orchestrator']
-    return ['isc']
-
-
 def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
     """
     Enable or disable the SONiC DHCPv4 feature flag and restart the DHCP service on the DUT.
@@ -614,11 +590,7 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
     # Save the config and restart DHCP relay service
     duthost.shell('sudo config save -y', module_ignore_errors=True)
-    if dhcpv4_config_flag:
-        relay_types = ['sonic']
-    else:
-        relay_types = _relay_types_after_sonic_disable(duthost)
-    restart_dhcp_service(duthost, relay_types)
+    restart_dhcp_service(duthost, ['sonic'] if dhcpv4_config_flag else ['isc'])
 
 
 @pytest.fixture()

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -59,15 +59,18 @@ def _validate_relay_types(caller, relay_types):
     if not relay_types:
         raise ValueError("%s: relay_types must be a non-empty iterable" % caller)
     relay_types = list(relay_types)
-    valid = {'isc', 'isc-internal', 'sonic', 'v6'}
+    valid = {'isc', 'isc-internal', 'isc-internal-idle', 'sonic', 'v6'}
     bad = [t for t in relay_types if t not in valid]
     if bad:
         raise ValueError("%s: invalid relay_types %s; allowed %s"
                          % (caller, bad, sorted(valid)))
-    v4_modes = [t for t in relay_types if t in {'isc', 'isc-internal', 'sonic'}]
+    v4_modes = [
+        t for t in relay_types
+        if t in {'isc', 'isc-internal', 'isc-internal-idle', 'sonic'}
+    ]
     if len(v4_modes) > 1:
         raise ValueError(
-            "%s: at most one of {'isc', 'isc-internal', 'sonic'} "
+            "%s: at most one of {'isc', 'isc-internal', 'isc-internal-idle', 'sonic'} "
             "may be requested per call (mutually exclusive in the relay container); got %s"
             % (caller, v4_modes))
     return relay_types
@@ -85,6 +88,8 @@ def restart_dhcp_service(duthost, relay_types):
                             - every dhcpmon-<Vlan> supervisord entry (paired
                               1:1 with the isc helpers via
                               dhcp-relay.monitors.j2)
+                            - the supervisor-owned `dhcp4relay` entry is
+                              STOPPED or absent
                           Notes:
                             - The expected per-Vlan entries are read from
                               supervisord at poll time (parsed from
@@ -97,39 +102,45 @@ def restart_dhcp_service(duthost, relay_types):
                               we wait on.
                             - If no Vlan has v4 dhcp_servers defined, the
                               matching set of isc-dhcpv4-relay-<Vlan> /
-                              dhcpmon-<Vlan> entries is empty, the loops
-                              iterate over nothing, and the 'isc' check
-                              passes immediately. This is intentional:
-                              there is genuinely nothing to wait for.
+                              dhcpmon-<Vlan> entries is empty. Readiness then
+                              requires no stale `dhcrelay` process.
 
         'isc-internal' -> mx internal mode. dhcprelayd consolidates v4 relay
                           into a single `dhcrelay -iu docker0 ...` proc
                           (not a supervisord entry).
                           Required:
-                            - exactly one such dhcrelay proc
+                            - exactly one `dhcrelay` process, which includes
+                              -iu docker0
+                            - external ISC and supervisor-owned SONiC v4 relay
+                              entries are STOPPED or absent
                           Not checked:
-                            - isc-dhcpv4-relay-<Vlan> supervisord entries
-                              (stay STOPPED by design in this mode)
-                            - dhcpmon-<Vlan> supervisord entries (also stay
-                              STOPPED today: dhcpmon does not yet support
-                              the mx/isc-internal layout, so when dhcprelayd
-                              takes over the v4 relay it does not (re)spawn
-                              dhcpmon)
-                          TODO: extend this check once dhcpmon supports the
-                          mx/isc-internal layout (when a single dhcpmon can
-                          monitor the consolidated `dhcrelay -iu docker0`
-                          proc); at that point we should require dhcpmon
-                          RUNNING here too, mirroring the 'isc' check.
+                            - dhcpmon-<Vlan> entries; monitor lifecycle is
+                              orthogonal to the active IPv4 relay mode
+
+        'isc-internal-idle'
+                        -> mx internal ISC mode with no enabled local DHCP
+                           server interface. dhcprelayd stops the external ISC
+                           relay entries and starts no dynamic `dhcrelay`.
+                           Required:
+                             - no `dhcrelay` process exists
+                             - every `isc-dhcpv4-relay-*` supervisor entry is
+                               STOPPED or absent
+                             - the supervisor-owned `dhcp4relay` entry is
+                               STOPPED or absent
+                           Not checked:
+                             - dhcpmon-<Vlan> entries; monitor lifecycle is
+                               orthogonal to the idle IPv4 relay mode
 
         'sonic'        -> Consolidated v4 relay layout
                           (dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2).
-                          One `/usr/sbin/dhcp4relay` proc handles all v4 VLANs.
-                          Required RUNNING:
-                            - the single `dhcp4relay` supervisord entry
+                          The SONiC DHCPv4 relay flag renders and starts the
+                          `dhcp4relay` supervisor program even when no
+                          DHCPV4_RELAY server configuration exists.
+                          Required:
+                            - the `dhcp4relay` supervisord entry is RUNNING
                           Not checked:
-                            - dhcpmon-<Vlan> supervisord entries (dhcp4relay
-                              publishes its own counters, so per-Vlan dhcpmon
-                              is not part of this layout)
+                            - dhcpmon-<Vlan> supervisord entries; monitor
+                              lifecycle is orthogonal to the active v4 relay
 
         'v6'           -> IPv6 relay.
                           Required RUNNING:
@@ -144,9 +155,9 @@ def restart_dhcp_service(duthost, relay_types):
     The orchestrator (`dhcprelayd`) is always required RUNNING. There is intentionally
     no default; each caller must declare which agent(s) it expects to be active.
 
-    At most one of {'isc', 'isc-internal', 'sonic'} may appear in relay_types: the
-    container layout makes them mutually exclusive (driven by has_sonic_dhcpv4_relay
-    + mx internal mode), so any combination is unsatisfiable and is rejected up front.
+    At most one IPv4 mode may appear in relay_types: the container layout makes
+    them mutually exclusive, so any combination is unsatisfiable and is rejected
+    up front.
     """
     relay_types = _validate_relay_types('restart_dhcp_service', relay_types)
 
@@ -168,8 +179,6 @@ def wait_dhcp_relay_ready(duthost, relay_types):
     """
     relay_types = _validate_relay_types('wait_dhcp_relay_ready', relay_types)
 
-    last_state = {'states': {}, 'internal_procs': []}
-
     def _supervisor_status_map():
         # supervisorctl returns rc != 0 if ANY entry is not RUNNING (e.g. the one-shot
         # 'start' / 'dependent-startup' entries are EXITED by design). Ignore the rc and
@@ -186,11 +195,22 @@ def wait_dhcp_relay_ready(duthost, relay_types):
 
     def _is_dhcp_relay_ready():
         states = _supervisor_status_map()
-        last_state['states'] = states
         if states.get('dhcprelayd') != 'RUNNING':
             return False
         if 'v6' in relay_types and states.get('dhcp6relay') != 'RUNNING':
             return False
+        v4_modes = {'isc', 'isc-internal', 'isc-internal-idle', 'sonic'}
+        if any(mode in relay_types for mode in v4_modes):
+            isc_relay_processes = duthost.shell(
+                "docker exec dhcp_relay sh -c "
+                "'pgrep -a -x dhcrelay || [ $? -eq 1 ]'"
+            )['stdout_lines']
+
+        isc_supervisor_states = [
+            state for name, state in states.items()
+            if name.startswith('isc-dhcpv4-relay-')
+        ]
+
         if 'isc' in relay_types:
             # Drive from supervisord's actual layout: every isc-dhcpv4-relay-*
             # entry currently present must be RUNNING. If none are present,
@@ -202,29 +222,42 @@ def wait_dhcp_relay_ready(duthost, relay_types):
                     return False
             # Same layout-driven rule for dhcpmon-Vlan*: each entry is paired
             # 1:1 with isc-dhcpv4-relay-<Vlan> in the same supervisord conf
-            # and must be RUNNING. Intentionally NOT checked in 'isc-internal'
-            # / 'sonic' / 'v6' modes - see the docstring for the per-mode
-            # rationale (and the v6 TODO for the upcoming dhcpv6mon).
+            # and must be RUNNING. Intentionally NOT checked in internal,
+            # SONiC, or v6-only modes; see the per-mode docstrings.
             for name, state in states.items():
                 if name.startswith('dhcpmon-') and state != 'RUNNING':
                     return False
+            if not isc_supervisor_states and isc_relay_processes:
+                return False
+            if any('-iu docker0' in process for process in isc_relay_processes):
+                return False
+            if states.get('dhcp4relay') not in (None, 'STOPPED'):
+                return False
         if 'isc-internal' in relay_types:
-            internal = duthost.shell(
-                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcrelay.*-iu docker0' || true"
-            )['stdout_lines']
-            internal = [line for line in internal if line.strip()]
-            last_state['internal_procs'] = internal
-            if len(internal) != 1:
+            if len(isc_relay_processes) != 1 or '-iu docker0' not in isc_relay_processes[0]:
+                return False
+            if any(state != 'STOPPED' for state in isc_supervisor_states):
+                return False
+            if states.get('dhcp4relay') not in (None, 'STOPPED'):
+                return False
+        if 'isc-internal-idle' in relay_types:
+            if isc_relay_processes:
+                return False
+            if any(state != 'STOPPED' for state in isc_supervisor_states):
+                return False
+            if states.get('dhcp4relay') not in (None, 'STOPPED'):
                 return False
         if 'sonic' in relay_types:
+            if isc_relay_processes:
+                return False
             if states.get('dhcp4relay') != 'RUNNING':
                 return False
         return True
 
     pytest_assert(
-        wait_until(240, 5, 10, _is_dhcp_relay_ready),
-        "dhcp_relay is not ready (relay_types=%s last_supervisor_states=%s isc_internal_procs=%s)"
-        % (relay_types, last_state['states'], last_state['internal_procs']))
+        wait_until(240, 5, 0, _is_dhcp_relay_ready),
+        "dhcp_relay is not ready (relay_types=%s)" % relay_types
+    )
 
 
 def init_dhcpmon_counters(duthost, is_v6=False):

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -610,9 +610,9 @@ def merge_counters(source_counter, merge_counter, is_v6=False):
                                                                     merge_counter.get(dir, {}).get(dhcp_type, 0)
 
 
-def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
+def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag, relay_type):
     """
-    Enable or disable the SONiC DHCPv4 feature flag and restart the DHCP service on the DUT.
+    Set the SONiC DHCPv4 feature flag and restart for the caller's explicit relay mode.
     """
     if dhcpv4_config_flag:
         duthost.shell('sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" "has_sonic_dhcpv4_relay" "True"',
@@ -623,7 +623,20 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
     # Save the config and restart DHCP relay service
     duthost.shell('sudo config save -y', module_ignore_errors=True)
-    restart_dhcp_service(duthost, ['sonic'] if dhcpv4_config_flag else ['isc'])
+    restart_dhcp_service(duthost, [relay_type])
+
+
+def get_isc_relay_type(duthost):
+    """Return the external, active internal, or idle internal ISC layout."""
+    features_state, _ = duthost.get_feature_status()
+    if 'enabled' not in features_state.get('dhcp_server', ''):
+        return 'isc'
+
+    config_facts = duthost.config_facts(host=duthost.hostname, source='running')['ansible_facts']
+    dhcp_server_ipv4 = config_facts.get('DHCP_SERVER_IPV4', {})
+    if any(config.get('state') == 'enabled' for config in dhcp_server_ipv4.values()):
+        return 'isc-internal'
+    return 'isc-internal-idle'
 
 
 @pytest.fixture()
@@ -644,14 +657,15 @@ def enable_sonic_dhcpv4_relay_agent(rand_selected_dut, request):
 
     try:
         if request.getfixturevalue("relay_agent") == "sonic-relay-agent":
-            sonic_dhcpv4_flag_config_and_unconfig(duthost, True)
+            sonic_dhcpv4_flag_config_and_unconfig(duthost, True, 'sonic')
             sonic_dhcp_relay_config(duthost, dut_dhcp_relay_data, True)
         yield
     finally:
-        # Cleanup: disable the feature flag
         if request.getfixturevalue("relay_agent") == "sonic-relay-agent":
-            sonic_dhcpv4_flag_config_and_unconfig(duthost, False)
             sonic_dhcp_relay_unconfig(duthost, dut_dhcp_relay_data)
+            # Resolve live state so teardown is independent of DHCP-server cleanup fixture ordering.
+            target_relay_type = get_isc_relay_type(duthost)
+            sonic_dhcpv4_flag_config_and_unconfig(duthost, False, target_relay_type)
 
 
 def check_dhcpv4_socket_status(duthost, dut_dhcp_relay_data=None, process_and_socket_check=None):

--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -201,7 +201,7 @@ def test_dhcpv4_feature_flag_validation(duthosts, rand_one_dut_hostname, dut_dhc
 
     # Apply valid relay config and enable feature flag
     sonic_dhcp_relay_config(duthost, dut_dhcp_relay_data, False)
-    sonic_dhcpv4_flag_config_and_unconfig(duthost, True)
+    sonic_dhcpv4_flag_config_and_unconfig(duthost, True, 'sonic')
 
     # Verify sonic-dhcpv4 socket are active
     pytest_assert(wait_until(40, 5, 0, check_dhcpv4_socket_status, duthost, dut_dhcp_relay_data,
@@ -209,7 +209,7 @@ def test_dhcpv4_feature_flag_validation(duthosts, rand_one_dut_hostname, dut_dhc
 
     # Cleanup config and disable feature flag
     sonic_dhcp_relay_unconfig(duthost, dut_dhcp_relay_data)
-    sonic_dhcpv4_flag_config_and_unconfig(duthost, False)
+    sonic_dhcpv4_flag_config_and_unconfig(duthost, False, 'isc')
 
 
 @pytest.mark.skip_config_dhcpv4_relay_agent

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -23,6 +23,9 @@ def dhcp_server_setup_teardown(duthost):
     dhcp_server_state = features_state[DHCP_SERVER_FEATRUE_NAME]
     py_require(dhcp_server_state in ('enabled', 'always_enabled', 'disabled'),
                "Skip on testbed with unsupported dhcp server feature state: {}".format(dhcp_server_state))
+    py_require(hasattr(dhcp_relay_utils, 'get_dhcp_relay_type'),
+               "Skip until required dependency #26525 provides get_dhcp_relay_type")
+    get_dhcp_relay_type = dhcp_relay_utils.get_dhcp_relay_type
 
     restore_state_flag = dhcp_server_state == 'disabled'
 
@@ -42,10 +45,10 @@ def dhcp_server_setup_teardown(duthost):
             cleanup_step('disable feature', lambda: duthost.shell("config feature state dhcp_server disabled"))
         cleanup_step('restore relay layout',
                      lambda: dhcp_relay_utils.restart_dhcp_service(
-                         duthost, [dhcp_relay_utils.get_dhcp_relay_type(duthost)]))
+                         duthost, [get_dhcp_relay_type(duthost)]))
         if restore_state_flag:
             def remove_dhcp_server_container():
-                result = duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
+                result = duthost.shell("docker rm {}".format(DHCP_SERVER_CONTAINER_NAME), module_ignore_errors=True)
                 if result['rc'] != 0 and "No such container" not in result.get('stderr', ''):
                     raise RuntimeError("Failed to remove dhcp_server container: {}".format(result.get('stderr', '')))
 
@@ -57,10 +60,12 @@ def dhcp_server_setup_teardown(duthost):
         if restore_state_flag:
             duthost.shell("config feature state dhcp_server enabled")
 
-        dhcp_relay_utils.restart_dhcp_service(duthost, [dhcp_relay_utils.get_dhcp_relay_type(duthost)])
+        dhcp_relay_utils.restart_dhcp_service(duthost, [get_dhcp_relay_type(duthost)])
 
         def is_supervisor_subprocess_running(duthost, container_name, app_name):
-            return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}")["stdout"]
+            result = duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}",
+                                   module_ignore_errors=True)
+            return result['rc'] == 0 and "RUNNING" in result.get('stdout', '')
 
         py_assert(
             wait_until(120, 1, 1,

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -48,9 +48,15 @@ def dhcp_server_setup_teardown(duthost):
                          duthost, [get_dhcp_relay_type(duthost)]))
         if restore_state_flag:
             def remove_dhcp_server_container():
-                result = duthost.shell("docker rm {}".format(DHCP_SERVER_CONTAINER_NAME), module_ignore_errors=True)
-                if result['rc'] != 0 and "No such container" not in result.get('stderr', ''):
-                    raise RuntimeError("Failed to remove dhcp_server container: {}".format(result.get('stderr', '')))
+                result = duthost.shell("docker rm -f {}".format(DHCP_SERVER_CONTAINER_NAME), module_ignore_errors=True)
+                inspection = duthost.shell("docker inspect {}".format(DHCP_SERVER_CONTAINER_NAME),
+                                           module_ignore_errors=True)
+                if inspection['rc'] != 0 and "No such object" in inspection.get('stderr', ''):
+                    return
+                raise RuntimeError(
+                    "Failed to remove dhcp_server container: stdout={} stderr={} inspect_stdout={} inspect_stderr={}"
+                    .format(result.get('stdout', ''), result.get('stderr', ''),
+                            inspection.get('stdout', ''), inspection.get('stderr', '')))
 
             cleanup_step('remove dhcp_server container', remove_dhcp_server_container)
 

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -2,6 +2,7 @@ import logging
 import sys
 
 import pytest
+from _pytest.outcomes import OutcomeException
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.helpers.assertions import pytest_require as py_require
@@ -26,13 +27,31 @@ def dhcp_server_setup_teardown(duthost):
     restore_state_flag = dhcp_server_state == 'disabled'
 
     def restore_dhcp_server_state():
+        first_cleanup_error = None
+
+        def cleanup_step(step_name, callback):
+            nonlocal first_cleanup_error
+            try:
+                callback()
+            except (Exception, OutcomeException) as cleanup_error:
+                logger.exception("DHCP server cleanup step '%s' failed", step_name)
+                if first_cleanup_error is None:
+                    first_cleanup_error = cleanup_error
+
         if restore_state_flag:
-            duthost.shell("config feature state dhcp_server disabled")
-        dhcp_relay_utils.restart_dhcp_service(duthost, [dhcp_relay_utils.get_dhcp_relay_type(duthost)])
+            cleanup_step('disable feature', lambda: duthost.shell("config feature state dhcp_server disabled"))
+        cleanup_step('restore relay layout',
+                     lambda: dhcp_relay_utils.restart_dhcp_service(
+                         duthost, [dhcp_relay_utils.get_dhcp_relay_type(duthost)]))
         if restore_state_flag:
-            result = duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
-            if result['rc'] != 0 and "No such container" not in result.get('stderr', ''):
-                raise RuntimeError("Failed to remove dhcp_server container: {}".format(result.get('stderr', '')))
+            def remove_dhcp_server_container():
+                result = duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
+                if result['rc'] != 0 and "No such container" not in result.get('stderr', ''):
+                    raise RuntimeError("Failed to remove dhcp_server container: {}".format(result.get('stderr', '')))
+
+            cleanup_step('remove dhcp_server container', remove_dhcp_server_container)
+
+        return first_cleanup_error
 
     try:
         if restore_state_flag:
@@ -54,13 +73,9 @@ def dhcp_server_setup_teardown(duthost):
         yield
     finally:
         setup_or_test_error = sys.exc_info()[1]
-        try:
-            restore_dhcp_server_state()
-        except Exception:
-            if setup_or_test_error is not None:
-                logger.exception("Failed to restore DHCP server state after fixture failure")
-            else:
-                raise
+        cleanup_error = restore_dhcp_server_state()
+        if cleanup_error is not None and setup_or_test_error is None:
+            raise cleanup_error
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.helpers.assertions import pytest_require as py_require
-from tests.common.dhcp_relay_utils import restart_dhcp_service
+from tests.common import dhcp_relay_utils
 from dhcp_server_test_common import clean_dhcp_server_config
 
 DHCP_SERVER_CONTAINER_NAME = "dhcp_server"
@@ -18,7 +18,7 @@ def dhcp_server_setup_teardown(duthost):
         restore_state_flag = True
         duthost.shell("config feature state dhcp_server enabled")
 
-    restart_dhcp_service(duthost, ['isc-internal'])
+    dhcp_relay_utils.restart_dhcp_service(duthost, [dhcp_relay_utils.get_dhcp_relay_type(duthost)])
 
     def is_supervisor_subprocess_running(duthost, container_name, app_name):
         return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}")["stdout"]
@@ -35,10 +35,10 @@ def dhcp_server_setup_teardown(duthost):
 
     if restore_state_flag:
         duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)
-        restart_dhcp_service(duthost, ['isc'])
+        dhcp_relay_utils.restart_dhcp_service(duthost, [dhcp_relay_utils.get_dhcp_relay_type(duthost)])
         duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
     else:
-        restart_dhcp_service(duthost, ['isc-internal'])
+        dhcp_relay_utils.restart_dhcp_service(duthost, [dhcp_relay_utils.get_dhcp_relay_type(duthost)])
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -2,55 +2,11 @@ import pytest
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.helpers.assertions import pytest_require as py_require
+from tests.common.dhcp_relay_utils import restart_dhcp_service
 from dhcp_server_test_common import clean_dhcp_server_config
 
-DHCP_RELAY_CONTAINER_NAME = "dhcp_relay"
 DHCP_SERVER_CONTAINER_NAME = "dhcp_server"
 DHCP_SERVER_FEATRUE_NAME = "dhcp_server"
-
-
-def is_dhcprelayd_running(duthost):
-    """
-    Check if dhcprelayd is running in the dhcp_relay container, handling
-    dynamic supervisor process naming.
-
-    The dhcp_relay container's supervisor config is dynamically generated from
-    a Jinja2 template (docker-dhcp-relay.supervisord.conf.j2) at container
-    startup based on CONFIG_DB state. The template conditionally includes
-    dhcp-relay.programs.j2, which creates a [group:dhcp-relay] section that
-    groups dhcprelayd and dhcp6relay together.
-
-    The group is created when there are VLANs with DHCP relay configured
-    (dhcp_servers or dhcpv6_servers in CONFIG_DB). On a normal production DUT,
-    this is almost always the case, and the process appears as
-    "dhcp-relay:dhcprelayd" (group:program format). In this state,
-    supervisorctl requires the group prefix; the bare name "dhcprelayd"
-    returns "ERROR (no such process)" (rc=4).
-
-    When the relay count is 0 (no VLANs with dhcp_servers or dhcpv6_servers),
-    the template skips the group section, and dhcprelayd becomes a standalone
-    [program:dhcprelayd]. In this state, the bare name works but the
-    group-prefixed name fails.
-
-    Note: the enable_sonic_dhcpv4_relay_agent fixture teardown does not cause
-    this condition — config dhcpv4_relay add/del does not modify VLAN.dhcp_servers,
-    so the original relay config remains intact after teardown. The no-group state
-    has been observed in practice but the exact trigger is unclear; it may result
-    from external CONFIG_DB modifications or edge cases during container restarts.
-
-    This function tries both naming conventions to handle either state.
-    """
-    # Try group format first (normal production state)
-    result = duthost.shell(
-        "docker exec {} supervisorctl status dhcp-relay:dhcprelayd".format(DHCP_RELAY_CONTAINER_NAME),
-        module_ignore_errors=True)
-    if "RUNNING" in result.get("stdout", ""):
-        return True
-    # Fall back to standalone format (after test fixture modifies CONFIG_DB)
-    result = duthost.shell(
-        "docker exec {} supervisorctl status dhcprelayd".format(DHCP_RELAY_CONTAINER_NAME),
-        module_ignore_errors=True)
-    return "RUNNING" in result.get("stdout", "")
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -61,7 +17,8 @@ def dhcp_server_setup_teardown(duthost):
     if "enabled" not in features_state.get(DHCP_SERVER_FEATRUE_NAME, ""):
         restore_state_flag = True
         duthost.shell("config feature state dhcp_server enabled")
-        duthost.shell("sudo systemctl restart dhcp_relay.service")
+
+    restart_dhcp_service(duthost, ['isc-internal'])
 
     def is_supervisor_subprocess_running(duthost, container_name, app_name):
         return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}")["stdout"]
@@ -74,18 +31,11 @@ def dhcp_server_setup_teardown(duthost):
                    "dhcp-server-ipv4:kea-dhcp4"),
         'feature dhcp_server is enabled but container is not running'
     )
-    py_assert(
-        wait_until(120, 1, 1,
-                   is_dhcprelayd_running,
-                   duthost),
-        'dhcprelayd in container dhcp_relay is not running'
-    )
-
     yield
 
     if restore_state_flag:
         duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)
-        duthost.shell("sudo systemctl restart dhcp_relay.service")
+        restart_dhcp_service(duthost, ['isc'])
         duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
 
 

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -10,7 +10,7 @@ from tests.common import dhcp_relay_utils
 from dhcp_server_test_common import clean_dhcp_server_config
 
 DHCP_SERVER_CONTAINER_NAME = "dhcp_server"
-DHCP_SERVER_FEATRUE_NAME = "dhcp_server"
+DHCP_SERVER_FEATURE_NAME = "dhcp_server"
 
 logger = logging.getLogger(__name__)
 
@@ -19,8 +19,8 @@ logger = logging.getLogger(__name__)
 def dhcp_server_setup_teardown(duthost):
     features_state, succeeded = duthost.get_feature_status()
     py_require(succeeded, "Skip when dhcp server feature status cannot be retrieved")
-    py_require(DHCP_SERVER_FEATRUE_NAME in features_state, "Skip on vs testbed without dhcp server feature")
-    dhcp_server_state = features_state[DHCP_SERVER_FEATRUE_NAME]
+    py_require(DHCP_SERVER_FEATURE_NAME in features_state, "Skip on vs testbed without dhcp server feature")
+    dhcp_server_state = features_state[DHCP_SERVER_FEATURE_NAME]
     py_require(dhcp_server_state in ('enabled', 'always_enabled', 'disabled'),
                "Skip on testbed with unsupported dhcp server feature state: {}".format(dhcp_server_state))
     py_assert(hasattr(dhcp_relay_utils, 'get_dhcp_relay_type'),

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -23,8 +23,8 @@ def dhcp_server_setup_teardown(duthost):
     dhcp_server_state = features_state[DHCP_SERVER_FEATRUE_NAME]
     py_require(dhcp_server_state in ('enabled', 'always_enabled', 'disabled'),
                "Skip on testbed with unsupported dhcp server feature state: {}".format(dhcp_server_state))
-    py_require(hasattr(dhcp_relay_utils, 'get_dhcp_relay_type'),
-               "Skip until required dependency #26525 provides get_dhcp_relay_type")
+    py_assert(hasattr(dhcp_relay_utils, 'get_dhcp_relay_type'),
+              "#26525 must merge first: get_dhcp_relay_type is required")
     get_dhcp_relay_type = dhcp_relay_utils.get_dhcp_relay_type
 
     restore_state_flag = dhcp_server_state == 'disabled'

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -37,6 +37,8 @@ def dhcp_server_setup_teardown(duthost):
         duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)
         restart_dhcp_service(duthost, ['isc'])
         duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
+    else:
+        restart_dhcp_service(duthost, ['isc-internal'])
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -11,11 +11,15 @@ DHCP_SERVER_FEATRUE_NAME = "dhcp_server"
 
 @pytest.fixture(scope="module", autouse=True)
 def dhcp_server_setup_teardown(duthost):
-    features_state, _ = duthost.get_feature_status()
+    features_state, succeeded = duthost.get_feature_status()
+    py_require(succeeded, "Skip when dhcp server feature status cannot be retrieved")
     py_require(DHCP_SERVER_FEATRUE_NAME in features_state, "Skip on vs testbed without dhcp server feature")
-    restore_state_flag = False
-    if "enabled" not in features_state.get(DHCP_SERVER_FEATRUE_NAME, ""):
-        restore_state_flag = True
+    dhcp_server_state = features_state[DHCP_SERVER_FEATRUE_NAME]
+    py_require(dhcp_server_state in ('enabled', 'always_enabled', 'disabled'),
+               "Skip on testbed with unsupported dhcp server feature state: {}".format(dhcp_server_state))
+
+    restore_state_flag = dhcp_server_state == 'disabled'
+    if restore_state_flag:
         duthost.shell("config feature state dhcp_server enabled")
 
     dhcp_relay_utils.restart_dhcp_service(duthost, [dhcp_relay_utils.get_dhcp_relay_type(duthost)])

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -1,3 +1,6 @@
+import logging
+import sys
+
 import pytest
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert as py_assert
@@ -7,6 +10,8 @@ from dhcp_server_test_common import clean_dhcp_server_config
 
 DHCP_SERVER_CONTAINER_NAME = "dhcp_server"
 DHCP_SERVER_FEATRUE_NAME = "dhcp_server"
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -19,30 +24,43 @@ def dhcp_server_setup_teardown(duthost):
                "Skip on testbed with unsupported dhcp server feature state: {}".format(dhcp_server_state))
 
     restore_state_flag = dhcp_server_state == 'disabled'
-    if restore_state_flag:
-        duthost.shell("config feature state dhcp_server enabled")
 
-    dhcp_relay_utils.restart_dhcp_service(duthost, [dhcp_relay_utils.get_dhcp_relay_type(duthost)])
-
-    def is_supervisor_subprocess_running(duthost, container_name, app_name):
-        return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}")["stdout"]
-
-    py_assert(
-        wait_until(120, 1, 1,
-                   is_supervisor_subprocess_running,
-                   duthost,
-                   DHCP_SERVER_CONTAINER_NAME,
-                   "dhcp-server-ipv4:kea-dhcp4"),
-        'feature dhcp_server is enabled but container is not running'
-    )
-    yield
-
-    if restore_state_flag:
-        duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)
+    def restore_dhcp_server_state():
+        if restore_state_flag:
+            duthost.shell("config feature state dhcp_server disabled")
         dhcp_relay_utils.restart_dhcp_service(duthost, [dhcp_relay_utils.get_dhcp_relay_type(duthost)])
-        duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
-    else:
+        if restore_state_flag:
+            result = duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
+            if result['rc'] != 0 and "No such container" not in result.get('stderr', ''):
+                raise RuntimeError("Failed to remove dhcp_server container: {}".format(result.get('stderr', '')))
+
+    try:
+        if restore_state_flag:
+            duthost.shell("config feature state dhcp_server enabled")
+
         dhcp_relay_utils.restart_dhcp_service(duthost, [dhcp_relay_utils.get_dhcp_relay_type(duthost)])
+
+        def is_supervisor_subprocess_running(duthost, container_name, app_name):
+            return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}")["stdout"]
+
+        py_assert(
+            wait_until(120, 1, 1,
+                       is_supervisor_subprocess_running,
+                       duthost,
+                       DHCP_SERVER_CONTAINER_NAME,
+                       "dhcp-server-ipv4:kea-dhcp4"),
+            'feature dhcp_server is enabled but container is not running'
+        )
+        yield
+    finally:
+        setup_or_test_error = sys.exc_info()[1]
+        try:
+            restore_dhcp_server_state()
+        except Exception:
+            if setup_or_test_error is not None:
+                logger.exception("Failed to restore DHCP server state after fixture failure")
+            else:
+                raise
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -1,100 +1,136 @@
+import logging
+import sys
+
 import pytest
+from _pytest.outcomes import OutcomeException
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.helpers.assertions import pytest_require as py_require
+from tests.common import dhcp_relay_utils
 from dhcp_server_test_common import clean_dhcp_server_config
 
-DHCP_RELAY_CONTAINER_NAME = "dhcp_relay"
 DHCP_SERVER_CONTAINER_NAME = "dhcp_server"
-DHCP_SERVER_FEATRUE_NAME = "dhcp_server"
+DHCP_SERVER_FEATURE_NAME = "dhcp_server"
+
+logger = logging.getLogger(__name__)
 
 
-def is_dhcprelayd_running(duthost):
-    """
-    Check if dhcprelayd is running in the dhcp_relay container, handling
-    dynamic supervisor process naming.
+def require_internal_relay_modes():
+    """Skip standalone runs until the prerequisite shared modes are available."""
+    try:
+        dhcp_relay_utils._validate_relay_types('dhcp_server_setup_teardown', ['isc-internal-idle'])
+    except (AttributeError, ValueError):
+        pytest.skip("#26526 requires the internal relay modes from #26525")
 
-    The dhcp_relay container's supervisor config is dynamically generated from
-    a Jinja2 template (docker-dhcp-relay.supervisord.conf.j2) at container
-    startup based on CONFIG_DB state. The template conditionally includes
-    dhcp-relay.programs.j2, which creates a [group:dhcp-relay] section that
-    groups dhcprelayd and dhcp6relay together.
 
-    The group is created when there are VLANs with DHCP relay configured
-    (dhcp_servers or dhcpv6_servers in CONFIG_DB). On a normal production DUT,
-    this is almost always the case, and the process appears as
-    "dhcp-relay:dhcprelayd" (group:program format). In this state,
-    supervisorctl requires the group prefix; the bare name "dhcprelayd"
-    returns "ERROR (no such process)" (rc=4).
-
-    When the relay count is 0 (no VLANs with dhcp_servers or dhcpv6_servers),
-    the template skips the group section, and dhcprelayd becomes a standalone
-    [program:dhcprelayd]. In this state, the bare name works but the
-    group-prefixed name fails.
-
-    Note: the enable_sonic_dhcpv4_relay_agent fixture teardown does not cause
-    this condition — config dhcpv4_relay add/del does not modify VLAN.dhcp_servers,
-    so the original relay config remains intact after teardown. The no-group state
-    has been observed in practice but the exact trigger is unclear; it may result
-    from external CONFIG_DB modifications or edge cases during container restarts.
-
-    This function tries both naming conventions to handle either state.
-    """
-    # Try group format first (normal production state)
-    result = duthost.shell(
-        "docker exec {} supervisorctl status dhcp-relay:dhcprelayd".format(DHCP_RELAY_CONTAINER_NAME),
-        module_ignore_errors=True)
-    if "RUNNING" in result.get("stdout", ""):
-        return True
-    # Fall back to standalone format (after test fixture modifies CONFIG_DB)
-    result = duthost.shell(
-        "docker exec {} supervisorctl status dhcprelayd".format(DHCP_RELAY_CONTAINER_NAME),
-        module_ignore_errors=True)
-    return "RUNNING" in result.get("stdout", "")
+def get_lifecycle_relay_type(duthost, internal):
+    """Select the lifecycle mode from the existing SONiC DHCPv4 relay flag."""
+    config_facts = duthost.config_facts(host=duthost.hostname, source='running')['ansible_facts']
+    device_metadata = config_facts['DEVICE_METADATA']['localhost']
+    sonic_relay = device_metadata.get('has_sonic_dhcpv4_relay', 'False') == 'True'
+    if sonic_relay:
+        return 'sonic'
+    if not internal:
+        return 'isc'
+    dhcp_server_ipv4 = config_facts.get('DHCP_SERVER_IPV4', {})
+    if any(config.get('state') == 'enabled' for config in dhcp_server_ipv4.values()):
+        return 'isc-internal'
+    return 'isc-internal-idle'
 
 
 @pytest.fixture(scope="module", autouse=True)
 def dhcp_server_setup_teardown(duthost):
-    features_state, _ = duthost.get_feature_status()
-    py_require(DHCP_SERVER_FEATRUE_NAME in features_state, "Skip on vs testbed without dhcp server feature")
-    restore_state_flag = False
-    if "enabled" not in features_state.get(DHCP_SERVER_FEATRUE_NAME, ""):
-        restore_state_flag = True
-        duthost.shell("config feature state dhcp_server enabled")
-        duthost.shell("sudo systemctl restart dhcp_relay.service")
-        duthost.critical_services_tracking_list()
+    require_internal_relay_modes()
+    features_state, succeeded = duthost.get_feature_status()
+    py_require(succeeded, "Skip when dhcp server feature status cannot be retrieved")
+    py_require(DHCP_SERVER_FEATURE_NAME in features_state, "Skip on vs testbed without dhcp server feature")
+    dhcp_server_state = features_state[DHCP_SERVER_FEATURE_NAME]
+    py_require(dhcp_server_state in ('enabled', 'always_enabled', 'disabled'),
+               "Skip on testbed with unsupported dhcp server feature state: {}".format(dhcp_server_state))
+    restore_state_flag = dhcp_server_state == 'disabled'
 
-    def is_supervisor_subprocess_running(duthost, container_name, app_name):
-        return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}")["stdout"]
+    def restore_dhcp_server_state():
+        first_cleanup_error = None
 
-    py_assert(
-        wait_until(120, 1, 1,
-                   is_supervisor_subprocess_running,
-                   duthost,
-                   DHCP_SERVER_CONTAINER_NAME,
-                   "dhcp-server-ipv4:kea-dhcp4"),
-        'feature dhcp_server is enabled but container is not running'
-    )
-    py_assert(
-        wait_until(120, 1, 1,
-                   is_dhcprelayd_running,
-                   duthost),
-        'dhcprelayd in container dhcp_relay is not running'
-    )
+        def cleanup_step(step_name, callback):
+            nonlocal first_cleanup_error
+            try:
+                callback()
+            except (Exception, OutcomeException) as cleanup_error:
+                logger.exception("DHCP server cleanup step '%s' failed", step_name)
+                if first_cleanup_error is None:
+                    first_cleanup_error = cleanup_error
 
-    yield
+        if restore_state_flag:
+            cleanup_step('disable feature', lambda: duthost.shell("config feature state dhcp_server disabled"))
+        cleanup_step('restore relay layout',
+                     lambda: dhcp_relay_utils.restart_dhcp_service(
+                         duthost, [get_lifecycle_relay_type(duthost, not restore_state_flag)]))
+        if restore_state_flag:
+            cleanup_step('refresh critical services', duthost.critical_services_tracking_list)
 
-    if restore_state_flag:
-        duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)
-        duthost.shell("sudo systemctl restart dhcp_relay.service")
-        duthost.critical_services_tracking_list()
-        duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
+            def remove_dhcp_server_container():
+                result = duthost.shell("docker rm -f {}".format(DHCP_SERVER_CONTAINER_NAME), module_ignore_errors=True)
+                inspection = duthost.shell("docker inspect {}".format(DHCP_SERVER_CONTAINER_NAME),
+                                           module_ignore_errors=True)
+                if inspection['rc'] != 0 and "No such object" in inspection.get('stderr', ''):
+                    return
+                raise RuntimeError(
+                    "Failed to remove dhcp_server container: stdout={} stderr={} inspect_stdout={} inspect_stderr={}"
+                    .format(result.get('stdout', ''), result.get('stderr', ''),
+                            inspection.get('stdout', ''), inspection.get('stderr', '')))
+
+            cleanup_step('remove dhcp_server container', remove_dhcp_server_container)
+
+        return first_cleanup_error
+
+    try:
+        if restore_state_flag:
+            duthost.shell("config feature state dhcp_server enabled")
+
+        dhcp_relay_utils.restart_dhcp_service(duthost, [get_lifecycle_relay_type(duthost, True)])
+        if restore_state_flag:
+            duthost.critical_services_tracking_list()
+
+        def is_supervisor_subprocess_running(duthost, container_name, app_name):
+            result = duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}",
+                                   module_ignore_errors=True)
+            return result['rc'] == 0 and "RUNNING" in result.get('stdout', '')
+
+        py_assert(
+            wait_until(120, 1, 1,
+                       is_supervisor_subprocess_running,
+                       duthost,
+                       DHCP_SERVER_CONTAINER_NAME,
+                       "dhcp-server-ipv4:kea-dhcp4"),
+            'feature dhcp_server is enabled but container is not running'
+        )
+        yield
+    finally:
+        setup_or_test_error = sys.exc_info()[1]
+        cleanup_error = restore_dhcp_server_state()
+        if cleanup_error is not None and setup_or_test_error is None:
+            raise cleanup_error
 
 
 @pytest.fixture(scope="function", autouse=True)
-def clean_dhcp_server_config_after_test(duthost):
-    clean_dhcp_server_config(duthost)
+def clean_dhcp_server_config_after_test(duthost, request, relay_agent):
+    clean_dhcp_server_config(duthost, relay_agent)
 
-    yield
-
-    clean_dhcp_server_config(duthost)
+    try:
+        yield
+    finally:
+        test_has_outcome = any(
+            getattr(request.node, report_name, None) is not None
+            and (
+                getattr(request.node, report_name).failed
+                or getattr(request.node, report_name).skipped
+            )
+            for report_name in ('rep_setup', 'rep_call')
+        )
+        try:
+            clean_dhcp_server_config(duthost, relay_agent)
+        except (Exception, OutcomeException):
+            if not test_has_outcome:
+                raise
+            logger.exception("DHCP server config cleanup failed after test outcome")

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -62,6 +62,7 @@ def dhcp_server_setup_teardown(duthost):
         restore_state_flag = True
         duthost.shell("config feature state dhcp_server enabled")
         duthost.shell("sudo systemctl restart dhcp_relay.service")
+        duthost.critical_services_tracking_list()
 
     def is_supervisor_subprocess_running(duthost, container_name, app_name):
         return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}")["stdout"]
@@ -86,6 +87,7 @@ def dhcp_server_setup_teardown(duthost):
     if restore_state_flag:
         duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)
         duthost.shell("sudo systemctl restart dhcp_relay.service")
+        duthost.critical_services_tracking_list()
         duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
 
 

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -57,11 +57,11 @@ def is_dhcprelayd_running(duthost):
 def dhcp_server_setup_teardown(duthost):
     features_state, _ = duthost.get_feature_status()
     py_require(DHCP_SERVER_FEATRUE_NAME in features_state, "Skip on vs testbed without dhcp server feature")
-    was_enabled_at_start = "enabled" in features_state.get(DHCP_SERVER_FEATRUE_NAME, "")
-    if not was_enabled_at_start:
+    restore_state_flag = False
+    if "enabled" not in features_state.get(DHCP_SERVER_FEATRUE_NAME, ""):
+        restore_state_flag = True
         duthost.shell("config feature state dhcp_server enabled")
         duthost.shell("sudo systemctl restart dhcp_relay.service")
-        duthost.critical_services_tracking_list()
 
     def is_supervisor_subprocess_running(duthost, container_name, app_name):
         return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}")["stdout"]
@@ -83,23 +83,15 @@ def dhcp_server_setup_teardown(duthost):
 
     yield
 
-    if not was_enabled_at_start:
-        # Leave dhcp_server enabled on platforms that ship the feature. Disabling
-        # it here persists disabled state in config while pytest may still track
-        # dhcp_server as critical (stale list from when the module enabled it),
-        # so later config_reload waits for a container that will not start.
-        duthost.shell("config feature state dhcp_server enabled", module_ignore_errors=True)
-        duthost.shell("sudo systemctl restart dhcp_relay.service", module_ignore_errors=True)
-        duthost.critical_services_tracking_list()
+    if restore_state_flag:
+        duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)
+        duthost.shell("sudo systemctl restart dhcp_relay.service")
+        duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
 
 
 @pytest.fixture(scope="function", autouse=True)
-def clean_dhcp_server_config_after_test(duthost, request):
+def clean_dhcp_server_config_after_test(duthost):
     clean_dhcp_server_config(duthost)
-
-    if "enable_sonic_dhcpv4_relay_agent" in request.fixturenames:
-        # Make relay restoration run after DHCP server configuration cleanup.
-        request.getfixturevalue("enable_sonic_dhcpv4_relay_agent")
 
     yield
 

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -96,7 +96,11 @@ def clean_dhcp_server_config_after_test(duthost, request):
     try:
         yield
     finally:
-        test_failed = hasattr(request.node, 'rep_call') and request.node.rep_call.failed
+        test_failed = any(
+            getattr(request.node, report_name, None) is not None
+            and getattr(request.node, report_name).failed
+            for report_name in ('rep_setup', 'rep_call')
+        )
         try:
             clean_dhcp_server_config(duthost)
         except (Exception, OutcomeException):

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -93,6 +93,13 @@ def dhcp_server_setup_teardown(duthost):
 def clean_dhcp_server_config_after_test(duthost):
     clean_dhcp_server_config(duthost)
 
-    yield
-
-    clean_dhcp_server_config(duthost)
+    try:
+        yield
+    finally:
+        active_error = sys.exc_info()[1]
+        try:
+            clean_dhcp_server_config(duthost)
+        except (Exception, OutcomeException):
+            if active_error is None:
+                raise
+            logger.exception("DHCP server config cleanup failed after test failure")

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -90,16 +90,16 @@ def dhcp_server_setup_teardown(duthost):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def clean_dhcp_server_config_after_test(duthost):
+def clean_dhcp_server_config_after_test(duthost, request):
     clean_dhcp_server_config(duthost)
 
     try:
         yield
     finally:
-        active_error = sys.exc_info()[1]
+        test_failed = hasattr(request.node, 'rep_call') and request.node.rep_call.failed
         try:
             clean_dhcp_server_config(duthost)
         except (Exception, OutcomeException):
-            if active_error is None:
+            if not test_failed:
                 raise
             logger.exception("DHCP server config cleanup failed after test failure")

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -96,14 +96,17 @@ def clean_dhcp_server_config_after_test(duthost, request):
     try:
         yield
     finally:
-        test_failed = any(
+        test_has_outcome = any(
             getattr(request.node, report_name, None) is not None
-            and getattr(request.node, report_name).failed
+            and (
+                getattr(request.node, report_name).failed
+                or getattr(request.node, report_name).skipped
+            )
             for report_name in ('rep_setup', 'rep_call')
         )
         try:
             clean_dhcp_server_config(duthost)
         except (Exception, OutcomeException):
-            if not test_failed:
+            if not test_has_outcome:
                 raise
-            logger.exception("DHCP server config cleanup failed after test failure")
+            logger.exception("DHCP server config cleanup failed after test outcome")

--- a/tests/dhcp_server/dhcp_server_test_common.py
+++ b/tests/dhcp_server/dhcp_server_test_common.py
@@ -7,6 +7,7 @@ import pytest
 import ptf.packet as scapy
 import ptf.testutils as testutils
 from tests.common.utilities import capture_and_check_packet_on_dut, wait_until
+from tests.common import dhcp_relay_utils
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 
 
@@ -35,6 +36,12 @@ DHCP_SERVER_SUPPORTED_OPTION_ID = (
     "191", "192", "193", "194", "195", "196", "197", "198", "199", "200", "201", "202", "203", "204",
     "205", "206", "207", "214", "215", "216", "217", "218", "219", "222", "223"
 )
+
+
+def _wait_dhcp_server_relay_ready(duthost):
+    selector = getattr(dhcp_relay_utils, 'get_dhcp_relay_type', None)
+    pytest_assert(callable(selector), "#26525 must merge first: get_dhcp_relay_type is required")
+    dhcp_relay_utils.wait_dhcp_relay_ready(duthost, [selector(duthost)])
 
 
 def vlan_i2n(vlan_id):
@@ -71,6 +78,7 @@ def clean_dhcp_server_config(duthost):
         for line in keys['stdout_lines']:
             if line.startswith(key + '|'):
                 duthost.shell("sonic-db-cli CONFIG_DB DEL '{}'".format(line))
+    _wait_dhcp_server_relay_ready(duthost)
 
 
 def verify_lease(duthost, dhcp_interface, client_mac, exp_ip, exp_lease_time):
@@ -118,6 +126,7 @@ def apply_dhcp_server_config_cli(duthost, config_commands):
     logging.info("The dhcp_server_config: %s" % config_commands)
     for cmd in config_commands:
         duthost.shell(cmd)
+    _wait_dhcp_server_relay_ready(duthost)
 
 
 def apply_dhcp_server_config_gcu(duthost, config_to_apply):
@@ -133,6 +142,7 @@ def apply_dhcp_server_config_gcu(duthost, config_to_apply):
         )
     finally:
         duthost.file(path=tmpfile, state='absent')
+    _wait_dhcp_server_relay_ready(duthost)
 
 
 def create_common_config_patch(vlan_name, gateway, net_mask, dut_ports, ip_ranges, customized_options=None):

--- a/tests/dhcp_server/dhcp_server_test_common.py
+++ b/tests/dhcp_server/dhcp_server_test_common.py
@@ -7,6 +7,7 @@ import pytest
 import ptf.packet as scapy
 import ptf.testutils as testutils
 from tests.common.utilities import capture_and_check_packet_on_dut, wait_until
+from tests.common import dhcp_relay_utils
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 
 
@@ -37,6 +38,18 @@ DHCP_SERVER_SUPPORTED_OPTION_ID = (
 )
 
 
+def get_expected_dhcp_server_relay_type(relay_agent, relay_configured):
+    """Return the relay mode explicitly selected by the test and config phase."""
+    if relay_agent == 'sonic-relay-agent':
+        return 'sonic'
+    return 'isc-internal' if relay_configured else 'isc-internal-idle'
+
+
+def _wait_dhcp_server_relay_ready(duthost, relay_agent, relay_configured):
+    relay_type = get_expected_dhcp_server_relay_type(relay_agent, relay_configured)
+    dhcp_relay_utils.wait_dhcp_relay_ready(duthost, [relay_type])
+
+
 def vlan_i2n(vlan_id):
     """
         Convert vlan id to vlan name
@@ -59,7 +72,7 @@ def ping_dut_refresh_fdb(ptfhost, interface):
     ptfhost.shell("timeout 1 ping -c 1 -w 1 -I {} 255.255.255.255 -b".format(interface), module_ignore_errors=True)
 
 
-def clean_dhcp_server_config(duthost):
+def clean_dhcp_server_config(duthost, relay_agent):
     keys = duthost.shell("sonic-db-cli CONFIG_DB KEYS DHCP_SERVER_IPV4*")
     clean_order = [
         "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS",
@@ -71,6 +84,7 @@ def clean_dhcp_server_config(duthost):
         for line in keys['stdout_lines']:
             if line.startswith(key + '|'):
                 duthost.shell("sonic-db-cli CONFIG_DB DEL '{}'".format(line))
+    _wait_dhcp_server_relay_ready(duthost, relay_agent, False)
 
 
 def verify_lease(duthost, dhcp_interface, client_mac, exp_ip, exp_lease_time):
@@ -102,25 +116,26 @@ def verify_lease(duthost, dhcp_interface, client_mac, exp_ip, exp_lease_time):
 
 
 @contextlib.contextmanager
-def dhcp_server_config(duthost, config_tool, config_to_apply):
-    clean_dhcp_server_config(duthost)
+def dhcp_server_config(duthost, config_tool, config_to_apply, relay_agent):
+    clean_dhcp_server_config(duthost, relay_agent)
     if config_tool == DHCP_SERVER_CONFIG_TOOL_GCU:
-        apply_dhcp_server_config_gcu(duthost, config_to_apply)
+        apply_dhcp_server_config_gcu(duthost, config_to_apply, relay_agent)
     elif config_tool == DHCP_SERVER_CONFIG_TOOL_CLI:
-        apply_dhcp_server_config_cli(duthost, config_to_apply)
+        apply_dhcp_server_config_cli(duthost, config_to_apply, relay_agent)
 
     yield
 
-    clean_dhcp_server_config(duthost)
+    clean_dhcp_server_config(duthost, relay_agent)
 
 
-def apply_dhcp_server_config_cli(duthost, config_commands):
+def apply_dhcp_server_config_cli(duthost, config_commands, relay_agent):
     logging.info("The dhcp_server_config: %s" % config_commands)
     for cmd in config_commands:
         duthost.shell(cmd)
+    _wait_dhcp_server_relay_ready(duthost, relay_agent, True)
 
 
-def apply_dhcp_server_config_gcu(duthost, config_to_apply):
+def apply_dhcp_server_config_gcu(duthost, config_to_apply, relay_agent, relay_configured=True):
     logging.info("The dhcp_server_config: %s" % config_to_apply)
     tmpfile = duthost.shell('mktemp')['stdout']
     try:
@@ -133,6 +148,7 @@ def apply_dhcp_server_config_gcu(duthost, config_to_apply):
         )
     finally:
         duthost.file(path=tmpfile, state='absent')
+    _wait_dhcp_server_relay_ready(duthost, relay_agent, relay_configured)
 
 
 def create_common_config_patch(vlan_name, gateway, net_mask, dut_ports, ip_ranges, customized_options=None):

--- a/tests/dhcp_server/test_dhcp_server.py
+++ b/tests/dhcp_server/test_dhcp_server.py
@@ -83,7 +83,7 @@ def test_dhcp_server_port_based_assignment_single_ip_tc1(
         config_to_apply = config_cli
     elif config_tool == DHCP_SERVER_CONFIG_TOOL_GCU:
         config_to_apply = config_gcu
-    with dhcp_server_config(duthost, config_tool, config_to_apply):
+    with dhcp_server_config(duthost, config_tool, config_to_apply, relay_agent):
         verify_discover_and_request_then_release(
             duthost=duthost,
             ptfhost=ptfhost,
@@ -126,7 +126,7 @@ def test_dhcp_server_port_based_assignment_single_ip_tc2(
         config_to_apply = config_cli
     elif config_tool == DHCP_SERVER_CONFIG_TOOL_GCU:
         config_to_apply = config_gcu
-    with dhcp_server_config(duthost, config_tool, config_to_apply):
+    with dhcp_server_config(duthost, config_tool, config_to_apply, relay_agent):
         verify_discover_and_request_then_release(
             duthost=duthost,
             ptfhost=ptfhost,
@@ -172,7 +172,7 @@ def test_dhcp_server_port_based_assignment_single_ip_tc3(
         config_to_apply = config_cli
     elif config_tool == DHCP_SERVER_CONFIG_TOOL_GCU:
         config_to_apply = config_gcu
-    with dhcp_server_config(duthost, config_tool, config_to_apply):
+    with dhcp_server_config(duthost, config_tool, config_to_apply, relay_agent):
         verify_discover_and_request_then_release(
             duthost=duthost,
             ptfhost=ptfhost,
@@ -221,7 +221,7 @@ def test_dhcp_server_port_based_assignment_single_ip_tc4(
         config_to_apply = config_cli
     elif config_tool == DHCP_SERVER_CONFIG_TOOL_GCU:
         config_to_apply = config_gcu
-    with dhcp_server_config(duthost, config_tool, config_to_apply):
+    with dhcp_server_config(duthost, config_tool, config_to_apply, relay_agent):
         verify_discover_and_request_then_release(
             duthost=duthost,
             ptfhost=ptfhost,
@@ -268,7 +268,7 @@ def test_dhcp_server_port_based_assignment_range_ip(
         config_to_apply = config_cli
     elif config_tool == DHCP_SERVER_CONFIG_TOOL_GCU:
         config_to_apply = config_gcu
-    with dhcp_server_config(duthost, config_tool, config_to_apply):
+    with dhcp_server_config(duthost, config_tool, config_to_apply, relay_agent):
         verify_discover_and_request_then_release(
             duthost=duthost,
             ptfhost=ptfhost,
@@ -318,7 +318,7 @@ def test_dhcp_server_port_based_assigenment_single_ip_mac_move(
         config_to_apply = config_cli
     elif config_tool == DHCP_SERVER_CONFIG_TOOL_GCU:
         config_to_apply = config_gcu
-    with dhcp_server_config(duthost, config_tool, config_to_apply):
+    with dhcp_server_config(duthost, config_tool, config_to_apply, relay_agent):
         verify_discover_and_request_then_release(
             duthost=duthost,
             ptfhost=ptfhost,
@@ -381,7 +381,7 @@ def test_dhcp_server_port_based_assigenment_single_ip_mac_swap(
         config_to_apply = config_cli
     elif config_tool == DHCP_SERVER_CONFIG_TOOL_GCU:
         config_to_apply = config_gcu
-    with dhcp_server_config(duthost, config_tool, config_to_apply):
+    with dhcp_server_config(duthost, config_tool, config_to_apply, relay_agent):
         verify_discover_and_request_then_release(
             duthost=duthost,
             ptfhost=ptfhost,
@@ -476,7 +476,7 @@ def test_dhcp_server_port_based_customize_options(
         [[expected_assigned_ip]],
         customized_options
     )
-    with dhcp_server_config(duthost, DHCP_SERVER_CONFIG_TOOL_GCU, config_patch):
+    with dhcp_server_config(duthost, DHCP_SERVER_CONFIG_TOOL_GCU, config_patch, relay_agent):
         pkts_validator = validate_dhcp_server_pkts_custom_option
         pkts_validator_args = [test_xid]
         pkts_validator_kwargs = {"%s" % random_option_id: option_info[1].encode('ascii')}
@@ -538,7 +538,7 @@ def test_dhcp_server_config_change_dhcp_interface(
     logging.info("expected assigned ip is %s, dut_port is %s, ptf_port_index is %s" %
                  (expected_assigned_ip, dut_port, ptf_port_index))
     config_to_apply = create_common_config_patch(vlan_name, gateway, net_mask, [dut_port], [[expected_assigned_ip]])
-    apply_dhcp_server_config_gcu(duthost, config_to_apply)
+    apply_dhcp_server_config_gcu(duthost, config_to_apply, relay_agent)
     verify_discover_and_request_then_release(
         duthost=duthost,
         ptfhost=ptfhost,
@@ -561,7 +561,7 @@ def test_dhcp_server_config_change_dhcp_interface(
             "value": "disabled"
         }
     ]
-    apply_dhcp_server_config_gcu(duthost, config_to_apply)
+    apply_dhcp_server_config_gcu(duthost, config_to_apply, relay_agent, relay_configured=False)
     verify_discover_and_request_then_release(
         duthost=duthost,
         ptfhost=ptfhost,
@@ -596,7 +596,7 @@ def test_dhcp_server_config_change_common(
     logging.info("expected assigned ip is %s, dut_port is %s, ptf_port_index is %s" %
                  (expected_assigned_ip, dut_port, ptf_port_index))
     config_to_apply = create_common_config_patch(vlan_name, gateway, net_mask, [dut_port], [[expected_assigned_ip]])
-    apply_dhcp_server_config_gcu(duthost, config_to_apply)
+    apply_dhcp_server_config_gcu(duthost, config_to_apply, relay_agent)
     verify_discover_and_request_then_release(
         duthost=duthost,
         ptfhost=ptfhost,
@@ -635,7 +635,7 @@ def test_dhcp_server_config_change_common(
             "value": "%s" % changed_gateway
         }
     ]
-    apply_dhcp_server_config_gcu(duthost, change_to_apply)
+    apply_dhcp_server_config_gcu(duthost, change_to_apply, relay_agent)
     change_to_apply = [
         {
             "op": "remove",
@@ -643,7 +643,7 @@ def test_dhcp_server_config_change_common(
             "value": "%s" % expected_assigned_ip
         }
     ]
-    apply_dhcp_server_config_gcu(duthost, change_to_apply)
+    apply_dhcp_server_config_gcu(duthost, change_to_apply, relay_agent)
     verify_discover_and_request_then_release(
         duthost=duthost,
         ptfhost=ptfhost,
@@ -682,7 +682,7 @@ def test_dhcp_server_config_vlan_member_change(
     logging.info("expected assigned ip is %s, dut_port is %s, ptf_port_index is %s" %
                  (expected_assigned_ip, dut_port, ptf_port_index))
     config_to_apply = create_common_config_patch(vlan_name, gateway, net_mask, [dut_port], [[expected_assigned_ip]])
-    apply_dhcp_server_config_gcu(duthost, config_to_apply)
+    apply_dhcp_server_config_gcu(duthost, config_to_apply, relay_agent)
     # delete member
     duthost.del_member_from_vlan(vlan_n2i(vlan_name), dut_port)
     try:
@@ -741,7 +741,7 @@ def test_dhcp_server_lease_config_change(
     logging.info("expected assigned ip is %s, dut_port is %s, ptf_port_index is %s" %
                  (expected_assigned_ip, dut_port, ptf_port_index))
     config_to_apply = create_common_config_patch(vlan_name, gateway, net_mask, [dut_port], [[expected_assigned_ip]])
-    apply_dhcp_server_config_gcu(duthost, config_to_apply)
+    apply_dhcp_server_config_gcu(duthost, config_to_apply, relay_agent)
     verify_discover_and_request_then_release(
         duthost=duthost,
         ptfhost=ptfhost,
@@ -766,7 +766,7 @@ def test_dhcp_server_lease_config_change(
             "value": "%s" % changed_lease_time
         }
     ]
-    apply_dhcp_server_config_gcu(duthost, change_to_apply)
+    apply_dhcp_server_config_gcu(duthost, change_to_apply, relay_agent)
     client_mac = ptfadapter.dataplane.get_mac(0, ptf_port_index).decode('utf-8')
     verify_lease(duthost, vlan_name, client_mac, expected_assigned_ip, DHCP_DEFAULT_LEASE_TIME)
     send_release_packet(ptfadapter, ptf_port_index, test_xid, client_mac, expected_assigned_ip, gateway)
@@ -806,7 +806,7 @@ def test_dhcp_server_config_vlan_intf_change(
         [dut_port_1],
         [[expected_assigned_ip_1]]
     )
-    apply_dhcp_server_config_gcu(duthost, config_to_apply)
+    apply_dhcp_server_config_gcu(duthost, config_to_apply, relay_agent)
 
     # When the VLAN has multiple IPv4 addresses, extra IPs on different subnets
     # can interfere with the DHCP server's subnet matching after IP swap/restore.

--- a/tests/dhcp_server/test_dhcp_server_multi_vlans.py
+++ b/tests/dhcp_server/test_dhcp_server_multi_vlans.py
@@ -14,6 +14,15 @@ pytestmark = [
 ]
 
 
+def get_configured_relay_agent(duthost):
+    """Return the relay backend currently selected in DEVICE_METADATA."""
+    config_facts = duthost.config_facts(host=duthost.hostname, source='running')['ansible_facts']
+    device_metadata = config_facts['DEVICE_METADATA']['localhost']
+    if device_metadata.get('has_sonic_dhcpv4_relay', 'False') == 'True':
+        return 'sonic-relay-agent'
+    return 'isc-relay-agent'
+
+
 @pytest.fixture(scope="module", autouse=True)
 def setup_multiple_vlans_and_teardown(duthost, tbinfo):
     vlan_brief = duthost.get_vlan_brief()
@@ -48,13 +57,15 @@ def setup_multiple_vlans_and_teardown(duthost, tbinfo):
     )
 
     logging.info("The patch for setup is %s" % patch_setup)
-    apply_dhcp_server_config_gcu(duthost, patch_setup)
+    apply_dhcp_server_config_gcu(
+        duthost, patch_setup, get_configured_relay_agent(duthost), relay_configured=False)
 
     logging.info("The four_vlans_info after setup is %s" % four_vlans_info)
     yield four_vlans_info
 
     logging.info("The patch for restore is %s" % patch_restore)
-    apply_dhcp_server_config_gcu(duthost, patch_restore)
+    apply_dhcp_server_config_gcu(
+        duthost, patch_restore, get_configured_relay_agent(duthost), relay_configured=False)
 
 
 def generate_four_vlans_config_patch(vlan_name, vlan_info, vlan_member_with_ptf_idx):
@@ -221,7 +232,7 @@ def test_single_ip_assignment(
             test_sets.append((vlan_name, gateway, net_mask, dut_ports[index], ptf_port_indexs[index],
                               exp_assigned_ip_ranges[index], test_xid))
 
-    apply_dhcp_server_config_gcu(duthost, config_to_apply)
+    apply_dhcp_server_config_gcu(duthost, config_to_apply, relay_agent)
     for vlan_name, gateway, net_mask, dut_port, ptf_port_index, exp_assigned_ip_range, test_xid in test_sets:
         logging.info("Testing for vlan %s, gateway %s, net_mask %s dut_port %s, ptf_port_index %s, \
                      expected_assigned_ip %s, test_xid %s" % (vlan_name, gateway, net_mask, dut_port,
@@ -294,7 +305,7 @@ def test_range_ip_assignment(
         [[expected_assigned_ip_2, last_ip_in_range_2]]
     )
 
-    apply_dhcp_server_config_gcu(duthost, config_to_apply)
+    apply_dhcp_server_config_gcu(duthost, config_to_apply, relay_agent)
     verify_discover_and_request_then_release(
         duthost=duthost,
         ptfhost=ptfhost,

--- a/tests/dhcp_server/test_dhcp_server_stress.py
+++ b/tests/dhcp_server/test_dhcp_server_stress.py
@@ -88,7 +88,7 @@ def test_dhcp_server_with_multiple_dhcp_clients(
             dut_ports,
             exp_assigned_ip_ranges
         )
-        apply_dhcp_server_config_gcu(duthost, config_to_apply)
+        apply_dhcp_server_config_gcu(duthost, config_to_apply, relay_agent)
         ptfhost.shell(start_command)
 
         def all_ip_shown_up(ptfhost, expected_assigned_ips):


### PR DESCRIPTION
### Description of PR

Summary:
Pass the expected internal relay mode explicitly after every DHCP-server setup, apply, and cleanup transition.

ADO Task: https://msazure.visualstudio.com/One/_workitems/edit/39301051
Parent PBI: https://msazure.visualstudio.com/One/_workitems/edit/38699914

Hardware root cause: DHCP-server test cleanup can remove all `DHCP_SERVER_IPV4` entries while the feature remains enabled, so active and idle ISC require different readiness modes.

Dependency: https://github.com/sonic-net/sonic-mgmt/pull/26525 at exact combined head `5182a573cacd011277b0152131d09a6e3da5cffa`. #26658 is now absorbed into that parent. This PR must not merge standalone.

Affected tests: 3 DHCP-server modules / 16 fixture-consuming test functions:
`tests/dhcp_server/test_dhcp_server.py` (13),
`tests/dhcp_server/test_dhcp_server_multi_vlans.py` (2), and
`tests/dhcp_server/test_dhcp_server_stress.py` (1). Their config apply and
cleanup transitions now wait for the selected relay mode.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39301051
Failure type: other

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- Review baseline: final combined #26525 head `5182a573cacd011277b0152131d09a6e3da5cffa`.
- Current `v1.1` head `3ad1424ff721dac461b306b7d65390a8bfe6b59c` is one remaining #26526 commit: 179 additions / 116 deletions across 5 files.
- The restack conflict was limited to `tests/dhcp_server/conftest.py`; resolution preserves the parent's two critical-service refresh points inside #26526's broader lifecycle structure.
- `git diff --check`, Python compilation, targeted pre-commit, one-commit count, and pushed-ref verification passed.
- Exact-head CI and Copilot review are pending. Earlier combined hardware evidence used superseded prerequisite heads and is not claimed.

### Approach
#### What is the motivation for this PR?

DHCP-server configuration changes can transition after fixture setup, not only during module setup/teardown. Internal ISC becomes `isc-internal-idle` after its last enabled interface is removed, while internal SONiC keeps its supervisor-owned relay process running.

#### How did you do it?

Map the test's `relay_agent` and known configured/idle phase to
`sonic`, `isc-internal`, or `isc-internal-idle`, then pass that mode
through config cleanup, CLI apply, and GCU apply helpers. Module lifecycle
setup/restoration limits live DUT inspection to the pre-existing SONiC relay
flag and current DHCP-server interface state. Function cleanup preserves an
active test failure if readiness restoration also fails.

#### How did you verify/test it?

Ran the static and master/202605 MX checks recorded above.

#### Any platform specific information?

Internal relay modes apply to the MX DHCP-server path.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Xichen review

Current review version: `v1.1`

Review baseline: final #26525 `5182a573cacd011277b0152131d09a6e3da5cffa`

Current review scope: `v1.0 -> v1.1`

Review status: preparation in progress after dependency split

### Documentation

No documentation update is required.







