### PR TITLE
[drop_packets] Retry neighbor population during wait

### DIFF
--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -515,8 +515,10 @@ def mock_server(fanouthosts, testbed_params, arp_responder, ptfadapter, duthosts
 
     def _check_arp_populated():
         if is_ipv4_address(server_dst_addr):
+            duthost.command("ping {} -c 1 -W 1".format(server_dst_addr), module_ignore_errors=True)
             result = duthost.command("show arp {}".format(server_dst_addr), module_ignore_errors=True)
         else:
+            duthost.command("ping6 {} -c 1 -W 1".format(server_dst_addr), module_ignore_errors=True)
             result = duthost.command("show ndp {}".format(server_dst_addr), module_ignore_errors=True)
         return server_dst_addr in result.get('stdout', '')
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #26560 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
 `test_neighbor_link_down` sends one setup ping to populate the DUT
  ARP/NDP entry, then waits by polling `show arp` or `show ndp`.

  If that initial ping misses a transient responder or mux readiness
  window, the wait loop only polls the neighbor table and does not
  generate another ARP/NDP request. In that case setup can fail with:

  ARP/NDP entry for <server-ip> was not populated

  Retry `ping` / `ping6` inside the existing wait condition before
  checking `show arp` / `show ndp`. This lets transient setup timing
  recover while still failing if the neighbor entry never becomes
  reachable.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue /flaky test 

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
**202605 :** 
***Failure :***
[msft_1379_drop_packets_test_configurable_drop_counters.log](https://github.com/user-attachments/files/30380094/msft_1379_drop_packets_test_configurable_drop_counters.log)
[msft_1379_drop_packets_test_configurable_drop_counters.xml](https://github.com/user-attachments/files/30380099/msft_1379_drop_packets_test_configurable_drop_counters.xml)
***After Fix :*** 
[pass_log_kvm003_fixed_test_neighbor_link_down_summary.txt](https://github.com/user-attachments/files/30380104/pass_log_kvm003_fixed_test_neighbor_link_down_summary.txt)
[pass_log_kvm003_fixed_test_neighbor_link_down.log](https://github.com/user-attachments/files/30380105/pass_log_kvm003_fixed_test_neighbor_link_down.log)


### Approach
#### What is the motivation for this PR?
 The MSFT run failed during setup because the DUT ARP/NDP entry for the
  mock server IP was not populated. The test sent only one setup ping and
  then waited by polling the neighbor table. If that first ping missed a
  transient responder or mux readiness window, the wait loop could not
  recover because it did not generate another ARP/NDP request.

#### How did you do it?
Kept the existing setup ping unchanged and added a retry ping inside the
  existing `_check_arp_populated()` wait condition. For IPv4 the test runs
  `ping -c 1 -W 1` before `show arp`; for IPv6 it runs `ping6 -c 1 -W 1`
  before `show ndp`.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Reproduced on kvm003 by stopping `arp_responder` in the PTF container
  after mock server fixture setup, waiting for the DUT setup ping window
  to pass, and then restarting `arp_responder`. With the unfixed code, the
  test failed because the wait loop only polled `show arp` / `show ndp`.

  Verified on kvm003 with the same trigger after applying the fix. The
  test retried ping during the wait loop, populated the neighbor entry,
  and passed.

  Run command:

  ```
cd /data/tests
  sudo ./run_tests.sh -n dt -m individual -r \
      -t t0,any,dualtor \
      -f ../ansible/testbed.yaml \
      -u \
      -p logs_drop_packets_trigger_fixed \
      -c "drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[PORT_INGRESS_DROPS-L3_EGRESS_LINK_DOWN]"

```
**Trigger used for reproduction:**

  A watcher was started on test server  before launching the test. It tailed the
  per-test log and waited until the mock server setup began. When the log
  showed either `fixture arp_responder setup ends` or `Creating mock
  server`, the watcher stopped `arp_responder` in the PTF container,
  waited 6 seconds, and then restarted it.

  This made the initial DUT setup ping miss the responder window while
  leaving `arp_responder` running again before the wait loop completed.

  Watcher command:

```
  timeout 900 bash -lc '
  log="/data/tests/logs_drop_packets_trigger_fixed/drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[PORT_INGRESS_DROPS-L3_EGRESS_LINK_DOWN].log"

  until docker exec sonic_mgmt_202605 test -f "$log"; do
      sleep 0.5
  done

  docker exec sonic_mgmt_202605 tail -n 0 -F "$log" | while IFS= read -r line; do
      case "$line" in
          *"fixture arp_responder setup ends"*|*"Creating mock server"*)
              echo "WATCHER_TRIGGER: $line"
              docker exec ptf_dt supervisorctl stop arp_responder || true
              docker exec ptf_dt supervisorctl status arp_responder || true
              sleep 6
              docker exec ptf_dt supervisorctl start arp_responder || true
              docker exec ptf_dt supervisorctl status arp_responder || true
              exit 0
              ;;
      esac
  done
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
