### PR TITLE
[dhcp_relay]: Wait for relay readiness with uplinks down

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -537,15 +537,8 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
         pytest_assert(wait_until(50, 5, 0, check_link_status, duthost, dhcp_relay['uplink_interfaces'], "down"),
                       "Not all uplinks go down")
 
-        # Restart DHCP relay service on DUT
-        # dhcp_relay service has 3 times restart limit in 20 mins, for 4 vlans config it will hit the maximum limit
-        # reset-failed before restart service
-        cmds = ['systemctl reset-failed dhcp_relay', 'systemctl restart dhcp_relay']
-        duthost.shell_cmds(cmds=cmds)
-
-        # Sleep to give the DHCP relay container time to start up and
-        # allow the relay agent to begin listening on the down interfaces
-        time.sleep(40)
+        relay_types = ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc']
+        restart_dhcp_service(duthost, relay_types)
 
         # Bring all uplink interfaces back up
         for iface in dhcp_relay['uplink_interfaces']:

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -3,6 +3,9 @@ import random
 import time
 import logging
 import re
+import sys
+
+from _pytest.outcomes import OutcomeException
 
 from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmon_counters
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
@@ -530,23 +533,44 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
     testing_mode, duthost = testing_config
 
     for dhcp_relay in dut_dhcp_relay_data:
-        # Bring all uplink interfaces down
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('config interface shutdown {}'.format(iface))
+        uplink_interfaces = dhcp_relay['uplink_interfaces']
 
-        pytest_assert(wait_until(50, 5, 0, check_link_status, duthost, dhcp_relay['uplink_interfaces'], "down"),
-                      "Not all uplinks go down")
+        def restore_uplinks():
+            first_cleanup_error = None
 
-        relay_types = ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc']
-        restart_dhcp_service(duthost, relay_types)
+            def cleanup_step(step_name, callback):
+                nonlocal first_cleanup_error
+                try:
+                    callback()
+                except (Exception, OutcomeException) as cleanup_error:
+                    logger.exception("DHCP relay uplink cleanup step '%s' failed", step_name)
+                    if first_cleanup_error is None:
+                        first_cleanup_error = cleanup_error
 
-        # Bring all uplink interfaces back up
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('config interface startup {}'.format(iface))
+            for iface in uplink_interfaces:
+                cleanup_step('start {}'.format(iface),
+                             lambda iface=iface: duthost.shell('config interface startup {}'.format(iface)))
+            cleanup_step('verify routes',
+                         lambda: pytest_assert(
+                             wait_until(50, 5, 0, check_routes_to_dhcp_server, duthost, dut_dhcp_relay_data),
+                             "Not all DHCP servers are routed"))
+            return first_cleanup_error
 
-        # Wait until uplinks are up and routes are recovered
-        pytest_assert(wait_until(50, 5, 0, check_routes_to_dhcp_server, duthost, dut_dhcp_relay_data),
-                      "Not all DHCP servers are routed")
+        try:
+            # Bring all uplink interfaces down
+            for iface in uplink_interfaces:
+                duthost.shell('config interface shutdown {}'.format(iface))
+
+            pytest_assert(wait_until(50, 5, 0, check_link_status, duthost, uplink_interfaces, "down"),
+                          "Not all uplinks go down")
+
+            relay_types = ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc']
+            restart_dhcp_service(duthost, relay_types)
+        finally:
+            original_error = sys.exc_info()[1]
+            cleanup_error = restore_uplinks()
+            if cleanup_error is not None and original_error is None:
+                raise cleanup_error
 
         # Run the DHCP relay test on the PTF host
         ptf_runner(ptfhost,

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -548,7 +548,7 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
                         first_cleanup_error = cleanup_error
 
             for iface in uplink_interfaces:
-                cleanup_step('start {}'.format(iface),
+                cleanup_step('startup {}'.format(iface),
                              lambda iface=iface: duthost.shell('config interface startup {}'.format(iface)))
             cleanup_step('verify routes',
                          lambda: pytest_assert(

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -519,7 +519,7 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
                         first_cleanup_error = cleanup_error
 
             for iface in uplink_interfaces:
-                cleanup_step('start {}'.format(iface),
+                cleanup_step('startup {}'.format(iface),
                              lambda iface=iface: duthost.shell('config interface startup {}'.format(iface)))
             cleanup_step('verify routes',
                          lambda: pytest_assert(

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -507,15 +507,8 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
         pytest_assert(wait_until(50, 5, 0, check_link_status, duthost, dhcp_relay['uplink_interfaces'], "down"),
                       "Not all uplinks go down")
 
-        # Restart DHCP relay service on DUT
-        # dhcp_relay service has 3 times restart limit in 20 mins, for 4 vlans config it will hit the maximum limit
-        # reset-failed before restart service
-        cmds = ['systemctl reset-failed dhcp_relay', 'systemctl restart dhcp_relay']
-        duthost.shell_cmds(cmds=cmds)
-
-        # Sleep to give the DHCP relay container time to start up and
-        # allow the relay agent to begin listening on the down interfaces
-        time.sleep(40)
+        relay_types = ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc']
+        restart_dhcp_service(duthost, relay_types)
 
         # Bring all uplink interfaces back up
         for iface in dhcp_relay['uplink_interfaces']:

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -2,6 +2,10 @@ import pytest
 import random
 import time
 import logging
+import re
+import sys
+
+from _pytest.outcomes import OutcomeException
 
 from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmon_counters, restart_dhcpmon_in_debug
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
@@ -500,23 +504,44 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
     testing_mode, duthost = testing_config
 
     for dhcp_relay in dut_dhcp_relay_data:
-        # Bring all uplink interfaces down
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('config interface shutdown {}'.format(iface))
+        uplink_interfaces = dhcp_relay['uplink_interfaces']
 
-        pytest_assert(wait_until(50, 5, 0, check_link_status, duthost, dhcp_relay['uplink_interfaces'], "down"),
-                      "Not all uplinks go down")
+        def restore_uplinks():
+            first_cleanup_error = None
 
-        relay_types = ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc']
-        restart_dhcp_service(duthost, relay_types)
+            def cleanup_step(step_name, callback):
+                nonlocal first_cleanup_error
+                try:
+                    callback()
+                except (Exception, OutcomeException) as cleanup_error:
+                    logger.exception("DHCP relay uplink cleanup step '%s' failed", step_name)
+                    if first_cleanup_error is None:
+                        first_cleanup_error = cleanup_error
 
-        # Bring all uplink interfaces back up
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('config interface startup {}'.format(iface))
+            for iface in uplink_interfaces:
+                cleanup_step('start {}'.format(iface),
+                             lambda iface=iface: duthost.shell('config interface startup {}'.format(iface)))
+            cleanup_step('verify routes',
+                         lambda: pytest_assert(
+                             wait_until(50, 5, 0, check_routes_to_dhcp_server, duthost, dut_dhcp_relay_data),
+                             "Not all DHCP servers are routed"))
+            return first_cleanup_error
 
-        # Wait until uplinks are up and routes are recovered
-        pytest_assert(wait_until(50, 5, 0, check_routes_to_dhcp_server, duthost, dut_dhcp_relay_data),
-                      "Not all DHCP servers are routed")
+        try:
+            # Bring all uplink interfaces down
+            for iface in uplink_interfaces:
+                duthost.shell('config interface shutdown {}'.format(iface))
+
+            pytest_assert(wait_until(50, 5, 0, check_link_status, duthost, uplink_interfaces, "down"),
+                          "Not all uplinks go down")
+
+            relay_types = ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc']
+            restart_dhcp_service(duthost, relay_types)
+        finally:
+            original_error = sys.exc_info()[1]
+            cleanup_error = restore_uplinks()
+            if cleanup_error is not None and original_error is None:
+                raise cleanup_error
 
         # Run the DHCP relay test on the PTF host
         ptf_runner(ptfhost,

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -2,7 +2,6 @@ import pytest
 import random
 import time
 import logging
-import re
 import sys
 
 from _pytest.outcomes import OutcomeException


### PR DESCRIPTION
### Description of PR

Summary:
Use the shared DHCP relay restart/readiness helper when the uplinks-down test restarts the relay, selecting the expected SONiC or ISC agent from the test parameter. Always restore every affected uplink when restart/readiness setup fails.

ADO Task: https://msazure.visualstudio.com/One/_workitems/edit/39301052
Parent PBI: https://msazure.visualstudio.com/One/_workitems/edit/38699914

Affected tests: 2 parameterized cases of
`tests/dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down`
(ISC and SONiC relay modes).

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39301052
Failure type: other

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master, `SONiC.internal.173569967-e2b6c23f55` on `testbed-bjw2-can-7215a1-4`: `test_dhcp_relay_start_with_uplinks_down` passed for both selected relay parameters (2 passed). The initial ISC cleanup route-convergence timeout passed on the focused rerun.
- 202605, `SONiC.20260510.07` (`1df5b92630`) on `testbed-bjw2-can-7215a1-4`: the same uplinks-down selection passed for both relay parameters (2 passed).

Both runs used the exact combined PR stacks.
- Rebased onto public master `609fe27e3851b0021191f6a4fe9a81494c65b53d`
  at head `9bead05f7928331442f7dbb072bbf15f44440bb3`.
  Conflict resolution preserved the readiness and failure-safe uplink cleanup
  behavior; diff check, Python compilation, targeted pre-commit, and fresh
  Copilot review passed.
### Approach
#### What is the motivation for this PR?

The test used a fixed delay after a manual restart, which can proceed before the selected relay agent is ready.

#### How did you do it?

Replace the manual restart and fixed sleep with `restart_dhcp_service`, using `sonic` for the SONiC relay parameter and `isc` otherwise. A `try/finally` independently restores every uplink and verifies route recovery; cleanup errors are logged and do not mask an active setup failure.

#### How did you verify/test it?

Ran the static and hardware checks recorded above. Exact-head CI is running.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation update is required.
