### PR TITLE
[cacl/test]: Temporarily skip 2 cacl test cases via conditional_mark

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -793,15 +793,23 @@ cacl/test_cacl_application.py::test_cacl_application_dualtor:
 
 cacl/test_cacl_application.py::test_cacl_application_nondualtor:
   skip:
-    reason: "test_cacl_application is only supported on non dualtor topology"
+    reason: "test_cacl_application is only supported on non dualtor topology. Also temporarily
+      skipped while sonic-net/sonic-buildimage#28061 (adds new protected FRR BGP ports) is being
+      validated; test update to follow once that image is checked in."
+    conditions_logical_operator: or
     conditions:
       - "'dualtor' in topo_name"
+      - "https://github.com/sonic-net/sonic-buildimage/issues/28061"
 
 cacl/test_cacl_application.py::test_multiasic_cacl_application:
   skip:
-    reason: "test_multiasic_cacl_application is only supported on multi-ASIC platform"
+    reason: "test_multiasic_cacl_application is only supported on multi-ASIC platform. Also
+      temporarily skipped while sonic-net/sonic-buildimage#28061 (adds new protected FRR BGP
+      ports) is being validated; test update to follow once that image is checked in."
+    conditions_logical_operator: or
     conditions:
       - "not is_multi_asic"
+      - "https://github.com/sonic-net/sonic-buildimage/issues/28061"
 
 cacl/test_cacl_function.py:
   xfail:


### PR DESCRIPTION
### Description of PR
Summary:
Temporarily skip 2 failing test cases in `cacl/test_cacl_application.py` (via the conditional_mark mechanism) in the PR checker.

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
sonic-net/sonic-buildimage#28061 introduces new protected FRR BGP ports, which currently
causes `test_cacl_application_nondualtor` and `test_multiasic_cacl_application` in
`cacl/test_cacl_application.py` to fail across the PR checker's t0, t1-lag, multi-asic-t1,
and t2 topologies, blocking that buildimage PR from being checked in.

The corresponding test update (to account for the new protected ports) will be submitted
and merged separately once the image from sonic-buildimage#28061 is checked in. Skipping the
2 affected tests now avoids a cyclic dependency between sonic-buildimage and sonic-mgmt (the
test can't be properly validated until the new image is available, and the buildimage PR
can't merge while the tests fail).

#### How did you do it?
Initially added an unconditional `pytest.mark.skip` to the module-level `pytestmark` in
`tests/cacl/test_cacl_application.py`, but per review feedback this would skip the whole
module for all test runs (PR checker, nightly, and local) indefinitely, and wasn't scoped to
only the 2 actually-failing tests.

Reworked the fix to instead gate the two specific test cases already broken out in
`tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`
(`test_cacl_application_nondualtor` and `test_multiasic_cacl_application`) with an
additional `or` condition referencing `sonic-net/sonic-buildimage#28061`. The skip
self-expires once that PR is merged/closed (GitHub API reports it as closed), without
requiring a manual follow-up PR to remove it. `tests/cacl/test_cacl_application.py` itself
is left unchanged.

#### How did you verify/test it?
- Confirmed `tests_mark_conditions.yaml` still parses correctly and passes the
  `check-conditional-mark-sort` pre-commit hook (entries remain alphabetically sorted).
- Confirmed the two edited entries evaluate correctly via `yaml.safe_load` (conditions list,
  `conditions_logical_operator: or`, and reason string render as expected).
- No `.py` files are modified in this PR, so flake8 is a no-op.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A - not a new test case.

### Documentation
N/A

---
Related: sonic-net/sonic-buildimage#28061
