### PR TITLE
[arp]: Extend VPP neighbor readiness wait

### DIFF
--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -25,7 +25,7 @@ class TestNeighborMac:
     DUT_INTF_NETMASK = "24"
     TEST_MAC = ["00:c0:ca:c0:1a:05", "00:c0:ca:c0:1a:06"]
     PTF_INTERFACE_READY_TIMEOUT = 10
-    PING_RETRY_TIMEOUT = 30
+    PING_RETRY_TIMEOUT = 120
 
     @pytest.fixture(scope="module", autouse=True)
     def interfaceConfig(self, duthosts, rand_one_dut_hostname):
@@ -198,9 +198,10 @@ class TestNeighborMac:
             )
         return is_ready
 
-    def __ping_dut_from_ptf(self, ptfhost):
+    def __ping_dut_from_ptf(self, ptfhost, quick_probe=False):
+        ping_options = "-c 1 -W 1" if quick_probe else "-c 3"
         return ptfhost.shell(
-            "ping {} -c 3 -I {}".format(self.DUT_INTF_IP, self.PTF_HOST_IP),
+            "ping {} {} -I {}".format(self.DUT_INTF_IP, ping_options, self.PTF_HOST_IP),
             module_ignore_errors=True
         )
 
@@ -225,16 +226,16 @@ class TestNeighborMac:
         self.__configureNeighborIp(ptfhost, macIndex)
         ping_result = {}
         ping_attempts = 0
+        is_vpp = duthost.facts.get("asic_type") == "vpp"
 
         def ping_dut():
             nonlocal ping_attempts
             ping_attempts += 1
             ping_result.clear()
-            ping_result.update(self.__ping_dut_from_ptf(ptfhost))
+            ping_result.update(self.__ping_dut_from_ptf(ptfhost, quick_probe=is_vpp))
             logger.info("PTF ping attempt %s rc=%s", ping_attempts, ping_result.get("rc"))
             return ping_result.get("rc") == 0
 
-        is_vpp = duthost.facts.get("asic_type") == "vpp"
         if is_vpp:
             ping_succeeded = wait_until(self.PING_RETRY_TIMEOUT, 1, 0, ping_dut)
         else:


### PR DESCRIPTION
### Description of PR

Summary:
Increase the VPP-specific readiness window in `test_neighbor_mac.py` and use short bounded ping probes so asynchronous VPP convergence does not cause false PR-test failures.

ADO: https://dev.azure.com/msazure/One/_workitems/edit/38927627

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: Other, VPP asynchronous readiness flake

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: validated on local `vms-kvm-vpp-t1-lag` 

Forced delayed-readiness reproduction with existing logic:

```text
OLD_ATTEMPT=8

PING 20.0.0.1 from 20.0.0.2
Destination Host Unreachable

3 packets transmitted, 0 received
100% packet loss

OLD_TIMEOUT attempts=8 elapsed=33

Proposed VPP readiness logic under the same delayed state:

PING 20.0.0.1 from 20.0.0.2

64 bytes from 20.0.0.1
1 packet transmitted, 1 received
0% packet loss

NEW_SUCCESS attempts=38 elapsed=74

Healthy VPP transition:

PING 20.0.0.1 from 20.0.0.2

64 bytes from 20.0.0.1
1 packet transmitted, 1 received
0% packet loss

HEALTHY_SUCCESS attempts=5 elapsed=8

Cleanup verification:

BondEthernet102 number of active members: 2
    bobm1
    bobm0 number of members: 2
    bobm1
    bobm0
```
 ### Approach

### What is the motivation for this PR?

 arp/test_neighbor_mac.py::TestNeighborMac::testNeighborMac[0]  is flaky on the  t1-lag-vpp  PR-test topology.

The test temporarily converts  Ethernet0  from a PortChannel member into a routed interface, assigns  20.0.0.1/24 , and pings it from PTF at  20.0.0.2 .

Related Elastictest failures consistently occur during fixture setup:
```
Failed to ping DUT interface 20.0.0.1
from PTF IP 20.0.0.2 within 30 seconds

3 packets transmitted, 0 received
100% packet loss
```
VPP processes the LAG-to-routed transition asynchronously. The existing 30-second readiness window can expire before the dataplane becomes reachable even though the transition later succeeds.

### How did you do it?

For VPP only:

• Increase the readiness timeout from 30 seconds to 120 seconds.
• Replace each three-packet ping with a one-packet probe bounded by a one-second response timeout.
• Continue probing once per second until connectivity succeeds or the 120-second bound expires.

Non-VPP platforms retain their existing single three-packet ping behavior.

### How did you verify/test it?

A deterministic readiness delay was introduced by pausing syncd while applying the interface configuration, then resuming it after configuration returned.

The existing 30-second logic timed out after 33 seconds.

The proposed short-probe logic recovered after 74 seconds under the same delayed state.

Without the forced delay, the proposed logic passed after 8 seconds.

The testbed cleanup restored both  BondEthernet102  members as active.

### Any platform specific information?

The extended retry behavior applies only when  asic_type == "vpp" .

### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A 