### PR TITLE
[action] PreCherryPick: add authorization check for cherry-pick label

### DIFF
--- a/.github/workflows/pr_cherrypick_label_auth.yml
+++ b/.github/workflows/pr_cherrypick_label_auth.yml
@@ -1,0 +1,60 @@
+name: CherryPickLabelAuthCheck
+on:
+  pull_request_target:
+    types:
+    - labeled
+    branches:
+    - master
+
+jobs:
+  check_label_auth:
+    if: github.repository_owner == 'sonic-net' && startsWith(github.event.label.name, 'Approved for 20')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check Authorization
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+        TOKEN: ${{ secrets.TOKEN }}
+      run: |
+        set -e
+
+        label=$(echo $GITHUB_CONTEXT | jq -r ".event.label.name")
+        sender=$(echo $GITHUB_CONTEXT | jq -r ".event.sender.login")
+        pr_url=$(echo $GITHUB_CONTEXT | jq -r ".event.pull_request._links.html.href")
+        repository=$(echo $GITHUB_CONTEXT | jq -r ".repository")
+        org=$(echo $repository | cut -d/ -f1)
+        branch=$(echo "$label" | grep -oE '202[0-9]{3}')
+        release_team="release-manager-${branch}"
+
+        echo =============================
+        echo Label:         $label
+        echo Sender:        $sender
+        echo Branch:        $branch
+        echo Org:           $org
+        echo Release team:  $release_team
+        echo =============================
+
+        echo ${TOKEN} | gh auth login --with-token
+
+        if [[ -z "$branch" ]]; then
+          echo "Could not extract branch from label '$label'. Skipping."
+          exit 0
+        fi
+
+        authorized=0
+        if [[ "$sender" == "StormLiangMS" ]]; then
+          authorized=1
+          echo "Sender $sender is an authorized maintainer."
+        elif gh api "orgs/${org}/teams/${release_team}/memberships/${sender}" --silent 2>/dev/null; then
+          authorized=1
+          echo "Sender $sender is a member of $release_team."
+        fi
+
+        if [[ "$authorized" != "1" ]]; then
+          echo "Sender $sender is not authorized. Removing label and posting comment."
+          gh pr edit "$pr_url" --remove-label "$label"
+          members=$(gh api "orgs/${org}/teams/${release_team}/members" --jq '.[].login' 2>/dev/null | sed 's/^/@/' | tr '\n' ' ')
+          gh pr comment "$pr_url" --body "The label \`$label\` can only be added by a member of the @${org}/${release_team} team or @StormLiangMS. Removing the label. Please contact @StormLiangMS or one of the release managers: ${members} to approve the cherry pick."
+        else
+          echo "Sender $sender is authorized. Label retained."
+        fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add authorization check to the PreCherryPick workflow so that only release managers and Strom can trigger a cherry-pick by adding an "Approved for X branch" label.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
### Approach
#### What is the motivation for this PR?
Previously, any GitHub user could add an "Approved for X branch" label to a merged PR and trigger an automated cherry-pick to a release branch. This change restricts that action to release managers only.
#### How did you do it?
When the workflow is triggered by a labeled event, it now checks whether the user who added the label is either:
- A member of the release-manager-<branch> GitHub team for the target release branch, or
- The designated maintainer StormLiangMS
If the user is not authorized, the label is automatically removed and a comment is posted on the PR directing them to contact an authorized person.
#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
