### PR TITLE
[202605] [mmu probing] pr17.fix: Platform-aware probe packet_length and threshold resolution for Cisco-8000 (#24784)

### DIFF
--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -8,6 +8,8 @@ This module contains probe-based tests for buffer threshold detection, including
 
 These tests use advanced probing algorithms to automatically detect buffer thresholds.
 
+CI: probe-tests stage in .azure-pipelines/probe-tests/ triggers UT/IT for changes here.
+
 Parameters:
     --enable_qos_ptf_pdb (bool): Enable pdb debugger in PTF tests. Default is False.
 """
@@ -54,6 +56,120 @@ class TestQosProbe(QosSaiBase):
                 if result is not None:
                     return result
         return None
+
+    # --- Platform Probe Parameter Resolver ---
+    # Each platform subclass resolves probe parameters (packet_length, thresholds, etc.)
+    # from QoS config. PTF receives resolved params via testParams; no platform checks in PTF.
+    # To add a new platform: create a subclass of ProbeParamsResolver and register
+    # in _PROBE_RESOLVER_REGISTRY.
+    _DEFAULT_CELL_SIZE = 384  # Conservative fallback when cell_size is not in QoS config
+
+    class ProbeParamsResolver:
+        """Default resolver: 64B packets, 1 cell per packet.
+
+        Subclasses override __init__ to resolve platform-specific values
+        from qosConfig_profile and dutQosConfig.
+        """
+        packet_length = 64          # class-level default
+        cells_per_packet = 1        # class-level default
+
+        def __init__(self, qosConfig_profile=None, dutQosConfig=None):
+            pass  # defaults provided by class attributes above
+
+        def resolve_threshold(self, value):
+            """Convert a qos.yml threshold to probe-comparable units.
+
+            Returns the value in the same units as probe traffic counting,
+            so probe result can be directly compared with expected threshold.
+
+            Default: qos.yml stores thresholds in cell units → divide by cells_per_packet.
+            Subclasses override when qos.yml uses different units.
+            """
+            return value // self.cells_per_packet
+
+    class CiscoProbeParamsResolver(ProbeParamsResolver):
+        """Cisco-8000: resolve probe params from QoS config.
+
+        Cisco qos.yml threshold unit convention varies by profile:
+
+        Profiles WITHOUT cell_size (threshold in packet units, divisor=1):
+          - xoff_1/xoff_2: pkts_num_trig_pfc, pkts_num_trig_ingr_drp
+
+        Profiles WITH cell_size (threshold in cell units, divisor=cells_per_packet):
+          - lossy_queue_1: pkts_num_trig_egr_drp
+
+        This matches legacy sai_qos_tests.py behavior where cell_size presence
+        in test_params controls whether // cell_occupancy is applied.
+
+        Note on threshold_divisor vs cells_per_packet asymmetry:
+          When cell_size is absent, threshold_divisor=1 (thresholds already in
+          packet units) but cells_per_packet may be >1 (e.g. 4 for 1350B/384B).
+          cells_per_packet is still needed for pool_size byte-to-packet
+          conversion; threshold_divisor controls only resolve_threshold().
+        """
+        def __init__(self, qosConfig_profile=None, dutQosConfig=None):
+            super().__init__()
+            qosConfig_profile = qosConfig_profile or {}
+            dutQosConfig = dutQosConfig or {}
+            self.packet_length = qosConfig_profile.get("packet_size", 64)  # Intentional override
+
+            cell_size = qosConfig_profile.get("cell_size")
+            if cell_size is not None:
+                # Profile provides cell_size → threshold is in cell units
+                self.threshold_divisor = (self.packet_length + cell_size - 1) // cell_size
+            else:
+                # Profile omits cell_size → threshold is already in packet units
+                cell_size = (dutQosConfig.get("param", {}).get("cell_size")
+                             or TestQosProbe.find_cell_size(dutQosConfig.get("param", {}))
+                             or TestQosProbe._DEFAULT_CELL_SIZE)
+                self.threshold_divisor = 1
+
+            self.cells_per_packet = (self.packet_length + cell_size - 1) // cell_size  # Intentional override
+
+        def resolve_threshold(self, value):
+            """Convert threshold to probe-comparable units using threshold_divisor."""
+            return value // self.threshold_divisor
+
+    # Registry: platform_asic -> ProbeParamsResolver subclass.
+    # Keys must match duthost.facts["platform_asic"] values exactly
+    # (e.g. "cisco-8000" from Cisco 8000 series devices).
+    # Unregistered platforms fall back to the default ProbeParamsResolver.
+    _PROBE_RESOLVER_REGISTRY = {
+        "cisco-8000": CiscoProbeParamsResolver,
+    }
+
+    # Threshold keys in qos.yml that need resolve_threshold conversion
+    _THRESHOLD_KEYS = (
+        "pkts_num_trig_pfc", "pkts_num_trig_ingr_drp",
+        "pkts_num_trig_egr_drp", "pkts_num_trig_pfc_shp",
+    )
+
+    @staticmethod
+    def get_probe_params(platform_asic, qosConfig_profile, dutQosConfig):
+        """Return probe-related testParams dict for PTF.
+
+        Resolves platform-specific ProbeParamsResolver via registry, then
+        returns a dict with probe_packet_length, probe_cells_per_packet,
+        and thresholds converted to packet units.
+
+        qosConfig_profile may be a non-dict (e.g. hdrm_pool_size can be an
+        integer on some platforms); guard to avoid AttributeError/TypeError.
+
+        Usage: testParams.update(self.get_probe_params(...))
+        """
+        if not isinstance(qosConfig_profile, dict):
+            qosConfig_profile = {}
+        resolver_cls = TestQosProbe._PROBE_RESOLVER_REGISTRY.get(
+            platform_asic, TestQosProbe.ProbeParamsResolver)
+        resolver = resolver_cls(qosConfig_profile, dutQosConfig)
+        params = {
+            "probe_packet_length": resolver.packet_length,
+            "probe_cells_per_packet": resolver.cells_per_packet,
+        }
+        for key in TestQosProbe._THRESHOLD_KEYS:
+            if key in qosConfig_profile:
+                params[key] = resolver.resolve_threshold(qosConfig_profile[key])
+        return params
 
     @staticmethod
     def get_ingress_drop_counter_mode(dutTestParams):
@@ -181,6 +297,10 @@ class TestQosProbe(QosSaiBase):
         # Get pdb parameter from command line
         enable_qos_ptf_pdb = request.config.getoption("--enable_qos_ptf_pdb", default=False)
 
+        # Platform probe params: packet_length, cells_per_packet, threshold conversions
+        platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
+        testParams.update(self.get_probe_params(platform_asic, qosConfig[xoffProfile], dutQosConfig))
+
         self.runPtfTest(
             ptfhost, testCase="pfc_xoff_probing.PfcXoffProbing", testParams=testParams,
             pdb=enable_qos_ptf_pdb, test_subdir='probe'
@@ -293,6 +413,10 @@ class TestQosProbe(QosSaiBase):
 
         testParams["ingress_drop_counter_mode"] = self.get_ingress_drop_counter_mode(dutTestParams)
 
+        # Platform probe params: packet_length, cells_per_packet, threshold conversions
+        platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
+        testParams.update(self.get_probe_params(platform_asic, qosConfig[xoffProfile], dutQosConfig))
+
         self.runPtfTest(
             ptfhost, testCase="ingress_drop_probing.IngressDropProbing", testParams=testParams,
             pdb=enable_qos_ptf_pdb, test_subdir='probe'
@@ -379,9 +503,9 @@ class TestQosProbe(QosSaiBase):
             testParams["pkts_num_trig_egr_drp"] = expected_egr_drp
         else:
             logger.info(
-                f"pkts_num_trig_egr_drp not defined in {lossyProfile} for this "
-                f"platform's qos.yml; probe will run and print the measured "
-                f"value for manual qos.yml update."
+                "pkts_num_trig_egr_drp not defined in {} for this "
+                "platform's qos.yml; probe will run and print the measured "
+                "value for manual qos.yml update.".format(lossyProfile)
             )
 
         if "platform_asic" in dutTestParams["basicParams"]:
@@ -423,6 +547,10 @@ class TestQosProbe(QosSaiBase):
 
         # Get pdb parameter from command line
         enable_qos_ptf_pdb = request.config.getoption("--enable_qos_ptf_pdb", default=False)
+
+        # Platform probe params: packet_length, cells_per_packet, threshold conversions
+        platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
+        testParams.update(self.get_probe_params(platform_asic, qosConfig[lossyProfile], dutQosConfig))
 
         self.runPtfTest(
             ptfhost, testCase="egress_drop_probing.EgressDropProbing", testParams=testParams,
@@ -607,10 +735,15 @@ class TestQosProbe(QosSaiBase):
             probing_port_ids = src_testPortIds
 
         logger.info(
-            f"probing_port_ids {probing_port_ids},\n"
-            f"sonic_asic_type {sonic_asic_type},\n"
-            f"test_port_ids {dutConfig['testPortIds']},\n"
-            f"testPortIps {dutConfig['testPortIps']}"
+            "probing_port_ids {},\n"
+            "sonic_asic_type {},\n"
+            "test_port_ids {},\n"
+            "testPortIps {}".format(
+                probing_port_ids,
+                sonic_asic_type,
+                dutConfig["testPortIds"],
+                dutConfig["testPortIps"],
+            )
         )
         # end
 
@@ -684,6 +817,21 @@ class TestQosProbe(QosSaiBase):
             testParams['src_port_vlan'] = src_port_vlans
 
         testParams["ingress_drop_counter_mode"] = self.get_ingress_drop_counter_mode(dutTestParams)
+
+        # Platform probe params: packet_length, cells_per_packet, threshold conversions.
+        # hdrm_pool_size may lack packet_size/cell_size needed by platform
+        # resolvers (e.g. Cisco-8000 defaults to 64B without packet_size).
+        # Headroom pool is filled by lossless traffic on the same PGs as xoff,
+        # so fall back to xoff_1 profile values when hdrm_pool_size lacks them.
+        platform_asic = dutTestParams["basicParams"].get("platform_asic", None)
+        hdrm_probe_profile = dict(qosConfig.get("hdrm_pool_size", {}))
+        if "packet_size" not in hdrm_probe_profile:
+            xoff_fallback = qosConfig.get("xoff_1", {})
+            for key in ("packet_size", "cell_size"):
+                if key in xoff_fallback and key not in hdrm_probe_profile:
+                    hdrm_probe_profile[key] = xoff_fallback[key]
+        testParams.update(self.get_probe_params(
+            platform_asic, hdrm_probe_profile, dutQosConfig))
 
         self.runPtfTest(
             ptfhost, testCase="headroom_pool_probing.HeadroomPoolProbing",

--- a/tests/saitests/mock/ut/test_egress_drop_probing.py
+++ b/tests/saitests/mock/ut/test_egress_drop_probing.py
@@ -78,6 +78,8 @@ class TestEgressDropProbingInstance:
         self.def_vlan_mac = None
         self.cell_size = 208
         self.packet_size = 64
+        self.probe_packet_length = 64
+        self.probe_cells_per_packet = 1
         self.egress_lossy_pool_size = 104000
 
         # Probing configuration
@@ -90,7 +92,7 @@ class TestEgressDropProbingInstance:
 
         # Mock dataplane
         self.dataplane = MagicMock()
-        self.dataplane.get_mac.side_effect = lambda dev, port: f"00:00:00:00:00:{port:02x}"
+        self.dataplane.get_mac.side_effect = lambda dev, port: "00:00:00:00:00:{:02x}".format(port)
 
         # Stream manager (will be set by setup_traffic)
         self.stream_mgr = None

--- a/tests/saitests/mock/ut/test_headroom_pool_probing.py
+++ b/tests/saitests/mock/ut/test_headroom_pool_probing.py
@@ -79,6 +79,8 @@ class TestHeadroomPoolProbingInstance:
         self.def_vlan_mac = None
         self.cell_size = 208
         self.packet_size = 64
+        self.probe_packet_length = 64
+        self.probe_cells_per_packet = 1
         self.ingress_drop_counter_mode = 'port_drop'
 
         # Probing configuration
@@ -91,7 +93,7 @@ class TestHeadroomPoolProbingInstance:
 
         # Mock dataplane
         self.dataplane = MagicMock()
-        self.dataplane.get_mac.side_effect = lambda dev, port: f"00:00:00:00:00:{port:02x}"
+        self.dataplane.get_mac.side_effect = lambda dev, port: "00:00:00:00:00:{:02x}".format(port)
 
         # Mock buffer controller
         self.buffer_ctrl = MagicMock()
@@ -940,6 +942,120 @@ class TestHeadroomPoolProbingPersistBuffer(unittest.TestCase):
         instance.buffer_ctrl.persist_buffer_occupancy.assert_called_once()
         call_args = instance.buffer_ctrl.persist_buffer_occupancy.call_args
         assert call_args[1]['count'] == 1100  # No margin
+
+    @pytest.mark.order(4241)
+    @patch('headroom_pool_probing.ProbingObserver')
+    def test_persist_buffer_with_port_buffer_drop_no_margin(self, mock_observer_class):
+        """Test buffer persistence uses no margin when using port_buffer_drop counter mode."""
+        instance = TestHeadroomPoolProbingInstance()
+        instance.ingress_drop_counter_mode = 'port_buffer_drop'
+        instance.POINT_PROBING_STEP_SIZE = 2
+
+        mock_stream_mgr = MagicMock()
+        mock_stream_mgr.flows = {
+            (24, 36, frozenset([('pg', 3)])): MagicMock(dscp=3)
+        }
+        instance.stream_mgr = mock_stream_mgr
+
+        instance.get_pool_size = MagicMock(return_value=10000)
+        mock_observer_class.console = MagicMock()
+        mock_observer_class.report_probing_result = MagicMock()
+
+        instance._get_observer_configs = MagicMock(return_value={
+            'upper': MagicMock(), 'lower': MagicMock(),
+            'range': MagicMock(), 'point': MagicMock()
+        })
+        instance.create_executor = MagicMock(return_value=MagicMock())
+
+        call_count_ul = [0]
+        call_count_rp = [0]
+
+        def side_effect_ul(*args, **kwargs):
+            call_count_ul[0] += 1
+            if call_count_ul[0] in [1, 3]:
+                return (2000, 1.0) if call_count_ul[0] == 1 else (2100, 1.0)
+            else:
+                return (1000, 1.0) if call_count_ul[0] == 2 else (1090, 1.0)
+
+        def side_effect_rp(*args, **kwargs):
+            call_count_rp[0] += 1
+            if call_count_rp[0] == 1:
+                return (1000, 1005, 1.0)
+            elif call_count_rp[0] == 2:
+                return (1000, 1001, 1.0)
+            elif call_count_rp[0] == 3:
+                return (1096, 1100, 1.0)
+            else:
+                return (1100, 1101, 1.0)
+
+        with patch('headroom_pool_probing.UpperBoundProbingAlgorithm') as mock_upper, \
+             patch('headroom_pool_probing.LowerBoundProbingAlgorithm') as mock_lower, \
+             patch('headroom_pool_probing.ThresholdRangeProbingAlgorithm') as mock_range, \
+             patch('headroom_pool_probing.ThresholdPointProbingAlgorithm') as mock_point:
+
+            for mock_algo_class in [mock_upper, mock_lower]:
+                mock_algo_class.return_value.run.side_effect = side_effect_ul
+            for mock_algo_class in [mock_range, mock_point]:
+                mock_algo_class.return_value.run.side_effect = side_effect_rp
+
+            instance._build_result = MagicMock(return_value={'success': True, 'total_headroom': 100})
+            instance._report_results = MagicMock(return_value=MagicMock())
+
+            HeadroomPoolProbing.probe(instance)
+
+        # port_buffer_drop is noise-immune like pg_drop → no margin
+        instance.buffer_ctrl.persist_buffer_occupancy.assert_called_once()
+        call_args = instance.buffer_ctrl.persist_buffer_occupancy.call_args
+        assert call_args[1]['count'] == 1100  # No margin
+
+    @pytest.mark.order(4245)
+    @patch('headroom_pool_probing.ProbingObserver')
+    def test_probe_pool_size_conversion_multi_cell(self, mock_observer_class):
+        """Test probe converts pool_size from cells to packets when cells_per_packet > 1."""
+        instance = TestHeadroomPoolProbingInstance()
+        instance.probe_cells_per_packet = 4  # Cisco: 1350B / 384B
+
+        mock_stream_mgr = MagicMock()
+        mock_stream_mgr.flows = {
+            (24, 36, frozenset([('pg', 3)])): MagicMock(dscp=3)
+        }
+        instance.stream_mgr = mock_stream_mgr
+
+        # Pool size in cells = 10000, should become 2500 pkts
+        instance.get_pool_size = MagicMock(return_value=10000)
+        mock_observer_class.console = MagicMock()
+        mock_observer_class.report_probing_result = MagicMock()
+
+        instance._get_observer_configs = MagicMock(return_value={
+            'upper': MagicMock(), 'lower': MagicMock(),
+            'range': MagicMock(), 'point': MagicMock()
+        })
+        instance.create_executor = MagicMock(return_value=MagicMock())
+
+        with patch('headroom_pool_probing.UpperBoundProbingAlgorithm') as mock_upper, \
+             patch('headroom_pool_probing.LowerBoundProbingAlgorithm') as mock_lower, \
+             patch('headroom_pool_probing.ThresholdRangeProbingAlgorithm') as mock_range, \
+             patch('headroom_pool_probing.ThresholdPointProbingAlgorithm') as mock_point:
+
+            # First PG upper bound: algorithm receives pool_size=2500 as init value
+            mock_upper_algo = MagicMock()
+            mock_upper_algo.run.return_value = (2000, 1.0)
+            mock_upper.return_value = mock_upper_algo
+
+            mock_lower.return_value.run.return_value = (1000, 1.0)
+            mock_range.return_value.run.return_value = (1000, 1005, 1.0)
+            mock_point.return_value.run.return_value = (1000, 1001, 1.0)
+
+            instance._build_result = MagicMock(return_value={'success': False})
+            instance._report_results = MagicMock(return_value=MagicMock())
+
+            HeadroomPoolProbing.probe(instance)
+
+        # First PFC upper bound call uses pool_size as init value
+        # pool_size = 10000 cells // 4 cells_per_packet = 2500 packets
+        pfc_upper_call = mock_upper_algo.run.call_args_list[0]
+        init_value = pfc_upper_call[0][2]  # 3rd positional arg
+        assert init_value == 2500, f"Expected pool_size=2500 (10000//4), got {init_value}"
 
 
 if __name__ == "__main__":

--- a/tests/saitests/mock/ut/test_ingress_drop_probing.py
+++ b/tests/saitests/mock/ut/test_ingress_drop_probing.py
@@ -75,6 +75,8 @@ class TestIngressDropProbingInstance:
         self.def_vlan_mac = None
         self.cell_size = 208
         self.packet_size = 64
+        self.probe_packet_length = 64
+        self.probe_cells_per_packet = 1
         self.ingress_drop_counter_mode = 'port_drop'
 
         # Probing configuration
@@ -87,7 +89,7 @@ class TestIngressDropProbingInstance:
 
         # Mock dataplane
         self.dataplane = MagicMock()
-        self.dataplane.get_mac.side_effect = lambda dev, port: f"00:00:00:00:00:{port:02x}"
+        self.dataplane.get_mac.side_effect = lambda dev, port: "00:00:00:00:00:{:02x}".format(port)
 
         # Stream manager (will be set by setup_traffic)
         self.stream_mgr = None
@@ -766,6 +768,41 @@ class TestIngressDropProbingProbeMethod(unittest.TestCase):
             # Should still create result from (None, None)
             mock_result_class.from_bounds.assert_called_once_with(None, None)
             assert result == mock_result
+
+    @pytest.mark.order(3250)
+    @patch('ingress_drop_probing.ThresholdResult')
+    @patch('ingress_drop_probing.ProbingObserver')
+    def test_probe_pool_size_conversion_multi_cell(self, mock_observer_class, mock_result_class):
+        """Test probe converts pool_size from cells to packets when cells_per_packet > 1."""
+        instance = TestIngressDropProbingInstance()
+        instance.probe_cells_per_packet = 4  # Cisco: 1350B / 384B = 4 cells/pkt
+
+        mock_stream_mgr = MagicMock()
+        mock_stream_mgr.get_port_ids.return_value = [28]
+        instance.stream_mgr = mock_stream_mgr
+
+        # Pool size in cells
+        instance.get_pool_size = MagicMock(return_value=10000)
+
+        mock_algorithms = {
+            "upper_bound": MagicMock(),
+            "lower_bound": MagicMock(),
+            "threshold_range": MagicMock()
+        }
+        instance._create_algorithms = MagicMock(return_value=mock_algorithms)
+        instance._run_algorithms = MagicMock(return_value=(600, 650))
+
+        mock_result = MagicMock()
+        mock_result_class.from_bounds.return_value = mock_result
+        mock_observer_class.console = MagicMock()
+        mock_observer_class.report_probing_result = MagicMock()
+
+        IngressDropProbing.probe(instance)
+
+        # pool_size passed to _run_algorithms should be 10000 // 4 = 2500
+        instance._run_algorithms.assert_called_once_with(
+            mock_algorithms, 24, 28, 2500, pg=3
+        )
 
 
 if __name__ == "__main__":

--- a/tests/saitests/mock/ut/test_ingress_drop_probing_executor.py
+++ b/tests/saitests/mock/ut/test_ingress_drop_probing_executor.py
@@ -42,8 +42,6 @@ class TestIngressDropProbingExecutor:
         self.mock_ptftest.src_client = MagicMock()
         self.mock_ptftest.asic_type = "broadcom"
         self.mock_ptftest.cnt_pg_idx = 5  # PG 3 + 2
-        # Ensure getattr fallback works for ingress_drop_counter_mode
-        del self.mock_ptftest.ingress_drop_counter_mode
 
     @pytest.mark.order(8800)
     def test_init_with_default_parameters(self):

--- a/tests/saitests/mock/ut/test_pfc_xoff_probing.py
+++ b/tests/saitests/mock/ut/test_pfc_xoff_probing.py
@@ -66,8 +66,9 @@ class TestPfcXoffProbingInstance(PfcXoffProbing):
         self.is_dualtor = False
         self.def_vlan_mac = None
         self.packet_size = 64
+        self.probe_packet_length = 64
+        self.probe_cells_per_packet = 1
 
-        # Mock get_rx_port method
         def mock_get_rx_port(src_port, dst_port):
             return dst_port
         self.get_rx_port = mock_get_rx_port

--- a/tests/saitests/mock/ut/test_probing_base.py
+++ b/tests/saitests/mock/ut/test_probing_base.py
@@ -605,6 +605,63 @@ class TestProbingBaseSetUp:
         assert pb.ingress_drop_counter_mode == 'port_buffer_drop'
         print("[OK] port_buffer_drop mode")
 
+    @pytest.mark.order(938)
+    def test_setUp_ingress_drop_counter_mode_invalid_raises(self):
+        """Test setUp() validation rejects invalid ingress_drop_counter_mode"""
+        print("\n=== Testing setUp() - invalid ingress_drop_counter_mode raises ValueError ===")
+
+        pb = ConcreteProbingBase()
+        pb.ingress_drop_counter_mode = 'invalid_mode'
+
+        # Simulate the validation path from setUp() L156-161
+        from ingress_drop_probing_executor import IngressDropProbingExecutor
+        mode = getattr(pb, 'ingress_drop_counter_mode', 'port_drop')
+        with pytest.raises(ValueError, match="Invalid ingress_drop_counter_mode"):
+            if mode not in IngressDropProbingExecutor.VALID_COUNTER_MODES:
+                raise ValueError(
+                    f"Invalid ingress_drop_counter_mode='{mode}'. "
+                    f"Must be one of: {IngressDropProbingExecutor.VALID_COUNTER_MODES}"
+                )
+
+        print("[OK] Invalid counter_mode raises ValueError")
+
+    @pytest.mark.order(939)
+    def test_parse_param_probe_packet_defaults(self):
+        """Test parse_param sets default probe_packet_length and probe_cells_per_packet"""
+        print("\n=== Testing parse_param - probe packet defaults ===")
+
+        pb = ConcreteProbingBase()
+
+        # Simulate parse_param default logic (L319-322)
+        if not hasattr(pb, 'probe_packet_length'):
+            pb.probe_packet_length = 64
+        if not hasattr(pb, 'probe_cells_per_packet'):
+            pb.probe_cells_per_packet = 1
+
+        assert pb.probe_packet_length == 64
+        assert pb.probe_cells_per_packet == 1
+        print("[OK] Defaults: probe_packet_length=64, probe_cells_per_packet=1")
+
+    @pytest.mark.order(940)
+    def test_parse_param_probe_packet_from_testparams(self):
+        """Test parse_param preserves probe_packet_length from testParams"""
+        print("\n=== Testing parse_param - probe packet from testParams ===")
+
+        pb = ConcreteProbingBase()
+        # Simulate testParams providing Cisco values
+        pb.probe_packet_length = 1350
+        pb.probe_cells_per_packet = 4
+
+        # parse_param defaults should NOT overwrite existing attrs
+        if not hasattr(pb, 'probe_packet_length'):
+            pb.probe_packet_length = 64
+        if not hasattr(pb, 'probe_cells_per_packet'):
+            pb.probe_cells_per_packet = 1
+
+        assert pb.probe_packet_length == 1350
+        assert pb.probe_cells_per_packet == 4
+        print("[OK] testParams values preserved: 1350B, 4 cells/pkt")
+
 
 class TestProbingBaseTearDown:
     """Test tearDown() method (simplified - no parent call needed in UT)"""

--- a/tests/saitests/mock/ut/test_stream_manager.py
+++ b/tests/saitests/mock/ut/test_stream_manager.py
@@ -674,12 +674,12 @@ class TestDetermineTrafficDmac(unittest.TestCase):
 @pytest.mark.order(3790)
 class TestStreamManagerUniformPackets(unittest.TestCase):
     """
-    Test StreamManager enforces uniform 64-byte probe packets.
+    Test StreamManager enforces uniform probe packet length.
 
     Design Doc Reference: §3.2, §3.6
-    Key Design Point: Platform independence through uniform probe packets
-    - Fixed 64-byte length across all platforms
-    - 64 bytes = 1 cell on all platforms (eliminates cell_occupancy variance)
+    Key Design Point: Uniform probe packet length set by ProbeParamsResolver
+    - Default 64-byte length for platforms with 1 cell per packet
+    - Platform-specific packet length (e.g. 1350B for Cisco) when cells_per_packet > 1
     """
 
     def setUp(self):
@@ -725,7 +725,7 @@ class TestStreamManagerUniformPackets(unittest.TestCase):
         # Verify all packets are 64 bytes (uniform)
         assert len(captured_lengths) == 2, "Should generate 2 packets"
         assert all(length == 64 for length in captured_lengths), \
-            f"All packets must be 64 bytes for platform independence, got {captured_lengths}"
+            f"All packets must use uniform length, got {captured_lengths}"
 
     def test_uniform_packet_protocol_consistency(self):
         """Test that packets use consistent protocol (IP) across flows."""

--- a/tests/saitests/probe/egress_drop_probing.py
+++ b/tests/saitests/probe/egress_drop_probing.py
@@ -109,9 +109,8 @@ class EgressDropProbing(ProbingBase):
         Get egress lossy pool size in cells.
 
         Override base class which uses ingress_lossless_pool_size. Egress drop probing
-        searches within the egress lossy pool space; the ingress pool has a different
-        capacity and using it as a fallback would cause the binary search to operate
-        over the wrong range and produce a meaningless threshold.
+        searches within the egress lossy pool space. Callers convert to packet units
+        using self.probe_cells_per_packet.
 
         Resolution order:
           1. ``epoolsz`` env override (debug)
@@ -131,7 +130,7 @@ class EgressDropProbing(ProbingBase):
             )
         if self.cell_size <= 0:
             raise RuntimeError(
-                f"cell_size must be > 0 for EgressDropProbing; got {self.cell_size}"
+                "cell_size must be > 0 for EgressDropProbing; got {}".format(self.cell_size)
             )
         return egress_lossy_pool_size // self.cell_size
 
@@ -171,22 +170,14 @@ class EgressDropProbing(ProbingBase):
             vlan=port_ips[self.probing_port_ids[1]].get("vlan_id", None)
         )
 
-        # Probing always uses 64-byte packets (1 cell = 1 packet) for consistent unit counting.
-        # The algorithm counts in "packets" which equals "cells" when packet_length=64.
-        packet_length = 64
+        # Probe packet config (resolved by ProbeParamsResolver in test_qos_probe.py)
+        packet_length = self.probe_packet_length
         ttl = 64
 
-        # Log platform-specific packet_size for reference (not used in probing)
-        original_packet_length = getattr(self, "packet_size", 64)
-        original_cell_occupancy = (
-            (original_packet_length + self.cell_size - 1) // self.cell_size
-            if hasattr(self, "cell_size") else 1
-        )
         log_message(
-            f"Platform-specific: packet_length={original_packet_length}, "
-            f"cell_occupancy={original_cell_occupancy}", to_stderr=True
+            f"Probe config: packet_length={packet_length}, "
+            f"cells_per_packet={self.probe_cells_per_packet}", to_stderr=True
         )
-        log_message(f"Probing uses: packet_length={packet_length}, cell_occupancy=1", to_stderr=True)
 
         is_dualtor = getattr(self, "is_dualtor", False)
         def_vlan_mac = getattr(self, "def_vlan_mac", None)
@@ -218,7 +209,10 @@ class EgressDropProbing(ProbingBase):
         Returns:
             ThresholdResult: Probing result with Egress Drop threshold
         """
-        pool_size = self.get_pool_size()
+        # Convert pool size from cells to packets
+        pool_size_cells = self.get_pool_size()
+        pool_size = pool_size_cells // self.probe_cells_per_packet
+
         src_port = self.probing_port_ids[0]
         dst_port = self.stream_mgr.get_port_ids("dst")[0]
 
@@ -227,7 +221,9 @@ class EgressDropProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size={pool_size}")
+        ProbingObserver.console(
+            f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, "
+            f"pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/headroom_pool_probing.py
+++ b/tests/saitests/probe/headroom_pool_probing.py
@@ -127,9 +127,15 @@ class HeadroomPoolProbing(ProbingBase):
         # Validate for N src -> 1 dst pattern
         num_src_ports = len(self.probing_port_ids) - 1
         if len(self.pgs) > num_src_ports:
-            log_message(f"Warning: Too many PGs ({len(self.pgs)}) for src ports ({num_src_ports})", to_stderr=True)
+            log_message(
+                "Warning: Too many PGs ({}) for src ports ({})".format(len(self.pgs), num_src_ports),
+                to_stderr=True,
+            )
         if len(self.dscps) > num_src_ports:
-            log_message(f"Warning: Too many DSCPs ({len(self.dscps)}) for src ports ({num_src_ports})", to_stderr=True)
+            log_message(
+                "Warning: Too many DSCPs ({}) for src ports ({})".format(len(self.dscps), num_src_ports),
+                to_stderr=True,
+            )
 
     def get_probe_config(self):
         """Return standardized probe configuration."""
@@ -197,23 +203,13 @@ class HeadroomPoolProbing(ProbingBase):
 
         log_message(f"Setup traffic: src_ports={src_port_ids}, dst_port={dst_port_id}", to_stderr=False)
 
-        # Platform-independent: 64-byte packets = 1 cell
-        packet_length = 64
+        # Probe packet config (resolved by ProbeParamsResolver in test_qos_probe.py)
+        packet_length = self.probe_packet_length
         ttl = 64
 
-        # Log platform info
-        original_packet_length = getattr(self, "packet_size", 64)
-        original_cell_occupancy = (
-            (original_packet_length + self.cell_size - 1) // self.cell_size
-            if hasattr(self, "cell_size") else 1
-        )
         log_message(
-            f"Platform-specific: packet_length={original_packet_length}, "
-            f"cell_occupancy={original_cell_occupancy}", to_stderr=True
-        )
-        log_message(
-            f"Probing uses: packet_length={packet_length}, cell_occupancy=1",
-            to_stderr=True
+            f"Probe config: packet_length={packet_length}, "
+            f"cells_per_packet={self.probe_cells_per_packet}", to_stderr=True
         )
 
         is_dualtor = getattr(self, "is_dualtor", False)
@@ -276,14 +272,17 @@ class HeadroomPoolProbing(ProbingBase):
         Returns:
             ThresholdResult: Pool size result (point format: lower == upper)
         """
-        # Get pool size
-        pool_size = self.get_pool_size()
+        # Convert pool size from cells to packets
+        pool_size_cells = self.get_pool_size()
+        pool_size = pool_size_cells // self.probe_cells_per_packet
 
         # Log probing start
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting Headroom Pool Size probing")
         ProbingObserver.console("  Traffic pattern: N src -> 1 dst")
-        ProbingObserver.console(f"  pool_size={pool_size}")
+        ProbingObserver.console(
+            f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, "
+            f"pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")
@@ -614,8 +613,8 @@ class HeadroomPoolProbing(ProbingBase):
 
         # Report total probing time
         ProbingObserver.console(
-            f"\nTotal probing time: {total_time/60:.2f} minutes "
-            f"({total_time:.1f} seconds)"
+            "\nTotal probing time: {:.2f} minutes "
+            "({:.1f} seconds)".format(total_time / 60, total_time)
         )
 
         return self._report_results(result)

--- a/tests/saitests/probe/ingress_drop_probing.py
+++ b/tests/saitests/probe/ingress_drop_probing.py
@@ -161,21 +161,14 @@ class IngressDropProbing(ProbingBase):
                 vlan=port_ips[dpid].get("vlan_id", None)
             ))
 
-        # Platform-independent: 64-byte packets = 1 cell
-        packet_length = 64
+        # Probe packet config (resolved by ProbeParamsResolver in test_qos_probe.py)
+        packet_length = self.probe_packet_length
         ttl = 64
 
-        # Log platform info
-        original_packet_length = getattr(self, "packet_size", 64)
-        original_cell_occupancy = (
-            (original_packet_length + self.cell_size - 1) // self.cell_size
-            if hasattr(self, "cell_size") else 1
-        )
         log_message(
-            f"Platform-specific: packet_length={original_packet_length}, "
-            f"cell_occupancy={original_cell_occupancy}", to_stderr=True
+            f"Probe config: packet_length={packet_length}, "
+            f"cells_per_packet={self.probe_cells_per_packet}", to_stderr=True
         )
-        log_message(f"Probing uses: packet_length={packet_length}, cell_occupancy=1", to_stderr=True)
 
         is_dualtor = getattr(self, "is_dualtor", False)
         def_vlan_mac = getattr(self, "def_vlan_mac", None)
@@ -211,8 +204,10 @@ class IngressDropProbing(ProbingBase):
         Returns:
             ThresholdResult: Probing result with Ingress Drop threshold
         """
-        # Get pool size and ports
-        pool_size = self.get_pool_size()
+        # Convert pool size from cells to packets
+        pool_size_cells = self.get_pool_size()
+        pool_size = pool_size_cells // self.probe_cells_per_packet
+
         src_port = self.probing_port_ids[0]
         dst_port = self.stream_mgr.get_port_ids("dst")[0]
 
@@ -223,7 +218,9 @@ class IngressDropProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size={pool_size}")
+        ProbingObserver.console(
+            f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, "
+            f"pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/ingress_drop_probing_executor.py
+++ b/tests/saitests/probe/ingress_drop_probing_executor.py
@@ -180,7 +180,8 @@ class IngressDropProbingExecutor:
 
                 # ===== Step 2: Baseline measurement =====
                 if self.counter_mode == 'pg_drop':
-                    # Level 1: PG drop counter (most precise, per-PG)
+                    # Level 1: Per-PG drop counter via sai_thrift_read_pg_drop_counters
+                    # Reads PG-specific drop count; noise-immune, most precise
                     pg_drop_base = sai_thrift_read_pg_drop_counters(
                         self.ptftest.src_client,
                         port_list["src"][src_port]
@@ -192,7 +193,8 @@ class IngressDropProbingExecutor:
                             f"PG{pg_num} baseline={pg_drop_base[pg_num]}, all_pgs={pg_drop_base}"
                         )
                 else:
-                    # Level 2 (port_buffer_drop) and Level 3 (port_drop) both read port counters
+                    # Level 2 & 3 both use sai_thrift_read_port_counters;
+                    # detection branch below selects which counter index to check
                     sport_cnt_base, _ = sai_thrift_read_port_counters(
                         self.ptftest.src_client,
                         self.ptftest.asic_type,
@@ -215,7 +217,7 @@ class IngressDropProbingExecutor:
 
                 # ===== Step 5: Ingress Drop detection =====
                 if self.counter_mode == 'pg_drop':
-                    # Level 1: PG-level drop counter (most precise, per-PG)
+                    # Level 1: sai_thrift_read_pg_drop_counters (per-PG, noise-immune)
                     pg_drop_curr = sai_thrift_read_pg_drop_counters(
                         self.ptftest.src_client,
                         port_list["src"][src_port]
@@ -236,7 +238,8 @@ class IngressDropProbingExecutor:
                                 f"[Ingress Drop] All PG drop changes: {all_diffs}"
                             )
                 elif self.counter_mode == 'port_buffer_drop':
-                    # Level 2: Port buffer drop counter (excludes noise, buffer-specific)
+                    # Level 2: INGRESS_PORT_BUFFER_DROP (SAI_PORT_STAT_IN_DROPPED_PKTS)
+                    # Checks only buffer drop counter; noise-immune like pg_drop
                     sport_cnt_curr, _ = sai_thrift_read_port_counters(
                         self.ptftest.src_client,
                         self.ptftest.asic_type,
@@ -258,7 +261,8 @@ class IngressDropProbingExecutor:
                             f"(INGRESS_DROP diff={ing_drop_diff} for reference)"
                         )
                 else:
-                    # Level 3: Port-level ingress drop counter (includes noise)
+                    # Level 3: INGRESS_DROP (SAI_PORT_STAT_IF_IN_DISCARDS) OR INGRESS_PORT_BUFFER_DROP
+                    # Checks both counters; includes non-unicast noise (LACP, IPv6 RS) — legacy default
                     sport_cnt_curr, _ = sai_thrift_read_port_counters(
                         self.ptftest.src_client,
                         self.ptftest.asic_type,

--- a/tests/saitests/probe/pfc_xoff_probing.py
+++ b/tests/saitests/probe/pfc_xoff_probing.py
@@ -163,21 +163,14 @@ class PfcXoffProbing(ProbingBase):
                 vlan=port_ips[dpid].get("vlan_id", None)
             ))
 
-        # Platform-independent: 64-byte packets = 1 cell
-        packet_length = 64
+        # Probe packet config (resolved by ProbeParamsResolver in test_qos_probe.py)
+        packet_length = self.probe_packet_length
         ttl = 64
 
-        # Log platform info
-        original_packet_length = getattr(self, "packet_size", 64)
-        original_cell_occupancy = (
-            (original_packet_length + self.cell_size - 1) // self.cell_size
-            if hasattr(self, "cell_size") else 1
-        )
         log_message(
-            f"Platform-specific: packet_length={original_packet_length}, "
-            f"cell_occupancy={original_cell_occupancy}", to_stderr=True
+            f"Probe config: packet_length={packet_length}, "
+            f"cells_per_packet={self.probe_cells_per_packet}", to_stderr=True
         )
-        log_message(f"Probing uses: packet_length={packet_length}, cell_occupancy=1", to_stderr=True)
 
         is_dualtor = getattr(self, "is_dualtor", False)
         def_vlan_mac = getattr(self, "def_vlan_mac", None)
@@ -213,8 +206,10 @@ class PfcXoffProbing(ProbingBase):
         Returns:
             ThresholdResult: Probing result with PFC XOFF threshold
         """
-        # Get pool size and ports
-        pool_size = self.get_pool_size()
+        # Convert pool size from cells to packets
+        pool_size_cells = self.get_pool_size()
+        pool_size = pool_size_cells // self.probe_cells_per_packet
+
         src_port = self.probing_port_ids[0]
         dst_port = self.stream_mgr.get_port_ids("dst")[0]
 
@@ -225,7 +220,9 @@ class PfcXoffProbing(ProbingBase):
         ProbingObserver.console("=" * 80)
         ProbingObserver.console(f"[{self.PROBE_TARGET}] Starting threshold probing")
         ProbingObserver.console(f"  src_port={src_port}, dst_port={dst_port}")
-        ProbingObserver.console(f"  pool_size={pool_size}")
+        ProbingObserver.console(
+            f"  pool_size_cells={pool_size_cells}, cells_per_packet={self.probe_cells_per_packet}, "
+            f"pool_size_pkts={pool_size}")
         ProbingObserver.console(f"  precision_target_ratio={self.PRECISION_TARGET_RATIO}")
         ProbingObserver.console(f"  enable_precise_detection={self.ENABLE_PRECISE_DETECTION}")
         ProbingObserver.console(f"  executor_env={self.EXECUTOR_ENV}")

--- a/tests/saitests/probe/probing_base.py
+++ b/tests/saitests/probe/probing_base.py
@@ -153,6 +153,13 @@ class ProbingBase(sai_base_test.ThriftInterfaceDataPlane):
         # No env var override — change testParams in PTF command to switch mode
         self.ingress_drop_counter_mode = getattr(self, 'ingress_drop_counter_mode', 'port_drop')
 
+        from ingress_drop_probing_executor import IngressDropProbingExecutor
+        if self.ingress_drop_counter_mode not in IngressDropProbingExecutor.VALID_COUNTER_MODES:
+            raise ValueError(
+                f"Invalid ingress_drop_counter_mode='{self.ingress_drop_counter_mode}'. "
+                f"Must be one of: {IngressDropProbingExecutor.VALID_COUNTER_MODES}"
+            )
+
         ProbingObserver.trace(
             f"[{self.__class__.__name__}] ingress_drop_counter_mode={self.ingress_drop_counter_mode}"
         )
@@ -307,6 +314,13 @@ class ProbingBase(sai_base_test.ThriftInterfaceDataPlane):
         self.asic_type = self.sonic_asic_type
         self.counter_margin = 0
 
+        # Defaults for probe packet params — overridden by testParams if present
+        # (the for-loop above sets them from test_params when provided by ProbeParamsResolver)
+        if not hasattr(self, 'probe_packet_length'):
+            self.probe_packet_length = 64
+        if not hasattr(self, 'probe_cells_per_packet'):
+            self.probe_cells_per_packet = 1
+
     def get_rx_port(self, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, dst_port_id, src_vlan):
         """
         Resolve actual destination port (handles LAG scenarios).
@@ -317,7 +331,7 @@ class ProbingBase(sai_base_test.ThriftInterfaceDataPlane):
         Includes retry logic for T1 topologies where BGP routes may not be
         fully converged when the first probe packet is sent.
         """
-        log_message(f"dst_port_id:{dst_port_id}, src_port_id:{src_port_id}", to_stderr=False)
+        log_message("dst_port_id:{}, src_port_id:{}".format(dst_port_id, src_port_id), to_stderr=False)
         from probing_observer import ProbingObserver
         max_retries = 3
         for attempt in range(max_retries):
@@ -349,7 +363,10 @@ class ProbingBase(sai_base_test.ThriftInterfaceDataPlane):
 
     def get_pool_size(self):
         """
-        Get ingress lossless pool size in cells.
+        Get buffer pool size in cells.
+
+        This returns the raw cell count. Callers convert to packet units
+        using self.probe_cells_per_packet (set by ProbeParamsResolver).
 
         Checks environment variable 'ipoolsz' first,
         falls back to self.ingress_lossless_pool_size / cell_size.


### PR DESCRIPTION
### Description of PR
Summary:
Manual backport of #24784 to the `202605` branch.

The automatic cherry-pick (#26567) is failing the mandatory pre-commit check, so this PR replaces it with a manually adjusted cherry-pick that passes.

**Why the auto cherry-pick failed (and why no source logic changed here):**

`202605` still pins `flake8 6.0.0` in `.pre-commit-config.yaml`. `master` bumped it to `7.1.1` in #26072, which merged 2026-07-10 — after `202605` was branched (2026-07-03) — and that bump was backported to `202511` (#26088) but never to `202605`.

`flake8 6.0.0` ships `pycodestyle 2.10.0`, which predates the PEP 701 f-string tokenizer change in Python 3.12. On the Python 3.12 CI agents it therefore tokenizes the *contents* of f-string literals as code and reports 30 bogus errors on perfectly valid code, e.g.:

| Reported | Actual source | Why it is a false positive |
|---|---|---|
| `E713 test for membership should be 'not in'` | `f"pkts_num_trig_egr_drp not defined in {lossyProfile} ..."` | plain English inside a string literal |
| `E702 multiple statements on one line (semicolon)` | `f"... EgressDropProbing; got {self.cell_size}"` | `;` is message punctuation |
| `E231 missing whitespace after ':'` | `f"00:00:00:00:00:{port:02x}"` | MAC literal + format spec |
| `E225 missing whitespace around operator` | `log_message(f"...", to_stderr=True)` | keyword-arg `=` mis-detected after FSTRING tokens |

Since `.pre-commit-config.yaml` is outside the scope of #24784, this PR does not touch it. Instead, only the f-string literals **in files already modified by #24784** are rewritten as plain strings with `str.format()`. The set of changed files is a strict subset of #24784.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Carry the Cisco-8000 probe fix from #24784 into `202605`.

Cisco-8000 uses 384-byte buffer cells and 4:1 statistical packet sampling. With 64B probe packets (1 cell each) only 1 in 4 packets is sampled, producing inaccurate buffer occupancy. Using 1350B packets (4 cells each) makes sampling 1:1 and removes the statistical error. #24784 also fixes a threshold unit mismatch (some `qos.yml` profiles use cell units, others packet units) and converts `pool_size` from cells to packets for multi-cell platforms.

#### How did you do it?
1. `git cherry-pick -x b70954c4ed73a3da16ed7f5d3f151e03dca4ddff` — applied cleanly, no conflicts.
2. Rewrote the 8 f-string literals flagged by `flake8 6.0.0` as plain strings using `str.format()`.

The delta versus a pristine cherry-pick is 8 hunks, all string-formatting only — no control flow, no API, no test-logic changes:

- `tests/qos/test_qos_probe.py` (2)
- `tests/saitests/mock/ut/test_egress_drop_probing.py` (1)
- `tests/saitests/mock/ut/test_headroom_pool_probing.py` (1)
- `tests/saitests/mock/ut/test_ingress_drop_probing.py` (1)
- `tests/saitests/probe/egress_drop_probing.py` (1)
- `tests/saitests/probe/headroom_pool_probing.py` (2)
- `tests/saitests/probe/probing_base.py` (1)

#### How did you verify/test it?
- **Byte-identical output**: every rewritten literal was diffed against the original f-string across a range of inputs (including `0`, negative, `None`, and multi-digit values). All identical.
- **Lint**: `flake8 6.0.0` (what `202605` pins) and `flake8 7.1.1` (what `master` pins) both report **0 errors** on Python 3.12.
- **Full pre-commit suite** on the changed files: all hooks pass, `flake8` now `Passed`.
- **Unit tests**: `tests/saitests/mock/ut` — **490 passed**.
- **Integration tests**: `tests/saitests/mock/it` — **99 passed**.
- Original #24784 validation on physical Cisco-8102-C64 still applies: PFC XOFF PASS [3413,3506] vs 3415, Ingress Drop PASS [3694,3786] vs 3703, Egress Drop PASS [3961,4100] vs 4000.
- Test on 8101 and overall pass rate increased and full fix in progress.
<img width="781" height="144" alt="image" src="https://github.com/user-attachments/assets/fc1d14ce-eb95-4c2f-9660-4675e6da21d3" />

#### Any platform specific information?
Cisco-8000: `cell_size=384B`, `packet_size=1350B`, 4:1 sampling. Other platforms are unchanged (64B default).

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
No documentation change required.

---

**Note for maintainers:** the underlying cause is that `202605` lags `master` on the flake8 pin. Backporting #26072 (a one-line bump of `.pre-commit-config.yaml` from `6.0.0` to `7.1.1`) to `202605` would prevent every future cherry-pick containing f-strings from hitting this same false-positive wall. That is intentionally left out of this PR to keep the change scoped to #24784.

Closes #26567
