### PR TITLE
[merge queue test] PR8

### DIFF
--- a/tests/generic_config_updater/test_monitor_config.py
+++ b/tests/generic_config_updater/test_monitor_config.py
@@ -10,6 +10,7 @@ from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback
 
 pytestmark = [
     pytest.mark.topology('any'),
+    pytest.mark.enable_monit_refresh,
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
- _test_pfcwd_status_ tests under _generic_config_updater_ test suite for _x86_64-nokia_ixr7220_h6_128-r0_ platform fails with the following issue eventhough the gcu apply patch command gets succeeded.

```python
        output = duthost.shell(cmds, module_ignore_errors=True)
        elapsed_time = time.time() - start_time
        gcu_timeout = get_gcu_timeout(duthost)
        if elapsed_time > gcu_timeout:
            logger.error("Command took too long: {} seconds".format(elapsed_time))
>           raise TimeoutError("Command execution timeout: {} seconds".format(elapsed_time))
E           TimeoutError: Command execution timeout: 726.0890581607819 seconds

```
#### How did you do it?

- Increase default timeout 600s to 1800 seconds timeout under GCUTIMEOUT_MAP of tests/common/gu_utils.py for
_x86_64-nokia_ixr7220_h6_128-r0_

#### How did you verify/test it?

- Ran _test_pfcwd_status_ tests with the change and made sure tests are passing without any issues.

#### Any platform specific information?

 _x86_64-nokia_ixr7220_h6_128-r0_

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
