### PR TITLE
[ssh/test_ssh_limit]: Switch AAA login to local after opening the admin session

### DIFF
--- a/tests/ssh/test_ssh_limit.py
+++ b/tests/ssh/test_ssh_limit.py
@@ -5,7 +5,7 @@ import time
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.tacacs import tacacs_creds     # noqa F401
 from tests.common.helpers.tacacs.tacacs_helper import setup_local_user
-from tests.common.utilities import paramiko_ssh, wait_until
+from tests.common.utilities import paramiko_ssh
 from tests.common.fixtures.tacacs import get_aaa_sub_options_value
 
 pytestmark = [
@@ -69,21 +69,11 @@ def modify_templates(duthost, tacacs_creds, creds):     # noqa F811
     sonic_admin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get(
         "ansible_altpassword")
     # Connect over SSH as admin (duthost.shell can't run commands containing J2 templates).
-    # This runs before AAA login is switched to local, so the admin credentials are still
-    # valid. Retry for up to a minute to ride out transient SSH unavailability.
-    admin_session_holder = {}
-
-    def _open_admin_session():
-        admin_session_holder['session'] = paramiko_ssh(
-            ip_address=dut_ip, username=creds['sonicadmin_user'],
-            passwords=[creds['sonicadmin_password'], sonic_admin_alt_password]
-            + creds["ansible_altpasswords"])
-        return True
-
-    pytest_assert(
-        wait_until(60, 5, 0, _open_admin_session),
-        "Failed to establish admin SSH session to {}".format(dut_ip))
-    admin_session = admin_session_holder['session']
+    # This runs before AAA login is switched to local, so the admin credentials are still valid.
+    admin_session = paramiko_ssh(
+        ip_address=dut_ip, username=creds['sonicadmin_user'],
+        passwords=[creds['sonicadmin_password'], sonic_admin_alt_password]
+        + creds["ansible_altpasswords"])
 
     # Backup and change /usr/share/sonic/templates/pam_limits.j2
     additional_content = "session  required  pam_limits.so"

--- a/tests/ssh/test_ssh_limit.py
+++ b/tests/ssh/test_ssh_limit.py
@@ -69,9 +69,8 @@ def modify_templates(duthost, tacacs_creds, creds):     # noqa F811
     sonic_admin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get(
         "ansible_altpassword")
     # Connect over SSH as admin (duthost.shell can't run commands containing J2 templates).
-    # This runs while the admin credentials are still valid (before setup_limit switches AAA
-    # login to local), so a single attempt should normally succeed. Retry for up to a minute
-    # anyway to ride out any transient SSH unavailability such as sshd briefly restarting.
+    # This runs before AAA login is switched to local, so the admin credentials are still
+    # valid. Retry for up to a minute to ride out transient SSH unavailability.
     admin_session_holder = {}
 
     def _open_admin_session():
@@ -83,7 +82,7 @@ def modify_templates(duthost, tacacs_creds, creds):     # noqa F811
 
     pytest_assert(
         wait_until(60, 5, 0, _open_admin_session),
-        "Failed to establish admin SSH session to {} after AAA change".format(dut_ip))
+        "Failed to establish admin SSH session to {}".format(dut_ip))
     admin_session = admin_session_holder['session']
 
     # Backup and change /usr/share/sonic/templates/pam_limits.j2
@@ -134,16 +133,12 @@ def setup_limit(duthosts, rand_one_dut_hostname, tacacs_creds, creds):      # no
         setup_local_user(duthost, tacacs_creds)
 
         # Modify templates and restart hostcfgd to render config files.
-        # modify_templates opens a fresh admin SSH session, so it must run BEFORE AAA login is
-        # switched to local below. On testbeds where admin is a TACACS user it has no matching
-        # local password, so switching to local first makes the admin re-login fail - this is
-        # the root cause of the intermittent "Failed to establish admin SSH session after AAA
-        # change" errors seen on virtual switches.
+        # modify_templates opens a new admin SSH session, so it must run before AAA login is
+        # switched to local: where admin is a TACACS user it has no local password and the
+        # admin login would be rejected after the switch.
         modify_templates(duthost, tacacs_creds, creds)
 
-        # If AAA authentication is enabled, disable it (switch login to local) so the local
-        # test user can log in during the test. Done after modify_templates so the admin
-        # session above is established while admin can still authenticate via TACACS.
+        # If AAA authentication enabled, disable it to allow local user login
         if get_aaa_sub_options_value(duthost, "authentication", "login") == "tacacs+":
             duthost.shell("sudo config aaa authentication login default")
             aaa_login_disabled = True

--- a/tests/ssh/test_ssh_limit.py
+++ b/tests/ssh/test_ssh_limit.py
@@ -69,9 +69,9 @@ def modify_templates(duthost, tacacs_creds, creds):     # noqa F811
     sonic_admin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get(
         "ansible_altpassword")
     # Connect over SSH as admin (duthost.shell can't run commands containing J2 templates).
-    # Retry the login for up to 1 minute instead of once, because the AAA config change above is
-    # applied asynchronously and may take a little time to take effect, during which the admin
-    # login can be transiently rejected.
+    # This runs while the admin credentials are still valid (before setup_limit switches AAA
+    # login to local), so a single attempt should normally succeed. Retry for up to a minute
+    # anyway to ride out any transient SSH unavailability such as sshd briefly restarting.
     admin_session_holder = {}
 
     def _open_admin_session():
@@ -131,15 +131,23 @@ def setup_limit(duthosts, rand_one_dut_hostname, tacacs_creds, creds):      # no
     template_file_exist = limit_template_exist(duthost)
     aaa_login_disabled = False
     if template_file_exist:
-        # If AAA authentication enabled, disable it to allow local user login
+        setup_local_user(duthost, tacacs_creds)
+
+        # Modify templates and restart hostcfgd to render config files.
+        # modify_templates opens a fresh admin SSH session, so it must run BEFORE AAA login is
+        # switched to local below. On testbeds where admin is a TACACS user it has no matching
+        # local password, so switching to local first makes the admin re-login fail - this is
+        # the root cause of the intermittent "Failed to establish admin SSH session after AAA
+        # change" errors seen on virtual switches.
+        modify_templates(duthost, tacacs_creds, creds)
+
+        # If AAA authentication is enabled, disable it (switch login to local) so the local
+        # test user can log in during the test. Done after modify_templates so the admin
+        # session above is established while admin can still authenticate via TACACS.
         if get_aaa_sub_options_value(duthost, "authentication", "login") == "tacacs+":
             duthost.shell("sudo config aaa authentication login default")
             aaa_login_disabled = True
 
-        setup_local_user(duthost, tacacs_creds)
-
-        # Modify templates and restart hostcfgd to render config files
-        modify_templates(duthost, tacacs_creds, creds)
         restart_hostcfgd(duthost)
 
     yield


### PR DESCRIPTION
### Description of PR

Summary:
`test_ssh_limits` intermittently fails in setup with `Failed to establish admin SSH session ... after AAA change`.

`setup_limit` switched AAA login to local (`config aaa authentication login default`) and then opened a new admin SSH session to edit the J2 templates. Where AAA login is `tacacs+`, `admin` authenticates via TACACS and has no matching local password, so after the switch the admin login is rejected by `pam_unix` and never recovers - the existing 60s retry cannot help. This reorders setup so the admin session is opened before the switch.

Fixes: Microsoft ADO work item 38920641

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

The same ordering exists on 202411, 202505, 202511, 202512 and 202605; the failure has been observed
repeatedly on the 202511 line, and 202605 carries the identical code, so those two are requested here.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): Microsoft ADO 38920641
Failure type: day-one issue (test setup ordering, not tied to any image or platform)

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Test result

Run against this change on an internal mirror of the file (the file is identical upstream).

- 4-ASIC KVM virtual switch, `t1-8-lag` - the configuration where the failure reproduces. AAA login was `tacacs+`, so the failing path was exercised: **1 passed**.
  https://elastictest.org/scheduler/testplan/6a680163c4dbc22bce9cdd2c
- `Arista-7060CX-32S-C32`, `t0`, physical - regression check where the case already passes: **1 passed**, including the `There were too many logins for 'test_louser'` assertion. AAA login there is already local, so the reordered branch is not taken and both orders are the same code path.
  https://elastictest.org/scheduler/testplan/6a6857e1101ed2146e8092b5

- 4-ASIC KVM virtual switch, a 202511 image, with the same change applied to that release line: **1 passed**. AAA login was `tacacs+`, so the failing path was exercised. On 202511 the unpatched code has no retry at all, so it fails setup with a raw `paramiko AuthenticationException`.
  https://elastictest.org/scheduler/testplan/6a68852f101ed2146e809314
- 4-ASIC KVM virtual switch, a 202605 image, same change applied to that release line: **1 passed**, AAA login `tacacs+` so the path was exercised.
  https://elastictest.org/scheduler/testplan/6a689315101ed2146e809328

For reference, the unpatched code errored on every run on that same virtual switch and image build.

### Approach
#### What is the motivation for this PR?

The case errors during setup on testbeds where AAA login is `tacacs+`, so the SSH session-limit check never runs.

#### How did you do it?

Moved `config aaa authentication login default` to after `setup_local_user` and `modify_templates`. That switch only exists so the local test user can log in during the test body, so it does not need to happen before the template edits.

Only the position of that one command changed:

- before: AAA -> local, `setup_local_user`, `modify_templates`, `restart_hostcfgd`
- after: `setup_local_user`, `modify_templates`, AAA -> local, `restart_hostcfgd`

`restart_hostcfgd` is still last, teardown is unchanged, and the assertions and template contents are untouched, so the state the test body sees at `yield` is the same. Nothing is masked: the failures this removes were setup errors, not `maxlogins` assertion failures. Nothing new can fail either - admin now logs in while AAA is still in its original state, which is the same condition ansible already uses to reach the DUT, and on testbeds already using local login the branch is not taken at all.

#### How did you verify/test it?

See Test result. The root cause was confirmed on a DUT: after the switch, admin auth never recovered within 200s (`pam_unix(sshd:auth): authentication failure ... user=admin`), restarting `hostcfgd` did not help, and restoring `tacacs+` restored the admin login immediately - so it is a credential-path problem, not timing.

#### Any platform specific information?

Only affects testbeds where AAA login is `tacacs+`. Seen mostly on virtual switches, but also on physical testbeds with that setting.

#### Supported testbed topology if it's a new test case?

N/A - existing test, no topology change.

### Documentation

N/A

