### PR TITLE
test: use shared DHCP relay readiness for telemetry

### DIFF
--- a/tests/telemetry/events/dhcp-relay_events.py
+++ b/tests/telemetry/events/dhcp-relay_events.py
@@ -6,8 +6,8 @@ import time
 import ptf.testutils as testutils
 
 from tests.common.helpers.assertions import pytest_assert as py_assert
-from tests.common.utilities import wait_until
 from tests.common.utilities import is_ipv6_only_topology
+from tests.common.dhcp_relay_utils import restart_dhcp_service, wait_dhcp_relay_ready
 from run_events_test import run_test
 from event_utils import find_test_vlan, find_test_client_port_and_mac, create_dhcp_discover_packet
 
@@ -53,8 +53,7 @@ def trigger_dhcp_relay_disparity(duthost, tbinfo, ptfadapter=None):
 
 def trigger_dhcp_relay_bind_failure(duthost, tbinfo):
     # Flush ipv6 vlan address and restart dhc6relay process
-    py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "dhcp_relay"),
-              "dhcp_relay container not started")
+    wait_dhcp_relay_ready(duthost, ['v6'])
 
     # Get Vlan with IPv6 address configured
     dhcp_test_info = find_test_vlan(duthost)
@@ -81,15 +80,11 @@ def trigger_dhcp_relay_bind_failure(duthost, tbinfo):
         # After bind failure test, dhcp6relay would exit because fail to bind. It's critical process of dhcp_relay,
         # hence maybe in that time dhcp_relay container has crashed, we need to restart whole dhcp_relay service to
         # recover
-        duthost.shell("systemctl reset-failed dhcp_relay")
-        duthost.restart_service("dhcp_relay")
-        py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started_per_asic_or_host, "dhcp_relay"),
-                  "dhcp_relay not started.")
+        restart_dhcp_service(duthost, ['v6'])
 
 
 def send_dhcp_discover_packets(duthost, tbinfo, ptfadapter, packets_to_send=5, interval=1):
-    py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "dhcp_relay"),
-              "dhcp_relay container not started")
+    wait_dhcp_relay_ready(duthost, ['isc'])
 
     # Get Vlan with IPv4 address configured
     dhcp_test_info = find_test_vlan(duthost)
@@ -106,6 +101,7 @@ def send_dhcp_discover_packets(duthost, tbinfo, ptfadapter, packets_to_send=5, i
 
         # Restart dhcrelay process
         duthost.shell("docker exec dhcp_relay supervisorctl restart {}".format(dhcrelay_process))
+        wait_dhcp_relay_ready(duthost, ['isc'])
 
         # Send packets
 


### PR DESCRIPTION
### Description of PR

Summary:
Use the shared DHCP relay readiness and recovery helpers for telemetry event preconditions and bind-failure recovery while retaining the individual relay restarts that induce telemetry failures.

ADO Task: [39301057](https://msazure.visualstudio.com/One/_workitems/edit/39301057)
Parent PBI: [38699914](https://msazure.visualstudio.com/One/_workitems/edit/38699914)

Affected test: 1 pytest entry point,
`tests/telemetry/test_events.py::test_events`, executing the 3 changed DHCP
relay event readiness/recovery paths in
`tests/telemetry/events/dhcp-relay_events.py`.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39301057
Failure type: other

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master, `SONiC.internal.173569967-e2b6c23f55` on `testbed-bjw2-can-7215a1-4`: the DHCP relay telemetry event selection passed (1 passed).
- 202605, `SONiC.20260510.07` (`1df5b92630`) on `testbed-bjw2-can-7215a1-4`: the same telemetry event selection passed (1 passed).

Both runs used the exact combined PR stacks. On master, a testbed certificate contaminated by device-ops-agent lacked the expected `ndastreamingservertest` name; a temporary correctly named certificate proved the test pass, and the original certificate was restored.
### Approach
#### What is the motivation for this PR?

Telemetry triggers need to wait for the specific IPv4 or IPv6 relay layout that they exercise and recovery must confirm the IPv6 relay is ready.

#### How did you do it?

Use `wait_dhcp_relay_ready()` for IPv4/IPv6 preconditions, `restart_dhcp_service(..., ['v6'])` after bind failure, and an ISC readiness wait after the restored IPv4 process restart.

#### How did you verify/test it?

Ran targeted pre-commit checks and targeted CI-equivalent pytest collection.

#### Any platform specific information?

Applies to supported non-MX DHCP-relay telemetry topologies.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

Not applicable.
