### PR TITLE
[dhcp_relay]: Use shared IPv6 readiness for interface binding

### DIFF
--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -231,13 +231,6 @@ def check_interface_status(duthost):
     return False
 
 
-def restart_dhcp_relay_and_check_dhcp6relay(duthost):
-    duthost.shell("sudo systemctl reset-failed dhcp_relay")
-    duthost.shell("sudo systemctl restart dhcp_relay")
-    wait_until(60, 3, 0, lambda: ("RUNNING" in duthost.shell("docker exec dhcp_relay supervisorctl status " +
-                                                             "dhcp-relay:dhcp6relay | awk '{print $2}'")["stdout"]))
-
-
 def ensure_client_reachability(duthost, vlan_name):
     """
     Ensure the DHCP client's link-local address is reachable from the relay agent.
@@ -259,13 +252,13 @@ def setup_and_teardown_no_servers_vlan(duthosts, rand_one_dut_hostname):
     new_vlan_ipv6 = "fc01:5000::1/64"
     duthost.shell("sudo config vlan add {}".format(new_vlan_id))
     duthost.shell("sudo config interface ip add Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
-    restart_dhcp_relay_and_check_dhcp6relay(duthost)
+    restart_dhcp_service(duthost, ['v6'])
 
     yield new_vlan_id
 
     duthost.shell("sudo config interface ip remove Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
     duthost.shell("sudo config vlan del {}".format(new_vlan_id))
-    restart_dhcp_relay_and_check_dhcp6relay(duthost)
+    restart_dhcp_service(duthost, ['v6'])
 
 
 def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data, setup_and_teardown_no_servers_vlan):
@@ -506,15 +499,7 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
         # Sleep a bit to ensure uplinks are down
         time.sleep(20)
 
-        # Restart DHCP relay service on DUT
-        # dhcp_relay service has 3 times restart limit in 20 mins, for 4 vlans config it will hit the maximum limit
-        # reset-failed before restart service
-        cmds = ['systemctl reset-failed dhcp_relay', 'systemctl restart dhcp_relay']
-        duthost.shell_cmds(cmds=cmds)
-
-        # Sleep to give the DHCP relay container time to start up and
-        # allow the relay agent to begin listening on the down interfaces
-        time.sleep(40)
+        restart_dhcp_service(duthost, ['v6'])
 
         # Bring all uplink interfaces back up
         for iface in dhcp_relay['uplink_interfaces']:

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -250,15 +250,16 @@ def setup_and_teardown_no_servers_vlan(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     new_vlan_id = 4001
     new_vlan_ipv6 = "fc01:5000::1/64"
-    duthost.shell("sudo config vlan add {}".format(new_vlan_id))
-    duthost.shell("sudo config interface ip add Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
-    restart_dhcp_service(duthost, ['v6'])
+    try:
+        duthost.shell("sudo config vlan add {}".format(new_vlan_id))
+        duthost.shell("sudo config interface ip add Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
+        restart_dhcp_service(duthost, ['v6'])
 
-    yield new_vlan_id
-
-    duthost.shell("sudo config interface ip remove Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
-    duthost.shell("sudo config vlan del {}".format(new_vlan_id))
-    restart_dhcp_service(duthost, ['v6'])
+        yield new_vlan_id
+    finally:
+        duthost.shell("sudo config interface ip remove Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
+        duthost.shell("sudo config vlan del {}".format(new_vlan_id))
+        restart_dhcp_service(duthost, ['v6'])
 
 
 def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data, setup_and_teardown_no_servers_vlan):
@@ -492,21 +493,22 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
     testing_mode, duthost = testing_config
 
     for dhcp_relay in dut_dhcp_relay_data:
-        # Bring all uplink interfaces down
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('ifconfig {} down'.format(iface))
+        try:
+            # Bring all uplink interfaces down
+            for iface in dhcp_relay['uplink_interfaces']:
+                duthost.shell('ifconfig {} down'.format(iface))
 
-        # Sleep a bit to ensure uplinks are down
-        time.sleep(20)
+            # Sleep a bit to ensure uplinks are down
+            time.sleep(20)
 
-        restart_dhcp_service(duthost, ['v6'])
+            restart_dhcp_service(duthost, ['v6'])
+        finally:
+            # Restore all uplinks even if restarting the relay fails.
+            for iface in dhcp_relay['uplink_interfaces']:
+                duthost.shell('ifconfig {} up'.format(iface))
 
-        # Bring all uplink interfaces back up
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('ifconfig {} up'.format(iface))
-
-        # Sleep a bit to ensure uplinks are up
-        wait_all_bgp_up(duthost)
+            # Wait for the restored uplinks to be usable before continuing.
+            wait_all_bgp_up(duthost)
 
         # Run the DHCP relay test on the PTF host
         ptf_runner(ptfhost,

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -1,9 +1,12 @@
 import ipaddress
 import pytest
 import random
+import sys
 import time
 import netaddr
 import logging
+
+from _pytest.outcomes import OutcomeException
 
 from tests.common.dhcp_relay_utils import restart_dhcp_service, wait_dhcp_relay_ready
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
@@ -250,16 +253,45 @@ def setup_and_teardown_no_servers_vlan(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     new_vlan_id = 4001
     new_vlan_ipv6 = "fc01:5000::1/64"
+    vlan_created = False
+    vlan_ipv6_assigned = False
+
+    def restore_no_servers_vlan():
+        first_cleanup_error = None
+
+        def cleanup_step(step_name, callback):
+            nonlocal first_cleanup_error
+            try:
+                callback()
+            except (Exception, OutcomeException) as cleanup_error:
+                logger.exception("DHCPv6 no-server VLAN cleanup step '%s' failed", step_name)
+                if first_cleanup_error is None:
+                    first_cleanup_error = cleanup_error
+
+        if vlan_ipv6_assigned:
+            cleanup_step('remove Vlan{} IPv6 address'.format(new_vlan_id),
+                         lambda: duthost.shell(
+                             "sudo config interface ip remove Vlan{} {}".format(new_vlan_id, new_vlan_ipv6)))
+        if vlan_created:
+            cleanup_step('delete Vlan{}'.format(new_vlan_id),
+                         lambda: duthost.shell("sudo config vlan del {}".format(new_vlan_id)))
+        cleanup_step('restore DHCPv6 relay readiness',
+                     lambda: restart_dhcp_service(duthost, ['v6']))
+        return first_cleanup_error
+
     try:
         duthost.shell("sudo config vlan add {}".format(new_vlan_id))
+        vlan_created = True
         duthost.shell("sudo config interface ip add Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
+        vlan_ipv6_assigned = True
         restart_dhcp_service(duthost, ['v6'])
 
         yield new_vlan_id
     finally:
-        duthost.shell("sudo config interface ip remove Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
-        duthost.shell("sudo config vlan del {}".format(new_vlan_id))
-        restart_dhcp_service(duthost, ['v6'])
+        original_error = sys.exc_info()[1]
+        cleanup_error = restore_no_servers_vlan()
+        if cleanup_error is not None and original_error is None:
+            raise cleanup_error
 
 
 def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data, setup_and_teardown_no_servers_vlan):
@@ -493,9 +525,29 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
     testing_mode, duthost = testing_config
 
     for dhcp_relay in dut_dhcp_relay_data:
+        uplink_interfaces = dhcp_relay['uplink_interfaces']
+
+        def restore_uplinks():
+            first_cleanup_error = None
+
+            def cleanup_step(step_name, callback):
+                nonlocal first_cleanup_error
+                try:
+                    callback()
+                except (Exception, OutcomeException) as cleanup_error:
+                    logger.exception("DHCPv6 relay uplink cleanup step '%s' failed", step_name)
+                    if first_cleanup_error is None:
+                        first_cleanup_error = cleanup_error
+
+            for iface in uplink_interfaces:
+                cleanup_step('start {}'.format(iface),
+                             lambda iface=iface: duthost.shell('ifconfig {} up'.format(iface)))
+            cleanup_step('wait for BGP recovery', lambda: wait_all_bgp_up(duthost))
+            return first_cleanup_error
+
         try:
             # Bring all uplink interfaces down
-            for iface in dhcp_relay['uplink_interfaces']:
+            for iface in uplink_interfaces:
                 duthost.shell('ifconfig {} down'.format(iface))
 
             # Sleep a bit to ensure uplinks are down
@@ -503,12 +555,10 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
 
             restart_dhcp_service(duthost, ['v6'])
         finally:
-            # Restore all uplinks even if restarting the relay fails.
-            for iface in dhcp_relay['uplink_interfaces']:
-                duthost.shell('ifconfig {} up'.format(iface))
-
-            # Wait for the restored uplinks to be usable before continuing.
-            wait_all_bgp_up(duthost)
+            original_error = sys.exc_info()[1]
+            cleanup_error = restore_uplinks()
+            if cleanup_error is not None and original_error is None:
+                raise cleanup_error
 
         # Run the DHCP relay test on the PTF host
         ptf_runner(ptfhost,

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -246,13 +246,6 @@ def check_interface_status(duthost):
     return False
 
 
-def restart_dhcp_relay_and_check_dhcp6relay(duthost):
-    duthost.shell("sudo systemctl reset-failed dhcp_relay")
-    duthost.shell("sudo systemctl restart dhcp_relay")
-    wait_until(60, 3, 0, lambda: ("RUNNING" in duthost.shell("docker exec dhcp_relay supervisorctl status " +
-                                                             "dhcp-relay:dhcp6relay | awk '{print $2}'")["stdout"]))
-
-
 def ensure_client_reachability(duthost, vlan_name):
     """
     Ensure the DHCP client's link-local address is reachable from the relay agent.
@@ -272,15 +265,24 @@ def setup_and_teardown_no_servers_vlan(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     new_vlan_id = 4001
     new_vlan_ipv6 = "fc01:5000::1/64"
-    duthost.shell("sudo config vlan add {}".format(new_vlan_id))
-    duthost.shell("sudo config interface ip add Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
-    restart_dhcp_relay_and_check_dhcp6relay(duthost)
+    vlan_created = False
+    vlan_ipv6_assigned = False
 
-    yield new_vlan_id
+    try:
+        duthost.shell("sudo config vlan add {}".format(new_vlan_id))
+        vlan_created = True
+        duthost.shell("sudo config interface ip add Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
+        vlan_ipv6_assigned = True
+        restart_dhcp_service(duthost, ['v6'])
 
-    duthost.shell("sudo config interface ip remove Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
-    duthost.shell("sudo config vlan del {}".format(new_vlan_id))
-    restart_dhcp_relay_and_check_dhcp6relay(duthost)
+        yield new_vlan_id
+    finally:
+        if vlan_ipv6_assigned:
+            duthost.shell("sudo config interface ip remove Vlan{} {}".format(new_vlan_id, new_vlan_ipv6),
+                          module_ignore_errors=True)
+        if vlan_created:
+            duthost.shell("sudo config vlan del {}".format(new_vlan_id), module_ignore_errors=True)
+            restart_dhcp_service(duthost, ['v6'])
 
 
 def get_dhcptest_expected_counters(dhcp_server_num):


### PR DESCRIPTION
### Description of PR

Summary:
Use shared DHCPv6 restart/readiness for the temporary no-server VLAN used by `test_interface_binding`, and guarantee partial fixture state is cleaned up when setup or the test fails.

ADO Task: https://msazure.visualstudio.com/One/_workitems/edit/39300952
Parent PBI: https://msazure.visualstudio.com/One/_workitems/edit/38699914

Affected test:
`tests/dhcp_relay/test_dhcpv6_relay.py::test_interface_binding`.

This PR is independent of the separate DHCPv6 uplinks-down readiness PR. Both
merge orders were applied locally and produced the same tree without conflicts.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39300952
Failure type: other

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master, `SONiC.internal.173569967-e2b6c23f55` on
  `testbed-bjw2-can-7215a1-4`: the interface-binding case passed as part of the
  previously validated combined DHCPv6 selection (2 passed).
- 202605, `SONiC.20260510.07` (`1df5b92630`) on
  `testbed-bjw2-can-7215a1-4`: the same interface-binding case passed as part of
  the combined DHCPv6 selection (2 passed).

The current head `e5984c896718d7ff3c853f8bac60551872488c5b` passed diff check, Python compilation, and targeted pre-commit checks. Existing master/202605 successful-path hardware evidence is reused because the added cleanup affects failure paths.

### Approach
#### What is the motivation for this PR?

The fixture used a local reset/restart wrapper whose readiness timeout was not
asserted.

#### How did you do it?

Replace both local-wrapper calls with `restart_dhcp_service(duthost, ['v6'])`. Track whether the temporary VLAN and IPv6 address were created, remove only created state from `finally`, and use `module_ignore_errors=True` so both applicable removal commands are attempted. The final shared restart/readiness check remains raising.

#### How did you verify/test it?

Reused the branch-specific successful-path hardware evidence above and ran exact-head diff, Python compilation, targeted pre-commit, composition, and merge-order checks.

#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

N/A; existing t0/m0 coverage.

### Documentation

No documentation change is required.

