### PR TITLE
[macsec] 202511: remove duplicated early wait_mka_establish in load_macsec_info

### DIFF
--- a/tests/common/macsec/__init__.py
+++ b/tests/common/macsec/__init__.py
@@ -132,17 +132,6 @@ class MacsecPlugin(object):
         """
 
         if get_macsec_enable_status(macsec_duthost) and get_macsec_profile(macsec_duthost):
-            # Ensure MKA sessions are established (SC/SA present in DB) if the
-            # test environment provides the wait_mka_establish fixture
-            # (defined in tests/macsec/conftest.py). For environments that do
-            # not define it, fall back to the original behaviour.
-            try:
-                request.getfixturevalue('wait_mka_establish')
-            except pytest.FixtureLookupError:
-                # Some environments do not define wait_mka_establish; fall back
-                # to the original behaviour when the fixture is missing.
-                pass
-
             if is_macsec_configured(macsec_duthost, macsec_profile, ctrl_links):
                 # MACsec is already configured (e.g., carried over from a
                 # previous module). Wait for MKA sessions to be established


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #26584

`202511` currently has **two** `request.getfixturevalue('wait_mka_establish')` calls in the module-scoped autouse fixture `load_macsec_info` (`tests/common/macsec/__init__.py`): an early unconditional one, and the correctly guarded one inside `if is_macsec_configured(...)`.

The early one is fatal: it runs **before** `macsec_setup`, so on a testbed where the current profile is not configured yet it polls `check_appl_db` for 300 s per profile, the `AssertionError` propagates (only `pytest.FixtureLookupError` is caught), and `macsec_setup` below is unreachable. MACsec is never configured, so **every** `tests/macsec` module errors at setup (each parametrized profile burns ~330 s), and every subsequent run on the testbed fails the same way.

The duplication came from two backports merging in the opposite order from master: #24874 (backport of #24736, which *moves* the wait inside the `is_macsec_configured` branch) was created before #24606 (backport of #21372, which *introduces* the early wait) had merged — so #24874's diff was a pure addition with nothing to delete. #24606 then merged first, #24874 second, and git combined both without a textual conflict. See the timeline in #26584. This is exactly the failure mode the #24736 commit message warns about ("surfaces ... as a hard failure for every macsec test on fresh testbeds"), unmasked by the honest `check_appl_db` from the same PR.

This PR deletes the early wait block (11 lines). The resulting file is byte-identical to the `202605` branch's copy, which carries both backports correctly. `master` is also correct (newer refactor).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

All macsec coverage on 202511 is void: modules fail at fixture setup before applying any MACsec configuration (~50 minutes of wasted testbed time per module run), and the failures masquerade as device-side MKA regressions.

#### How did you do it?

Deleted the early `request.getfixturevalue('wait_mka_establish')` block in `load_macsec_info`, restoring the flow #24736 intended: if the profile is already configured (carry-over), wait then load; otherwise run `macsec_setup` first.

#### How did you verify/test it?

- After the change, `tests/common/macsec/__init__.py` is byte-identical to the `202605` branch's copy (which behaves correctly); flake8 clean.
- Failure mechanism confirmed from failing-run artifacts on T2 testbeds with SONiC neighbors (`--enable_macsec`): zero `config macsec` commands in the module log, `MACSEC_*` APPL_DB tables empty on DUT and neighbors for the whole run, `Check appl_db: N/N port pair(s) not yet ready` on every poll, 36/36 errors in ~2990 s for `test_interop_protocol` (9 profiles x ~330 s).
- With the fixed fixture ordering, `test_controlplane` (37 passed / 8 skipped / 0 failed) and `test_dataplane` (34 passed / 11 skipped / 0 failed) complete green on a T2 testbed with vSONiC neighbors across all 9 profiles.
- Device-path sanity: manually configuring the same profile on a control link on the same image brings MKA up within seconds — only the fixture ordering was broken.

#### Any platform specific information?

None — fixture-ordering fix, applies to all macsec-capable testbeds.

#### Supported testbed topology if it's a new test case?

N/A
