### PR TITLE
Fix/202611 ptf image tag

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -35,7 +35,7 @@ parameters:
 
 - name: PTF_IMAGE_TAG
   type: string
-  default: ""
+  default: "202611"
 
 - name: PTF_MODIFIED
   type: string

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -1,13 +1,13 @@
 
 # The PTF image built from different branches may be incompatible. The ptf_imagetag variable added here is to
 # support using different PTF images for different branches. When the ptf_imagetag variable is not specified,
-# the PTF image with the branch-specific "202611" tag will be used. When a specific PTF image version is required, we can
+# the PTF image with default "latest" tag will be used. When a specific PTF image version is required, we can
 # specify a value for the ptf_imagetag variable somewhere, for example, specify from command line:
 #    ./testbed-cli.sh add-topo <testbed_name>-<topo> vault -e ptf_imagetag=201811
 # By using this practice, we suggest to add different tags for different PTF image versions in docker registry.
 - name: Set default value for ptf_imagetag
   set_fact:
-    ptf_imagetag: "202611"
+    ptf_imagetag: "latest"
   when: ptf_imagetag is not defined
 
 - name: set "PTF" container type, by default

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -1,13 +1,13 @@
 
 # The PTF image built from different branches may be incompatible. The ptf_imagetag variable added here is to
 # support using different PTF images for different branches. When the ptf_imagetag variable is not specified,
-# the PTF image with default "latest" tag will be used. When a specific PTF image version is required, we can
+# the PTF image with the branch-specific "202611" tag will be used. When a specific PTF image version is required, we can
 # specify a value for the ptf_imagetag variable somewhere, for example, specify from command line:
 #    ./testbed-cli.sh add-topo <testbed_name>-<topo> vault -e ptf_imagetag=201811
 # By using this practice, we suggest to add different tags for different PTF image versions in docker registry.
 - name: Set default value for ptf_imagetag
   set_fact:
-    ptf_imagetag: "latest"
+    ptf_imagetag: "202611"
   when: ptf_imagetag is not defined
 
 - name: set "PTF" container type, by default


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Use 202611 PTF image tag by default 
Fixes 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Consolidate docker-ptf image to use tags for release branch

#### How did you do it?
Modify the pr test template

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
  