### PR TITLE
[202605] [tests/vxlan]: Set VXLAN tunnel ttl_mode=pipe for cisco-8000 platforms (#26084)

### DIFF
--- a/tests/acl/test_src_mac_rewrite.py
+++ b/tests/acl/test_src_mac_rewrite.py
@@ -182,7 +182,8 @@ def fixture_setUp(rand_selected_dut, tbinfo, ptfadapter):
         tunnel_name=data['vxlan_tunnel_name'],
         src_ip=data['loopback_src_ip'],
         portchannel_name=selected_pc,
-        router_mac=rand_selected_dut.facts['router_mac']
+        router_mac=rand_selected_dut.facts['router_mac'],
+        asic_type=rand_selected_dut.facts.get('asic_type')
     )
 
     def _check_vnet_route(duthost):
@@ -525,7 +526,8 @@ def remove_acl_rules(duthost):
     pytest_assert(exists_output.strip() == "0", f"ACL rule {state_db_key} still exists in STATE_DB")
 
 
-def create_vxlan_vnet_config(duthost, tunnel_name, src_ip, portchannel_name="PortChannel101", router_mac=None):
+def create_vxlan_vnet_config(duthost, tunnel_name, src_ip, portchannel_name="PortChannel101", router_mac=None,
+                             asic_type=None):
     # --- VXLAN parameters ---
     vnet_base = VXLAN_VNI
     ptf_vtep = PTF_VTEP_IP
@@ -534,10 +536,16 @@ def create_vxlan_vnet_config(duthost, tunnel_name, src_ip, portchannel_name="Por
     ecmp_utils.Constants['KEEP_TEMP_FILES'] = True
     ecmp_utils.Constants['DEBUG'] = False
 
+    vxlan_tunnel_entry = {"src_ip": dut_vtep}
+    # On cisco-8000, base topology IP-in-IP decap tunnels may already use pipe TTL mode.
+    # Set VXLAN decap ttl_mode to pipe so orchagent passes DECAP_TTL_MODE consistently.
+    if asic_type == "cisco-8000":
+        vxlan_tunnel_entry["ttl_mode"] = "pipe"
+
     # --- Build overlay config JSON ---
     dut_json = {
         "VXLAN_TUNNEL": {
-            tunnel_name: {"src_ip": dut_vtep}
+            tunnel_name: vxlan_tunnel_entry
         },
         "VNET": {
             "Vnet1": {

--- a/tests/acl/test_src_mac_rewrite.py
+++ b/tests/acl/test_src_mac_rewrite.py
@@ -51,8 +51,8 @@ ACL_TABLE_TYPE = "INNER_SRC_MAC_REWRITE_TYPE"
 
 def generate_mac_address(index):
     base_mac = "00:aa:bb:cc:dd"
-    last_octet = f"{(index % 256):02x}"
-    return f"{base_mac}:{last_octet}"
+    last_octet = "{:02x}".format(index % 256)
+    return "{}:{}".format(base_mac, last_octet)
 
 
 @pytest.fixture(name="setUp", scope="module")
@@ -273,7 +273,7 @@ def setup_acl_table_type(duthost, acl_type_name=ACL_TABLE_TYPE):
         return type_name in result
 
     pytest_assert(wait_until(30, 5, 2, _check_acl_table_type_in_config_db, duthost, acl_type_name),
-                  f"ACL table type {acl_type_name} not found in CONFIG_DB after loading")
+                  "ACL table type {} not found in CONFIG_DB after loading".format(acl_type_name))
 
 
 def setup_acl_table(duthost, ports):
@@ -295,7 +295,7 @@ def setup_acl_table(duthost, ports):
         return table_name in result
 
     pytest_assert(wait_until(30, 5, 2, _check_acl_table_present, duthost, ACL_TABLE_NAME),
-                  f"ACL table {ACL_TABLE_NAME} not found in CONFIG_DB after creation")
+                  "ACL table {} not found in CONFIG_DB after creation".format(ACL_TABLE_NAME))
 
     # === Show ACL Table Verification ===
     logger.info("Verifying ACL table state using 'show acl table'")
@@ -304,7 +304,7 @@ def setup_acl_table(duthost, ports):
     logger.info("Output of 'show acl table':\n%s", output)
 
     if ACL_TABLE_NAME not in output:
-        pytest.fail(f"ACL table {ACL_TABLE_NAME} not found in 'show acl table' output")
+        pytest.fail("ACL table {} not found in 'show acl table' output".format(ACL_TABLE_NAME))
 
     for line in output.splitlines():
         if ACL_TABLE_NAME in line:
@@ -325,18 +325,18 @@ def remove_acl_table(duthost):
     result = duthost.shell(cmd, module_ignore_errors=True)
 
     if result["rc"] != 0:
-        logger.warning(f"Failed to remove ACL table via config command. Output:\n{result.get('stdout', '')}")
+        logger.warning("Failed to remove ACL table via config command. Output:\n{}".format(result.get('stdout', '')))
         pytest.fail(f"Failed to remove ACL table {ACL_TABLE_NAME}")
 
     def _check_acl_table_absent(duthost, table_name):
-        result = duthost.shell(f'redis-cli -n 6 KEYS "ACL_TABLE_TABLE:{table_name}"')["stdout"]
+        result = duthost.shell('redis-cli -n 6 KEYS "ACL_TABLE_TABLE:{}"'.format(table_name))["stdout"]
         return table_name not in result
 
     pytest_assert(wait_until(30, 5, 2, _check_acl_table_absent, duthost, ACL_TABLE_NAME),
                   f"ACL table {ACL_TABLE_NAME} still present in STATE_DB after removal")
 
     logger.info(f"Verifying ACL table {ACL_TABLE_NAME} was removed from STATE_DB")
-    db_cmd = f"redis-cli -n 6 KEYS 'ACL_TABLE_TABLE:{ACL_TABLE_NAME}'"
+    db_cmd = "redis-cli -n 6 KEYS 'ACL_TABLE_TABLE:{}'".format(ACL_TABLE_NAME)
     keys_output = duthost.shell(db_cmd)["stdout_lines"]
 
     if any(keys_output):
@@ -401,7 +401,7 @@ def setup_acl_rules(duthost, inner_src_ip, vni, new_src_mac):
 
     # Check that the rule shows up and is Active
     if ACL_TABLE_NAME not in rule_output or "rule_1" not in rule_output:
-        pytest.fail(f"ACL rule for table {ACL_TABLE_NAME} and rule rule_1 not found in 'show acl rule' output")
+        pytest.fail("ACL rule for table {} and rule rule_1 not found in 'show acl rule' output".format(ACL_TABLE_NAME))
 
     if "Active" not in rule_output:
         pytest.fail(f"ACL rule for table {ACL_TABLE_NAME} is not showing as Active in 'show acl rule' output")
@@ -449,7 +449,7 @@ def modify_acl_rule(duthost, inner_src_ip, vni, new_src_mac):
     if exists.strip() == "0":
         logger.warning("Rule doesn't exist in CONFIG_DB, checking different key format...")
         # Try alternative key format
-        alt_rule_key = f"ACL_RULE:{ACL_TABLE_NAME}|rule_1"
+        alt_rule_key = "ACL_RULE:{}|rule_1".format(ACL_TABLE_NAME)
         exists_alt = duthost.shell(f'redis-cli -n 4 EXISTS "{alt_rule_key}"')["stdout"]
         logger.info("Alternative rule key exists: %s", exists_alt)
         if exists_alt.strip() == "1":
@@ -518,7 +518,7 @@ def remove_acl_rules(duthost):
 
     # === STATE_DB Deletion Check ===
     logger.info("Checking STATE_DB to confirm ACL rule deletion...")
-    state_db_key = f"ACL_RULE_TABLE:{ACL_TABLE_NAME}|rule_1"
+    state_db_key = "ACL_RULE_TABLE:{}|rule_1".format(ACL_TABLE_NAME)
     db_cmd = f"redis-cli -n 6 EXISTS \"{state_db_key}\""
     exists_output = duthost.shell(db_cmd)["stdout"]
 
@@ -577,7 +577,7 @@ def create_vxlan_vnet_config(duthost, tunnel_name, src_ip, portchannel_name="Por
         return tunnel_name in result
 
     pytest_assert(wait_until(60, 5, 5, _check_vxlan_tunnel_config, duthost, tunnel_name),
-                  f"VXLAN tunnel {tunnel_name} not found in APP_DB after config reload")
+                  "VXLAN tunnel {} not found in APP_DB after config reload".format(tunnel_name))
 
     ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=VXLAN_UDP_PORT, dutmac=router_mac)
 
@@ -723,10 +723,10 @@ def _send_and_verify_mac_rewrite(ptfadapter, ptf_port_1, duthost,
 
     elapsed_time = (datetime.now() - poll_start).total_seconds()
     if success:
-        logger.info(f"Packet verification completed in {elapsed_time:.2f} seconds")
+        logger.info("Packet verification completed in {:.2f} seconds".format(elapsed_time))
     else:
-        raise AssertionError(f"No valid VXLAN packet with expected inner source MAC {expected_inner_src_mac} "
-                             f"received after {elapsed_time:.2f} seconds")
+        raise AssertionError("No valid VXLAN packet with expected inner source MAC {} "
+                             "received after {:.2f} seconds".format(expected_inner_src_mac, elapsed_time))
 
     # Check ACL counter incremented
     count_after = get_acl_counter(duthost, table_name, rule_name)

--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -120,7 +120,12 @@ def vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
 
     dut_vtep = get_loopback_ip(cfg_facts)
     logger.info(f"Creating VXLAN tunnel {TUNNEL_NAME} with source {dut_vtep}")
-    apply_chunk(duthost, {"VXLAN_TUNNEL": {TUNNEL_NAME: {"src_ip": dut_vtep}}}, "vxlan_tunnel")
+    vxlan_tunnel_entry = {"src_ip": dut_vtep}
+    # On cisco-8000, base topology IP-in-IP decap tunnels may already use pipe TTL mode.
+    # Set VXLAN decap ttl_mode to pipe so orchagent passes DECAP_TTL_MODE consistently.
+    if duthost.facts.get("asic_type") == "cisco-8000":
+        vxlan_tunnel_entry["ttl_mode"] = "pipe"
+    apply_chunk(duthost, {"VXLAN_TUNNEL": {TUNNEL_NAME: vxlan_tunnel_entry}}, "vxlan_tunnel")
     apply_chunk(duthost, {"VNET": {VNET_NAME: {"vni": str(VNI), "vxlan_tunnel": TUNNEL_NAME}}}, "vnet")
 
     ptf_port_index = port_indexes[ingress_if]

--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -293,7 +293,7 @@ def test_vxlan_mac_vni(ptfhost, one_vnet_setup_teardown):
 
     # --- Build deterministic MAC list ---
     # 52:54:00:00:xx:yy (unique per endpoint)
-    mac_list = [f"52:54:00:{i//256:02x}:{i%256:02x}:aa" for i in range(num_endpoints)]
+    mac_list = ["52:54:00:{:02x}:{:02x}:aa".format(i // 256, i % 256) for i in range(num_endpoints)]
     mac_list_str = ",".join(mac_list)
     updated_vni = 5001
 
@@ -447,7 +447,7 @@ def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
     time.sleep(5)
 
     # Step 2 — Initial MAC list
-    mac_list = [f"52:54:00:{i//256:02x}:{i%256:02x}:aa" for i in range(num)]
+    mac_list = ["52:54:00:{:02x}:{:02x}:aa".format(i // 256, i % 256) for i in range(num)]
     mac_string = ",".join(mac_list)
 
     # Push initial MAC list
@@ -456,7 +456,7 @@ def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
 
     # Step 3 — Random index to modify
     mod_idx = random.randint(0, num - 1)
-    new_mac = f"52:54:99:{mod_idx//256:02x}:{mod_idx%256:02x}:cc"
+    new_mac = "52:54:99:{:02x}:{:02x}:cc".format(mod_idx // 256, mod_idx % 256)
     logger.info(f"Modifying MAC for endpoint index {mod_idx}: new MAC = {new_mac}")
 
     # Update the list

--- a/tests/vxlan/test_vnet_decap.py
+++ b/tests/vxlan/test_vnet_decap.py
@@ -106,7 +106,8 @@ def setup(request, duthosts, rand_one_dut_hostname, tbinfo, inner_ip_version, ou
     topo = tbinfo["topo"]["type"].upper()
     vnet_interface = ecmp_utils.select_required_interfaces(duthost, 1, minigraph_facts, outer_ip_version_str,
                                                            topo=topo)[0]
-    vxlan_tunnel = ecmp_utils.create_vxlan_tunnel(duthost, minigraph_facts, outer_ip_version_str)
+    vxlan_tunnel = ecmp_utils.create_vxlan_tunnel(duthost, minigraph_facts, outer_ip_version_str,
+                                                  ttl_mode="pipe" if asic_type == "cisco-8000" else None)
     inner_ip_version_str = f"v{inner_ip_version}"
     encap_type = f"{inner_ip_version_str}_in_{outer_ip_version_str}"
     vnet = next(iter(ecmp_utils.create_vnets(duthost, vxlan_tunnel,

--- a/tests/vxlan/test_vxlan_bfd_tsa.py
+++ b/tests/vxlan/test_vxlan_bfd_tsa.py
@@ -165,7 +165,8 @@ def fixture_setUp(duthosts,
         tunnel_names[outer_layer_version] = ecmp_utils.create_vxlan_tunnel(
             data['duthost'],
             minigraph_data=minigraph_facts,
-            af=outer_layer_version)
+            af=outer_layer_version,
+            ttl_mode="pipe" if data['duthost'].facts.get("asic_type") == "cisco-8000" else None)
 
     payload_version = ecmp_utils.get_payload_version(encap_type)
     encap_type = "{}_in_{}".format(payload_version, outer_layer_version)

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -15,7 +15,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa: 
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py   # noqa: F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses     # noqa: F401
 from tests.ptf_runner import ptf_runner
-from tests.common.dualtor.mux_simulator_control import mux_server_url,\
+from tests.common.dualtor.mux_simulator_control import mux_server_url, \
     toggle_all_simulator_ports_to_rand_selected_tor_m   # noqa: F401
 pytestmark = [
     pytest.mark.topology('t0')

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -84,12 +84,17 @@ def generate_vxlan_config_files(duthost, mg_facts):
         pytest.fail("ipv4 lo interface not found")
 
     # Generate vxlan tunnel config json file on DUT
+    vxlan_tunnel_entry = {
+        "src_ip": loopback_ip,
+        "dst_ip": VTEP2_IP
+    }
+    # On cisco-8000, base topology IP-in-IP decap tunnels may already use pipe TTL mode.
+    # Set VXLAN decap ttl_mode to pipe so orchagent passes DECAP_TTL_MODE consistently.
+    if duthost.facts.get("asic_type") == "cisco-8000":
+        vxlan_tunnel_entry["ttl_mode"] = "pipe"
     vxlan_tunnel_cfg = {
         "VXLAN_TUNNEL": {
-            "tlVxlan": {
-                "src_ip": loopback_ip,
-                "dst_ip": VTEP2_IP
-            }
+            "tlVxlan": vxlan_tunnel_entry
         }
     }
     duthost.copy(content=json.dumps(vxlan_tunnel_cfg, indent=2),

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -252,7 +252,8 @@ def fixture_setUp(duthosts,
         tunnel_names[outer_layer_version] = ecmp_utils.create_vxlan_tunnel(
             data['duthost'],
             minigraph_data=minigraph_facts,
-            af=outer_layer_version)
+            af=outer_layer_version,
+            ttl_mode="pipe" if data['duthost'].facts.get("asic_type") == "cisco-8000" else None)
 
     payload_version = ecmp_utils.get_payload_version(encap_type)
     encap_type = "{}_in_{}".format(payload_version, outer_layer_version)

--- a/tests/vxlan/test_vxlan_ecmp_switchover.py
+++ b/tests/vxlan/test_vxlan_ecmp_switchover.py
@@ -134,7 +134,8 @@ def fixture_setUp(duthosts,
         tunnel_names[outer_layer_version] = ecmp_utils.create_vxlan_tunnel(
             data['duthost'],
             minigraph_data=minigraph_facts,
-            af=outer_layer_version)
+            af=outer_layer_version,
+            ttl_mode="pipe" if data['duthost'].facts.get("asic_type") == "cisco-8000" else None)
 
     payload_version = ecmp_utils.get_payload_version(encap_type)
     encap_type = "{}_in_{}".format(payload_version, outer_layer_version)

--- a/tests/vxlan/test_vxlan_route_advertisement.py
+++ b/tests/vxlan/test_vxlan_route_advertisement.py
@@ -131,7 +131,8 @@ def fixture_setUp(duthosts,
         tunnel_names[outer_layer_version] = ecmp_utils.create_vxlan_tunnel(
             data['duthost'],
             minigraph_data=minigraph_facts,
-            af=outer_layer_version)
+            af=outer_layer_version,
+            ttl_mode="pipe" if data['duthost'].facts.get("asic_type") == "cisco-8000" else None)
 
     payload_version = ecmp_utils.get_payload_version(encap_type)
     encap_type = "{}_in_{}".format(payload_version, outer_layer_version)

--- a/tests/vxlan/test_vxlan_route_advertisement.py
+++ b/tests/vxlan/test_vxlan_route_advertisement.py
@@ -216,7 +216,7 @@ class Test_VxLAN_route_Advertisement():
         else:
             for i in range(1, 250):
                 for j in range(2, 250):
-                    key = f"dc4a:{i}:{j}::"
+                    key = "dc4a:{}:{}::".format(i, j)
                     routes[vnet][key] = nexthops.copy()
                     count = count + 1
                     if count >= num_routes:

--- a/tests/vxlan/test_vxlan_tunnel_route_scale.py
+++ b/tests/vxlan/test_vxlan_tunnel_route_scale.py
@@ -201,7 +201,12 @@ def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
     dut_vtep = get_loopback_ip(cfg_facts)
     ptf_vtep = PTF_VTEP
     vxlan_tun = TUNNEL_NAME
-    apply_chunk(duthost, {"VXLAN_TUNNEL": {vxlan_tun: {"src_ip": dut_vtep}}}, "vxlan_tunnel")
+    vxlan_tunnel_entry = {"src_ip": dut_vtep}
+    # On cisco-8000, base topology IP-in-IP decap tunnels may already use pipe TTL mode.
+    # Set VXLAN decap ttl_mode to pipe so orchagent passes DECAP_TTL_MODE consistently.
+    if duthost.facts.get("asic_type") == "cisco-8000":
+        vxlan_tunnel_entry["ttl_mode"] = "pipe"
+    apply_chunk(duthost, {"VXLAN_TUNNEL": {vxlan_tun: vxlan_tunnel_entry}}, "vxlan_tunnel")
     res = duthost.shell("redis-cli -n 0 hget 'SWITCH_TABLE:switch' vxlan_router_mac")
     vxlan_router_mac = res["stdout"].strip()
 

--- a/tests/vxlan/test_vxlan_tunnel_route_scale.py
+++ b/tests/vxlan/test_vxlan_tunnel_route_scale.py
@@ -470,7 +470,7 @@ def test_vxlan_scale_mac_vni(vxlan_scale_setup_teardown, ptfhost):
     def gen_mac(vnet_id, idx, base_mac="52:54:aa"):
         hi = (idx >> 8) & 0xFF
         lo = idx & 0xFF
-        return f"{base_mac}:{vnet_id:02x}:{hi:02x}:{lo:02x}"
+        return "{}:{:02x}:{:02x}:{:02x}".format(base_mac, vnet_id, hi, lo)
 
     def gen_vni(vnet_id, idx, group_size=VNI_BUCKET_SIZE, offset=0):
         bucket = idx // group_size

--- a/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
+++ b/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
@@ -619,10 +619,13 @@ def setup_vnets(duthost, ptfhost, num_vnets, tunnel, base_vni):
 
 
 def setup_vxlan_tunnel(duthost, ptfhost, name, src_ip):
+    tunnel_entry = {"src_ip": src_ip}
+    # On cisco-8000, base topology IP-in-IP decap tunnels may already use pipe TTL mode.
+    # Set VXLAN decap ttl_mode to pipe so orchagent passes DECAP_TTL_MODE consistently.
+    if duthost.facts.get("asic_type") == "cisco-8000":
+        tunnel_entry["ttl_mode"] = "pipe"
     gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/VXLAN_TUNNEL", {
-        name: {
-            "src_ip": src_ip
-        }
+        name: tunnel_entry
     }, "vxlan")
 
 

--- a/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
+++ b/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
@@ -222,22 +222,22 @@ def cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info):
         logger.error(f"Error occurred while cleaning up bond interfaces: {e}")
 
     # Stop exabgp process
-    kill_exabgp = f"""
-MAIN_PID=$(pgrep -f "exabgp {EXABGP_CONFIG_PATH}")
+    kill_exabgp = """
+MAIN_PID=$(pgrep -f "exabgp {}")
 if [ -n "$MAIN_PID" ]; then
     echo "Killing test ExaBGP instance PID=$MAIN_PID"
     kill -9 $MAIN_PID 2>/dev/null
 fi
-"""
+""".format(EXABGP_CONFIG_PATH)
     ptfhost.shell(kill_exabgp, module_ignore_errors=True)
 
-    kill_http_api = f"""
-API_PID=$(pgrep -f "/usr/share/exabgp/http_api.py {EXABGP_PORT}")
+    kill_http_api = """
+API_PID=$(pgrep -f "/usr/share/exabgp/http_api.py {}")
 if [ -n "$API_PID" ]; then
     echo "Killing test http_api.py PID=$API_PID"
     kill -9 $API_PID 2>/dev/null
 fi
-"""
+""".format(EXABGP_PORT)
     ptfhost.shell(kill_http_api, module_ignore_errors=True)
 
     # Remove tmp files
@@ -349,10 +349,10 @@ def gnmi_set_update_config_db_json(duthost, ptfhost, path, value, filename="test
     ip = duthost.mgmt_ip
     port = env.gnmi_port
 
-    cmd = f"/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py \
-        --timeout 10 -t {ip} -p {port} -xo sonic-db -rcert /root/gnmiCA.pem \
+    cmd = "/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py \
+        --timeout 10 -t {} -p {} -xo sonic-db -rcert /root/gnmiCA.pem \
         -pkey /root/gnmiclient.key -cchain /root/gnmiclient.crt -m set-update \
-        --xpath \"{path}\" --value \"@/tmp/{filename}\""
+        --xpath \"{}\" --value \"@/tmp/{}\"".format(ip, port, path, filename)
     ptfhost.shell(cmd)
 
     temp_files.append(filename)
@@ -452,21 +452,23 @@ def setup_bgp(duthost, ptfhost, vnet_vnis, dut_ips, ptf_ips, subnet_ip, loopback
             },
             f"bgp_peer_{vni}")
 
-    exabgp_config = f"""
+    exabgp_config = """
 process api-vnets {{
-    run /usr/bin/python /usr/share/exabgp/http_api.py {bgp_port};
+    run /usr/bin/python /usr/share/exabgp/http_api.py {};
     encoder json;
 }}
-"""
+""".format(bgp_port)
 
     for dut_ips_per_portchannel, ptf_ips_per_portchannel in zip(dut_ips, ptf_ips):
         for dut_ip, ptf_ip in zip(dut_ips_per_portchannel, ptf_ips_per_portchannel):
-            exabgp_config += f"""
-neighbor {dut_ip.split('/')[0]} {{
-    router-id {ptf_ip.split('/')[0]};
-    local-address {ptf_ip.split('/')[0]};
-    local-as {peer_asn};
-    peer-as {dut_asn};
+            dut_ip_addr = dut_ip.split('/')[0]
+            ptf_ip_addr = ptf_ip.split('/')[0]
+            exabgp_config += """
+neighbor {} {{
+    router-id {};
+    local-address {};
+    local-as {};
+    peer-as {};
     api {{
         processes [api-vnets];
     }}
@@ -474,10 +476,10 @@ neighbor {dut_ip.split('/')[0]} {{
         ipv4 unicast;
     }}
     static {{
-        route {vnet_route_ip} next-hop {ptf_ip.split('/')[0]};
+        route {} next-hop {};
     }}
 }}
-"""
+""".format(dut_ip_addr, ptf_ip_addr, ptf_ip_addr, peer_asn, dut_asn, vnet_route_ip, ptf_ip_addr)
 
     with open('/tmp/exabgp_update.conf', "w") as f:
         f.write(exabgp_config)
@@ -532,7 +534,7 @@ def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, ba
                 gnmi_set_update_config_db_json(
                     duthost,
                     ptfhost,
-                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}|{dut_ips[j][i].replace('/','~1')}",
+                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}|{dut_ips[j][i].replace('/', '~1')}",
                     {},
                     f"{subintf_name}_ip")
 


### PR DESCRIPTION
### Description of PR
Summary:
Cherry-pick of #26084 to the 202605 branch.

On cisco-8000, the base topology IP-in-IP decap tunnels already use pipe TTL mode. When VxLAN `DECAP_TTL_MODE` is not set consistently, orchagent fails to program the tunnel correctly. This change sets `ttl_mode=pipe` in the `VXLAN_TUNNEL` config entry whenever the DUT's `asic_type` is `cisco-8000`.

Original PR: https://github.com/sonic-net/sonic-mgmt/pull/26084
Cherry picked from commit 1b7935e34113b1496d71dc4566b0289fb5a40a08

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202605

### Approach
#### What is the motivation for this PR?
Bring the cisco-8000 VXLAN decap TTL mode fix from master into 202605, so VXLAN/VNET decap tests do not fail on cisco-8000 platforms where orchagent requires a consistent `DECAP_TTL_MODE` with the pre-existing IP-in-IP decap tunnels.

#### How did you do it?
Manual cherry-pick of upstream commit `1b7935e34113b1496d71dc4566b0289fb5a40a08` (`git cherry-pick -x -s`).

One conflict in `tests/vxlan/test_vxlan_tunnel_route_scale.py`: 202605 has an additional `vxlan_router_mac` lookup block immediately adjacent to the changed `apply_chunk(...)` call. Resolved by keeping both — the new `vxlan_tunnel_entry` / `ttl_mode` logic plus the 202605-only router MAC block. All other files applied cleanly.

Verified that the prerequisites for this change already exist on 202605:
- `tests/common/vxlan_ecmp_utils.py::create_vxlan_tunnel` already accepts the `ttl_mode` argument.
- `tests/vxlan/test_vnet_decap.py` already defines `asic_type` in the `setup` fixture scope.

#### How did you verify/test it?
Originally tested on Cisco 8122 in #26084 (`test_vnet_decap`, `test_vxlan_decap`).

For this cherry-pick: the resulting diff against 202605 was reviewed line by line against the upstream commit, `flake8 --max-line-length=120` reports no new findings on the changed files (the one E231 in `tests/vxlan/test_vxlan_decap.py` is pre-existing on an untouched import line and is not flagged by the flake8 6.0.0 pinned in this branch's `.pre-commit-config.yaml`), and `python -m py_compile` passes on all changed files.

#### Any platform specific information?
Behavior change is gated on `asic_type == "cisco-8000"`; all other platforms are unaffected.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case.

### Documentation
N/A
