### PR TITLE
[ansible]: add bmc topology to veos inventories

### DIFF
--- a/ansible/veos
+++ b/ansible/veos
@@ -13,6 +13,9 @@ all:
     servers:
       vars:
         topologies:
+          - bmc
+          - bmc-dual-mgmt
+          - bmc-shared-mgmt
           - t1
           - t1-lag
           - t1-28-lag


### PR DESCRIPTION
### Description of PR

Summary:
Add BMC topology support to sonic-mgmt test infrastructure by adding bmc topologies to `veos` inventory file for proper topology validation. It is to enable testbed automation to properly support BMC topologies (portless SONiC switches).

Fixes https://github.com/sonic-net/sonic-mgmt/issues/26511

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608


### Test result

Topology validation passes with 'bmc' recognized in inventory. PTF container successfully created with management bridge networking.


### Approach
#### What is the motivation for this PR?

BMC topologies (portless SONiC switches) were not properly recognized in the testbed automation framework, causing playbooks to fail during topology validation. Additionally, PTF container networking was not properly configured for portless topologies, leading to SSH reachability timeouts.

#### How did you do it?

**Inventory topology list updates**: Added bmc topologies to the topology list in `ansible/veos` inventory file. This allows playbooks to pass topology validation checks that verify the topology is in the supported list.

#### How did you verify/test it?

Testbed renumbering playbook execution on BMC topology (bmc-dual-mgmt) completed successfully:
- Topology validation passed with 'bmc' in inventory. This task is skipped, which means the topo variable is defined.
```
TASK [Check that variable topo is defined] *************************************
task path: /var/src/sonic-mgmt_<testbed>/ansible/testbed_renumber_vm_topology.yml:64
skipping: [ACS-SERV] => {"changed": false, "false_condition": "topo is not defined", "skip_reason": "Conditional result was False"}
```
- PTF container created and reachable via SSH
- Playbook execution continued through all necessary topology renumbering stages

#### Any platform specific information?

Portless design means no data-plane interfaces are configured on the PTF container, requiring special network handling.

#### Supported testbed topology if it's a new test case?

N/A - This is an infrastructure change supporting existing BMC topology definitions.

### Documentation

N/A