### PR TITLE
Changing drop packets exceeded mtu TC to check on TX

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -9,10 +9,10 @@ import ptf.testutils as testutils
 from collections import defaultdict
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
-from tests.common.helpers.drop_counters.drop_counters import verify_drop_counters, \
+from tests.common.helpers.drop_counters.drop_counters import verify_drop_counters, get_pkt_drops, \
     ensure_no_l3_drops, ensure_no_l2_drops, ensure_no_l3_and_l2_drops, ensure_no_l2_and_l3_drops
-from .drop_packets import L2_COL_KEY, L3_COL_KEY, RX_ERR, RX_DRP, ACL_COUNTERS_UPDATE_INTERVAL, \
-    MELLANOX_MAC_UPDATE_SCRIPT, expected_packet_mask, log_pkt_params, setup, fanouthost, pkt_fields, \
+from .drop_packets import L2_COL_KEY, L3_COL_KEY, RX_ERR, RX_DRP, ACL_COUNTERS_UPDATE_INTERVAL,\
+    MELLANOX_MAC_UPDATE_SCRIPT, expected_packet_mask, log_pkt_params, setup, fanouthost, pkt_fields,\
     send_packets, ports_info, tx_dut_ports, rif_port_down, sai_acl_drop_adj_enabled, acl_ingress, \
     acl_egress, configure_copp_drop_for_ttl_error, test_equal_smac_dmac_drop, test_multicast_smac_drop, \
     test_not_expected_vlan_tag_drop, test_dst_ip_is_loopback_addr, test_src_ip_is_loopback_addr, \
@@ -34,7 +34,6 @@ logger = logging.getLogger(__name__)
 PTF_PORT_MAPPING_MODE = 'use_orig_interface'
 
 PKT_NUMBER = 1000
-WEAK_SERVER_PKT_NUMBER = 100
 
 # CLI commands to obtain drop counters.
 NAMESPACE_PREFIX = "sudo ip netns exec {} "
@@ -46,6 +45,42 @@ LOG_EXPECT_PORT_ADMIN_UP_RE = ".*Port {} oper state set from down to up.*"
 
 COMBINED_L2L3_DROP_COUNTER = False
 COMBINED_ACL_DROP_COUNTER = False
+
+MTU_DROP_COUNTER_KEY = "TX_DRP"
+
+
+def get_ipv4_peer_for_interface(mg_facts, iface):
+    """Return directly connected IPv4 peer for the L3 interface where MTU is configured."""
+    for intf_list_key in ("minigraph_interfaces", "minigraph_portchannel_interfaces"):
+        for intf in mg_facts.get(intf_list_key, []):
+            peer_addr = intf.get("peer_addr")
+            if intf.get("attachto") == iface and peer_addr and "." in peer_addr:
+                return peer_addr
+    return None
+
+
+def verify_mtu_drop_counters(duthosts, packets_count):
+    """
+    Verify MTU exceeded TX_DRP on any port. On Cisco-8000 non-GB platforms, drops may be
+    counted on a port other than the ingress interface where MTU was configured.
+    """
+    def _find_mtu_drop():
+        for duthost in duthosts.frontend_nodes:
+            pkt_drops = get_pkt_drops(duthost, GET_L2_COUNTERS)
+            for iface, stats in pkt_drops.items():
+                try:
+                    val = int(stats.get(MTU_DROP_COUNTER_KEY, "0").replace(",", ""))
+                except ValueError:
+                    continue
+                if val >= packets_count:
+                    logger.info("MTU drop on {} {}={}".format(iface, MTU_DROP_COUNTER_KEY, val))
+                    return True
+        return False
+
+    pytest_assert(
+        wait_until(25, 1, 0, _find_mtu_drop),
+        "MTU drop counter {} not found on any port. Sent == {}".format(MTU_DROP_COUNTER_KEY, packets_count)
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -167,14 +202,11 @@ def handle_backend_acl(duthost, tbinfo):
 
 def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info,     # noqa: F811
                       tx_dut_ports=None, skip_counter_check=False, drop_information=None,  # noqa: F811
-                      weak_server=False):  # noqa: F811
+                      verify_mtu_drop=False):  # noqa: F811
     """
     Base test function for verification of L2 or L3 packet drops. Verification type depends on 'discard_group' value.
     Supported 'discard_group' values: 'L2', 'L3', 'ACL', 'NO_DROPS'
     """
-    def get_pkt_number():
-        return WEAK_SERVER_PKT_NUMBER if weak_server else PKT_NUMBER
-
     def clear_sonic_counters(dut):
         dut.command("sonic-clear counters")
         namespace_list = dut.get_asic_namespace_list() if dut.is_multi_asic else ['']
@@ -188,8 +220,7 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
         for duthost in duthosts.frontend_nodes:
             executor.submit(clear_sonic_counters, duthost)
 
-    pkt_number = get_pkt_number()
-    send_packets(pkt, ptfadapter, ports_info["ptf_tx_port_id"], pkt_number)
+    send_packets(pkt, ptfadapter, ports_info["ptf_tx_port_id"], PKT_NUMBER)
 
     # Some test cases will not increase the drop counter consistently on certain platforms
     if skip_counter_check:
@@ -197,30 +228,33 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
         return None
 
     if discard_group == "L2":
-        verify_drop_counters(duthosts, asic_index, ports_info["dut_iface"],
-                             GET_L2_COUNTERS, L2_COL_KEY, packets_count=pkt_number)
+        if verify_mtu_drop:
+            verify_mtu_drop_counters(duthosts, packets_count=PKT_NUMBER)
+        else:
+            verify_drop_counters(duthosts, asic_index, ports_info["dut_iface"],
+                                 GET_L2_COUNTERS, L2_COL_KEY, packets_count=PKT_NUMBER)
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
             for duthost in duthosts.frontend_nodes:
-                executor.submit(ensure_no_l3_drops, duthost, packets_count=pkt_number)
+                executor.submit(ensure_no_l3_drops, duthost, packets_count=PKT_NUMBER)
     elif discard_group == "L3":
         if COMBINED_L2L3_DROP_COUNTER:
             verify_drop_counters(duthosts, asic_index, ports_info["dut_iface"],
-                                 GET_L2_COUNTERS, L2_COL_KEY, packets_count=pkt_number)
+                                 GET_L2_COUNTERS, L2_COL_KEY, packets_count=PKT_NUMBER)
 
             with SafeThreadPoolExecutor(max_workers=8) as executor:
                 for duthost in duthosts.frontend_nodes:
-                    executor.submit(ensure_no_l3_drops, duthost, packets_count=pkt_number)
+                    executor.submit(ensure_no_l3_drops, duthost, packets_count=PKT_NUMBER)
         else:
             if not tx_dut_ports:
                 pytest.fail("No L3 interface specified")
 
             verify_drop_counters(duthosts, asic_index, tx_dut_ports[ports_info["dut_iface"]],
-                                 GET_L3_COUNTERS, L3_COL_KEY, packets_count=pkt_number)
+                                 GET_L3_COUNTERS, L3_COL_KEY, packets_count=PKT_NUMBER)
 
             with SafeThreadPoolExecutor(max_workers=8) as executor:
                 for duthost in duthosts.frontend_nodes:
-                    executor.submit(ensure_no_l2_drops, duthost, packets_count=pkt_number)
+                    executor.submit(ensure_no_l2_drops, duthost, packets_count=PKT_NUMBER)
     elif discard_group == "ACL":
         if not tx_dut_ports:
             pytest.fail("No L3 interface specified")
@@ -235,18 +269,18 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
                     continue
                 acl_drops += duthost.acl_facts(namespace=namespace)["ansible_facts"]["ansible_acl_facts"][
                     drop_information if drop_information else "DATAACL"]["rules"]["RULE_1"]["packets_count"]
-        if acl_drops != pkt_number:
+        if acl_drops != PKT_NUMBER:
             fail_msg = "ACL drop counter was not incremented on iface {}. DUT ACL counter == {}; Sent pkts == {}"\
-                .format(tx_dut_ports[ports_info["dut_iface"]], acl_drops, pkt_number)
+                .format(tx_dut_ports[ports_info["dut_iface"]], acl_drops, PKT_NUMBER)
             pytest.fail(fail_msg)
         if not COMBINED_ACL_DROP_COUNTER:
             with SafeThreadPoolExecutor(max_workers=8) as executor:
                 for duthost in duthosts.frontend_nodes:
-                    executor.submit(ensure_no_l3_and_l2_drops, duthost, packets_count=pkt_number)
+                    executor.submit(ensure_no_l3_and_l2_drops, duthost, packets_count=PKT_NUMBER)
     elif discard_group == "NO_DROPS":
         with SafeThreadPoolExecutor(max_workers=8) as executor:
             for duthost in duthosts.frontend_nodes:
-                executor.submit(ensure_no_l2_and_l3_drops, duthost, packets_count=pkt_number)
+                executor.submit(ensure_no_l2_and_l3_drops, duthost, packets_count=PKT_NUMBER)
     else:
         pytest.fail("Incorrect 'discard_group' specified. Supported values: 'L2', 'L3', 'ACL' or 'NO_DROPS'")
 
@@ -308,6 +342,8 @@ def mtu_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
 
         @classmethod
         def restore_mtu(cls):
+            if cls.iface is None or cls.key is None:
+                return
             duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
             namespace = duthost.get_namespace_from_asic_id(
                 cls.asic_index
@@ -330,9 +366,10 @@ def check_if_skip():
 
 
 @pytest.fixture(scope='module')
-def do_test(duthosts, weak_server):
+def do_test(duthosts):
     def do_counters_test(discard_group, pkt, ptfadapter, ports_info, sniff_ports, tx_dut_ports=None,    # noqa: F811
-                         comparable_pkt=None, skip_counter_check=False, drop_information=None, ip_ver='ipv4'):
+                         comparable_pkt=None, skip_counter_check=False, drop_information=None,
+                         ip_ver='ipv4', verify_mtu_drop=False):
         """
         Execute test - send packet, check that expected discard counters were incremented and packet was dropped
         @param discard_group: Supported 'discard_group' values: 'L2', 'L3', 'ACL', 'NO_DROPS'
@@ -351,7 +388,7 @@ def do_test(duthosts, weak_server):
         asic_index = ports_info["asic_index"]
         base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info, tx_dut_ports,
                           skip_counter_check=skip_counter_check, drop_information=drop_information,
-                          weak_server=weak_server)
+                          verify_mtu_drop=verify_mtu_drop)
 
         # Verify packets were not egresed the DUT
         if discard_group != "NO_DROPS":
@@ -463,23 +500,28 @@ def test_ip_pkt_with_exceeded_mtu(do_test, duthosts, enum_rand_one_per_hwsku_fro
     if "vlan" in tx_dut_ports[ports_info["dut_iface"]].lower():
         pytest.skip("Test case is not supported on VLAN interface")
 
+    mtu_iface = tx_dut_ports[ports_info["dut_iface"]]
+    ip_dst = get_ipv4_peer_for_interface(setup["mg_facts"], mtu_iface)
+    pytest_require(ip_dst, "IPv4 peer is not defined for interface {}".format(mtu_iface))
+
+    hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
+    verify_mtu_drop = duthost.facts["asic_type"] == "cisco-8000" and duthost.facts["hwsku"] not in hostvars["cisco-8000_gb_hwskus"]
     tmp_port_mtu = 1500
 
     log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"],
-                   pkt_fields["ipv4_dst"], pkt_fields["ipv4_src"])
+                   ip_dst, pkt_fields["ipv4_src"])
 
-    # Get the asic_index
     asic_index = ports_info["asic_index"]
 
     # Set temporal MTU. This will be restored by 'mtu' fixture
-    mtu_config.set_mtu(tmp_port_mtu, tx_dut_ports[ports_info["dut_iface"]], asic_index)
+    mtu_config.set_mtu(tmp_port_mtu, mtu_iface, asic_index)
 
     pkt = testutils.simple_tcp_packet(
         pktlen=9100,
         eth_dst=ports_info["dst_mac"],  # DUT port
         eth_src=ports_info["src_mac"],  # PTF port
         ip_src=pkt_fields["ipv4_src"],  # PTF source
-        ip_dst=pkt_fields["ipv4_dst"],  # VM IP address
+        ip_dst=ip_dst,                  # VM IP address
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"]
     )
@@ -487,6 +529,7 @@ def test_ip_pkt_with_exceeded_mtu(do_test, duthosts, enum_rand_one_per_hwsku_fro
     try:
         do_test("L2", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
                 # VPP drops the packet but does not increment the drop counter
-                skip_counter_check=(duthost.facts["asic_type"] == "vpp"))
+                skip_counter_check=(duthost.facts["asic_type"] == "vpp"),
+                verify_mtu_drop=verify_mtu_drop)
     finally:
         L2_COL_KEY = RX_DRP

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -11,8 +11,8 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.common.helpers.drop_counters.drop_counters import verify_drop_counters, get_pkt_drops, \
     ensure_no_l3_drops, ensure_no_l2_drops, ensure_no_l3_and_l2_drops, ensure_no_l2_and_l3_drops
-from .drop_packets import L2_COL_KEY, L3_COL_KEY, RX_ERR, RX_DRP, ACL_COUNTERS_UPDATE_INTERVAL,\
-    MELLANOX_MAC_UPDATE_SCRIPT, expected_packet_mask, log_pkt_params, setup, fanouthost, pkt_fields,\
+from .drop_packets import L2_COL_KEY, L3_COL_KEY, RX_ERR, RX_DRP, ACL_COUNTERS_UPDATE_INTERVAL, \
+    MELLANOX_MAC_UPDATE_SCRIPT, expected_packet_mask, log_pkt_params, setup, fanouthost, pkt_fields, \
     send_packets, ports_info, tx_dut_ports, rif_port_down, sai_acl_drop_adj_enabled, acl_ingress, \
     acl_egress, configure_copp_drop_for_ttl_error, test_equal_smac_dmac_drop, test_multicast_smac_drop, \
     test_not_expected_vlan_tag_drop, test_dst_ip_is_loopback_addr, test_src_ip_is_loopback_addr, \
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 PTF_PORT_MAPPING_MODE = 'use_orig_interface'
 
 PKT_NUMBER = 1000
+WEAK_SERVER_PKT_NUMBER = 100
 
 # CLI commands to obtain drop counters.
 NAMESPACE_PREFIX = "sudo ip netns exec {} "
@@ -47,6 +48,14 @@ COMBINED_L2L3_DROP_COUNTER = False
 COMBINED_ACL_DROP_COUNTER = False
 
 MTU_DROP_COUNTER_KEY = "TX_DRP"
+
+
+def _get_dut_hostvars(duthost):
+    _vm = duthost.host.options['variable_manager']
+    if _vm._hostvars is not None:
+        return _vm._hostvars[duthost.hostname]
+    _host_obj = duthost.host.options['inventory_manager'].get_host(duthost.hostname)
+    return _vm.get_vars(host=_host_obj) if _host_obj is not None else {}
 
 
 def get_ipv4_peer_for_interface(mg_facts, iface):
@@ -202,11 +211,14 @@ def handle_backend_acl(duthost, tbinfo):
 
 def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info,     # noqa: F811
                       tx_dut_ports=None, skip_counter_check=False, drop_information=None,  # noqa: F811
-                      verify_mtu_drop=False):  # noqa: F811
+                      weak_server=False, verify_mtu_drop=False):  # noqa: F811
     """
     Base test function for verification of L2 or L3 packet drops. Verification type depends on 'discard_group' value.
     Supported 'discard_group' values: 'L2', 'L3', 'ACL', 'NO_DROPS'
     """
+    def get_pkt_number():
+        return WEAK_SERVER_PKT_NUMBER if weak_server else PKT_NUMBER
+
     def clear_sonic_counters(dut):
         dut.command("sonic-clear counters")
         namespace_list = dut.get_asic_namespace_list() if dut.is_multi_asic else ['']
@@ -220,7 +232,8 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
         for duthost in duthosts.frontend_nodes:
             executor.submit(clear_sonic_counters, duthost)
 
-    send_packets(pkt, ptfadapter, ports_info["ptf_tx_port_id"], PKT_NUMBER)
+    pkt_number = get_pkt_number()
+    send_packets(pkt, ptfadapter, ports_info["ptf_tx_port_id"], pkt_number)
 
     # Some test cases will not increase the drop counter consistently on certain platforms
     if skip_counter_check:
@@ -229,32 +242,32 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
 
     if discard_group == "L2":
         if verify_mtu_drop:
-            verify_mtu_drop_counters(duthosts, packets_count=PKT_NUMBER)
+            verify_mtu_drop_counters(duthosts, packets_count=pkt_number)
         else:
             verify_drop_counters(duthosts, asic_index, ports_info["dut_iface"],
-                                 GET_L2_COUNTERS, L2_COL_KEY, packets_count=PKT_NUMBER)
+                                 GET_L2_COUNTERS, L2_COL_KEY, packets_count=pkt_number)
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
             for duthost in duthosts.frontend_nodes:
-                executor.submit(ensure_no_l3_drops, duthost, packets_count=PKT_NUMBER)
+                executor.submit(ensure_no_l3_drops, duthost, packets_count=pkt_number)
     elif discard_group == "L3":
         if COMBINED_L2L3_DROP_COUNTER:
             verify_drop_counters(duthosts, asic_index, ports_info["dut_iface"],
-                                 GET_L2_COUNTERS, L2_COL_KEY, packets_count=PKT_NUMBER)
+                                 GET_L2_COUNTERS, L2_COL_KEY, packets_count=pkt_number)
 
             with SafeThreadPoolExecutor(max_workers=8) as executor:
                 for duthost in duthosts.frontend_nodes:
-                    executor.submit(ensure_no_l3_drops, duthost, packets_count=PKT_NUMBER)
+                    executor.submit(ensure_no_l3_drops, duthost, packets_count=pkt_number)
         else:
             if not tx_dut_ports:
                 pytest.fail("No L3 interface specified")
 
             verify_drop_counters(duthosts, asic_index, tx_dut_ports[ports_info["dut_iface"]],
-                                 GET_L3_COUNTERS, L3_COL_KEY, packets_count=PKT_NUMBER)
+                                 GET_L3_COUNTERS, L3_COL_KEY, packets_count=pkt_number)
 
             with SafeThreadPoolExecutor(max_workers=8) as executor:
                 for duthost in duthosts.frontend_nodes:
-                    executor.submit(ensure_no_l2_drops, duthost, packets_count=PKT_NUMBER)
+                    executor.submit(ensure_no_l2_drops, duthost, packets_count=pkt_number)
     elif discard_group == "ACL":
         if not tx_dut_ports:
             pytest.fail("No L3 interface specified")
@@ -269,18 +282,18 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
                     continue
                 acl_drops += duthost.acl_facts(namespace=namespace)["ansible_facts"]["ansible_acl_facts"][
                     drop_information if drop_information else "DATAACL"]["rules"]["RULE_1"]["packets_count"]
-        if acl_drops != PKT_NUMBER:
+        if acl_drops != pkt_number:
             fail_msg = "ACL drop counter was not incremented on iface {}. DUT ACL counter == {}; Sent pkts == {}"\
-                .format(tx_dut_ports[ports_info["dut_iface"]], acl_drops, PKT_NUMBER)
+                .format(tx_dut_ports[ports_info["dut_iface"]], acl_drops, pkt_number)
             pytest.fail(fail_msg)
         if not COMBINED_ACL_DROP_COUNTER:
             with SafeThreadPoolExecutor(max_workers=8) as executor:
                 for duthost in duthosts.frontend_nodes:
-                    executor.submit(ensure_no_l3_and_l2_drops, duthost, packets_count=PKT_NUMBER)
+                    executor.submit(ensure_no_l3_and_l2_drops, duthost, packets_count=pkt_number)
     elif discard_group == "NO_DROPS":
         with SafeThreadPoolExecutor(max_workers=8) as executor:
             for duthost in duthosts.frontend_nodes:
-                executor.submit(ensure_no_l2_and_l3_drops, duthost, packets_count=PKT_NUMBER)
+                executor.submit(ensure_no_l2_and_l3_drops, duthost, packets_count=pkt_number)
     else:
         pytest.fail("Incorrect 'discard_group' specified. Supported values: 'L2', 'L3', 'ACL' or 'NO_DROPS'")
 
@@ -366,7 +379,7 @@ def check_if_skip():
 
 
 @pytest.fixture(scope='module')
-def do_test(duthosts):
+def do_test(duthosts, weak_server):
     def do_counters_test(discard_group, pkt, ptfadapter, ports_info, sniff_ports, tx_dut_ports=None,    # noqa: F811
                          comparable_pkt=None, skip_counter_check=False, drop_information=None,
                          ip_ver='ipv4', verify_mtu_drop=False):
@@ -388,7 +401,7 @@ def do_test(duthosts):
         asic_index = ports_info["asic_index"]
         base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info, tx_dut_ports,
                           skip_counter_check=skip_counter_check, drop_information=drop_information,
-                          verify_mtu_drop=verify_mtu_drop)
+                          weak_server=weak_server, verify_mtu_drop=verify_mtu_drop)
 
         # Verify packets were not egresed the DUT
         if discard_group != "NO_DROPS":
@@ -504,8 +517,10 @@ def test_ip_pkt_with_exceeded_mtu(do_test, duthosts, enum_rand_one_per_hwsku_fro
     ip_dst = get_ipv4_peer_for_interface(setup["mg_facts"], mtu_iface)
     pytest_require(ip_dst, "IPv4 peer is not defined for interface {}".format(mtu_iface))
 
-    hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
-    verify_mtu_drop = duthost.facts["asic_type"] == "cisco-8000" and duthost.facts["hwsku"] not in hostvars["cisco-8000_gb_hwskus"]
+    verify_mtu_drop = False
+    if duthost.facts["asic_type"] == "cisco-8000":
+        hostvars = _get_dut_hostvars(duthost)
+        verify_mtu_drop = duthost.facts["hwsku"] not in hostvars.get("cisco-8000_gb_hwskus", [])
     tmp_port_mtu = 1500
 
     log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"],
@@ -521,15 +536,19 @@ def test_ip_pkt_with_exceeded_mtu(do_test, duthosts, enum_rand_one_per_hwsku_fro
         eth_dst=ports_info["dst_mac"],  # DUT port
         eth_src=ports_info["src_mac"],  # PTF port
         ip_src=pkt_fields["ipv4_src"],  # PTF source
-        ip_dst=ip_dst,                  # VM IP address
+        ip_dst=ip_dst,
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"]
     )
-    L2_COL_KEY = RX_ERR
+    saved_l2_col_key = L2_COL_KEY
+    if not verify_mtu_drop:
+        L2_COL_KEY = RX_ERR
     try:
         do_test("L2", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
-                # VPP drops the packet but does not increment the drop counter
                 skip_counter_check=(duthost.facts["asic_type"] == "vpp"),
                 verify_mtu_drop=verify_mtu_drop)
     finally:
-        L2_COL_KEY = RX_DRP
+        if not verify_mtu_drop:
+            L2_COL_KEY = RX_DRP
+        else:
+            L2_COL_KEY = saved_l2_col_key


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
This PR changes the behaviour of the exceeded mtu drop counters test case, to check for drops on TX instead of RX, because on non-GB Cisco platforms, MTU is configured on sys TX, and therefore packets will be dropped there. We were seeing this testcase fail because we were checking for drops on RX_ERR, when they were happening on TX.

#### How did you do it?


#### How did you verify/test it?
[output.txt](https://github.com/user-attachments/files/30564979/output.txt)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
