### PR TITLE
Fix SNMP v2 MIB sysLocation validation

### DIFF
--- a/tests/snmp/test_snmp_v2mib.py
+++ b/tests/snmp/test_snmp_v2mib.py
@@ -25,8 +25,8 @@ def test_snmp_v2mib(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds
     debian_ver = duthost.shell('cat /etc/debian_version')['stdout']
     cmd = 'docker exec snmp grep "sysContact" /etc/snmp/snmpd.conf'
     sys_contact = " ".join(duthost.shell(cmd)['stdout'].split()[1:])
-    sys_location = duthost.shell(
-        "grep 'snmp_location' /etc/sonic/snmp.yml")['stdout'].split()[-1]
+    cmd = 'docker exec snmp grep "sysLocation" /etc/snmp/snmpd.conf'
+    sys_location = " ".join(duthost.shell(cmd)['stdout'].split()[1:])
 
     expected_res = {'kernel_version': dut_facts['ansible_kernel'],
                     'hwsku': duthost.facts['hwsku'],


### PR DESCRIPTION
### Description of PR

Summary:
Fixes the SNMP v2 MIB test to derive expected sysLocation from the running SNMP daemon configuration instead of requiring legacy `/etc/sonic/snmp.yml` to contain `snmp_location`.

Related ADO PBI: https://msazure.visualstudio.com/One/_workitems/edit/38956884

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38956884
Failure type: regression

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
Pre-commit on changed file passed locally:
`python -m pre_commit run --files tests/snmp/test_snmp_v2mib.py`

The nightly failure on 202605/Arista-7050CX3-32S-C32 showed `/etc/sonic/snmp.yml` existed but did not contain `snmp_location`, while the SNMP daemon still exposes `sysLocation` from `/etc/snmp/snmpd.conf` (defaulting to `public` when not configured). This patch validates against the running daemon configuration.

### Approach
#### What is the motivation for this PR?

`test_snmp_v2mib` failed before assertions because it ran `grep 'snmp_location' /etc/sonic/snmp.yml` and treated grep rc=1 as a test failure. On newer images/configurations the legacy YAML may not carry `snmp_location`, while the effective SNMP location is still present in `/etc/snmp/snmpd.conf`.

#### How did you do it?

Read expected `sysLocation` from `/etc/snmp/snmpd.conf` inside the `snmp` container, matching how the test already reads expected `sysContact`.

#### How did you verify/test it?

Ran Python compile and sonic-mgmt pre-commit on the changed test file; all hooks passed.

#### Any platform specific information?

Observed on Arista-7050CX3-32S-C32, DUALTOR, branch 20260510.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.