### PR TITLE
[crm] Make test_acl_entry ACL-entry stabilization timeout overridable per testbed

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -16,7 +16,7 @@ from tests.common.helpers.crm import get_used_percent, CRM_UPDATE_TIME, CRM_POLL
      EXPECT_CLEAR, THR_VERIFY_CMDS
 from tests.common.fixtures.duthost_utils import disable_route_checker   # noqa: F401
 from tests.common.fixtures.duthost_utils import disable_fdb_aging       # noqa: F401
-from tests.common.utilities import wait_until, get_data_acl, is_ipv6_only_topology
+from tests.common.utilities import wait_until, get_data_acl, is_ipv6_only_topology, get_plt_wait_time
 from tests.common.mellanox_data import is_mellanox_device
 from tests.common.helpers.dut_utils import get_sai_sdk_dump_file
 
@@ -1263,8 +1263,12 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
         # Wait for ACL entry resources to stabilize using polling
         expected_acl_used = new_crm_stats_acl_entry_used + nexthop_group_num - CRM_COUNTER_TOLERANCE
         logger.info("Waiting for {} ACL entry resources to stabilize".format(nexthop_group_num))
+        # ACL rule programming can be very slow on some platforms (e.g. Broadcom DNX on the
+        # max topology) where the full batch takes ~2min to land in the ASIC. Allow the
+        # stabilization timeout to be overridden per-testbed via inventory plt_wait_time.
+        acl_stabilize_timeout = get_plt_wait_time(duthost, "crm/test_crm.py").get("timeout", 60)
         wait_for_crm_counter_update(get_acl_entry_stats, duthost, expected_used=expected_acl_used,
-                                    oper_used=">=", timeout=60, interval=5)
+                                    oper_used=">=", timeout=acl_stabilize_timeout, interval=5)
 
     # Verify thresholds for "ACL entry" CRM resource
     verify_thresholds(duthost, asichost, crm_cli_res="acl group entry", crm_cmd=get_acl_entry_stats)


### PR DESCRIPTION
### Description of PR

Summary:
`crm/test_crm.py::test_acl_entry` fails on slow ACL-programming platforms (e.g. max topology testbeds(64ports)): programming the test's ~20 DATAACL entries to the ASIC takes ~2 min, and `crm_stats_acl_entry_used` only reflects the full batch once programming completes, so the fixed 60s wait in `verify_acl_crm_stats` times out (`used=4, expected >= 20`) even though the rules do program correctly. This PR reads the ACL-entry stabilization timeout from the existing `plt_wait_time` inventory mechanism (the same pattern `acl/test_acl.py` and `everflow` already use), defaulting to 60 so behavior is unchanged on all other platforms. Slow testbeds can set `crm/test_crm.py: timeout: <sec>` in their inventory. The timeout is only a ceiling — `wait_until` returns as soon as the counter reaches the target — so this does not slow passing runs.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- 202511: `t2_single_node_max_64p` testbed — `crm/test_crm.py::test_acl_entry` **1 passed (~401s)**, with the stabilization branch exercised (table clean: `used=0, available=2048`) so the configured timeout path actually ran.
- master: code-identical single-file change (same hunk applies to `master`); `py_compile` + `flake8` clean.

### Approach
#### What is the motivation for this PR?

Fix a test-only timeout: `test_acl_entry` fails on platforms where ASIC ACL programming is slow. The rules program correctly, but not within the hardcoded 60s window, so `crm_stats_acl_entry_used` hasn't reached the expected value when the test checks it.

#### How did you do it?

In `verify_acl_crm_stats`, replaced the hardcoded `timeout=60` on the ACL-entry `wait_for_crm_counter_update` with `acl_stabilize_timeout = get_plt_wait_time(duthost, "crm/test_crm.py").get("timeout", 60)`. Default remains 60, so no behavior change on any other platform; a testbed can opt into a longer wait via `plt_wait_time` in its inventory.

#### How did you verify/test it?

Ran `crm/test_crm.py::test_acl_entry` on max-topology testbed. Confirmed `get_plt_wait_time` resolves the per-testbed value at runtime, that the ASIC does program all entries (measured ~120s), and that the test passes (`1 passed`, ~401s) with the stabilization branch actually entered. `flake8` clean.

#### Any platform specific information?
 ACL rule programming to the ASIC is slow (~1 entry every 5–6s; ~2 min for ~20 entries), and the CRM ACL-entry counter updates only once the full `acl-loader` batch completes. Other platforms are unaffected (default 60s).

#### Supported testbed topology if it's a new test case?

N/A (not a new test case).

### Documentation

N/A.