### PR TITLE
[loganalyzer] Ignore syncd ACL-entry watchdog on slow Broadcom DNX

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -520,3 +520,14 @@ r, ".* ERR auditd.*: auditd queue full reporting limit reached - ending dropped 
 # ctrmgrd k8s join warnings (old k8s version incompatibility with Docker 28.x)
 r, ".* ERR ctrmgrd\.py: Refer file .* for troubleshooting tips.*"
 r, ".* ERR ctrmgrd\.py:.*\[WARNING SystemVerification\]:.*Docker version is not on the list of validated versions.*"
+
+# syncd watchdog fires on Broadcom DNX (Jericho3, e.g. NH-5010) because ACL entry
+# programming is slow (~30s per SAI_OBJECT_TYPE_ACL_ENTRY create). This is a
+# performance watchdog on the ACL-entry create path only, not a functional
+# failure - the entries do get programmed. Scoped strictly to the ACL_ENTRY
+# create event dump so genuine slow-programming of other SAI objects is still
+# caught.
+r, ".* ERR syncd\d*#syncd:.*threadFunction: time span WD exceeded \d+ ms for create:SAI_OBJECT_TYPE_ACL_ENTRY:oid:0x[0-9a-fA-F]+.*"
+r, ".* ERR syncd\d*#syncd:.*setEndTime: event 'create:SAI_OBJECT_TYPE_ACL_ENTRY:oid:0x[0-9a-fA-F]+' took \d+ ms to execute.*"
+r, ".* ERR syncd\d*#syncd:.*logEventData: op: create, key: SAI_OBJECT_TYPE_ACL_ENTRY:oid:0x[0-9a-fA-F]+.*"
+r, ".* ERR syncd\d*#syncd:.*logEventData: fv: SAI_ACL_ENTRY_ATTR_.*"


### PR DESCRIPTION
### Description of PR

**Summary:**
On certain ASIC platforms, programming a single `SAI_OBJECT_TYPE_ACL_ENTRY` into the ASIC can take on the order of the syncd operation-watchdog threshold (~30s). When it does, syncd emits `ERR` lines for that event — `threadFunction: time span WD exceeded ... for create:SAI_OBJECT_TYPE_ACL_ENTRY`, `setEndTime: event 'create:SAI_OBJECT_TYPE_ACL_ENTRY...' took N ms to execute`, and the associated `logEventData` attribute dumps. The ACL entries are still programmed correctly, so this is a performance watchdog, not a functional failure.

Because these are `ERR` lines, LogAnalyzer flags them, causing tests that apply a full ACL table (e.g. `show_techsupport/test_techsupport[acl]`) to error at teardown even though the test body passes.

This PR adds LogAnalyzer common-ignore regexes scoped strictly to the `create:SAI_OBJECT_TYPE_ACL_ENTRY` watchdog event dump (and its `SAI_ACL_ENTRY_ATTR_*` field lines), so slow programming of any *other* SAI object type is still caught by LogAnalyzer.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other (platform performance watchdog — not a functional regression)

### Tested branch
- [x] master
- [ ] N/A

### Test result
- master: `<image-version>` — `show_techsupport/test_techsupport.py -k acl` → **1 passed, 3 deselected in 537s, 0 teardown errors**. During the run the syncd watchdog did fire (`ERR syncd#syncd: threadFunction: time span WD exceeded 30987 ms for create:SAI_OBJECT_TYPE_ACL_ENTRY:oid:0x...`), confirming the new ignore regexes matched and suppressed the event. Without this change the same run errored at teardown on 112 matched syncd `ERR` lines.

### Approach
#### What is the motivation for this PR?
`show_techsupport[acl]` (and any test whose LogAnalyzer window covers a full ACL-table apply) intermittently errors at teardown on platforms where ACL-entry programming is slow enough to trip syncd's operation watchdog, even though the ACL entries program correctly and the test itself passes.

#### How did you do it?
Added four LogAnalyzer common-ignore regexes to `ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt`, each anchored on `create:SAI_OBJECT_TYPE_ACL_ENTRY` (the watchdog line, the `took N ms` line, the `logEventData op: create` line, and the `SAI_ACL_ENTRY_ATTR_*` field lines). The patterns are intentionally narrow so only this specific ACL-entry-create watchdog event is ignored.

#### How did you verify/test it?
Ran `show_techsupport/test_techsupport.py -k acl` on a DUT that reproduces the slow ACL programming. The syncd watchdog fired during the run (verified in the DUT syslog) and the test passed with zero teardown errors; the same scenario errored before the change. Also verified the ignore file still parses cleanly through LogAnalyzer's `create_msg_regex` (no regex/CSV errors) and that the new patterns do not match unrelated syncd/orchagent `ERR` lines.

#### Any platform specific information?
None required — the ignore is keyed on the SAI object type / event, not on any platform or ASIC identifier.

#### Supported testbed topology if it's a new test case?
N/A (not a new test case).

### Documentation
N/A
