### PR TITLE
Fix password aging login check

### DIFF
--- a/tests/passw_hardening/test_passw_hardening.py
+++ b/tests/passw_hardening/test_passw_hardening.py
@@ -7,6 +7,7 @@ Tests Password Hardening Feature:
 
 import logging
 import re
+import shlex
 import pytest
 import datetime
 import six
@@ -189,15 +190,23 @@ def verify_age_flow(duthost, passw_hardening_ob, expected_login_error):
     # verify Age configuration in Linux files
     compare_passw_age_in_pam_dir(duthost, passw_hardening_ob, passw_hardening_utils.USERNAME_AGE)
 
-    # login expecting to require passw change
-    user_age_cmd = 'echo {} | sudo -S su {}'.format(passw_test, passw_hardening_utils.USERNAME_AGE)
+    # Run su from the non-root SSH login user so PAM authenticates the test user.
+    host_vars = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars
+    login_user = host_vars.get('ansible_user')
+    pytest_assert(login_user and login_user != 'root',
+                  "Password-aging validation requires a non-root ansible_user")
+    su_cmd = "printf '%s\\n' {} | timeout 10 su -c true {}".format(
+        shlex.quote(passw_test),
+        shlex.quote(passw_hardening_utils.USERNAME_AGE)
+    )
+    user_age_cmd = 'runuser -u {} -- sh -c {}'.format(
+        shlex.quote(login_user),
+        shlex.quote(su_cmd)
+    )
     login_cmd = duthost.shell(user_age_cmd, module_ignore_errors=True)
 
-    # test login results
-    if 'Warning' in expected_login_error:  # expiration warning time case, the cmd is not failing
-        login_response = login_cmd['stdout']
-    else:  # expiration time case the cmd is failing
-        login_response = login_cmd['stderr']
+    # PAM messages may be emitted on stdout or stderr depending on the distro/PAM stack.
+    login_response = '{}\n{}'.format(login_cmd.get('stdout', ''), login_cmd.get('stderr', ''))
     pytest_assert(expected_login_error in login_response,
                   "Fail: the username='{}' could login by error, expected_login_error={} , but got this msg={}".format(
                       passw_hardening_utils.USERNAME_AGE, expected_login_error, login_response))


### PR DESCRIPTION
### Description of PR
Fix password-aging login validation in `passw_hardening/test_passw_hardening.py`.

`duthost.shell()` executes with Ansible become enabled, so the old `sudo -S su <user>` command ran `su` as root. Root bypassed the test user's PAM authentication; the piped password was then interpreted by the spawned shell, producing `sh: 1: a_n_y_1989_2022: not found` instead of the expected password-aging message.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
N/A for public release branches. Current Kusto data (last 7 days) shows 202511 at 96/96 functional passes and 202605 at 190/190 functional passes; the two 202605 non-successes were unrelated host-unreachable setup errors. The password-aging assertion failure affects `sonic-mgmt-int/internal` (0/8 in the last 7 days) and was also seen on `internal-202509` (0/6 in the last 30 days, latest July 17). These targets should receive the merged master fix through internal sync/cherry-pick if still maintained, rather than through public 202511/202605 backport labels.

### Approach
#### What is the motivation for this PR?
Internal nightly PBI 38956889 consistently fails `test_passw_hardening_age_expiration` and the warning variant because the test does not actually authenticate as the test user when checking password aging.

#### How did you do it?
- Read the DUT's inventory `ansible_user` and require it to be non-root.
- Use root only to invoke `runuser -u <ansible_user>`, then execute `su` from that non-root login context so PAM must authenticate the password-aging test user.
- Pipe the quoted test password to `su -c true` and use `timeout 10` so an interactive password-change prompt cannot hang the test.
- Check both stdout and stderr because PAM messages vary by distro/PAM stack.

#### How did you verify/test it?
- `python -m py_compile tests/passw_hardening/test_passw_hardening.py`
- `python -m flake8 tests/passw_hardening/test_passw_hardening.py --max-line-length=120`
- Validated the exact `runuser -> su` flow on a disposable Ubuntu 22.04 dev-VM account with guaranteed cleanup:
  - warning case: rc=0 and `Warning: your password will expire ...`
  - expired case: rc=1 and `You are required to change your password immediately (password expired).`
- The prior PR CI failure was unrelated: VPP test plan `6a66ffd9b63289adaeeed7f9` stopped on `arp/test_neighbor_mac.py`; the password-hardening test was not involved. The PR branch has been rebuilt on current master without the unrelated VXLAN skip file and CI is rerunning.

#### Any platform specific information?
Observed on internal nightly, `Arista-7060CX-32S-C32`, topology `t1-lag`.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A