### PR TITLE
[fanout]: Auto-configure console switch on SONiC console fanouts

### DIFF
--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -122,3 +122,8 @@
   when: >
     '202511' in fanout_sonic_version['build_version']  and
     not is_cisco_env
+
+- name: provision console switch on SONiC console fanout (from serial links)
+  include_tasks:
+    sonic/fanout_sonic_console.yml
+  when: dry_run is not defined

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_console.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_console.yml
@@ -1,0 +1,28 @@
+# Enable the console switch feature and provision console lines on a SONiC
+# console fanout, derived from its serial links (sonic_<inv>_serial_links.csv).
+#
+# The DUT (via generate_c0_golden_config_db during deploy-mg) and the mc0
+# management/console switch (via mcx.yml) already get their CONSOLE_SWITCH /
+# CONSOLE_PORT config generated automatically. The SONiC console fanout
+# (e.g. FanoutLeafSonic) did not, so "config console enable" and
+# "config console line add -b <baud> <line>" had to be run by hand after each
+# deployment. This task closes that gap.
+- name: Collect serial links for this fanout
+  set_fact:
+    fanout_serial_links: "{{ (device_serial_link | default({}))[inventory_hostname] | default({}) }}"
+
+- name: Provision console switch on SONiC console fanout
+  when: fanout_serial_links | length > 0
+  block:
+    - name: Render CONSOLE_PORT / CONSOLE_SWITCH config
+      template:
+        src: console_config.j2
+        dest: /tmp/console_config.json
+
+    - name: Write console config into CONFIG_DB
+      shell: sonic-cfggen -j /tmp/console_config.json --write-to-db
+      become: yes
+
+    - name: Persist config
+      shell: config save -y
+      become: yes

--- a/ansible/roles/fanout/templates/console_config.j2
+++ b/ansible/roles/fanout/templates/console_config.j2
@@ -1,0 +1,16 @@
+{
+    "CONSOLE_PORT": {
+{% for port, link in fanout_serial_links.items() %}
+        "{{ port }}": {
+            "baud_rate": "{{ link.baud_rate | default('9600') }}",
+            "flow_control": "{{ link.flow_control | default('0') }}",
+            "remote_device": "{{ link.peerdevice }}"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+    },
+    "CONSOLE_SWITCH": {
+        "console_mgmt": {
+            "enabled": "yes"
+        }
+    }
+}


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (N/A - ADO 38711418)

Auto-configure CONSOLE_SWITCH / CONSOLE_PORT on SONiC console fanouts during
deploy, so the console lines no longer have to be enabled by hand after every
testbed deployment.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: N/A

### Tested branch
- [x] master
- [ ] N/A

### Test result

- master: validated on a SONiC console fanout. Ran the new task through real
  ansible scoped to the SONiC fanout: PLAY RECAP ok=8 changed=3 failed=0.
  conn_graph_facts populated device_serial_link; CONSOLE_SWITCH came up enabled
  and the CONSOLE_PORT lines rendered from the serial links were written to
  CONFIG_DB and persisted via config save.

### Approach
#### What is the motivation for this PR?
The DUT (via generate_c0_golden_config_db during deploy-mg) and the mc0
management/console switch (via mcx.yml) already get CONSOLE_SWITCH / CONSOLE_PORT
generated automatically. The SONiC console fanout (FanoutLeafSonic) did not, so
`config console enable` and `config console line add -b <baud> <line>` had to be
run by hand after each deployment.

#### How did you do it?
Added a console-provisioning task to the SONiC fanout deploy that renders
CONSOLE_PORT + CONSOLE_SWITCH from the fanout's serial links (device_serial_link)
and writes it to CONFIG_DB, mirroring the existing DUT/mc0 patterns. It only runs
when the fanout actually has serial links, so regular Ethernet fanouts are
unaffected.

#### How did you verify/test it?
See Test result above: real ansible run on a SONiC console fanout, RECAP
ok=8 changed=3 failed=0, CONSOLE_SWITCH enabled and console lines persisted in
CONFIG_DB.

#### Any platform specific information?
Applies only to SONiC console fanouts (FanoutLeafSonic) that have serial links.
Ethernet-only fanouts are skipped via the length guard.

#### Supported testbed topology if it's a new test case?
N/A (not a test case; testbed framework improvement).

### Documentation
N/A
