### PR TITLE
[lldp] Fix test_lldp_syncd flakiness from transient mgmt-port neighbor and fanout duplicate neighbors

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -161,15 +161,21 @@ def get_lldpctl_output(duthost):
     return resultDict
 
 
+def exclude_mgmt_interfaces(interfaces):
+    # LLDP_ENTRY_TABLE does not track the management interface (e.g. eth0), but
+    # `show lldp table` and lldpctl list it whenever the mgmt network has an
+    # LLDP-speaking neighbor. That neighbor ages in and out independently in each
+    # source, so leaving it in makes the membership comparison flap. Drop the
+    # management interface(s) rather than assuming every front-panel port is
+    # named "Ethernet*".
+    return [name for name in interfaces if not name.startswith("eth")]
+
+
 # Helper function to get show lldp table output
 def get_show_lldp_table_output(duthost):
     lines = duthost.shell("show lldp table")["stdout"].split("\n")[3:-2]
     interface_list = [line.split()[0] for line in lines]
-    # LLDP_ENTRY_TABLE only tracks front-panel Ethernet ports. `show lldp table`
-    # also lists the management interface (e.g. eth0) whenever the mgmt network
-    # has an LLDP-speaking neighbor, which would otherwise make the comparison
-    # against LLDP_ENTRY_TABLE flap, so drop non-front-panel interfaces here.
-    interface_list = [name for name in interface_list if name.startswith("Ethernet")]
+    interface_list = exclude_mgmt_interfaces(interface_list)
     # Deduplicate: in dualtor / physical fanout topologies, an uplink port may
     # have multiple LLDP neighbors (T1 switch + fanout), causing duplicate
     # interface entries.
@@ -188,7 +194,7 @@ def check_lldp_table_keys(duthost, db_instance):
     # Check if LLDP_ENTRY_TABLE keys match show lldp table output
     lldp_entry_keys = get_lldp_entry_keys(db_instance)
     show_lldp_table_int_list = get_show_lldp_table_output(duthost)
-    db_front_panel = {name for name in lldp_entry_keys if name.startswith("Ethernet")}
+    db_front_panel = set(exclude_mgmt_interfaces(lldp_entry_keys))
     return db_front_panel == set(show_lldp_table_int_list)
 
 
@@ -258,14 +264,13 @@ def assert_lldp_interfaces(
     """
     Assert that LLDP_ENTRY_TABLE keys match show lldp table output and lldpctl output
     """
-    # LLDP_ENTRY_TABLE only tracks front-panel Ethernet ports. The management
-    # interface (e.g. eth0) can show up in both `show lldp table` and lldpctl
-    # whenever the mgmt network has an LLDP-speaking neighbor, and it is not
-    # written to LLDP_ENTRY_TABLE by design. Scope every comparison to the set
-    # of front-panel Ethernet ports so a transient mgmt-port neighbor does not
-    # make the test flap.
-    db_set = {name for name in lldp_entry_keys if name.startswith("Ethernet")}
-    cli_set = {name for name in show_lldp_table_int_list if name.startswith("Ethernet")}
+    # The management interface (e.g. eth0) can show up in both `show lldp table`
+    # and lldpctl whenever the mgmt network has an LLDP-speaking neighbor, but it
+    # is not written to LLDP_ENTRY_TABLE by design. Drop the management interface
+    # from every source so a transient mgmt-port neighbor does not make the test
+    # flap.
+    db_set = set(exclude_mgmt_interfaces(lldp_entry_keys))
+    cli_set = set(exclude_mgmt_interfaces(show_lldp_table_int_list))
     pytest_assert(
         db_set == cli_set,
         "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output. "
@@ -291,12 +296,10 @@ def assert_lldp_interfaces(
     # physical fanout testbeds, lists a front-panel port once per neighbor it
     # sees (the emulated topology peer AND the physical fanout switch), so the
     # same interface name can appear multiple times. LLDP_ENTRY_TABLE is keyed
-    # per front-panel interface (one entry per port), so compare the set of
-    # front-panel Ethernet ports rather than the raw, possibly-duplicated list.
-    lldpctl_front_panel_ports = {
-        name for name in lldpctl_interfaces if name.startswith("Ethernet")
-    }
-    db_port_set = {name for name in lldp_entry_keys if name.startswith("Ethernet")}
+    # per front-panel interface (one entry per port), so drop the management
+    # interface and compare sets rather than the raw, possibly-duplicated list.
+    lldpctl_front_panel_ports = set(exclude_mgmt_interfaces(lldpctl_interfaces))
+    db_port_set = set(exclude_mgmt_interfaces(lldp_entry_keys))
     pytest_assert(
         db_port_set == lldpctl_front_panel_ports,
         "LLDP_ENTRY_TABLE keys do not match lldpctl interface indexes. "

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -162,12 +162,11 @@ def get_lldpctl_output(duthost):
 
 
 def exclude_mgmt_interfaces(interfaces):
-    # LLDP_ENTRY_TABLE does not track the management interface (e.g. eth0), but
-    # `show lldp table` and lldpctl list it whenever the mgmt network has an
-    # LLDP-speaking neighbor. That neighbor ages in and out independently in each
-    # source, so leaving it in makes the membership comparison flap. Drop the
-    # management interface(s) rather than assuming every front-panel port is
-    # named "Ethernet*".
+    # The management interface (e.g. eth0) can pick up a transient LLDP neighbor
+    # on the mgmt network that ages in and out independently in LLDP_ENTRY_TABLE,
+    # `show lldp table`, and lldpctl. Leaving it in makes the cross-source
+    # membership comparison flap, so drop the management interface(s) rather than
+    # assuming every front-panel port is named "Ethernet*".
     return [name for name in interfaces if not name.startswith("eth")]
 
 
@@ -438,11 +437,13 @@ def verify_each_interface_lldp_content(db_instance, interface, lldpctl_interface
             if list(iface.keys())[0].lower() == interface.lower()
         ]
         for candidate in matching_ifaces:
+            if not isinstance(candidate, dict):
+                continue
             if db_sys_name is not None and db_sys_name in candidate.get("chassis", {}):
                 lldpctl_interface = candidate
                 break
-        if lldpctl_interface is None and matching_ifaces:
-            lldpctl_interface = matching_ifaces[0]
+        if lldpctl_interface is None:
+            lldpctl_interface = next((c for c in matching_ifaces if isinstance(c, dict)), None)
     assert_lldp_entry_content(interface, entry_content, lldpctl_interface)
 
 

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -165,8 +165,14 @@ def get_lldpctl_output(duthost):
 def get_show_lldp_table_output(duthost):
     lines = duthost.shell("show lldp table")["stdout"].split("\n")[3:-2]
     interface_list = [line.split()[0] for line in lines]
-    # Deduplicate: in dualtor topology, uplink ports may have multiple
-    # LLDP neighbors (T1 switch + fanout), causing duplicate interface entries
+    # LLDP_ENTRY_TABLE only tracks front-panel Ethernet ports. `show lldp table`
+    # also lists the management interface (e.g. eth0) whenever the mgmt network
+    # has an LLDP-speaking neighbor, which would otherwise make the comparison
+    # against LLDP_ENTRY_TABLE flap, so drop non-front-panel interfaces here.
+    interface_list = [name for name in interface_list if name.startswith("Ethernet")]
+    # Deduplicate: in dualtor / physical fanout topologies, an uplink port may
+    # have multiple LLDP neighbors (T1 switch + fanout), causing duplicate
+    # interface entries.
     return list(dict.fromkeys(interface_list))
 
 
@@ -182,7 +188,8 @@ def check_lldp_table_keys(duthost, db_instance):
     # Check if LLDP_ENTRY_TABLE keys match show lldp table output
     lldp_entry_keys = get_lldp_entry_keys(db_instance)
     show_lldp_table_int_list = get_show_lldp_table_output(duthost)
-    return set(lldp_entry_keys) == set(show_lldp_table_int_list)
+    db_front_panel = {name for name in lldp_entry_keys if name.startswith("Ethernet")}
+    return db_front_panel == set(show_lldp_table_int_list)
 
 
 def _shutdown_startup_interface(duthost, interface, asic_str=""):
@@ -251,8 +258,14 @@ def assert_lldp_interfaces(
     """
     Assert that LLDP_ENTRY_TABLE keys match show lldp table output and lldpctl output
     """
-    db_set = set(lldp_entry_keys)
-    cli_set = set(show_lldp_table_int_list)
+    # LLDP_ENTRY_TABLE only tracks front-panel Ethernet ports. The management
+    # interface (e.g. eth0) can show up in both `show lldp table` and lldpctl
+    # whenever the mgmt network has an LLDP-speaking neighbor, and it is not
+    # written to LLDP_ENTRY_TABLE by design. Scope every comparison to the set
+    # of front-panel Ethernet ports so a transient mgmt-port neighbor does not
+    # make the test flap.
+    db_set = {name for name in lldp_entry_keys if name.startswith("Ethernet")}
+    cli_set = {name for name in show_lldp_table_int_list if name.startswith("Ethernet")}
     pytest_assert(
         db_set == cli_set,
         "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output. "
@@ -274,9 +287,23 @@ def assert_lldp_interfaces(
             "Unexpected type for lldpctl interfaces: {}".format(type(lldpctl_interface))
         )
 
+    # lldpctl reports LLDP on the management interface (e.g. eth0) and, on
+    # physical fanout testbeds, lists a front-panel port once per neighbor it
+    # sees (the emulated topology peer AND the physical fanout switch), so the
+    # same interface name can appear multiple times. LLDP_ENTRY_TABLE is keyed
+    # per front-panel interface (one entry per port), so compare the set of
+    # front-panel Ethernet ports rather than the raw, possibly-duplicated list.
+    lldpctl_front_panel_ports = {
+        name for name in lldpctl_interfaces if name.startswith("Ethernet")
+    }
+    db_port_set = {name for name in lldp_entry_keys if name.startswith("Ethernet")}
     pytest_assert(
-        sorted(lldp_entry_keys) == sorted(lldpctl_interfaces),
-        "LLDP_ENTRY_TABLE keys do not match lldpctl interface indexes",
+        db_port_set == lldpctl_front_panel_ports,
+        "LLDP_ENTRY_TABLE keys do not match lldpctl interface indexes. "
+        "In DB but not in lldpctl: {}. In lldpctl but not in DB: {}".format(
+            db_port_set - lldpctl_front_panel_ports,
+            lldpctl_front_panel_ports - db_port_set,
+        ),
     )
 
 
@@ -391,14 +418,28 @@ def verify_each_interface_lldp_content(db_instance, interface, lldpctl_interface
     wait_until(30, 1, 0, get_lldp_entry_content_with_retry)
 
     logger.debug("Interface {}, entry_content:{}".format(interface, entry_content))
+    # On physical fanout testbeds lldpctl can report more than one neighbor for
+    # the same front-panel port (the emulated topology peer AND the physical
+    # fanout switch). LLDP_ENTRY_TABLE stores a single neighbor per port, so
+    # pick the lldpctl entry whose chassis matches the neighbor system name the
+    # DB actually recorded; fall back to the first match for the single-neighbor
+    # case (or when the DB name is unavailable).
     lldpctl_interface = None
+    db_sys_name = entry_content.get("lldp_rem_sys_name") if isinstance(entry_content, dict) else None
     if isinstance(lldpctl_interfaces, dict):
         lldpctl_interface = lldpctl_interfaces.get(interface)
     elif isinstance(lldpctl_interfaces, list):
-        for iface in lldpctl_interfaces:
-            if list(iface.keys())[0].lower() == interface.lower():
-                lldpctl_interface = iface.get(list(iface.keys())[0])
+        matching_ifaces = [
+            iface.get(list(iface.keys())[0])
+            for iface in lldpctl_interfaces
+            if list(iface.keys())[0].lower() == interface.lower()
+        ]
+        for candidate in matching_ifaces:
+            if db_sys_name is not None and db_sys_name in candidate.get("chassis", {}):
+                lldpctl_interface = candidate
                 break
+        if lldpctl_interface is None and matching_ifaces:
+            lldpctl_interface = matching_ifaces[0]
     assert_lldp_entry_content(interface, entry_content, lldpctl_interface)
 
 


### PR DESCRIPTION
### Description of PR

Fixes `lldp/test_lldp_syncd.py::test_lldp_entry_table_content` (and the sibling cases that rely on `check_lldp_table_keys`) flaking on high-radix lt2 / physical-fanout testbeds such as the 512-port 7060X6.

The test compares the set of interfaces tracked in `LLDP_ENTRY_TABLE` (APPL_DB) against `show lldp table` and raw `lldpctl` output. Two things break that comparison on these testbeds:

1. **Transient management-port (eth0) LLDP neighbor.** The mgmt network can have an LLDP-speaking neighbor on `eth0`. That neighbor ages in and out **independently** in each source, so at any instant `eth0` may appear in `LLDP_ENTRY_TABLE`, in `show lldp table`, and/or in `lldpctl` output but not the others. This produces a spurious, timing-dependent membership mismatch — e.g. `In CLI but not in DB: {'eth0'}` on one run and `In DB but not in CLI: {'eth0'}` on the next.
2. **Fanout duplicate neighbors.** On physical fanout testbeds a front-panel port has two real LLDP neighbors (the emulated topology peer **and** the physical fanout switch), so `show lldp table` and `lldpctl` list the same interface more than once. `LLDP_ENTRY_TABLE` is keyed once per front-panel interface, so the raw sorted-list comparison against `lldpctl` never matches.

#### Fix

- Exclude the **management interface** (drop `eth*` via a new `exclude_mgmt_interfaces()` helper, **rather than whitelisting `Ethernet*`**) from every membership comparison — both assertions in `assert_lldp_interfaces` and the `check_lldp_table_keys` poll helper — **consistently on the DB, CLI, and lldpctl sides**. Using a blacklist avoids assuming every front-panel port is named `Ethernet*`, so platforms with different front-panel naming are unaffected.
- Drop the management interface and de-duplicate in `get_show_lldp_table_output`.
- Compare **sets** instead of sorted lists for the lldpctl assertion, and surface the offending interfaces in the assertion message.
- In `verify_each_interface_lldp_content`, when lldpctl reports multiple neighbors for a port, pick the entry whose chassis matches the neighbor system name stored in `LLDP_ENTRY_TABLE` (fall back to the first match), so the per-interface content check is correct with dual neighbors.

Real membership defects (a front-panel port missing from, or unexpectedly present in, any source) are still caught. Per-interface content for `eth0` is still validated when it is present.

This **completes the fanout dual-neighbor handling started in #23193**, which fixed only the `show lldp table` comparison and left the `lldpctl` comparison as a raw sorted-list compare.

### Type of change

- [ ] Test case (new/updated)
- [x] Bug fix
- [ ] New feature
- [ ] Documentation

### Approach

Exclude the management interface (drop `eth*`, rather than whitelisting `Ethernet*`) from every LLDP interface-membership comparison and use set (not list) comparisons, so a transient mgmt-port neighbor and duplicate fanout neighbors no longer cause false failures while genuine membership defects still fail.

### How did you verify/test it?

Validated on `tbtk5-lt2-7060x6-1` (Arista-7060X6-64PE, 512-port lt2, internal-202511):

- `test_lldp_entry_table_content` **fails without** this change (both `eth0`-in-CLI-not-DB and `eth0`-in-DB-not-CLI timing variants observed) and **passes with** it.
- Offline replay against the captured `lldpctl -f json` and DB keys confirms: transient `eth0` in any subset of {DB, CLI, lldpctl} → PASS; a genuinely missing or extra front-panel port → FAIL.
- t0/t1 topologies are unaffected (single neighbor per port, no mgmt-port flakiness).

### Which release branch to backport (if applicable)?

- [x] 202511
