### PR TITLE
[pc] Skip higher LAG ID test before PTF setup

### DIFF
--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -575,7 +575,7 @@ def test_po_update_with_higher_lagids(
         duthosts,
         enum_rand_one_per_hwsku_frontend_hostname,
         tbinfo,
-        ptfadapter,
+        request,
         reload_testbed_on_failed, localhost):
     """
     Test Port Channel Traffic with Higher LAG IDs:
@@ -595,6 +595,7 @@ def test_po_update_with_higher_lagids(
         # Skip the test if the setup is not T2 Chassis
         pytest.skip("Test is Applicable for T2 VOQ Chassis Setup")
 
+    ptfadapter = request.getfixturevalue("ptfadapter")
     dut_mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     # Send initial data to the device


### PR DESCRIPTION
### Description of PR
Fix `test_po_update_with_higher_lagids` so non-T2/non-VOQ topologies skip before initializing the PTF adapter. The test is only applicable to T2 VOQ chassis, but `ptfadapter` was in the test signature, so pytest initialized it before the in-test applicability check and could fail with `PtfAdapterNNConnectionError` on inapplicable topologies.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Approach
#### What is the motivation for this PR?
SONiC nightly PBI 38951218 failed on a dualtor Arista testbed during setup with `Failed to connect to ptf_nn_agent`, before the test could skip as non-T2.

#### How did you do it?
Resolve `ptfadapter` lazily with `request.getfixturevalue("ptfadapter")` after the T2 VOQ chassis applicability check.

#### How did you verify/test it?
Ran `python -m py_compile tests/pc/test_po_update.py`.

#### Any platform specific information?
Observed on Arista-7260CX3-D108C8 dualtor in 202605 nightly; fix is topology-gating logic and applies generally.

#### Supported testbed topology if it's a new test case?
Existing test; intended for T2 VOQ chassis.

### Documentation
N/A