### PR TITLE
Relax pddf_ledutil invalid LED error assertions for platform-specific output

### DIFF
--- a/tests/platform_tests/cli/test_pddf_ledutil.py
+++ b/tests/platform_tests/cli/test_pddf_ledutil.py
@@ -27,6 +27,7 @@ TEST_CONFIG_FILE = os.path.join(os.path.split(__file__)[0], "pddf_ledutil.yml")
 
 _INVALID_LED = "NONEXISTENT_LED"
 _INVALID_COLOR = "NONEXISTENT_COLOR"
+_INVALID_LED_ERRORS = ("not configured", "Invalid led device name")
 
 
 @pytest.fixture(scope="module")
@@ -310,8 +311,7 @@ def test_getstatusled_invalid_led(dut):  # noqa: F811
     stdout = dut.shell(
         f"sudo pddf_ledutil getstatusled {_INVALID_LED}", module_ignore_errors=True
     )["stdout"].strip()
-    assert "not configured" in stdout, f"Expected 'not configured', got {stdout!r}"
-
+    assert any(err in stdout for err in _INVALID_LED_ERRORS), f"Expected one of {_INVALID_LED_ERRORS}, got {stdout!r}"
 
 def test_setstatusled_valid_led_valid_color(dut, valid_single_led, led_service_manager):  # noqa: F811
     with led_service_manager(valid_single_led.type_config, valid_single_led.name):
@@ -351,5 +351,6 @@ def test_setstatusled_invalid_led(dut, valid_single_led):  # noqa: F811
         stdout = dut.shell(
             f"sudo pddf_ledutil setstatusled {_INVALID_LED} {color}", module_ignore_errors=True
         )["stdout"].strip()
-        assert "not configured" in stdout, f"Expected 'not configured' for color {color!r}, got {stdout!r}"
-        assert "False" in stdout, f"Expected 'False' for color {color!r}, got {stdout!r}"
+        assert any(err in stdout for err in _INVALID_LED_ERRORS), f"Expected one of {_INVALID_LED_ERRORS} for color {color!r}, got {stdout!r}"
+        if "not configured" in stdout:
+            assert "False" in stdout, f"Expected 'False' for color {color!r}, got {stdout!r}"


### PR DESCRIPTION

### Description of PR
Relax pddf_ledutil invalid LED error assertions for platform-specific output
Fixes https://github.com/sonic-net/sonic-mgmt/issues/27788

Summary:
Fix flaky failures in PDDF LED CLI negative tests by accepting valid platform-specific invalid LED error strings observed on Marvell platforms.
This change updates existing negative assertions in the LED utility test so they no longer assume a single exact error output for invalid LED names. 

### Type of change



- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605


### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
platform_tests/cli/test_pddf_ledutil.py passed on Marvell testbed

### Approach
Current negative tests expect only one invalid LED error text ("not configured").
On Marvell platform images, pddf_ledutil may return "Invalid led device name" for the same invalid input.
This causes false failures even though device behavior is correct.

#### How did you do it?
Added a shared expected error tuple for invalid LED checks.
Updated invalid LED assertion paths to accept either valid message.
Kept the "False" check only when the output contains "not configured", preserving previous strictness for that path while avoiding over-constraining other valid outputs.

#### How did you verify/test it?
Triggered platform CLI LED tests on Marvell environment.
Confirmed invalid LED negative tests pass for both accepted outputs.
Confirmed no change in valid LED status test behavior.

#### Any platform specific information?
Yes.
This fix is motivated by output variance seen on Marvell platform PDDF LED utility responses.

#### Supported testbed topology if it's a new test case?

### Documentation

