### PR TITLE
conserver: Add send_command_timing

### DIFF
--- a/tests/common/connections/conserver_console_conn.py
+++ b/tests/common/connections/conserver_console_conn.py
@@ -1,6 +1,7 @@
 import logging
 import pexpect
 import os
+import time
 
 CONSERVER_CLI_PROMPT = "admin@[a-zA-Z0-9]{1,10}:~\\$"
 CONSERVER_DEBUG_FILE = "/tmp/conserver_console_debug.log"
@@ -64,3 +65,28 @@ class ConserverConsoleConn():
         self.console_cli.sendline('\x05c.')
         self.console_cli.close(force=True)
         self.logger.debug("Conserver connection closed.")
+
+    def send_command_timing(self, cmd, read_timeout=30, last_read=1.0):
+        """Send command and read output until no data for 'last_read' seconds."""
+        self.logger.debug("send_command_timing: cmd='%s'", cmd[:80])
+
+        start_time = time.time()
+        self.console_cli.sendline(cmd)
+
+        output = ""
+        deadline = start_time + read_timeout
+
+        while time.time() < deadline:
+            try:
+                self.console_cli.expect(r'.+', timeout=last_read)
+                output += self.console_cli.match.group().decode()
+            except pexpect.TIMEOUT:
+                break
+            except pexpect.EOF:
+                self.logger.warning("send_command_timing: connection closed")
+                break
+
+        elapsed = time.time() - start_time
+        self.logger.debug("send_command_timing: finished in %.1fs, %d bytes collected",
+                          elapsed, len(output))
+        return output


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
 `test_console_stress_input` calls `send_command_timing` on the DUT console
  connection. This works for Netmiko-backed console classes, but the
  pexpect-based `ConserverConsoleConn` does not implement the method.

  Add a compatible `send_command_timing` implementation for
  `ConserverConsoleConn` so `dut_console/test_console_stress.py` can run with
  conserver-backed console connections.

Summary:
  Fixes #26604
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue


### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202605: 
Fail Logs (befor fix )
[test_console_stress.log](https://github.com/user-attachments/files/30442187/test_console_stress.log)
[test_console_stress.xml](https://github.com/user-attachments/files/30442190/test_console_stress.xml)
Pass Logs (after fix)
[test_console_stress.log](https://github.com/user-attachments/files/30442201/test_console_stress.log)
[test_console_stress.xml](https://github.com/user-attachments/files/30442202/test_console_stress.xml)



### Approach
#### What is the motivation for this PR?
dut_console/test_console_stress.py::test_console_stress_input expects the
  console connection object to support send_command_timing. SSH/Telnet console
  connections get this API from Netmiko, but ConserverConsoleConn is a
  standalone pexpect-based class and does not provide it. This causes the test to
  fail when the DUT console uses conserver.
#### How did you do it?
Added ConserverConsoleConn.send_command_timing. The method sends the command
  through the existing pexpect console session and reads output until no data is
  received for last_read seconds or read_timeout is reached.

  #### How did you verify/test it?
  Verified the original failure on 202605 with a conserver-backed console:

  ```
dut_console/test_console_stress.py::test_console_stress_input[ldp203]
  AttributeError: 'ConserverConsoleConn' object has no attribute
  'send_command_timing'

```
  Verified the patched run passes on 202605:

  ```
dut_console/test_console_stress.py::test_console_stress_input[ldp203]
  PASSED
```

  The same patched run also passed the full test_console_stress.py file:

`  testsuite errors="0" failures="0" skipped="0" tests="2"`


#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A