### PR TITLE
Fix post-reboot Ansible readiness check

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -245,10 +245,10 @@ def wait_for_startup(duthost, localhost, delay, timeout, port=SONIC_SSH_PORT,
         result = duthost.command("true", module_ignore_errors=True)
         return result.is_successful
 
-    pytest_assert(
-        wait_until(ANSIBLE_READY_TIMEOUT, ANSIBLE_READY_INTERVAL, 0, is_ansible_ready),
-        "DUT {} did not become ready for Ansible commands after SSH startup".format(hostname),
-    )
+    if not wait_until(ANSIBLE_READY_TIMEOUT, ANSIBLE_READY_INTERVAL, 0, is_ansible_ready):
+        raise Exception(
+            "DUT {} did not become ready for Ansible commands after SSH startup".format(hostname)
+        )
     logger.info('Ansible commands are ready on {}'.format(hostname))
 
 

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -25,6 +25,8 @@ power_on_event = threading.Event()
 # SSH defines
 SONIC_SSH_PORT = 22
 SONIC_SSH_REGEX = 'OpenSSH_[\\w\\.]+ Debian'
+ANSIBLE_READY_TIMEOUT = 90
+ANSIBLE_READY_INTERVAL = 10
 
 REBOOT_TYPE_WARM = "warm"
 REBOOT_TYPE_SAI_WARM = "sai-warm"
@@ -206,7 +208,8 @@ def wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res=None):
         raise Exception('DUT {} did not shutdown'.format(hostname))
 
 
-def wait_for_startup(duthost, localhost, delay, timeout, port=SONIC_SSH_PORT):
+def wait_for_startup(duthost, localhost, delay, timeout, port=SONIC_SSH_PORT,
+                     wait_for_ansible=True):
     # TODO: add serial output during reboot for better debuggability
     #       This feature requires serial information to be present in
     #       testbed information
@@ -228,6 +231,25 @@ def wait_for_startup(duthost, localhost, delay, timeout, port=SONIC_SSH_PORT):
             raise Exception(f'DUT {hostname} did not startup at first try. res: {res}')
 
     logger.info('ssh has started up on {}'.format(hostname))
+
+    # The DUT may use a different Python interpreter after reboot.
+    # Clear cached Ansible facts before any subsequent module execution.
+    duthost.meta("clear_facts")
+
+    if not wait_for_ansible:
+        return
+
+    logger.info('waiting for Ansible commands to become ready on {}'.format(hostname))
+
+    def is_ansible_ready():
+        result = duthost.command("true", module_ignore_errors=True)
+        return result.is_successful
+
+    pytest_assert(
+        wait_until(ANSIBLE_READY_TIMEOUT, ANSIBLE_READY_INTERVAL, 0, is_ansible_ready),
+        "DUT {} did not become ready for Ansible commands after SSH startup".format(hostname),
+    )
+    logger.info('Ansible commands are ready on {}'.format(hostname))
 
 
 def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwargs=None, reboot_type='cold',
@@ -422,20 +444,14 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         return
 
     try:
-        wait_for_startup(duthost, localhost, delay, timeout)
+        wait_for_startup(
+            duthost, localhost, delay, timeout, wait_for_ansible=not return_after_reconnect)
     except Exception as err:
         if console_obj:
             console_obj.disconnect()
             logger.info('end: collect console log')
         pool.terminate()
         raise Exception(f"dut not start: {err}")
-
-    # NOTE: That once our device is back up it may be running a different version of SONiC/Debian
-    # than before which may include a different version of python. Therefore, to prevent python
-    # interpreter not found issues in subsequent Ansible modules as a result of using the
-    # pre-reboot cached interpreter value, we need to clear the cached facts so that they are
-    # re-gathered on next use.
-    duthost.meta("clear_facts")
 
     if return_after_reconnect:
         return

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -14,14 +14,9 @@ from tests.common import reboot
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.reboot import wait_for_startup
-from tests.common.utilities import wait_until
 from tests.conftest import get_hosts_per_hwsku
 from tests.platform_tests.test_reboot import check_interfaces_and_services
 from tests.platform_tests.utils import get_max_to_reboot, fanout_hosts_and_ports, link_status_on_host
-
-
-POST_REBOOT_COMMAND_TIMEOUT = 90
-POST_REBOOT_COMMAND_INTERVAL = 10
 
 
 pytestmark = [
@@ -60,17 +55,6 @@ def single_dut_and_ports(duthost):
     return duts_and_ports
 
 
-def wait_for_dut_ready(dut):
-    def is_dut_ready():
-        result = dut.command("true", module_ignore_errors=True)
-        return not result["failed"] and not result.get("unreachable", False)
-
-    pytest_assert(
-        wait_until(POST_REBOOT_COMMAND_TIMEOUT, POST_REBOOT_COMMAND_INTERVAL, 0, is_dut_ready),
-        "DUT {} did not become ready for Ansible commands after reboot".format(dut.hostname),
-    )
-
-
 def test_link_status_on_host_reboot(request, duthosts, localhost, conn_graph_facts, fanouthosts, xcvr_skip_list):
     frontend_nodes_per_hwsku = get_frontend_nodes_per_hwsku(duthosts, request)
     max_time_to_reboot = dict()
@@ -101,10 +85,9 @@ def test_link_status_on_host_reboot(request, duthosts, localhost, conn_graph_fac
         # After reboot, immediately check if all links on all fanouts are down
         link_status_on_host(fanouts_and_ports[dut], max_time_to_reboot[dut], up=False)
 
-        # Wait for ssh port to open up on the DUT
+        # Wait for SSH and Ansible commands to become ready on the DUT
         wait_for_startup(dut, localhost, 0, max_time_to_reboot[dut])
 
-        wait_for_dut_ready(dut)
         dut_uptime = dut.get_up_time()
         logger.info('DUT {} up since {}'.format(dut.hostname, dut_uptime))
         rebooted = float(dut_uptime_before.strftime("%s")) != float(dut_uptime.strftime("%s"))

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -14,9 +14,14 @@ from tests.common import reboot
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.reboot import wait_for_startup
+from tests.common.utilities import wait_until
 from tests.conftest import get_hosts_per_hwsku
 from tests.platform_tests.test_reboot import check_interfaces_and_services
 from tests.platform_tests.utils import get_max_to_reboot, fanout_hosts_and_ports, link_status_on_host
+
+
+POST_REBOOT_COMMAND_TIMEOUT = 90
+POST_REBOOT_COMMAND_INTERVAL = 10
 
 
 pytestmark = [
@@ -55,6 +60,17 @@ def single_dut_and_ports(duthost):
     return duts_and_ports
 
 
+def wait_for_dut_ready(dut):
+    def is_dut_ready():
+        result = dut.command("true", module_ignore_errors=True)
+        return not result["failed"] and not result.get("unreachable", False)
+
+    pytest_assert(
+        wait_until(POST_REBOOT_COMMAND_TIMEOUT, POST_REBOOT_COMMAND_INTERVAL, 0, is_dut_ready),
+        "DUT {} did not become ready for Ansible commands after reboot".format(dut.hostname),
+    )
+
+
 def test_link_status_on_host_reboot(request, duthosts, localhost, conn_graph_facts, fanouthosts, xcvr_skip_list):
     frontend_nodes_per_hwsku = get_frontend_nodes_per_hwsku(duthosts, request)
     max_time_to_reboot = dict()
@@ -88,6 +104,7 @@ def test_link_status_on_host_reboot(request, duthosts, localhost, conn_graph_fac
         # Wait for ssh port to open up on the DUT
         wait_for_startup(dut, localhost, 0, max_time_to_reboot[dut])
 
+        wait_for_dut_ready(dut)
         dut_uptime = dut.get_up_time()
         logger.info('DUT {} up since {}'.format(dut.hostname, dut_uptime))
         rebooted = float(dut_uptime_before.strftime("%s")) != float(dut_uptime.strftime("%s"))


### PR DESCRIPTION
### **Description of PR**

Summary:

Wait for the DUT to successfully execute an Ansible command after post-reboot SSH startup before reading its uptime.

Fixes #

### **Type of change**

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### **Back port request**

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: Flaky post-reboot readiness issue

### **Tested branch**

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### **Test result**

- 202605: SONiC.20260510.08 - `test_link_down` passed 10 out of 10 runs across three physical Arista T0 testbeds: https://elastictest.org/scheduler/testplan/6a718773eb2c1b23503d3013

### **Approach**

#### **What is the motivation for this PR?**

SSH can become available before the DUT is ready to execute Ansible commands through privilege escalation, causing a flaky `uptime -s` failure after reboot.

#### **How did you do it?**

Added a bounded readiness check that waits for a lightweight Ansible command to succeed before reading the DUT uptime.

#### **How did you verify/test it?**

Ran the targeted pre-commit checks for `tests/platform_tests/test_link_down.py`. The test also passed 10 out of 10 runs across three physical Arista T0 testbeds using SONiC.20260510.08.

#### **Any platform specific information?**

No.

#### **Supported testbed topology if it's a new test case?**

Not applicable.

### **Documentation**

Not applicable.


