### PR TITLE
test: wait for internal relay in autorestart setup

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -119,6 +119,11 @@ def single_container_timeout(container_name, timeout_secs=SINGLE_CONTAINER_TEST_
 
 @pytest.fixture(autouse=True, scope='module')
 def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tbinfo):
+    if tbinfo["topo"]["type"] == "mx":
+        pytest_require(
+            hasattr(dhcp_relay_utils, "get_dhcp_relay_type"),
+            "P6 requires #26525 to provide dhcp_relay_utils.get_dhcp_relay_type; merge #26525 first."
+        )
     dhcp_server_hosts = []
     # Enable autorestart for all features before the test begins
     for hostname in selected_rand_one_per_hwsku_hostname:

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -16,6 +16,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common import config_reload
 from tests.common.helpers.dut_utils import get_disabled_container_list
+from tests.common.dhcp_relay_utils import restart_dhcp_service
 
 logger = logging.getLogger(__name__)
 
@@ -133,15 +134,7 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tb
             dhcp_server_hosts.append(hostname)
             duthost.shell("config feature state %s enabled" % DHCP_SERVER)
             duthost.shell("sudo config feature autorestart %s enabled" % DHCP_SERVER)
-            duthost.shell("sudo systemctl restart %s.service" % DHCP_RELAY)
-            pytest_require(
-                wait_until(120, 1, 1,
-                           is_supervisor_program_running,
-                           duthost,
-                           DHCP_RELAY,
-                           "dhcp-relay:dhcprelayd"),
-                "dhcp-relay:dhcprelayd is not running"
-            )
+            restart_dhcp_service(duthost, ['isc-internal'])
     yield
     # Config reload should set the auto restart back to state before test started
     for hostname in selected_rand_one_per_hwsku_hostname:
@@ -149,10 +142,6 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tb
         config_reload(duthost, config_source='config_db', safe_reload=True, wait_for_bgp=True)
         if hostname in dhcp_server_hosts:
             duthost.shell("docker rm %s" % DHCP_SERVER, module_ignore_errors=True)
-
-
-def is_supervisor_program_running(duthost, container_name, program_name):
-    return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {program_name}")["stdout"]
 
 
 def enable_autorestart(duthost):

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -15,8 +15,8 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common import config_reload
+from tests.common import dhcp_relay_utils
 from tests.common.helpers.dut_utils import get_disabled_container_list
-from tests.common.dhcp_relay_utils import restart_dhcp_service
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +134,8 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tb
             dhcp_server_hosts.append(hostname)
             duthost.shell("config feature state %s enabled" % DHCP_SERVER)
             duthost.shell("sudo config feature autorestart %s enabled" % DHCP_SERVER)
-            restart_dhcp_service(duthost, ['isc-internal'])
+            relay_type = dhcp_relay_utils.get_dhcp_relay_type(duthost)
+            dhcp_relay_utils.restart_dhcp_service(duthost, [relay_type])
     yield
     # Config reload should set the auto restart back to state before test started
     for hostname in selected_rand_one_per_hwsku_hostname:

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -120,7 +120,7 @@ def single_container_timeout(container_name, timeout_secs=SINGLE_CONTAINER_TEST_
 @pytest.fixture(autouse=True, scope='module')
 def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tbinfo):
     if tbinfo["topo"]["type"] == "mx":
-        pytest_require(
+        pytest_assert(
             hasattr(dhcp_relay_utils, "get_dhcp_relay_type"),
             "P6 requires #26525 to provide dhcp_relay_utils.get_dhcp_relay_type; merge #26525 first."
         )

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -53,6 +53,15 @@ SINGLE_CONTAINER_TEST_TIMEOUT_SECS = 2400
 RECOVERY_RELOAD_TIMEOUT_SECS = 600
 
 
+def get_internal_idle_relay_type(duthost):
+    """Return the explicit internal idle mode selected by the SONiC relay flag."""
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
+    device_metadata = config_facts["DEVICE_METADATA"]["localhost"]
+    if device_metadata.get("has_sonic_dhcpv4_relay", "False") == "True":
+        return "sonic-internal"
+    return "isc-internal-idle"
+
+
 class ContainerAutorestartTimeout(BaseException):
     """Raised when a single container's autorestart sub-test exceeds its watchdog budget.
 
@@ -119,11 +128,6 @@ def single_container_timeout(container_name, timeout_secs=SINGLE_CONTAINER_TEST_
 
 @pytest.fixture(autouse=True, scope='module')
 def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tbinfo):
-    if tbinfo["topo"]["type"] == "mx":
-        pytest_assert(
-            hasattr(dhcp_relay_utils, "get_dhcp_relay_type"),
-            "P6 requires #26525 to provide dhcp_relay_utils.get_dhcp_relay_type; merge #26525 first."
-        )
     dhcp_server_hosts = []
     # Enable autorestart for all features before the test begins
     for hostname in selected_rand_one_per_hwsku_hostname:
@@ -139,8 +143,7 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tb
             dhcp_server_hosts.append(hostname)
             duthost.shell("config feature state %s enabled" % DHCP_SERVER)
             duthost.shell("sudo config feature autorestart %s enabled" % DHCP_SERVER)
-            relay_type = dhcp_relay_utils.get_dhcp_relay_type(duthost)
-            dhcp_relay_utils.restart_dhcp_service(duthost, [relay_type])
+            dhcp_relay_utils.restart_dhcp_service(duthost, [get_internal_idle_relay_type(duthost)])
     yield
     # Config reload should set the auto restart back to state before test started
     for hostname in selected_rand_one_per_hwsku_hostname:

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -58,7 +58,7 @@ def get_internal_idle_relay_type(duthost):
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
     device_metadata = config_facts["DEVICE_METADATA"]["localhost"]
     if device_metadata.get("has_sonic_dhcpv4_relay", "False") == "True":
-        return "sonic-internal"
+        return "sonic"
     return "isc-internal-idle"
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Replace the MX DHCP-server autorestart fixture's service restart and dhcprelayd-only probe with the shared restart/readiness helper and a locally selected internal idle mode.

Depends on https://github.com/sonic-net/sonic-mgmt/pull/26525; merge that PR first. Standalone merge is prohibited.

Hardware rationale: On MX hardware, internal ISC starts a relay only after a
`DHCP_SERVER_IPV4` interface is enabled, so P1 selects `isc-internal-idle`
before configuration. SONiC keeps its supervisor-owned relay process running
and uses the shared `sonic` readiness layout before and after local
configuration.
Physical MX validation is deferred to the combined P1+P6 stack.

Affected test: 1 exact MX node,
`tests/autorestart/test_container_autorestart.py::test_containers_autorestart[...-dhcp_server]`.

ADO Task: [39301055](https://msazure.visualstudio.com/One/_workitems/edit/39301055)
Parent PBI: [38699914](https://msazure.visualstudio.com/One/_workitems/edit/38699914)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39301055
Failure type: other

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- `git diff --check`, Python compilation, targeted pre-commit checks, and an
  explicit-mode AST probe passed on head `4be210cd1`.
- Prior hardware evidence applies to the previous #26525 dependency head. Exact-stack revalidation is pending.
### Approach
#### What is the motivation for this PR?

MX DHCP-server setup must wait for the internal idle mode selected by the existing SONiC DHCPv4 relay flag.

#### How did you do it?

Read `has_sonic_dhcpv4_relay` locally in the autorestart test and explicitly
choose `sonic` or `isc-internal-idle`, then pass that mode to
`restart_dhcp_service()`.

#### How did you verify/test it?

Prior targeted checks passed; exact-stack revalidation is pending.

#### Any platform specific information?

The changed fixture path applies to MX DHCP-server setup.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

Not applicable.
