### PR TITLE
Fix mux container status check for Ansible compatibility

### DIFF
--- a/tests/common/dualtor/tor_failure_utils.py
+++ b/tests/common/dualtor/tor_failure_utils.py
@@ -7,6 +7,7 @@ Reboot a ToR
 """
 from tests.common.reboot import reboot, SONIC_SSH_PORT, SONIC_SSH_REGEX, \
                                 REBOOT_TYPE_COLD
+import json
 import ipaddress
 import pytest
 import logging
@@ -163,9 +164,14 @@ def check_mux_feature(duthost):
     return "disabled" not in str(output)
 
 
+def get_container_status(duthost, container_name):
+    """Return Docker container state without using a Go template."""
+    output = duthost.shell("docker inspect --type container {}".format(container_name))["stdout"]
+    return json.loads(output)[0]["State"]["Status"]
+
+
 def check_mux_container(duthost):
-    output = duthost.shell("docker inspect -f '{{ .State.Status }}' mux")['stdout_lines']
-    return "running" in str(output)
+    return get_container_status(duthost, "mux") == "running"
 
 
 @pytest.fixture
@@ -189,8 +195,7 @@ def wait_for_mux_container(duthost):
 
 
 def check_pmon_container(duthost):
-    output = duthost.shell("docker inspect -f '{{ .State.Status }}' pmon")['stdout_lines']
-    return "running" in str(output)
+    return get_container_status(duthost, "pmon") == "running"
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
  Fix DualToR mux/pmon container status checks to avoid Docker
  Go-template parsing by Ansible/Jinja.

  The current check uses Docker Go-template syntax in an Ansible shell
  command. With Ansible 2.18.16, the Go-template expression can be parsed
  as a Jinja template before the command reaches the shell, causing:


`  template error while templating string: unexpected '.'`

  This PR uses docker inspect --type container and parses the returned
  JSON in Python.


Summary:
  Fixes #26549
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression from https://github.com/sonic-net/sonic-mgmt/pull/26007 ( Fix did not make it backward compatible with Ansible < 2.19 )

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202605 Results 

Ansible 2.21 : 
[console.log](https://github.com/user-attachments/files/30338666/console.log)
[summary.txt](https://github.com/user-attachments/files/30338667/summary.txt)
[test_tor_failure.log](https://github.com/user-attachments/files/30338668/test_tor_failure.log)
[test_tor_failure.xml](https://github.com/user-attachments/files/30338673/test_tor_failure.xml)

Ansible 2.18 : 
[test_tor_failure.log](https://github.com/user-attachments/files/30340001/test_tor_failure.log)
[test_tor_failure.xml](https://github.com/user-attachments/files/30340020/test_tor_failure.xml)
[runtime.txt](https://github.com/user-attachments/files/30340023/runtime.txt)
[summary.txt](https://github.com/user-attachments/files/30340024/summary.txt)


### Approach

#### What is the motivation for this PR?
 DualToR ToR failure tests can fail with Ansible 2.18 while waiting for
  mux/pmon containers after reboot. The existing helper uses Docker
  Go-template syntax in an Ansible shell command:

`  docker inspect -f '{{ .State.Status }}' mux`

  With Ansible/Jinja, this can be parsed before the command reaches the
  shell and fail with:
`template error while templating string: unexpected '.'`

#### How did you do it?
Added a small helper that reads container status from Docker JSON output
  instead of using Docker Go-template syntax.
  The mux and pmon checks now use:
  docker inspect --type container <container>
  and parse State.Status in Python.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Tested on kvm003 with the sonic_mgmt_202605 container.

  Default container environment:

1.   Python 3.12.3
2.   pytest 9.1.1
3.   Ansible 2.21.2
4.   pytest-ansible 26.6.0


  Command:
 ```
 sudo ./run_tests.sh -n dt -m individual -r \
    -t any,util,dualtor,t0 \
    -f ../ansible/testbed.yaml \
    -u \
    -c dualtor_io/test_tor_failure.py

```
  Result:

  `4 passed, 6 skipped, 537 warnings in 1915.49s (0:31:55)`

  Also installed Ansible 2.18.16 as an overlay in the same container:

  /opt/ansible-core-2.18.16-overlay

  and ran:

  ```
sudo env PYTHONPATH=/opt/ansible-core-2.18.16-overlay ./run_tests.sh \
    -n dt -m individual -r \
    -t any,util,dualtor,t0 \
    -f ../ansible/testbed.yaml \
    -u \
    -p logsansible218_tor_failure \
    -c dualtor_io/test_tor_failure.py
```
1.   Python 3.12.3
2.   pytest 9.1.1
3.   Ansible 2.18.16
4.   pytest-ansible 26.6.0



#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A

