### PR TITLE
Initial Repair - Test BGP Peer Shutdown T2 Update

### DIFF
--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -143,11 +143,16 @@ def constants(is_quagga, setup_interfaces, pytestconfig):
     return _constants
 
 
+def _get_bgp_neighbors(duthost, neighbor):
+    """Return bgp_neighbors dict for the ASIC where the pseudo-neighbor session lives."""
+    asichost = duthost.asic_instance_from_namespace(neighbor.namespace)
+    return asichost.bgp_facts()['ansible_facts']['bgp_neighbors']
+
+
 def is_neighbor_session_established(duthost, neighbor):
-    # handle both multi-asic and single-asic
-    bgp_facts = duthost.bgp_facts(num_npus=duthost.sonichost.num_asics())["ansible_facts"]
-    return (neighbor.ip in bgp_facts["bgp_neighbors"]
-            and bgp_facts["bgp_neighbors"][neighbor.ip]["state"] == "established")
+    bgp_neighbors = _get_bgp_neighbors(duthost, neighbor)
+    return (neighbor.ip in bgp_neighbors
+            and bgp_neighbors[neighbor.ip]["state"] == "established")
 
 
 def bgp_notification_packets(pcap_file, is_v6_topo):
@@ -186,11 +191,15 @@ def match_bgp_notification(packet, src_ip, dst_ip, action, bgp_session_down_time
 
 
 def is_neighbor_session_down(duthost, neighbor):
-    # handle both multi-asic and single-asic
-    bgp_neighbors = duthost.bgp_facts(num_npus=duthost.sonichost.num_asics())["ansible_facts"]["bgp_neighbors"]
-    return (neighbor.ip in bgp_neighbors and
-            bgp_neighbors[neighbor.ip]["admin"] == "down" and
-            bgp_neighbors[neighbor.ip]["state"] == "idle")
+    bgp_neighbors = _get_bgp_neighbors(duthost, neighbor)
+    return (neighbor.ip in bgp_neighbors
+            and bgp_neighbors[neighbor.ip]["admin"] == "down"
+            and bgp_neighbors[neighbor.ip]["state"] == "idle")
+
+
+def _flush_route(duthost, neighbor, prefix):
+    asichost = duthost.asic_instance_from_namespace(neighbor.namespace)
+    asichost.shell("{} route flush {}".format(asichost.ip_cmd, prefix), module_ignore_errors=True)
 
 
 def get_bgp_down_timestamp(duthost, namespace, peer_ip, timestamp_before_teardown):
@@ -266,6 +275,8 @@ def test_bgp_peer_shutdown(
 
             local_pcap_filename = fetch_and_delete_pcap_file(bgp_pcap, constants.log_dir, duthost, request)
             bpg_notifications = bgp_notification_packets(local_pcap_filename, is_v6_topo)
+            if not bpg_notifications:
+                pytest.fail("No BGP notification packets captured after session teardown")
             for bgp_packet in bpg_notifications:
                 logging.debug(
                     "bgp notification packet, capture time %s, packet details:\n%s",
@@ -287,4 +298,4 @@ def test_bgp_peer_shutdown(
                 pytest.fail("route %s still exists in DUT after BGP shutdown" % announced_route["prefix"])
         finally:
             n0.stop_session()
-            duthost.shell("ip route flush %s" % announced_route["prefix"])
+            _flush_route(duthost, n0, announced_route["prefix"])

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -89,7 +89,7 @@ def _write_variable_from_j2_to_configdb(duthost, template_file, **kwargs):
         duthost.file(path=save_dest_path, state="absent")
 
 
-def _config_bgp_neighbor_with_vtysh(duthost, peer_addr, peer_asn, dut_addr, dut_asn):
+def _config_bgp_neighbor_with_vtysh(duthost, peer_addr, peer_asn, dut_addr, dut_asn, namespace=None):
     """Configure BGP neighbor using vtysh command"""
     cmd = (
         "vtysh "
@@ -98,13 +98,11 @@ def _config_bgp_neighbor_with_vtysh(duthost, peer_addr, peer_asn, dut_addr, dut_
         "-c 'neighbor {peer_addr} remote-as {peer_asn}' "
         "-c 'neighbor {peer_addr} activate' "
     )
-    duthost.shell(cmd.format(peer_addr=peer_addr,
-                             peer_asn=peer_asn,
-                             dut_addr=dut_addr,
-                             dut_asn=dut_asn))
+    cmd = cmd.format(peer_addr=peer_addr, peer_asn=peer_asn, dut_addr=dut_addr, dut_asn=dut_asn)
+    duthost.shell(duthost.get_vtysh_cmd_for_namespace(cmd, namespace))
 
 
-def _remove_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn):
+def _remove_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn, namespace=None):
     """Remove BGP neighbor using vtysh command"""
     cmd = (
         "vtysh "
@@ -112,11 +110,11 @@ def _remove_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn):
         "-c 'router bgp {dut_asn}' "
         "-c 'no neighbor {peer_addr}' "
     )
-    duthost.shell(cmd.format(peer_addr=peer_addr,
-                             dut_asn=dut_asn))
+    cmd = cmd.format(peer_addr=peer_addr, dut_asn=dut_asn)
+    duthost.shell(duthost.get_vtysh_cmd_for_namespace(cmd, namespace))
 
 
-def _shutdown_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn):
+def _shutdown_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn, namespace=None):
     """Shutdown BGP neighbor using vtysh command"""
     cmd = (
         "vtysh "
@@ -124,8 +122,8 @@ def _shutdown_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn):
         "-c 'router bgp {dut_asn}' "
         "-c 'neighbor {peer_addr} shutdown' "
     )
-    duthost.shell(cmd.format(peer_addr=peer_addr,
-                             dut_asn=dut_asn))
+    cmd = cmd.format(peer_addr=peer_addr, dut_asn=dut_asn)
+    duthost.shell(duthost.get_vtysh_cmd_for_namespace(cmd, namespace))
 
 
 def run_bgp_facts(duthost, enum_asic_index):
@@ -238,7 +236,8 @@ class BGPNeighbor(object):
                 peer_addr=self.ip,
                 peer_asn=self.asn,
                 dut_addr=self.peer_ip,
-                dut_asn=self.peer_asn
+                dut_asn=self.peer_asn,
+                namespace=self.namespace,
             )
         elif not self.is_passive:
             _write_variable_from_j2_to_configdb(
@@ -297,12 +296,13 @@ class BGPNeighbor(object):
             _remove_bgp_neighbor_with_vtysh(
                 self.duthost,
                 peer_addr=self.ip,
-                dut_asn=self.peer_asn
+                dut_asn=self.peer_asn,
+                namespace=self.namespace,
             )
         elif not self.is_passive:
-            for asichost in self.duthost.asics:
-                asichost.run_sonic_db_cli_cmd("CONFIG_DB del 'BGP_NEIGHBOR|{}'".format(self.ip))
-                asichost.run_sonic_db_cli_cmd("CONFIG_DB del 'DEVICE_NEIGHBOR_METADATA|{}'".format(self.name))
+            asichost = self.duthost.asic_instance_from_namespace(self.namespace)
+            asichost.run_sonic_db_cli_cmd("CONFIG_DB del 'BGP_NEIGHBOR|{}'".format(self.ip))
+            asichost.run_sonic_db_cli_cmd("CONFIG_DB del 'DEVICE_NEIGHBOR_METADATA|{}'".format(self.name))
 
         self.ptfhost.exabgp(name=self.name, state="absent")
 
@@ -326,7 +326,8 @@ class BGPNeighbor(object):
             _shutdown_bgp_neighbor_with_vtysh(
                 self.duthost,
                 peer_addr=self.ip,
-                dut_asn=self.peer_asn
+                dut_asn=self.peer_asn,
+                namespace=self.namespace,
             )
         elif not self.is_passive:
             for asichost in self.duthost.asics:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
@@ -53,11 +53,6 @@ bgp/test_bgp_gr_helper.py:
     conditions:
     - asic_type in ['vs'] and 't2' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
-bgp/test_bgp_peer_shutdown.py:
-  skip:
-    conditions:
-    - asic_type in ['vs'] and 't2' in topo_name
-    reason: This test case either cannot pass or should be skipped on virtual chassis
 bgp/test_bgp_port_disable.py:
   skip:
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable test_bgp_peer_shutdown on VS T2 multi-ASIC by scoping BGP session checks and cleanup to the correct ASIC namespace, and fixing namespace-aware vtysh/CONFIG_DB handling in BGPNeighbor.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
N/A

### Approach
#### What is the motivation for this PR?
The test already supports T2, but it was skipped on VS T2. On multi-ASIC, it was checking BGP and cleaning up routes in the wrong namespace.

#### How did you do it?
- Check BGP session state on the ASIC where the test neighbor lives
- Flush test routes in that same namespace after each run
- Make BGPNeighbor vtysh and CONFIG_DB cleanup namespace-aware for T2 confederation setups
- Fail the test if no BGP Cease packet is captured after teardown
- Remove the VS T2 skip for this test

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
- Code verification prior to PR
- Pull Request on Github, PR checks. T0/T1 behavior should be unchanged on single-ASIC.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
