### PR TITLE
[merge-queue-test] PR9 - fix for PR3

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -2,6 +2,7 @@
 # Test plan in docs/testplan/LLDP-syncd-test-plan.md
 import pytest
 import json
+import time
 from tests.common.helpers.sonic_db import SonicDbCli
 import logging
 from tests.common.reboot import reboot, REBOOT_TYPE_COLD

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -36,6 +36,63 @@ def ignore_expected_loganalyzer_exceptions(duthosts, loganalyzer):
             )
 
 
+@pytest.fixture(scope="module", autouse=True)
+def wait_for_lldp_appl_db(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    appl_db = []
+    for asic in duthost.asics:
+        appl_db.append(SonicDbCli(asic, APPL_DB))
+    is_chassis = duthost.get_facts().get("modular_chassis")
+    if duthost.facts['switch_type'] == "voq" and (not is_chassis and len(duthost.asics) > 1):
+        appl_db.append(SonicDbCli(duthost, APPL_DB))
+
+    def lldpctl_ifaces():
+        try:
+            ifaces = get_lldpctl_output(duthost)["lldp"]["interface"]
+            names = list(ifaces.keys()) if isinstance(ifaces, dict) else [list(i.keys())[0] for i in ifaces]
+            return set(n for n in names if "Ethernet-BP" not in n and "Ethernet-IB" not in n)
+        except Exception:
+            return set()
+
+    # Wait for lldpctl output to stabilize (same set across 2 consecutive polls = all active neighbors learned)
+    # Using deterministic polling: max 25 retries with 10s interval
+    max_lldpctl_retries = 25
+    poll_interval = 10
+    prev, stable_count = set(), 0
+    for retry in range(max_lldpctl_retries):
+        current = lldpctl_ifaces()
+        if current and current == prev:
+            stable_count += 1
+            logger.info("lldpctl stable ({}/2): {} interfaces (retry {}/{})".format(
+                stable_count, len(current), retry + 1, max_lldpctl_retries))
+            if stable_count > 2:
+                break
+        else:
+            logger.info("lldpctl: {} interfaces (changed or empty), retry {}/{}".format(
+                len(current), retry + 1, max_lldpctl_retries))
+            stable_count = 0
+        prev = current
+        time.sleep(poll_interval)
+    else:
+        pytest.fail("lldpctl did not stabilize after {} retries. Last seen: {}".format(
+            max_lldpctl_retries, sorted(prev)))
+
+    expected = prev
+    logger.info("lldpd stable with {} active neighbors: {}".format(len(expected), sorted(expected)))
+
+    # Wait for APPL_DB convergence: max 10 retries with 3s interval
+    max_appl_db_retries = 10
+    appl_db_poll_interval = 3
+    for retry in range(max_appl_db_retries):
+        if expected <= set(get_lldp_entry_keys(appl_db)):
+            logger.info("All {} interfaces converged in APPL_DB (retry {}/{})".format(
+                len(expected), retry + 1, max_appl_db_retries))
+            return
+        time.sleep(appl_db_poll_interval)
+    pytest.fail("APPL_DB did not converge after {} retries. Missing: {}".format(
+        max_appl_db_retries, sorted(expected - set(get_lldp_entry_keys(appl_db)))))
+
+
 @pytest.fixture(autouse="True")
 def db_instance(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]


### PR DESCRIPTION
### Description of PR

Summary:
PR https://github.com/sonic-net/sonic-mgmt/pull/25085 removed the import time statement because no one was using it at the time. However, PR https://github.com/sonic-net/sonic-mgmt/pull/24876 — which adds code that uses time — was merged afterward, which caused the issue.

`tests/lldp/test_lldp_syncd.py` uses `time.sleep()` inside the `wait_for_lldp_appl_db()` helper, but the `time` module is never imported. As soon as the `lldpctl` stabilization retry loop is entered, the test raises:

```
NameError: name 'time' is not defined. Did you forget to import 'time'?
  File "tests/lldp/test_lldp_syncd.py", line 73, in wait_for_lldp_appl_db
    time.sleep(poll_interval)
```

This is a deterministic (100%) failure of `test_lldp_syncd.py` whenever the retry/poll path runs. The fix adds the missing `import time` to the stdlib import block.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_lldp_syncd.py` fails immediately with `NameError("name 'time' is not defined")` because the `time` module is referenced (`time.sleep(poll_interval)` and `time.sleep(appl_db_poll_interval)`) but never imported. The test cannot pass on any platform until this import is added.

#### How did you do it?
Added `import time` to the module-level import block, alongside the other stdlib imports (`json`, `logging`).

#### How did you verify/test it?
- Confirmed the file references `time.` in two places (`wait_for_lldp_appl_db` retry loops) with no corresponding import.
- Verified `python -c "import ast; ast.parse(open('tests/lldp/test_lldp_syncd.py').read())"` parses cleanly after the change.
- Single-line, import-only change with no behavioral impact beyond resolving the `NameError`.

#### Any platform specific information?
None — platform-independent Python import fix.

#### Supported testbed topology if it's a new test case? N/A — existing test fix.

### Documentation
N/A

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
