### PR TITLE
[generic_config_updater]: Wait for DHCP relay readiness

### DIFF
--- a/tests/generic_config_updater/test_dhcp_relay.py
+++ b/tests/generic_config_updater/test_dhcp_relay.py
@@ -2,14 +2,13 @@ import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until
 from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_orig, \
     utils_vlan_intfs_dict_add, utils_create_test_vlans      # noqa: F401
 from tests.common.gu_utils import apply_patch, expect_op_success, expect_res_success, expect_op_failure
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import format_json_patch_for_multiasic
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload, rollback
-from tests.common.dhcp_relay_utils import restart_dhcp_service
+from tests.common.dhcp_relay_utils import restart_dhcp_service, wait_dhcp_relay_ready
 
 
 pytestmark = [
@@ -18,8 +17,6 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
-DHCP_RELAY_TIMEOUT = 120
-DHCP_RELAY_INTERVAL = 10
 SETUP_ENV_CP = "test_setup_checkpoint"
 CONFIG_ADD_DEFAULT = "config_add_default"
 
@@ -50,15 +47,6 @@ def first_avai_vlan_port(rand_selected_dut, tbinfo):
 
     logger.error("No vlan port member ready for test")
     pytest_assert(False, "No vlan port member ready for test")
-
-
-def ensure_dhcp_relay_running(duthost):
-    if not duthost.is_service_fully_started('dhcp_relay'):
-        duthost.shell('sudo systemctl start dhcp_relay')
-        pytest_assert(
-            duthost.is_service_fully_started('dhcp_relay'),
-            "dhcp_relay service is not running before test dhcp servers"
-        )
 
 
 def create_test_vlans(duthost, cfg_facts, vlan_intfs_dict, first_avai_vlan_port):
@@ -149,7 +137,6 @@ def setup_vlan(duthosts, rand_one_dut_hostname, vlan_intfs_dict, first_avai_vlan
 
     # --------------------- Setup -----------------------
     create_test_vlans(duthost, cfg_facts, vlan_intfs_dict, first_avai_vlan_port)
-    ensure_dhcp_relay_running(duthost)
 
     default_setup(duthost, vlan_intfs_list)
 
@@ -186,31 +173,6 @@ def vlan_intfs_list(vlan_intfs_dict):
     return [key for key, value in list(vlan_intfs_dict.items()) if not value['orig']]
 
 
-def ensure_dhcp_server_up(duthost):
-    """Wait till dhcp-relay server is setup
-
-    Sample output
-    admin@vlab-01:~$ docker exec dhcp_relay supervisorctl status | grep ^dhcp-relay
-    dhcp-relay:isc-dhcpv4-relay-Vlan100    RUNNING   pid 72, uptime 0:00:09
-    dhcp-relay:isc-dhcpv4-relay-Vlan1000   RUNNING   pid 73, uptime 0:00:09
-
-    """
-    def _dhcp_server_up():
-        cmds = 'docker exec dhcp_relay supervisorctl status | grep ^dhcp-relay'
-        output = duthost.shell(cmds)
-        pytest_assert(
-            not output['rc'],
-            "'{}' is not running successfully".format(cmds)
-        )
-
-        return 'RUNNING' in output['stdout']
-
-    pytest_assert(
-        wait_until(DHCP_RELAY_TIMEOUT, DHCP_RELAY_INTERVAL, 0, _dhcp_server_up),
-        "The dhcp relay server is not running"
-    )
-
-
 def dhcp_severs_by_vlanid(duthost, vlanid):
     """Get pid and then only output the related dhcp server info for that pid
 
@@ -244,7 +206,7 @@ def dhcp_severs_by_vlanid(duthost, vlanid):
 
 
 def expect_res_success_by_vlanid(duthost, vlanid, expected_content_list, unexpected_content_list):
-    ensure_dhcp_server_up(duthost)
+    wait_dhcp_relay_ready(duthost, ['isc'])
     output = dhcp_severs_by_vlanid(duthost, vlanid)
     expect_res_success(duthost, output, expected_content_list, unexpected_content_list)
 
@@ -329,10 +291,7 @@ def test_dhcp_relay_tc3_add_and_rm(rand_selected_dut, vlan_intfs_list):
     try:
         output = apply_patch(rand_selected_dut, json_data=dhcp_add_rm_json, dest_file=tmpfile)
         expect_op_success(rand_selected_dut, output)
-        pytest_assert(
-            rand_selected_dut.is_service_fully_started('dhcp_relay'),
-            "dhcp_relay service is not running"
-        )
+        wait_dhcp_relay_ready(rand_selected_dut, ['isc'])
 
         expected_content_list = ["192.0." + str(vlan_intfs_list[0]) + ".5"]
         unexpected_content_list = ["192.0." + str(vlan_intfs_list[1]) + ".4"]
@@ -374,10 +333,7 @@ def test_dhcp_relay_tc4_replace(rand_selected_dut, vlan_intfs_list):
     try:
         output = apply_patch(rand_selected_dut, json_data=dhcp_replace_json, dest_file=tmpfile)
         expect_op_success(rand_selected_dut, output)
-        pytest_assert(
-            rand_selected_dut.is_service_fully_started('dhcp_relay'),
-            "dhcp_relay service is not running"
-        )
+        wait_dhcp_relay_ready(rand_selected_dut, ['isc'])
 
         expected_content_list = ["192.0." + str(vlan_intfs_list[0]) + ".8"]
         unexpected_content_list = ["192.0." + str(vlan_intfs_list[0]) + ".1"]

--- a/tests/generic_config_updater/test_dhcp_relay.py
+++ b/tests/generic_config_updater/test_dhcp_relay.py
@@ -206,7 +206,6 @@ def dhcp_severs_by_vlanid(duthost, vlanid):
 
 
 def expect_res_success_by_vlanid(duthost, vlanid, expected_content_list, unexpected_content_list):
-    wait_dhcp_relay_ready(duthost, ['isc'])
     output = dhcp_severs_by_vlanid(duthost, vlanid)
     expect_res_success(duthost, output, expected_content_list, unexpected_content_list)
 


### PR DESCRIPTION
### Description of PR

Summary:
Use the shared DHCP relay readiness helper for the DHCP relay generic-config-updater tests, replacing redundant service starts and partial process checks.

ADO Task: https://msazure.visualstudio.com/One/_workitems/edit/39301053
Parent PBI: https://msazure.visualstudio.com/One/_workitems/edit/38699914

Affected tests: all 4 test functions in
`tests/generic_config_updater/test_dhcp_relay.py`.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39301053
Failure type: other

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master, `SONiC.internal.173569967-e2b6c23f55` on `testbed-bjw2-can-7215a1-4`: the full DHCP relay GCU module passed (4 passed).
- 202605, `SONiC.20260510.07` (`1df5b92630`) on `testbed-bjw2-can-7215a1-4`: the full DHCP relay GCU module passed (4 passed).

Both runs used the exact combined PR stacks.
### Approach
#### What is the motivation for this PR?
Ensure generic-config-updater changes wait for the complete external ISC relay layout, rather than only systemd or a partial supervisord signal.

#### How did you do it?
Remove the redundant relay starter and local readiness poll; use `wait_dhcp_relay_ready(duthost, ['isc'])` before process-command assertions and after successful GCU patches.

#### How did you verify/test it?
Ran the targeted syntax, pre-commit, and collection checks recorded above.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
N/A; existing t0/m0 coverage.

### Documentation
No documentation change is required for this test refactor.
