### PR TITLE
[action] PreCherryPick: fix remaining auth bypass gaps after label auth workflow

### DIFF
--- a/.github/workflows/pr_cherrypick_label_auth.yml
+++ b/.github/workflows/pr_cherrypick_label_auth.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check_label_auth:
-    if: github.repository_owner == 'sonic-net' && startsWith(github.event.label.name, 'Approved for 20')
+    if: github.repository_owner == 'sonic-net' && github.event.pull_request.state == 'open' && startsWith(github.event.label.name, 'Approved for 20')
     runs-on: ubuntu-latest
     steps:
     - name: Check Authorization

--- a/.github/workflows/pr_cherrypick_prestep.yml
+++ b/.github/workflows/pr_cherrypick_prestep.yml
@@ -73,11 +73,15 @@ jobs:
               local authorized=0
               if [[ "$sender" == "StormLiangMS" ]]; then
                 authorized=1
-              elif gh api "orgs/${org}/teams/release-manager-${branch}/memberships/${sender}" --silent 2>/dev/null; then
+              elif [[ "$(gh api "orgs/${org}/teams/release-manager-${branch}/memberships/${sender}" --jq '.state' 2>/dev/null)" == "active" ]]; then
                 authorized=1
               fi
               if [[ "$authorized" != "1" ]]; then
-                echo "User $sender is not authorized to approve cherry-pick to $branch branch. Skipping."
+                echo "User $sender is not authorized to approve cherry-pick to $branch branch. Removing label."
+                local release_team="release-manager-${branch}"
+                local members=$(gh api "orgs/${org}/teams/${release_team}/members" --jq '.[].login' 2>/dev/null | sed 's/^/@/' | tr '\n' ' ')
+                gh pr edit "$pr_url" --remove-label "$event_label"
+                gh pr comment "$pr_url" --body "The label \`$event_label\` can only be added by an active member of the @${org}/${release_team} team or @StormLiangMS. Removing the label. Please contact @StormLiangMS or one of the release managers: ${members} to approve the cherry pick."
                 return 0
               fi
             fi
@@ -118,7 +122,7 @@ jobs:
             local authorized=0
             if [[ "$label_adder" == "StormLiangMS" ]]; then
               authorized=1
-            elif [[ -n "$label_adder" ]] && gh api "orgs/${org}/teams/release-manager-${branch}/memberships/${label_adder}" --silent 2>/dev/null; then
+            elif [[ -n "$label_adder" ]] && [[ "$(gh api "orgs/${org}/teams/release-manager-${branch}/memberships/${label_adder}" --jq '.state' 2>/dev/null)" == "active" ]]; then
               authorized=1
             fi
             if [[ "$authorized" != "1" ]]; then

--- a/.github/workflows/pr_cherrypick_prestep.yml
+++ b/.github/workflows/pr_cherrypick_prestep.yml
@@ -63,6 +63,25 @@ jobs:
 
         cherry_pick(){
           set -e
+          local action=$(echo $GITHUB_CONTEXT | jq -r ".event.action")
+          # Authorization check: only applies when a label is being added
+          if [[ "$action" == "labeled" ]]; then
+            local event_label=$(echo $GITHUB_CONTEXT | jq -r ".event.label.name")
+            if [[ "$event_label" == "Approved for $branch branch" ]]; then
+              local sender=$(echo $GITHUB_CONTEXT | jq -r ".event.sender.login")
+              local org=$(echo $repository | cut -d/ -f1)
+              local authorized=0
+              if [[ "$sender" == "StormLiangMS" ]]; then
+                authorized=1
+              elif gh api "orgs/${org}/teams/release-manager-${branch}/memberships/${sender}" --silent 2>/dev/null; then
+                authorized=1
+              fi
+              if [[ "$authorized" != "1" ]]; then
+                echo "User $sender is not authorized to approve cherry-pick to $branch branch. Skipping."
+                return 0
+              fi
+            fi
+          fi
           local create_pr=''
           while read label
           do
@@ -88,6 +107,30 @@ jobs:
             echo "Didn't find 'Approved for $branch branch' tag."
             return 0
           fi
+
+          # For 'closed' events, verify the label was added by an authorized user.
+          # Guards against race condition where label was added before merge.
+          if [[ "$action" == "closed" ]]; then
+            local org=$(echo $repository | cut -d/ -f1)
+            local label_adder=$(gh api "repos/${repository}/issues/${pr_id}/events" --paginate \
+              --jq ".[] | select(.event == \"labeled\" and .label.name == \"Approved for ${branch} branch\") | .actor.login" \
+              2>/dev/null | tail -1)
+            local authorized=0
+            if [[ "$label_adder" == "StormLiangMS" ]]; then
+              authorized=1
+            elif [[ -n "$label_adder" ]] && gh api "orgs/${org}/teams/release-manager-${branch}/memberships/${label_adder}" --silent 2>/dev/null; then
+              authorized=1
+            fi
+            if [[ "$authorized" != "1" ]]; then
+              echo "Label 'Approved for $branch branch' was added by unauthorized user '${label_adder}'. Skipping cherry-pick."
+              local release_team="release-manager-${branch}"
+              local members=$(gh api "orgs/${org}/teams/${release_team}/members" --jq '.[].login' 2>/dev/null | sed 's/^/@/' | tr '\n' ' ')
+              gh pr edit "$pr_url" --remove-label "Approved for ${branch} branch"
+              gh pr comment "$pr_url" --body "The label \`Approved for ${branch} branch\` was added by @${label_adder} who is not authorized to approve cherry-picks. Removing the label. Please contact @StormLiangMS or one of the release managers: ${members} to approve the cherry pick."
+              return 0
+            fi
+          fi
+
           # Begin to cherry-pick PR
           git cherry-pick --abort 2>/dev/null || true
           git clean -xdff 2>/dev/null || true


### PR DESCRIPTION
### Description of PR
Summary: Fix two authorization bypass scenarios not covered by the existing `CherryPickLabelAuthCheck` workflow.

### Type of change
- [x] Bug fix

### Back port request
N/A

### Approach
#### What is the motivation for this PR?
`CherryPickLabelAuthCheck` checks authorization when a label is added, but it originally triggered for both open and merged PRs. Meanwhile, `PreCherryPick` only fires when `merged == true`. This left two gaps:

1. **No auth check on merged PRs (`labeled` event)**: adding an "Approved for X branch" label directly to an already-merged PR triggers `PreCherryPick` via the `labeled` event with no authorization check.

2. **Race condition (`closed` event)**: an unauthorized user adds the label to an open PR → the PR merges before `CherryPickLabelAuthCheck` finishes removing the label → the `closed` event fires in `PreCherryPick` with the label still present and no auth check → cherry-pick proceeds.

#### How did you do it?
Two changes:

1. **`pr_cherrypick_label_auth.yml`**: restricted to open PRs only (`github.event.pull_request.state == 'open'`), since `PreCherryPick` does not run for open PRs and the merged PR cases are now handled below.

2. **`pr_cherrypick_prestep.yml`**: added authorization checks inside `cherry_pick()` for both trigger paths:
   - **`labeled` path** (merged PR): validates the sender against `StormLiangMS` or `release-manager-<branch>` team membership. Returns early without cherry-picking if unauthorized.
   - **`closed` path** (race condition guard): queries the PR's issue event history (`GET /repos/{repo}/issues/{pr}/events`) to find who last added the label, then applies the same authorization check. Removes the label and notifies if unauthorized.

#### How did you verify/test it?
Tested the `labeled`-on-merged-PR path by adding a label as an unauthorized user to a merged test PR and confirming the cherry-pick was skipped.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A