### PR TITLE
Fix lossy queue cell_size parameter handling

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1311,6 +1311,8 @@ class TestQosSai(QosSaiBase):
 
         if "packet_size" in list(qosConfig["lossy_queue_1"].keys()):
             testParams["packet_size"] = qosConfig["lossy_queue_1"]["packet_size"]
+
+        if "cell_size" in list(qosConfig["lossy_queue_1"].keys()):
             testParams["cell_size"] = qosConfig["lossy_queue_1"]["cell_size"]
 
         if "pkts_num_margin" in list(qosConfig["lossy_queue_1"].keys()):


### PR DESCRIPTION
### Description of PR

Fixes ADO PBI 38946834.

`LossyQueueTest` in `sai_qos_tests.py` now always reads `cell_size` before checking whether an optional `packet_size` override is present. `testQosSaiLossyQueue` only passed `cell_size` when `packet_size` was also defined, so platforms that define `cell_size` without `packet_size` hit `KeyError: 'cell_size'` in PTF.

This PR passes `cell_size` independently from `packet_size` when it is present in `lossy_queue_1` QoS params.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

Nightly `qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue` failed on master with `KeyError: 'cell_size'` from `sai_qos_tests.LossyQueueTest`.

#### How did you do it?

Changed `testQosSaiLossyQueue` to add `testParams["cell_size"]` whenever `lossy_queue_1.cell_size` exists, instead of only when `packet_size` exists.

#### How did you verify/test it?

Ran Python syntax validation:

```
python -m py_compile tests/qos/test_qos_sai.py
```

#### Any platform specific information?

Observed on Arista-7260CX3-C64 / t1-64-lag with Broadcom TH2 ASIC, but the fix is generic for any QoS params that provide `cell_size` without `packet_size`.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

No documentation changes needed.