### PR TITLE
[202511][PR22412] Backport

### DIFF
--- a/tests/gnmi/test_gnmi_2038.py
+++ b/tests/gnmi/test_gnmi_2038.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('any'),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.usefixtures("setup_gnmi_ntp_client_server", "setup_gnmi_server",
+                            "setup_gnmi_rotated_server", "check_dut_timestamp")
 ]
 
 ROOT_CERT_DAYS = 4850


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This is a partial backport of
https://github.com/sonic-net/sonic-mgmt/pull/22412 into 202511, including just the changes to the file test_gnmi_2038.py. All other changes from that PR have already been backported in https://github.com/sonic-net/sonic-mgmt/pull/24392.

We're cherry-picking this change because without in the test breaks in mgmtIpv6Only setups.

Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
- 202511: `sudo ./run_tests.sh -n ardut -x -m individual -r -e "--collect_techsupport=False --deep_clean --pdb" -u -t any,m0,m0 -c gnmi/test_gnmi_2038.py | "All tests passed"`

### Approach
#### What is the motivation for this PR?
In mgmtIpv6Only setups, this test fails because it can't connect to the NTP server when checking if it's synced. This turns out to be because the tests didn't run the `setup_gnmi_ntp_client_server` fixture. This fixture has code that detects when the mgmt IP is IPv6 and adjusts the NTP server connection accordingly. Without running the fixture, the NTP server is unreachable.

#### How did you do it?
I cherry-picked this change https://github.com/sonic-net/sonic-mgmt/pull/22412/changes#diff-275d3a5b952e4a35e207097d8799fedf0306f7c8aad2811433fd64d10d6cb110 from https://github.com/sonic-net/sonic-mgmt/pull/22412/, which adds that fixture, as well as the other gnmi setup fixtures, to the test's `pytestmark` section.


#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
I ran the test in a sonicmgmt.pkz.m0 cluster, sanitized with `mgmtIpv6Only:True`, and confirmed that with this change the test passes, and that it fails without the change.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/a

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
