### PR TITLE
Disable memory utilization for memory checker tests

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('any'),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.disable_memory_utilization
 ]
 
 CONTAINER_STOP_THRESHOLD_SECS = 200


### PR DESCRIPTION
### Description of PR

Summary:
Disable the generic memory_utilization fixture for memory_checker tests because this module intentionally changes container memory usage to validate monit behavior. The generic fixture can treat the expected gnmi memory transition as a teardown alarm and fail test_monit_reset_counter_failure even when the test body passes.

Fixes #
ADO: https://msazure.visualstudio.com/One/_workitems/edit/38927892

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38927892
Failure type: other

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

Not run on a physical testbed. Verified with pre-commit on the changed file:
`python -m pre_commit run --files tests/memory_checker/test_memory_checker.py`

### Approach
#### What is the motivation for this PR?

Nightly PBI 38927892 tracks memory_checker.test_memory_checker::test_monit_reset_counter_failure on Nokia-M0-7215. The test passed its body, but failed during teardown because the autouse memory_utilization fixture reported the expected gnmi memory usage transition as an alarm.

#### How did you do it?

Added pytest.mark.disable_memory_utilization to tests/memory_checker/test_memory_checker.py. This follows the existing marker pattern used by tests that intentionally manipulate memory or restart services, and leaves memory validation to the memory_checker test assertions themselves.

#### How did you verify/test it?

Ran pre-commit for the changed file; all hooks passed.

#### Any platform specific information?

Observed on Nokia-M0-7215, M0/MX topology, 202605 nightly. The fix is test-framework scoped and not platform-specific.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.