### PR TITLE
Update SRv6 data plane test to support no dscp mode scenario

### DIFF
--- a/docs/testplan/srv6/SRv6-static-ptf-testplan.md
+++ b/docs/testplan/srv6/SRv6-static-ptf-testplan.md
@@ -40,7 +40,7 @@ and meets the diversified requirements of more new services.
 The test is to verify the functions in SRv6 phase I and II.
 
 ### Scale
-Max number of MY_SID entries is 10, it would be covered in this test plan.
+Max number of MY_SID entries is 128, it would be covered in this test plan.
 
 ### Control-plane Test
 #### uN Config
@@ -61,28 +61,28 @@ Max number of MY_SID entries is 10, it would be covered in this test plan.
 ### Data-plane Test
 
 #### Comprehensive Test for SRv6 dataplane uN function
-1. Configure SRV6_MY_SIDS with uN action at the same time for different SIDs <br>
-  a. Configure all of the SRV6_MY_SIDS as __pipe__ mode <br>
-2. Validate correct SRv6 CRM resource items had been used
-3. Clear srv6 counter <br>
-4. Send IPv6 packets from downstream to upstream neighbors <br>
-  a. Including IPv6 packets with reduced SRH(no SRH header) for uN action <br>
-  b. Including IPv6 packets with 1 uSID container in SRH for uN action <br>
-  c. Including IPv6 packets with 2 uSID container in SRH for uN action <br>
-  d. Including IPinIPv6 packets with reduced SRH(no SRH header) and uSID container in SRH for USD flavor<br>
-  e. Including IPv6inIPv6 packets with reduced SRH(no SRH header) and uSID container in SRH for USD flavor <br>
-5. All types of IPv6 packets should be handled correctly <br>
-  a. For uN action, DIP shift/ uSID container copy to DIP/ segment left decrement should happen <br>
-  b. For uN action USD flavor, IP tunnel decap should happen <br>
-  c. For each SID, the SRv6 counter for packet number and size should be updated correctly
-6. Randomly choose one action from cold reboot/config reload and do it
-7. Resend the all types of IPv6 packets
-8. All types of IPv6 packets should be handled correctly <br>
-  a. For uN action, DIP shift/ uSID container copy to DIP/ segment left decrement should happen <br>
-  b. For uN action USD flavor, IP tunnel decap should happen <br>
-  c. For each SID, the SRv6 counter for packet number and size should be updated correctly
-9. Remove all the configured SRV6_MY_SIDS <br>
-10. Check all the SRv6 CRM resource had been released <br>
+1. Configure SRV6_MY_SIDS with uN action for all test SIDs (128 entries in implementation).<br>
+  a. Configure all SIDs with decap_dscp_mode = __pipe__ (current tunnel mode in test).<br>
+  b. Validate correct SRv6 CRM resource usage after configuration.
+2. Clear SRv6 counters.
+3. Run dataplane validation with `--srv6_dscp_mode_test` option:
+  a. `both` (default): run both `dscp_mode` and `no_dscp_mode` stages.<br>
+  b. `dscp_mode`: run only decap_dscp_mode-configured stage.<br>
+  c. `no_dscp_mode`: run only stage without decap_dscp_mode.
+4. In `dscp_mode` stage, send IPv6 packets from downstream to upstream neighbors including:
+  a. IPv6 packets with reduced SRH (no SRH header) for uN action.<br>
+  b. IPv6 packets with 1 uSID container in SRH for uN action.<br>
+  c. IPv6 packets with 2 uSID containers in SRH for uN action.<br>
+  d. USD flavor traffic (IPinIPv6/IPv6inIPv6 decapsulation cases).
+5. For `no_dscp_mode` stage, SRv6 configuration update is done by reconfigure all the SRv6 SIDs without dscp_mode value.
+6. In `no_dscp_mode` stage, generate and send 128 non-USD traffic patterns (USD flavor patterns are excluded in this stage) so all tested SIDs are verifiable by counters.
+7. Validate packet processing result:
+  a. For uN action, DIP shift/uSID container copy to DIP/segment-left decrement should happen.<br>
+  b. In `dscp_mode` stage, USD flavor decapsulation should happen.<br>
+  c. SRv6 counters (packets/bytes) should match sent traffic for the active stage.
+8. In the `no_dscp_mode` stage, randomly choose one action from cold reboot/config reload/BGP restart and execute it.
+9. Re-run dataplane validation for the selected `--srv6_dscp_mode_test` stage after reboot/reload/restart.
+10. Remove all configured SRV6_MY_SIDS/SRV6_MY_LOCATORS and verify SRv6 CRM resources are released.
 
 #### Test SRv6 uN forwarding function and control-plane integrity after configuration reload
 - Set up SRv6 configuration and relevant static-route configuration in CONFIG_DB

--- a/tests/common/helpers/srv6_helper.py
+++ b/tests/common/helpers/srv6_helper.py
@@ -27,7 +27,7 @@ class SRv6Packets():
     }
 
     @classmethod
-    def generate_srv6_packets(cls, my_locator_list, srv6_packet_type):
+    def generate_srv6_packets(cls, my_locator_list, srv6_packet_type, include_usd=True):
         """
         Generate SRv6 test packets based on the provided locator list.
         Each packet will have different configurations for comprehensive testing.
@@ -35,6 +35,7 @@ class SRv6Packets():
         Args:
             my_locator_list (list): List of locator entries
             srv6_packet_type (str): Type of SRv6 packet to generate
+            include_usd (bool): Whether to include USD flavor packet patterns
 
         Returns:
             list: List of SRv6 packet configurations
@@ -182,6 +183,8 @@ class SRv6Packets():
             packet for packet in base_packets
             if packet['srv6_packet_type'] == packet_type_map.get(srv6_packet_type, 'no_srh')
         ]
+        if not include_usd:
+            filtered_base_packets = [packet for packet in filtered_base_packets if not packet['validate_usd_flavor']]
         # Generate packets for each SID
         for i, sid_entry in enumerate(my_locator_list):
             # Select base packet type based on index
@@ -250,7 +253,7 @@ def create_srv6_packet(
         exp_dscp_pipe,
         exp_dscp_uniform,
         seg_left,
-        sef_list,
+        seg_list,
         inner_pkt_ver,
         dscp_mode,
         router_mac,
@@ -274,7 +277,7 @@ def create_srv6_packet(
         exp_dscp_pipe (int): Expected DSCP value in pipe mode
         exp_dscp_uniform (int): Expected DSCP value in uniform mode
         seg_left (int): Segment left value
-        sef_list (list): Segment list
+        seg_list (list): Segment list
         inner_pkt_ver (str): Inner packet version ('4' for IPv4, '6' for IPv6)
         dscp_mode (str): DSCP mode ('pipe' or 'uniform')
         router_mac (str): Router MAC address
@@ -282,6 +285,9 @@ def create_srv6_packet(
         inner_dst_ip (str): Inner destination IPv4 address
         inner_src_ipv6 (str): Inner source IPv6 address
         inner_dst_ipv6 (str): Inner destination IPv6 address
+        inner_ttl (int): TTL/hop limit value for inner packet (default: 64)
+        outer_hop_limit (int): Hop limit value for outer IPv6 packet (default: 64)
+        random_ttl (bool): Enable random TTL generation (default: True)
 
     Returns:
         tuple: (srv6_pkt, exp_pkt) - Created SRv6 packet and expected packet
@@ -326,7 +332,7 @@ def create_srv6_packet(
 
     if srv6_action == SRv6.uN:
         if exp_outer_dst_pkt_ip:
-            if seg_left or sef_list:
+            if seg_left or seg_list:
                 logger.info('Create SRv6 packets with SRH')
                 srv6_pkt = testutils.simple_ipv6_sr_packet(
                     eth_dst=outer_dst_mac,
@@ -334,7 +340,7 @@ def create_srv6_packet(
                     ipv6_src=outer_src_pkt_ip,
                     ipv6_dst=outer_dst_pkt_ip,
                     srh_seg_left=seg_left,
-                    srh_seg_list=sef_list,
+                    srh_seg_list=seg_list,
                     ipv6_tc=outer_dscp * 4 if outer_dscp else 0,
                     srh_nh=srv6_next_header[scapy_ver],
                     inner_frame=inner_pkt[scapy_ver],
@@ -345,7 +351,7 @@ def create_srv6_packet(
                     ipv6_src=outer_src_pkt_ip,
                     ipv6_dst=exp_outer_dst_pkt_ip,
                     srh_seg_left=exp_seg_left,
-                    srh_seg_list=sef_list,
+                    srh_seg_list=seg_list,
                     ipv6_tc=exp_dscp * 4 if exp_dscp else 0,
                     srh_nh=srv6_next_header[scapy_ver],
                     inner_frame=exp_inner_pkt[scapy_ver],
@@ -378,7 +384,7 @@ def create_srv6_packet(
             exp_pkt.set_do_not_care_packet(scapy.Ether, 'src')
 
         else:
-            if seg_left or sef_list:
+            if seg_left or seg_list:
                 logger.info('Create SRv6 packets with SRH for USD flavor validation')
                 srv6_pkt = testutils.simple_ipv6_sr_packet(
                     eth_dst=outer_dst_mac,
@@ -386,7 +392,7 @@ def create_srv6_packet(
                     ipv6_src=outer_src_pkt_ip,
                     ipv6_dst=outer_dst_pkt_ip,
                     srh_seg_left=seg_left,
-                    srh_seg_list=sef_list,
+                    srh_seg_list=seg_list,
                     ipv6_tc=outer_dscp * 4 if outer_dscp else 0,
                     srh_nh=srv6_next_header[scapy_ver],
                     inner_frame=inner_pkt[scapy_ver],
@@ -488,11 +494,14 @@ def create_srv6_sid(duthost,
                     decap_vrf='default',
                     decap_dscp_mode=SRv6.uniform_mode):
     logger.info(f'Configure sid: SRV6_MY_SIDS|{locator_name}|{ip_addr}/{SRv6.prefix_len}')
-    duthost.shell(
+    cmd = (
         f'sonic-db-cli CONFIG_DB HSET "SRV6_MY_SIDS|{locator_name}|{ip_addr}/{SRv6.prefix_len}" '
         f'"action" "{action}" '
-        f'"decap_vrf" "{decap_vrf}" '
-        f'"decap_dscp_mode" "{decap_dscp_mode}"')
+        f'"decap_vrf" "{decap_vrf}"'
+    )
+    if decap_dscp_mode is not None:
+        cmd += f' "decap_dscp_mode" "{decap_dscp_mode}"'
+    duthost.shell(cmd)
 
 
 def del_srv6_sid(duthost, locator_name, ip_addr):

--- a/tests/srv6/conftest.py
+++ b/tests/srv6/conftest.py
@@ -8,11 +8,10 @@ from tests.common.helpers.ptf_tests_helper import get_stream_ptf_ports
 from tests.common.helpers.ptf_tests_helper import select_random_link
 from tests.common.helpers.ptf_tests_helper import downstream_links, upstream_links  # noqa F401
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from tests.common.helpers.srv6_helper import SRv6Packets, create_srv6_locator, del_srv6_locator, create_srv6_sid, \
-    del_srv6_sid
+from tests.common.helpers.srv6_helper import SRv6Packets
 from tests.srv6.srv6_utils import MyLocators, MySIDs, get_srv6_mysid_entry_usage, \
     enable_srv6_counterpoll, disable_srv6_counterpoll, set_srv6_counterpoll_interval, verify_srv6_counterpoll_status, \
-    verify_srv6_crm_status, ROUTE_BASE
+    verify_srv6_crm_status, ROUTE_BASE, create_all_srv6_locators_and_sids, delete_all_srv6_locators_and_sids
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +21,7 @@ def prepare_param(rand_selected_dut, srv6_packet_type, downstream_links, upstrea
     prepare_param = {}
     prepare_param['packet_num'] = 100
     prepare_param['router_mac'] = rand_selected_dut.facts["router_mac"]
+    prepare_param['srv6_packet_type'] = srv6_packet_type
     prepare_param['srv6_packets'] = SRv6Packets.generate_srv6_packets(MyLocators.my_locator_list, srv6_packet_type)
     prepare_param['srv6_next_header'] = SRv6Packets.srv6_next_header
 
@@ -92,18 +92,11 @@ def config_setup(request, rand_selected_dut, srv6_crm_total_sids, upstream_links
         verify_srv6_counterpoll_status(rand_selected_dut, 'enable', 1000)
 
     with allure.step('Create SRv6 Locators and SIDs'):
-        for locator_param in MyLocators.my_locator_list:
-            locator_name = locator_param[0]
-            locator_prefix = locator_param[1]
-            create_srv6_locator(rand_selected_dut, locator_name, locator_prefix)
-
-        for sid_param in MySIDs.MY_SID_LIST:
-            locator_name = sid_param[0]
-            ip_addr = sid_param[1]
-            action = sid_param[2]
-            vrf = sid_param[3]
-            dscp_mode = request.param
-            create_srv6_sid(rand_selected_dut, locator_name, ip_addr, action, vrf, dscp_mode)
+        dscp_mode_test = request.config.getoption("--srv6_dscp_mode_test")
+        dscp_mode = request.param
+        if dscp_mode_test == "no_dscp_mode":
+            dscp_mode = None
+        create_all_srv6_locators_and_sids(rand_selected_dut, dscp_mode)
 
     with allure.step('Verify the CRM usage of SRv6 SID'):
         used_mysid_num = len(MySIDs.MY_SID_LIST)
@@ -119,14 +112,7 @@ def config_setup(request, rand_selected_dut, srv6_crm_total_sids, upstream_links
         verify_srv6_counterpoll_status(rand_selected_dut, 'disable')
 
     with allure.step('Delete SRv6 Locators and SIDs'):
-        for sid_param in MySIDs.MY_SID_LIST:
-            locator_name = sid_param[0]
-            ip_addr = sid_param[1]
-            del_srv6_sid(rand_selected_dut, locator_name, ip_addr)
-
-        for locator_param in MyLocators.my_locator_list:
-            locator_name = locator_param[0]
-            del_srv6_locator(rand_selected_dut, locator_name)
+        delete_all_srv6_locators_and_sids(rand_selected_dut)
 
     with allure.step('Verify the CRM usage of SRv6 SID after the test'):
         used_mysid_num = 0
@@ -146,10 +132,10 @@ def pytest_addoption(parser):
     parser.addoption(
         "--srv6_reboot_type",
         action="store",
-        choices=['random', 'reload', 'cold', 'bgp'],
+        choices=['random', 'reload', 'cold', 'warm', 'bgp'],
         default='random',
         required=False,
-        help="reboot type such as random, reload, cold, bgp"
+        help="reboot type such as random, reload, cold, warm, bgp"
     )
 
     parser.addoption(
@@ -157,6 +143,16 @@ def pytest_addoption(parser):
         action="store",
         default="srh,no_srh",
         help="SRv6 test parameters, comma separated values, default: srh,no_srh"
+    )
+
+    parser.addoption(
+        "--srv6_dscp_mode_test",
+        action="store",
+        choices=["both", "dscp_mode", "no_dscp_mode"],
+        default="both",
+        required=False,
+        help="Select SRv6 DSCP mode test scope: "
+             "'both' (default), 'dscp_mode' only, or 'no_dscp_mode' only"
     )
 
 

--- a/tests/srv6/srv6_utils.py
+++ b/tests/srv6/srv6_utils.py
@@ -6,7 +6,7 @@ import ptf.testutils as testutils
 from tests.common.helpers.dut_utils import get_available_tech_support_files, get_new_techsupport_files_list, \
     extract_techsupport_tarball_file
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.srv6_helper import SRv6
+from tests.common.helpers.srv6_helper import SRv6, create_srv6_locator, create_srv6_sid, del_srv6_locator, del_srv6_sid
 
 logger = logging.getLogger(__name__)
 LOCATOR_NUM = 128
@@ -27,6 +27,67 @@ class MySIDs(MyLocators):
         [locator_name, sid, SRv6.uN, 'default']
         for locator_name, sid, _ in MyLocators.my_locator_list
     ]
+
+
+def create_all_srv6_locators_and_sids(duthost, decap_dscp_mode):
+    """
+    Create all SRv6 locators and SIDs defined for SRv6 dataplane tests.
+    """
+    for locator_name, locator_prefix, _ in MyLocators.my_locator_list:
+        create_srv6_locator(duthost, locator_name, locator_prefix)
+
+    create_all_srv6_sids(duthost, decap_dscp_mode)
+
+
+def create_all_srv6_sids(duthost, decap_dscp_mode):
+    """
+    Create all SRv6 SIDs defined for SRv6 dataplane tests.
+    """
+    for locator_name, ip_addr, action, vrf in MySIDs.MY_SID_LIST:
+        create_srv6_sid(
+            duthost,
+            locator_name,
+            ip_addr,
+            action,
+            vrf,
+            decap_dscp_mode=decap_dscp_mode
+        )
+
+
+def delete_all_srv6_sids(duthost):
+    """
+    Delete all SRv6 SIDs defined for SRv6 dataplane tests.
+    """
+    for locator_name, ip_addr, _, _ in MySIDs.MY_SID_LIST:
+        del_srv6_sid(duthost, locator_name, ip_addr)
+
+
+def delete_all_srv6_locators_and_sids(duthost):
+    """
+    Delete all SRv6 locators and SIDs defined for SRv6 dataplane tests.
+    """
+    delete_all_srv6_sids(duthost)
+
+    for locator_name, _, _ in MyLocators.my_locator_list:
+        del_srv6_locator(duthost, locator_name)
+
+
+def rebuild_all_srv6_locators_and_sids(duthost, decap_dscp_mode):
+    """
+    Rebuild SRv6 config by deleting all entries then creating new ones.
+    """
+    logger.info("Rebuild SRv6 config: delete all locators/SIDs then create all")
+    delete_all_srv6_locators_and_sids(duthost)
+    create_all_srv6_locators_and_sids(duthost, decap_dscp_mode)
+
+
+def rebuild_all_srv6_sids(duthost, decap_dscp_mode):
+    """
+    Rebuild SRv6 SID config by deleting and recreating all SIDs only.
+    """
+    logger.info("Rebuild SRv6 config: delete all SIDs then create all")
+    delete_all_srv6_sids(duthost)
+    create_all_srv6_sids(duthost, decap_dscp_mode)
 
 
 def validate_sai_sdk_dump_files(duthost, techsupport_folder, feature_list=[]):

--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -9,18 +9,18 @@ from scapy.layers.inet6 import IPv6, UDP
 from scapy.layers.l2 import Ether
 from ptf.testutils import simple_ipv6_sr_packet, send_packet, verify_no_packet_any
 from ptf.mask import Mask
-from tests.srv6.srv6_utils import MySIDs, runSendReceive, verify_appl_db_sid_entry_exist, SRv6, \
+from tests.srv6.srv6_utils import MyLocators, MySIDs, runSendReceive, verify_appl_db_sid_entry_exist, SRv6, \
     validate_techsupport_generation, validate_srv6_counters, clear_srv6_counters, \
-    get_neighbor_mac, verify_asic_db_sid_entry_exist, ROUTE_BASE
+    get_neighbor_mac, verify_asic_db_sid_entry_exist, ROUTE_BASE, rebuild_all_srv6_sids
 from tests.common.reboot import reboot
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.portstat_utilities import parse_portstat
 from tests.common.utilities import wait_until
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from tests.common.mellanox_data import is_mellanox_device
+from tests.common.mellanox_data import is_mellanox_device, get_chip_type
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
-from tests.common.helpers.srv6_helper import create_srv6_packet, send_verify_srv6_packet, \
+from tests.common.helpers.srv6_helper import SRv6Packets, create_srv6_packet, send_verify_srv6_packet, \
     validate_srv6_in_appl_db, validate_srv6_in_asic_db, validate_srv6_route, is_bgp_route_synced
 
 logger = logging.getLogger(__name__)
@@ -29,6 +29,18 @@ pytestmark = [
     pytest.mark.asic("mellanox", "broadcom", "vpp"),
     pytest.mark.topology("t0", "t1")
 ]
+
+
+# Chips known not to support SRv6 warm-reboot.
+SRV6_WARM_REBOOT_UNSUPPORTED_CHIPS = ("spectrum6",)
+
+
+def is_srv6_warm_reboot_support(duthost):
+    """Return True for Mellanox chips not in the unsupported list; non-Mellanox is not supported."""
+    if not is_mellanox_device(duthost):
+        return False
+    chip_type = get_chip_type(duthost)
+    return chip_type not in SRV6_WARM_REBOOT_UNSUPPORTED_CHIPS
 
 
 def get_ptf_src_port_and_dut_port_and_neighbor(dut, tbinfo):
@@ -102,8 +114,107 @@ def run_srv6_traffic_test(duthost, dut_mac, ptf_src_ports, neighbor_ip, ptfadapt
         runSendReceive(injected_pkt, ptf_src_port, expected_pkt, ptf_src_ports_list, True, ptfadapter)
 
 
+def _get_srv6_dscp_mode_test_flags(request):
+    dscp_mode_test = request.config.getoption("--srv6_dscp_mode_test")
+    run_dscp_mode = dscp_mode_test in ("both", "dscp_mode")
+    run_no_dscp_mode = dscp_mode_test in ("both", "no_dscp_mode")
+    return run_dscp_mode, run_no_dscp_mode
+
+
+def _reconfigure_un_sid(duthost, sonic_db_cli, decap_dscp_mode=SRv6.pipe_mode):
+    duthost.command(sonic_db_cli + " CONFIG_DB DEL SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48")
+    if decap_dscp_mode:
+        duthost.command(sonic_db_cli +
+                        f" CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48 action uN "
+                        f"decap_dscp_mode {decap_dscp_mode}")
+    else:
+        duthost.command(sonic_db_cli +
+                        " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48 action uN")
+    duthost.command("config save -y")
+    pytest_assert(wait_until(20, 5, 0, verify_asic_db_sid_entry_exist, duthost, sonic_db_cli),
+                  "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY entries are missing in ASIC_DB")
+    pytest_assert(wait_until(180, 2, 0, verify_appl_db_sid_entry_exist, duthost, sonic_db_cli,
+                             "SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1::", True),
+                  "SID is missing in APPL_DB")
+
+
+def _get_enabled_un_sid_modes(request):
+    run_dscp_mode, run_no_dscp_mode = _get_srv6_dscp_mode_test_flags(request)
+    modes = []
+    if run_dscp_mode:
+        modes.append((SRv6.pipe_mode, 'with decap_dscp_mode configured'))
+    if run_no_dscp_mode:
+        modes.append((None, 'without decap_dscp_mode configured'))
+    return modes
+
+
+def _verify_un_forwarding(setup_uN, ptfadapter, ptfhost, with_srh):
+    run_srv6_traffic_test(
+        setup_uN['duthost'], setup_uN['dut_mac'], setup_uN['ptf_src_ports'],
+        setup_uN['neighbor_ip'], ptfadapter, ptfhost, with_srh
+    )
+
+
+def _run_srv6_resilience_test(request, setup_uN, ptfadapter, ptfhost, with_srh,
+                              disruptive_action_fn, disruptive_step):
+    """Run disruptive action once; pre/post forwarding checks per enabled dscp mode."""
+    duthost = setup_uN['duthost']
+    sonic_db_cli = "sonic-db-cli" + setup_uN['cli_options']
+    neighbor_ip = setup_uN['neighbor_ip']
+    dscp_mode_test = request.config.getoption("--srv6_dscp_mode_test")
+    current_mode = [None if dscp_mode_test == "no_dscp_mode" else SRv6.pipe_mode]
+
+    def _set_mode(decap_dscp_mode):
+        if current_mode[0] != decap_dscp_mode:
+            _reconfigure_un_sid(duthost, sonic_db_cli, decap_dscp_mode)
+            current_mode[0] = decap_dscp_mode
+
+    for decap_dscp_mode, label in _get_enabled_un_sid_modes(request):
+        with allure.step(f'Pre-check forwarding {label}'):
+            _set_mode(decap_dscp_mode)
+            _verify_un_forwarding(setup_uN, ptfadapter, ptfhost, with_srh)
+
+    with allure.step(disruptive_step):
+        disruptive_action_fn()
+        _wait_for_srv6_un_ready(duthost, sonic_db_cli, neighbor_ip)
+
+    for decap_dscp_mode, label in _get_enabled_un_sid_modes(request):
+        with allure.step(f'Post-check forwarding {label}'):
+            _set_mode(decap_dscp_mode)
+            _verify_un_forwarding(setup_uN, ptfadapter, ptfhost, with_srh)
+
+
+def _run_srv6_dscp_mode_phases(request, setup_uN, test_fn, dscp_mode_step="", no_dscp_mode_step=""):
+    """Run a lightweight test function once per enabled dscp mode configuration."""
+    run_dscp_mode, run_no_dscp_mode = _get_srv6_dscp_mode_test_flags(request)
+    duthost = setup_uN['duthost']
+    sonic_db_cli = "sonic-db-cli" + setup_uN['cli_options']
+
+    if run_dscp_mode:
+        with allure.step(dscp_mode_step or 'Run test with decap_dscp_mode configured'):
+            test_fn()
+
+    if run_no_dscp_mode:
+        if run_dscp_mode:
+            with allure.step('Change the SRv6 configuration to no dscp_mode'):
+                _reconfigure_un_sid(duthost, sonic_db_cli, decap_dscp_mode=None)
+        with allure.step(no_dscp_mode_step or 'Run test without decap_dscp_mode configured'):
+            test_fn()
+
+
+def _wait_for_srv6_un_ready(duthost, sonic_db_cli, neighbor_ip):
+    pytest_assert(wait_until(180, 2, 0, verify_appl_db_sid_entry_exist, duthost, sonic_db_cli,
+                             "SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1::", True),
+                  "SID is missing in APPL_DB")
+    pytest_assert(wait_until(20, 5, 0, verify_asic_db_sid_entry_exist, duthost, sonic_db_cli),
+                  "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY entries are missing in ASIC_DB")
+    pytest_assert(wait_until(60, 5, 0, is_bgp_route_synced, duthost), "BGP route is not synced")
+    pytest_assert(wait_until(60, 5, 0, get_neighbor_mac, duthost, neighbor_ip),
+                  "IP table not updating MAC for neighbour")
+
+
 @pytest.fixture()
-def setup_uN(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, tbinfo):
+def setup_uN(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, tbinfo, request):
     duthost = duthosts[enum_frontend_dut_hostname]
     asic_index = enum_frontend_asic_index
 
@@ -148,8 +259,13 @@ def setup_uN(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, tbi
     # add a locator configuration entry
     duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_LOCATORS\\|loc1 prefix fcbb:bbbb:1:: func_len 0")
     # add a uN sid configuration entry
-    duthost.command(sonic_db_cli +
-                    " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48 action uN decap_dscp_mode pipe")
+    dscp_mode_test = request.config.getoption("--srv6_dscp_mode_test")
+    if dscp_mode_test == "no_dscp_mode":
+        duthost.command(sonic_db_cli +
+                        " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48 action uN")
+    else:
+        duthost.command(sonic_db_cli +
+                        " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48 action uN decap_dscp_mode pipe")
     random.seed(time.time())
     # add the static route for IPv6 forwarding towards PTF's uSID and the blackhole route in a random order
     if random.randint(0, 1) == 0:
@@ -192,7 +308,17 @@ class SRv6Base():
     def use_param(self, prepare_param):
         self.params = prepare_param
 
-    def _validate_srv6_function(self, duthost, ptfadapter, dscp_mode, weak_server):
+    def _reconfigure_sids_with_full_reset(self, duthost, decap_dscp_mode):
+        with allure.step('Reconfigure SRv6 by deleting and recreating all SIDs'):
+            logger.info("SRv6 does not support in-place update, rebuilding all SIDs")
+            rebuild_all_srv6_sids(duthost, decap_dscp_mode)
+            duthost.shell('sudo config save -y')
+
+    def _reconfigure_sids_without_dscp_mode(self, duthost):
+        self._reconfigure_sids_with_full_reset(duthost, decap_dscp_mode=None)
+
+    def _validate_srv6_function(self, duthost, ptfadapter, dscp_mode, weak_server,
+                                include_decap=True):
         srv6_pkt_list = []
         logger.info('Clear the SRv6 counters')
         clear_srv6_counters(duthost)
@@ -213,8 +339,18 @@ class SRv6Base():
         if weak_server:
             delay_interval = 0.4
             self.params['packet_num'] = 10
+
+        packet_dscp_mode = dscp_mode if dscp_mode is not None else SRv6.pipe_mode
+        packets_to_validate = self.params['srv6_packets']
+        if dscp_mode is None and not include_decap:
+            packets_to_validate = SRv6Packets.generate_srv6_packets(
+                MyLocators.my_locator_list,
+                self.params['srv6_packet_type'],
+                include_usd=False
+            )
+
         ptf_src_mac = ptfadapter.dataplane.get_mac(0, self.params['ptf_downlink_port']).decode('utf-8')
-        for srv6_packet in self.params['srv6_packets']:
+        for srv6_packet in packets_to_validate:
             if duthost.facts["asic_type"] == "broadcom" and \
                (srv6_packet['srh_seg_left'] or srv6_packet['srh_seg_list']):
                 logger.info("Skip the test for Broadcom ASIC with SRH")
@@ -225,12 +361,15 @@ class SRv6Base():
                 logger.info("Skip the test for VPP with USD flavor.")
                 continue
 
+            if not include_decap and srv6_packet['validate_usd_flavor']:
+                logger.info("Skip decap validation for SIDs without decap_dscp_mode")
+                continue
+
             logger.info('-------------------------------------------------------------------------')
             if srv6_packet['validate_dip_shift']:
                 logger.info('Validate DIP shift')
             if srv6_packet['validate_usd_flavor']:
-                logger.info('Validate USD flavor')
-            logger.info(f'SRv6 tunnel decapsulation mode: {dscp_mode}')
+                logger.info('Validate USD flavor (decap)')
             logger.info(f'Send {self.params["packet_num"]} SRv6 packets with action: {srv6_packet["action"]}')
             logger.info(f'Pkt Src MAC: {ptf_src_mac}')
             logger.info(f'Pkt Dst MAC: {self.params["router_mac"]}')
@@ -239,16 +378,18 @@ class SRv6Base():
                 logger.info(f'Outer Pkt Dst IP: {srv6_packet["dst_ipv6"]}')
                 if srv6_packet["exp_dst_ipv6"]:
                     logger.info(f'Expect Outer Pkt Dst IP: {srv6_packet["exp_dst_ipv6"]}')
-            if dscp_mode == SRv6.uniform_mode:
-                if srv6_packet['outer_dscp']:
-                    logger.info(f'Outer DSCP value: {srv6_packet["outer_dscp"]}')
-                if srv6_packet['exp_outer_dscp_uniform']:
-                    logger.info(f'Expect inner DSCP value: {srv6_packet["exp_outer_dscp_uniform"]}')
-            else:
-                if srv6_packet['inner_dscp']:
-                    logger.info(f'Inner DSCP value: {srv6_packet["inner_dscp"]}')
-                if srv6_packet['exp_inner_dscp_pipe']:
-                    logger.info(f'Expect inner DSCP value: {srv6_packet["exp_inner_dscp_pipe"]}')
+            if dscp_mode is not None:
+                logger.info(f'SRv6 tunnel decapsulation mode: {dscp_mode}')
+                if dscp_mode == SRv6.uniform_mode:
+                    if srv6_packet['outer_dscp']:
+                        logger.info(f'Outer DSCP value: {srv6_packet["outer_dscp"]}')
+                    if srv6_packet['exp_outer_dscp_uniform']:
+                        logger.info(f'Expect inner DSCP value: {srv6_packet["exp_outer_dscp_uniform"]}')
+                else:
+                    if srv6_packet['inner_dscp']:
+                        logger.info(f'Inner DSCP value: {srv6_packet["inner_dscp"]}')
+                    if srv6_packet['exp_inner_dscp_pipe']:
+                        logger.info(f'Expect inner DSCP value: {srv6_packet["exp_inner_dscp_pipe"]}')
             logger.info(f'SRH Segment List: {srv6_packet["srh_seg_list"]}')
             logger.info(f'SRH Segment Left: {srv6_packet["srh_seg_left"]}')
 
@@ -269,9 +410,9 @@ class SRv6Base():
                 exp_dscp_pipe=srv6_packet['exp_inner_dscp_pipe'],
                 exp_dscp_uniform=srv6_packet['exp_outer_dscp_uniform'],
                 seg_left=srv6_packet['srh_seg_left'],
-                sef_list=srv6_packet['srh_seg_list'],
+                seg_list=srv6_packet['srh_seg_list'],
                 inner_pkt_ver=srv6_packet['inner_pkt_ver'],
-                dscp_mode=dscp_mode,
+                dscp_mode=packet_dscp_mode,
                 router_mac=self.params['router_mac'],
                 inner_src_ip=srv6_packet['inner_src_ip'],
                 inner_dst_ip=srv6_packet['inner_dst_ip'],
@@ -303,126 +444,140 @@ class TestSRv6DataPlaneBase(SRv6Base):
                             toggle_all_simulator_ports_to_rand_selected_tor,  # noqa: F811
                             ptfadapter, rand_selected_dut, localhost, request, enum_frontend_asic_index, weak_server):
 
-        with allure.step('Validate SRv6 packet process'):
-            srv6_pkt_list = self._validate_srv6_function(rand_selected_dut, ptfadapter, config_setup, weak_server)
+        dscp_mode = config_setup
+        dscp_mode_test = request.config.getoption("--srv6_dscp_mode_test")
+        run_dscp_mode = dscp_mode_test in ("both", "dscp_mode")
+        run_no_dscp_mode = dscp_mode_test in ("both", "no_dscp_mode")
+        current_dscp_mode = dscp_mode
+        current_include_decap = current_dscp_mode is not None
 
-        with allure.step('Validate SRv6 counters'):
-            pytest_assert(wait_until(60, 5, 0, validate_srv6_counters, rand_selected_dut, srv6_pkt_list,
-                                     MySIDs.MY_SID_LIST, self.params['packet_num']),
-                          "SRv6 counters are not as expected")
+        if run_dscp_mode:
+            with allure.step('Validate SRv6 packet shift, forward and decap with decap_dscp_mode configured'):
+                srv6_pkt_list_dscp = self._validate_srv6_function(
+                    rand_selected_dut, ptfadapter, dscp_mode, weak_server, include_decap=True)
 
-        if random.random() < 0.5:
+            with allure.step('Validate SRv6 counters with decap_dscp_mode configured'):
+                pytest_assert(wait_until(60, 5, 0, validate_srv6_counters, rand_selected_dut, srv6_pkt_list_dscp,
+                                         MySIDs.MY_SID_LIST, self.params['packet_num']),
+                              "SRv6 counters are not as expected")
 
-            with allure.step('Execute reboot test'):
-                reboot_type = request.config.getoption("--srv6_reboot_type")
+        if run_no_dscp_mode:
+            # For "both", switch from dscp_mode config to no_dscp_mode config.
+            # For "no_dscp_mode" only, fixture already configures no_dscp_mode directly.
+            if run_dscp_mode:
+                with allure.step('Change the SRv6 configuration to no dscp_mode'):
+                    self._reconfigure_sids_without_dscp_mode(rand_selected_dut)
+                    current_dscp_mode = None
+                    current_include_decap = False
 
-                if reboot_type == "random":
-                    reboot_type = random.choice(["cold", "reload", "bgp"])
+            with allure.step('Validate SRv6 packet shift and forward without decap_dscp_mode configured'):
+                srv6_pkt_list = self._validate_srv6_function(
+                    rand_selected_dut, ptfadapter, dscp_mode=None, weak_server=weak_server, include_decap=False)
 
-                if reboot_type == "cold":
-                    with allure.step('Execute cold reboot'):
-                        reboot(rand_selected_dut, localhost, reboot_type=reboot_type, wait_warmboot_finalizer=True,
-                               safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
-                elif reboot_type == "reload":
-                    with allure.step('Execute config reload'):
-                        config_reload(rand_selected_dut, safe_reload=True, check_intf_up_ports=True)
-                else:
-                    with allure.step('Execute BGP restart'):
-                        if rand_selected_dut.is_multi_asic:
-                            rand_selected_dut.command(
-                                f"systemctl restart bgp@{enum_frontend_asic_index}")
-                        else:
-                            rand_selected_dut.command("systemctl restart bgp")
+            with allure.step('Validate SRv6 counters without decap_dscp_mode configured'):
+                pytest_assert(wait_until(60, 5, 0, validate_srv6_counters, rand_selected_dut, srv6_pkt_list,
+                                         MySIDs.MY_SID_LIST, self.params['packet_num']),
+                              "SRv6 counters are not as expected")
 
-                with allure.step('Validate BGP docker UP'):
-                    pytest_assert(wait_until(100, 10, 0, rand_selected_dut.is_service_fully_started_per_asic_or_host,
-                                             "bgp"),
-                                  "BGP not started.")
+            if random.random() < 0.5:
 
-                with allure.step('Validate BGP route sync'):
-                    pytest_assert(wait_until(120, 5, 0, is_bgp_route_synced,
-                                             rand_selected_dut), "BGP route is not synced")
+                with allure.step('Execute reboot test'):
+                    reboot_type = request.config.getoption("--srv6_reboot_type")
 
-                with allure.step('Validate SRv6 packet process'):
-                    self._validate_srv6_function(rand_selected_dut, ptfadapter, config_setup, weak_server)
+                    if reboot_type == "random":
+                        reboot_options = ["cold", "reload", "bgp"]
+                        if is_srv6_warm_reboot_support(rand_selected_dut):
+                            reboot_options.append("warm")
+                        reboot_type = random.choice(reboot_options)
 
-                with allure.step('Validate SRv6 counters'):
-                    pytest_assert(wait_until(60, 5, 0, validate_srv6_counters, rand_selected_dut, srv6_pkt_list,
-                                             MySIDs.MY_SID_LIST, self.params['packet_num']),
-                                  "SRv6 counters are not as expected")
+                    if reboot_type == "warm" and not is_srv6_warm_reboot_support(rand_selected_dut):
+                        chip_type = get_chip_type(rand_selected_dut) if is_mellanox_device(rand_selected_dut) else None
+                        platform = chip_type or rand_selected_dut.facts['asic_type']
+                        pytest.skip(f"Warm-reboot not supported on {platform}")
 
-            if is_mellanox_device(rand_selected_dut) and config_setup == SRv6.pipe_mode:
-                with allure.step('Validate SAI SDK dump contains SRv6 information'):
-                    validate_techsupport_generation(rand_selected_dut, feature_list=['SRv6'])
+                    if reboot_type in ("cold", "warm"):
+                        with allure.step(f'Execute {reboot_type} reboot'):
+                            reboot(rand_selected_dut, localhost, reboot_type=reboot_type, wait_warmboot_finalizer=True,
+                                   safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
+                    elif reboot_type == "reload":
+                        with allure.step('Execute config reload'):
+                            config_reload(rand_selected_dut, safe_reload=True,
+                                          check_intf_up_ports=True, wait_for_bgp=True)
+                    else:
+                        with allure.step('Execute BGP restart'):
+                            if rand_selected_dut.is_multi_asic:
+                                rand_selected_dut.command(
+                                    f"systemctl restart bgp@{enum_frontend_asic_index}")
+                            else:
+                                rand_selected_dut.command("systemctl restart bgp")
 
+                    with allure.step('Validate BGP docker UP'):
+                        pytest_assert(
+                            wait_until(100, 10, 0,
+                                       rand_selected_dut.is_service_fully_started_per_asic_or_host, "bgp"),
+                            "BGP not started.")
 
-@pytest.mark.parametrize("with_srh", [True, False])
-def test_srv6_dataplane_after_config_reload(setup_uN, ptfadapter, ptfhost, with_srh):
-    duthost = setup_uN['duthost']
-    dut_mac = setup_uN['dut_mac']
-    ptf_src_ports = setup_uN['ptf_src_ports']
-    neighbor_ip = setup_uN['neighbor_ip']
+                    with allure.step('Validate BGP route sync'):
+                        pytest_assert(wait_until(120, 5, 0, is_bgp_route_synced,
+                                                 rand_selected_dut), "BGP route is not synced")
 
-    # verify the forwarding works
-    run_srv6_traffic_test(duthost, dut_mac, ptf_src_ports, neighbor_ip, ptfadapter, ptfhost, with_srh)
+                    with allure.step('Validate SRv6 packet shift and forward after reboot'):
+                        srv6_pkt_list = self._validate_srv6_function(
+                            rand_selected_dut,
+                            ptfadapter,
+                            dscp_mode=current_dscp_mode,
+                            weak_server=weak_server,
+                            include_decap=current_include_decap
+                        )
 
-    # reload the config
-    duthost.command("config reload -y -f")
-    time.sleep(180)
+                    with allure.step('Validate SRv6 counters after reboot'):
+                        pytest_assert(wait_until(60, 5, 0, validate_srv6_counters, rand_selected_dut, srv6_pkt_list,
+                                                 MySIDs.MY_SID_LIST, self.params['packet_num']),
+                                      "SRv6 counters are not as expected")
 
-    sonic_db_cli = "sonic-db-cli" + setup_uN['cli_options']
-    # wait for the config to be reprogrammed
-    assert wait_until(180, 2, 0, verify_appl_db_sid_entry_exist, duthost, sonic_db_cli,
-                      "SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1::", True), "SID is missing in APPL_DB"
-    # Verify that the ASIC DB has the SRv6 SID entries
-    assert wait_until(20, 5, 0, verify_asic_db_sid_entry_exist, duthost, sonic_db_cli), \
-        "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY entries are missing in ASIC_DB after config reload"
+                if is_mellanox_device(rand_selected_dut) and config_setup == SRv6.pipe_mode:
+                    with allure.step('Validate SAI SDK dump contains SRv6 information'):
+                        validate_techsupport_generation(rand_selected_dut, feature_list=['SRv6'])
 
-    pytest_assert(wait_until(60, 5, 0, is_bgp_route_synced, duthost), "BGP route is not synced")
-
-    pytest_assert(wait_until(60, 5, 0, get_neighbor_mac, duthost, neighbor_ip),
-                  "IP table not updating MAC for neighbour")
-
-    # verify the forwarding works after config reload
-    run_srv6_traffic_test(duthost, dut_mac, ptf_src_ports, neighbor_ip, ptfadapter, ptfhost, with_srh)
-
-
-@pytest.mark.parametrize("with_srh", [True, False])
-def test_srv6_dataplane_after_bgp_restart(setup_uN, ptfadapter, ptfhost, with_srh):
-    duthost = setup_uN['duthost']
-    dut_mac = setup_uN['dut_mac']
-    ptf_src_ports = setup_uN['ptf_src_ports']
-    neighbor_ip = setup_uN['neighbor_ip']
-
-    # verify the forwarding works
-    run_srv6_traffic_test(duthost, dut_mac, ptf_src_ports, neighbor_ip, ptfadapter, ptfhost, with_srh)
-
-    # restart BGP service, which will restart the BGP container
-    if duthost.is_multi_asic:
-        duthost.command("systemctl restart bgp@{}".format(setup_uN['asic_index']))
-    else:
-        duthost.command("systemctl restart bgp")
-    time.sleep(180)
-
-    sonic_db_cli = "sonic-db-cli" + setup_uN['cli_options']
-    # wait for the config to be reprogrammed
-    assert wait_until(180, 2, 0, verify_appl_db_sid_entry_exist, duthost, sonic_db_cli,
-                      "SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1::", True), "SID is missing in APPL_DB"
-    # Verify that the ASIC DB has the SRv6 SID entries
-    assert wait_until(20, 5, 0, verify_asic_db_sid_entry_exist, duthost, sonic_db_cli), \
-        "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY entries are missing in ASIC_DB after BGP restart"
-
-    pytest_assert(wait_until(60, 5, 0, is_bgp_route_synced, duthost), "BGP route is not synced")
-    # verify the forwarding works after BGP restart
-    run_srv6_traffic_test(duthost, dut_mac, ptf_src_ports, neighbor_ip, ptfadapter, ptfhost, with_srh)
+            if run_dscp_mode and run_no_dscp_mode:
+                with allure.step('Restore SRv6 configuration to decap_dscp_mode'):
+                    self._reconfigure_sids_with_full_reset(rand_selected_dut, decap_dscp_mode=dscp_mode)
 
 
 @pytest.mark.parametrize("with_srh", [True, False])
-def test_srv6_dataplane_after_reboot(setup_uN, ptfadapter, ptfhost, localhost, with_srh, loganalyzer):
+def test_srv6_dataplane_after_config_reload(setup_uN, ptfadapter, ptfhost, with_srh, request):
     duthost = setup_uN['duthost']
-    dut_mac = setup_uN['dut_mac']
-    ptf_src_ports = setup_uN['ptf_src_ports']
-    neighbor_ip = setup_uN['neighbor_ip']
+
+    def _config_reload():
+        duthost.command("config reload -y -f")
+        time.sleep(180)
+
+    _run_srv6_resilience_test(
+        request, setup_uN, ptfadapter, ptfhost, with_srh, _config_reload,
+        disruptive_step='Execute config reload'
+    )
+
+
+@pytest.mark.parametrize("with_srh", [True, False])
+def test_srv6_dataplane_after_bgp_restart(setup_uN, ptfadapter, ptfhost, with_srh, request):
+    duthost = setup_uN['duthost']
+
+    def _bgp_restart():
+        if duthost.is_multi_asic:
+            duthost.command("systemctl restart bgp@{}".format(setup_uN['asic_index']))
+        else:
+            duthost.command("systemctl restart bgp")
+        time.sleep(180)
+
+    _run_srv6_resilience_test(
+        request, setup_uN, ptfadapter, ptfhost, with_srh, _bgp_restart,
+        disruptive_step='Execute BGP restart'
+    )
+
+
+@pytest.mark.parametrize("with_srh", [True, False])
+def test_srv6_dataplane_after_reboot(setup_uN, ptfadapter, ptfhost, localhost, with_srh, loganalyzer, request):
+    duthost = setup_uN['duthost']
 
     # Reloading the configuration will restart eth0 and update the TACACS settings.
     # This change may introduce a delay, potentially causing temporary TACACS reporting errors.
@@ -430,85 +585,79 @@ def test_srv6_dataplane_after_reboot(setup_uN, ptfadapter, ptfhost, localhost, w
         loganalyzer[duthost.hostname].ignore_regex.extend([r".*tac_connect_single: .*",
                                                            r".*nss_tacplus: .*"])
 
-    # verify the forwarding works
-    run_srv6_traffic_test(duthost, dut_mac, ptf_src_ports, neighbor_ip, ptfadapter, ptfhost, with_srh)
+    def _reboot_dut():
+        reboot(duthost, localhost, safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
 
-    # reboot DUT
-    reboot(duthost, localhost, wait=300, safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
-
-    sonic_db_cli = "sonic-db-cli" + setup_uN['cli_options']
-    # wait for the config to be reprogrammed
-    assert wait_until(180, 2, 0, verify_appl_db_sid_entry_exist, duthost, sonic_db_cli,
-                      "SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1::", True), "SID is missing in APPL_DB"
-    # Verify that the ASIC DB has the SRv6 SID entries
-    assert wait_until(20, 5, 0, verify_asic_db_sid_entry_exist, duthost, sonic_db_cli), \
-        "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY entries are missing in ASIC_DB after reboot"
-
-    pytest_assert(wait_until(60, 5, 0, is_bgp_route_synced, duthost), "BGP route is not synced")
-    # verify the forwarding works after reboot
-    run_srv6_traffic_test(duthost, dut_mac, ptf_src_ports, neighbor_ip, ptfadapter, ptfhost, with_srh)
+    _run_srv6_resilience_test(
+        request, setup_uN, ptfadapter, ptfhost, with_srh, _reboot_dut,
+        disruptive_step='Execute reboot'
+    )
 
 
 @pytest.mark.parametrize("with_srh", [True, False])
-def test_srv6_no_sid_blackhole(setup_uN, ptfadapter, ptfhost, with_srh):
+def test_srv6_no_sid_blackhole(setup_uN, ptfadapter, ptfhost, with_srh, request):
     duthost = setup_uN['duthost']
     dut_mac = setup_uN['dut_mac']
     dut_port = setup_uN['dut_port']
     ptf_src_ports = setup_uN['ptf_src_ports']
     neighbor_ip = setup_uN['neighbor_ip']
     ptf_port_ids = setup_uN['ptf_port_ids']
-
-    # Use the first port to send traffic
-    first_ptf_port = ptf_src_ports[0] if isinstance(ptf_src_ports, list) else ptf_src_ports
-
-    # Verify that the ASIC DB has the SRv6 SID entries
     sonic_db_cli = "sonic-db-cli" + setup_uN['cli_options']
-    assert wait_until(20, 5, 0, verify_asic_db_sid_entry_exist, duthost, sonic_db_cli), \
-        "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY entries are missing in ASIC_DB before blackhole test"
 
-    # get the drop counter before traffic test
-    if duthost.facts["asic_type"] == "broadcom":
-        portstat = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])
-        before_count = int(portstat[dut_port]['rx_drp'])
-    elif duthost.facts["asic_type"] == "mellanox":
-        before_count = int(duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines'][6].split()[0])
+    ptf_src_port = ptf_src_ports[0] if isinstance(ptf_src_ports, list) else ptf_src_ports
 
-    # inject a number of packets with random payload
-    pkt_count = 100
-    payload = ''.join(random.choices(string.ascii_letters + string.digits, k=20))
-    if with_srh:
-        injected_pkt = simple_ipv6_sr_packet(
-            eth_dst=dut_mac,
-            eth_src=ptfadapter.dataplane.get_mac(0, first_ptf_port).decode(),
-            ipv6_src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1",
-            ipv6_dst="fcbb:bbbb:3:2::",
-            srh_seg_left=1,
-            srh_nh=41,
-            inner_frame=IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1") / UDP(
-                dport=4791) / Raw(load=payload)
-        )
-    else:
-        injected_pkt = Ether(dst=dut_mac, src=ptfadapter.dataplane.get_mac(0, first_ptf_port).decode()) \
-                       / IPv6(src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1", dst="fcbb:bbbb:3:2::") \
-                       / IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1") \
-                       / UDP(dport=4791) / Raw(load=payload)
+    def _run_blackhole_test():
+        pytest_assert(wait_until(20, 5, 0, verify_asic_db_sid_entry_exist, duthost, sonic_db_cli),
+                      "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY entries are missing in ASIC_DB before blackhole test")
 
-    expected_pkt = injected_pkt.copy()
-    expected_pkt['IPv6'].dst = "fcbb:bbbb:3:2::"
-    expected_pkt['IPv6'].hlim -= 1
-    logger.debug("Expected packet: {}".format(expected_pkt.summary()))
+        if duthost.facts["asic_type"] == "broadcom":
+            portstat = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])
+            before_count = int(portstat[dut_port]['rx_drp'])
+        elif duthost.facts["asic_type"] == "mellanox":
+            rif_output = duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines']
+            before_count = int(rif_output[6].split()[0])
 
-    expected_pkt = Mask(expected_pkt)
-    expected_pkt.set_do_not_care_packet(Ether, "dst")
-    expected_pkt.set_do_not_care_packet(Ether, "src")
-    send_packet(ptfadapter, first_ptf_port, injected_pkt, count=pkt_count)
-    verify_no_packet_any(ptfadapter, expected_pkt, ptf_port_ids, 0, 1)
+        pkt_count = 100
+        payload = ''.join(random.choices(string.ascii_letters + string.digits, k=20))
+        if with_srh:
+            injected_pkt = simple_ipv6_sr_packet(
+                eth_dst=dut_mac,
+                eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode(),
+                ipv6_src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1",
+                ipv6_dst="fcbb:bbbb:3:2::",
+                srh_seg_left=1,
+                srh_nh=41,
+                inner_frame=IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1") / UDP(
+                    dport=4791) / Raw(load=payload)
+            )
+        else:
+            injected_pkt = Ether(dst=dut_mac, src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode()) \
+                           / IPv6(src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1", dst="fcbb:bbbb:3:2::") \
+                           / IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1") \
+                           / UDP(dport=4791) / Raw(load=payload)
 
-    # verify that the RX_DROP counter is incremented
-    if duthost.facts["asic_type"] == "broadcom":
-        portstat = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])
-        after_count = int(portstat[dut_port]['rx_drp'])
-        assert after_count >= (before_count + pkt_count), "RX_DRP counter is not incremented as expected"
-    elif duthost.facts["asic_type"] == "mellanox":
-        after_count = int(duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines'][6].split()[0])
-        assert after_count >= (before_count + pkt_count), "RIF RX_ERR counter is not incremented as expected"
+        expected_pkt = injected_pkt.copy()
+        expected_pkt['IPv6'].dst = "fcbb:bbbb:3:2::"
+        expected_pkt['IPv6'].hlim -= 1
+        logger.debug("Expected packet: {}".format(expected_pkt.summary()))
+
+        expected_pkt = Mask(expected_pkt)
+        expected_pkt.set_do_not_care_packet(Ether, "dst")
+        expected_pkt.set_do_not_care_packet(Ether, "src")
+        send_packet(ptfadapter, ptf_src_port, injected_pkt, count=pkt_count)
+        verify_no_packet_any(ptfadapter, expected_pkt, ptf_port_ids, 0, 1)
+
+        if duthost.facts["asic_type"] == "broadcom":
+            portstat = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])
+            after_count = int(portstat[dut_port]['rx_drp'])
+            assert after_count >= (before_count + pkt_count), "RX_DRP counter is not incremented as expected"
+        elif duthost.facts["asic_type"] == "mellanox":
+            rif_output = duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines']
+            after_count = int(rif_output[6].split()[0])
+            assert after_count >= (before_count + pkt_count), "RIF RX_ERR counter is not incremented as expected"
+
+    _run_srv6_dscp_mode_phases(
+        request, setup_uN, _run_blackhole_test,
+        dscp_mode_step='Validate SRv6 no SID blackhole with decap_dscp_mode configured',
+        no_dscp_mode_step='Validate SRv6 no SID blackhole without decap_dscp_mode configured'
+    )


### PR DESCRIPTION

### Description of PR
Enable warm-reboot on sn5640 in srv6 test case
Add a new scenario
128 Sid configured without dscp_mode, validate SRv6 packet shift & forward with and without SRH 
Move the heavy part(config reload/reboot/bgp restart)to the no dscp_mode scenario 
Only do a traffic test for the dscp_mode configured scenario

Add a new pytest option --srv6_dscp_mode_test
There should be a way to run one type or both for all the cases

Validate PASS
<img width="586" height="431" alt="image" src="https://github.com/user-attachments/assets/8a93a581-ea33-4504-8196-ea9fa073d3b1" />
<img width="577" height="133" alt="image" src="https://github.com/user-attachments/assets/f74be988-d32a-4dd0-a597-49e047585371" />

Related design PR:
https://github.com/sonic-net/sonic-swss/pull/4371

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
Validate PASS
<img width="586" height="431" alt="image" src="https://github.com/user-attachments/assets/8a93a581-ea33-4504-8196-ea9fa073d3b1" />
<img width="577" height="133" alt="image" src="https://github.com/user-attachments/assets/f74be988-d32a-4dd0-a597-49e047585371" />

### Approach
#### What is the motivation for this PR?
Update according to the design code change:
https://github.com/sonic-net/sonic-swss/pull/4371
#### How did you do it?
Add a new scenario
128 Sid configured without dscp_mode, validate SRv6 packet shift & forward with and without SRH 
Move the heavy part(config reload/reboot/bgp restart)to the no dscp_mode scenario 
Only do a traffic test for the dscp_mode configured scenario

Add a new pytest option --srv6_dscp_mode_test
There should be a way to run one type or both for all the cases
#### How did you verify/test it?
Run pass in local setup

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
