### PR TITLE
Add COUNTER_MARGIN tolerance for cisco-8000 in test_qos_sai

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -5491,9 +5491,11 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
             diff = recv_counters[self.pg] - recv_counters_base[self.pg]
             assert diff == 0, "Unexpected PFC frames {}".format(diff)
             # recv port no ingress drop
+            # Adding COUNTER_MARGIN to tolerate background counter drift on cisco-8000
+            counter_margin = COUNTER_MARGIN if self.asic_type == "cisco-8000" else 0
             for cntr in ingress_counters:
                 diff = recv_counters[cntr] - recv_counters_base[cntr]
-                assert diff == 0, "Unexpected ingress drop {} on port {}".format(
+                assert diff <= counter_margin, "Unexpected ingress drop {} on port {}".format(
                     diff, self.src_port_id)
             # xmit port no egress drop
             for cntr in egress_counters:
@@ -5517,9 +5519,11 @@ class LossyQueueVoqTest(sai_base_test.ThriftInterfaceDataPlane):
             diff = recv_counters[self.pg] - recv_counters_base[self.pg]
             assert diff == 0, "Unexpected PFC frames {}".format(diff)
             # recv port no ingress drop
+            # Adding COUNTER_MARGIN to tolerate background counter drift on cisco-8000
+            counter_margin = COUNTER_MARGIN if self.asic_type == "cisco-8000" else 0
             for cntr in ingress_counters:
                 diff = recv_counters[cntr] - recv_counters_base[cntr]
-                assert diff == 0, "Unexpected ingress drop {} on port {}".format(
+                assert diff <= counter_margin, "Unexpected ingress drop {} on port {}".format(
                     diff, self.src_port_id)
             # xmit port egress drop
             for cntr in egress_counters:
@@ -7251,12 +7255,14 @@ class LossyQueueVoqMultiSrcTest(sai_base_test.ThriftInterfaceDataPlane):
             diff = recv_counters_2[self.pg] - recv_counters_2_base[self.pg]
             assert diff == 0, "Unexpected PFC frames {} on port {}".format(diff, self.src_port_2_id)
             # recv port no ingress drop
+            # Adding COUNTER_MARGIN to tolerate background counter drift on cisco-8000
+            counter_margin = COUNTER_MARGIN if self.asic_type == "cisco-8000" else 0
             for cntr in ingress_counters:
                 diff = recv_counters[cntr] - recv_counters_base[cntr]
-                assert diff == 0, "Unexpected ingress drop {} on port {}".format(diff, self.src_port_id)
+                assert diff <= counter_margin, "Unexpected ingress drop {} on port {}".format(diff, self.src_port_id)
             for cntr in ingress_counters:
                 diff = recv_counters_2[cntr] - recv_counters_2_base[cntr]
-                assert diff == 0, "Unexpected ingress drop {} on port {}".format(diff, self.src_port_2_id)
+                assert diff <= counter_margin, "Unexpected ingress drop {} on port {}".format(diff, self.src_port_2_id)
             # xmit port no egress drop
             for cntr in egress_counters:
                 diff = xmit_counters[cntr] - xmit_counters_base[cntr]
@@ -7285,12 +7291,14 @@ class LossyQueueVoqMultiSrcTest(sai_base_test.ThriftInterfaceDataPlane):
             diff = recv_counters_2[self.pg] - recv_counters_2_base[self.pg]
             assert diff == 0, "Unexpected PFC frames {} on port {}".format(diff, self.src_port_2_id)
             # recv port no ingress drop
+            # Adding COUNTER_MARGIN to tolerate background counter drift on cisco-8000
+            counter_margin = COUNTER_MARGIN if self.asic_type == "cisco-8000" else 0
             for cntr in ingress_counters:
                 diff = recv_counters[cntr] - recv_counters_base[cntr]
-                assert diff == 0, "Unexpected ingress drop {} on port {}".format(diff, self.src_port_id)
+                assert diff <= counter_margin, "Unexpected ingress drop {} on port {}".format(diff, self.src_port_id)
             for cntr in ingress_counters:
                 diff = recv_counters_2[cntr] - recv_counters_2_base[cntr]
-                assert diff == 0, "Unexpected ingress drop {} on port {}".format(diff, self.src_port_2_id)
+                assert diff <= counter_margin, "Unexpected ingress drop {} on port {}".format(diff, self.src_port_2_id)
             # xmit port egress drop
             for cntr in egress_counters:
                 drops = xmit_counters[cntr] - xmit_counters_base[cntr]


### PR DESCRIPTION

Summary:
Fixes # (issue)
Add COUNTER_MARGIN tolerance for cisco-8000 in LossyQueueVoqTest and LossyQueueVoqMultiSrcTest ingress drop assertions. Without this fix, background counter drift (e.g., IPv6 NS/RA) of 1-2 packets causes spurious test failures.

Changes:
LossyQueueVoqTest: 2 assertion sites (short-of-drop + trigger-drop)
LossyQueueVoqMultiSrcTest: 2 assertion sites (short-of-drop + trigger-drop)

This is an existing cisco-8000 background RX drop counter drift issue — the same issue addressed by [PR #23672](https://github.com/sonic-net/sonic-mgmt/pull/23672) for LossyQueueTest, LossyQueueVoqTest (single-flow path), and TrafficSanityTest.

### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result 
sonic@sonic-ucs-m3-4:/data/tests$ sonic@sonic-ucs-m3-4:/data/tests$ ./run_tests.sh -n chu-t1-56-lag -d chu-dut -u -c qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc -l info -p /run_logs/qos_sai_sonmathu_042126 -e --disable_loganalyzer -e --skip_sanity


---------------------------- live log sessionfinish -----------------------------
22/04/2026 01:15:10 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
============================ short test summary info ============================
SKIPPED [1] qos/test_qos_sai.py:2420: Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests
SKIPPED [3] qos/test_qos_sai.py:2420: multi-dut is not supported on T1 topologies

Results (1273.23s (0:21:13)):
       1 passed
       4 skipped
DEBUG:tests.conftest:[log_custom_msg] item: <Function testQosSaiLossyQueueVoqMultiSrc[multi_dut_shortlink_to_longlink]>
INFO:root:Can not get Allure report URL. Please check logs
sonic@sonic-ucs-m3-4:/data/tests$ sonic@sonic-ucs-m3-4:/data/tests$ ./run_tests.sh -n chu-t1-56-lag -d chu-dut -u -c qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc -l info -p /run_logs/qos_sai_sonmathu_042126 -e --disable_loganalyzer -e --skip_sanity





sonic@sonic-ucs-m3-4:/data/tests$ ./run_tests.sh -n chu-t1-56-lag -d chu-dut -u -c qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq -l info -p /run_logs/qos_sai_sonmathu_042126_RUN -e --disable_loganalyzer -e --skip_sanity

------------------------------------------------ generated xml file: /run_logs/qos_sai_sonmathu_042126_RUN/tr_2026-04-22-05-11-12.xml -------------------------------------------------
------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------
22/04/2026 05:32:58 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
=============================================================================== short test summary info ===============================================================================
SKIPPED [1] qos/test_qos_sai.py:1414: LossyQueueVoq: lossy_queue_voq_2 test is not applicable for split-voq.
SKIPPED [2] qos/test_qos_sai.py:1376: Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests
SKIPPED [6] qos/test_qos_sai.py:1376: multi-dut is not supported on T1 topologies

Results (1289.99s (0:21:29)):
       1 passed
       9 skipped
DEBUG:tests.conftest:[log_custom_msg] item: <Function testQosSaiLossyQueueVoq[multi_dut_shortlink_to_longlink-lossy_queue_voq_2]>
INFO:root:Can not get Allure report URL. Please check logs
sonic@sonic-ucs-m3-4:/data/tests$
sonic@sonic-ucs-m3-4:/data/tests$

### Approach
#### What is the motivation for this PR?
Successfully testing and validating test_qos_sai tests

#### How did you do it?
This is an existing cisco-8000 background RX drop counter drift issue — the same issue addressed by [PR #23672](https://github.com/sonic-net/sonic-mgmt/pull/23672) for LossyQueueTest, LossyQueueVoqTest (single-flow path), and TrafficSanityTest.
Adding the same logic here 

#### How did you verify/test it?
Tested the same problem and resolution in 202511 branch. Since fix not present in master and 202605 branches, this issue keeps showing up

#### Any platform specific information?
Limiting the scope of change to Cisco devices only

#### Supported testbed topology if it's a new test case?

### Documentation