### PR TITLE
[202605] Fix VxLAN scale-test defaults/limits and configure sport as part of vxlan switch configuration (#25063, #25839)

### DIFF
--- a/tests/common/vxlan_ecmp_utils.py
+++ b/tests/common/vxlan_ecmp_utils.py
@@ -6,6 +6,7 @@
 '''
 
 from sys import getsizeof
+import json
 import re
 import time
 import logging
@@ -373,29 +374,31 @@ class Ecmp_Utils(object):
 
         return ret_list
 
-    def configure_vxlan_switch(self, duthost, vxlan_port=4789, dutmac=None):
+    def configure_vxlan_switch(self, duthost, vxlan_port=4789, dutmac=None,
+                               vxlan_sport=None, vxlan_mask=None):
         '''
            Configure the VxLAN parameters for the DUT.
            This step is completely optional.
 
-           duthost: AnsibleHost structure of the DUT.
+           duthost    : AnsibleHost structure of the DUT.
            vxlan_port : The UDP port to be used for VxLAN traffic.
            dutmac     : The mac address to be configured in the DUT.
+           vxlan_sport: The base UDP source port for VxLAN sport entropy.
+           vxlan_mask : The number of bits to vary in the source port range.
         '''
         if dutmac is None:
             dutmac = "aa:bb:cc:dd:ee:ff"
 
-        switch_config = '''
-    [
-            {{
-                    "SWITCH_TABLE:switch": {{
-                            "vxlan_port": "{}",
-                            "vxlan_router_mac": "{}"
-                    }},
-                    "OP": "SET"
-            }}
-    ]
-    '''.format(vxlan_port, dutmac)
+        switch_fields = {
+            "vxlan_port": str(vxlan_port),
+            "vxlan_router_mac": str(dutmac)
+        }
+        if vxlan_sport is not None:
+            switch_fields["vxlan_sport"] = str(vxlan_sport)
+        if vxlan_mask is not None:
+            switch_fields["vxlan_mask"] = str(vxlan_mask)
+
+        switch_config = json.dumps([{"SWITCH_TABLE:switch": switch_fields, "OP": "SET"}], indent=4)
         self.apply_config_in_swss(duthost, switch_config, "vnet_switch")
 
     def apply_config_in_swss(self, duthost, config, name="swss_"):

--- a/tests/common/vxlan_ecmp_utils.py
+++ b/tests/common/vxlan_ecmp_utils.py
@@ -76,7 +76,7 @@ class Ecmp_Utils(object):
 
         ttl_entry = ""
         if ttl_mode:
-            ttl_entry = f',\n"ttl_mode": "{ttl_mode}"\n'
+            ttl_entry = ',\n"ttl_mode": "{}"\n'.format(ttl_mode)
 
         config = '''{{
             "VXLAN_TUNNEL": {{

--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -56,7 +56,7 @@ def pytest_addoption(parser):
     vxlan_group.addoption(
         "--num_vnet",
         action="store",
-        default=8,
+        default=5,
         type=int,
         help="number of VNETs for VNET VxLAN test"
     )
@@ -64,7 +64,7 @@ def pytest_addoption(parser):
     vxlan_group.addoption(
         "--num_endpoints",
         action="store",
-        default=4000,
+        default=511,
         type=int,
         help="number of endpoints for VNET VxLAN"
     )
@@ -257,7 +257,7 @@ def scaled_vnet_params(request):
     params[NUM_VNET_KEY] = request.config.option.num_vnet
     params[NUM_ROUTES_KEY] = request.config.option.num_routes
     if params[NUM_ROUTES_KEY] is None:
-        params[NUM_ROUTES_KEY] = 16000
+        params[NUM_ROUTES_KEY] = 1000
     params[NUM_ENDPOINTS_KEY] = request.config.option.num_endpoints
     return params
 

--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -54,6 +54,22 @@ def pytest_addoption(parser):
     )
 
     vxlan_group.addoption(
+        "--vxlan_sport",
+        action="store",
+        default=5120,
+        type=int,
+        help="Base UDP source port for VxLAN sport entropy"
+    )
+
+    vxlan_group.addoption(
+        "--vxlan_mask",
+        action="store",
+        default=7,
+        type=int,
+        help="Number of bits to vary in the VxLAN UDP source port range"
+    )
+
+    vxlan_group.addoption(
         "--num_vnet",
         action="store",
         default=5,

--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -107,7 +107,8 @@ def get_available_vlan_id_and_ports(cfg_facts, num_ports_needed):
 
 # ---------- Single-VNET setup ----------
 def vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
-                         config_facts, dut_indx, vxlan_port):
+                         config_facts, dut_indx, vxlan_port,
+                         vxlan_sport=None, vxlan_mask=None):
     ports = get_available_vlan_id_and_ports(config_facts, 1)
     pytest_assert(ports and len(ports) >= 1, "Not enough ports for VNET setup")
 
@@ -159,7 +160,8 @@ def vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
     )
     time.sleep(5)
 
-    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=vxlan_port)
+    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=vxlan_port,
+                                      vxlan_sport=vxlan_sport, vxlan_mask=vxlan_mask)
 
     return {
         "dut_vtep": dut_vtep,
@@ -193,6 +195,8 @@ def one_vnet_setup_teardown(
         duts_map = tbinfo["duts_map"]
         dut_indx = duts_map[duthost.hostname]
         vxlan_port = request.config.option.vxlan_port
+        vxlan_sport = request.config.option.vxlan_sport
+        vxlan_mask = request.config.option.vxlan_mask
 
         # Determine platform-specific ECMP limit
         platform = duthost.facts.get("platform", "").lower()
@@ -207,7 +211,8 @@ def one_vnet_setup_teardown(
             num_endpoints = min(num_endpoints, max_ecmp_limit)
 
         setup_params = vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
-                                            config_facts, dut_indx, vxlan_port)
+                                            config_facts, dut_indx, vxlan_port,
+                                            vxlan_sport=vxlan_sport, vxlan_mask=vxlan_mask)
         setup_params["num_endpoints"] = num_endpoints
     except Exception as e:
         logger.error("Exception raised in setup: {}".format(repr(e)))

--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -30,6 +30,13 @@ INITIAL_ENDPOINTS = ["100.0.1.10", "100.0.2.10"]
 CHANGED_ENDPOINTS = ["100.0.3.10", "100.0.4.10"]
 PACKET_MULTIPLIER = 10
 
+# Platform-specific ECMP limits
+PLATFORM_ECMP_LIMITS = {
+    "8101": 510,
+    "8102": 510,
+    "8223": 4094
+}
+
 
 # ---------- Utility ----------
 def get_loopback_ip(cfg_facts):
@@ -187,10 +194,21 @@ def one_vnet_setup_teardown(
         dut_indx = duts_map[duthost.hostname]
         vxlan_port = request.config.option.vxlan_port
 
-        num_endpoints = scaled_vnet_params.get("num_endpoints", 511) or 511
+        # Determine platform-specific ECMP limit
+        platform = duthost.facts.get("platform", "").lower()
+        max_ecmp_limit = None
+        for platform_key, limit in PLATFORM_ECMP_LIMITS.items():
+            if platform_key in platform:
+                max_ecmp_limit = limit
+                break
+
+        num_endpoints = int(scaled_vnet_params.get("num_endpoints"))
+        if max_ecmp_limit:
+            num_endpoints = min(num_endpoints, max_ecmp_limit)
+
         setup_params = vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
                                             config_facts, dut_indx, vxlan_port)
-        setup_params["num_endpoints"] = int(num_endpoints)
+        setup_params["num_endpoints"] = num_endpoints
     except Exception as e:
         logger.error("Exception raised in setup: {}".format(repr(e)))
         logger.error(json.dumps(
@@ -203,7 +221,25 @@ def one_vnet_setup_teardown(
     config_reload(duthost, safe_reload=True, yang_validate=False)
 
 
+@pytest.fixture(scope="function", autouse=True)
+def clean_vnet_route(one_vnet_setup_teardown):
+    """Clean VNET route state before each test"""
+    setup, duthost, _ = one_vnet_setup_teardown
+
+    # Delete the entire route entry to ensure clean state
+    duthost.shell(
+        f"sonic-db-cli CONFIG_DB del 'VNET_ROUTE_TUNNEL|{VNET_NAME}|{PREFIX}' || true"
+    )
+    time.sleep(2)
+
+    # Reprogram the route with initial endpoints and VNI
+    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, INITIAL_ENDPOINTS, VNI)
+
+    yield
+
 # ---------- PTF runner helper ----------
+
+
 def run_vxlan_ptf_test(ptfhost, endpoints, params, num_packets, mac_list=None):
     logger.info(f"Calling VXLAN ECMP PTF test: {len(endpoints)} endpoints, {num_packets} packets")
 

--- a/tests/vxlan/test_vxlan_tunnel_route_scale.py
+++ b/tests/vxlan/test_vxlan_tunnel_route_scale.py
@@ -190,16 +190,18 @@ def get_vxlan_router_mac(duthost):
     return vxlan_router_mac
 
 
-def configure_vxlan_switch_with_mac(duthost, vxlan_port):
+def configure_vxlan_switch_with_mac(duthost, vxlan_port, vxlan_sport=None, vxlan_mask=None):
     """Configure VXLAN switch and return the MAC address used"""
     vxlan_router_mac = get_vxlan_router_mac(duthost)
     logger.info(f"Using VXLAN router MAC: {vxlan_router_mac}")
-    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=vxlan_port, dutmac=vxlan_router_mac)
+    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=vxlan_port, dutmac=vxlan_router_mac,
+                                      vxlan_sport=vxlan_sport, vxlan_mask=vxlan_mask)
     return vxlan_router_mac
 
 
 def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
-                       tbinfo, num_vnets, routes_per_vnet, vnet_base, vxlan_port, samples_per_vnet):
+                       tbinfo, num_vnets, routes_per_vnet, vnet_base, vxlan_port, samples_per_vnet,
+                       vxlan_sport=None, vxlan_mask=None):
     ports = get_available_vlan_id_and_ports(config_facts, num_vnets)
     pytest_assert(ports and len(ports) >= num_vnets, "Not enough ports for VNET setup")
 
@@ -316,7 +318,8 @@ def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
     pytest_assert(egress_ptf_if, "No egress PTF interfaces discovered from PortChannels")
     logger.info(f"Egress PTF interfaces: {egress_ptf_if}")
 
-    vxlan_router_mac = configure_vxlan_switch_with_mac(duthost, vxlan_port)
+    vxlan_router_mac = configure_vxlan_switch_with_mac(duthost, vxlan_port,
+                                                       vxlan_sport=vxlan_sport, vxlan_mask=vxlan_mask)
 
     logger.info("Waiting for all VNET routes to appear in STATE_DB (max 120s)")
     ready_state = wait_until(
@@ -341,6 +344,8 @@ def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
         "vnet_ptf_map": vnet_ptf_map,
         "egress_ptf_if": egress_ptf_if,
         "vxlan_port": vxlan_port,
+        "vxlan_sport": vxlan_sport,
+        "vxlan_mask": vxlan_mask,
         "router_mac": duthost.facts["router_mac"],
         "mac_switch": vxlan_router_mac,
         "samples_per_vnet": samples_per_vnet,
@@ -367,6 +372,8 @@ def vxlan_scale_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, tbinfo,
         duts_map = tbinfo["duts_map"]
         dut_indx = duts_map[duthost.hostname]
         vxlan_port = request.config.option.vxlan_port
+        vxlan_sport = request.config.option.vxlan_sport
+        vxlan_mask = request.config.option.vxlan_mask
 
         logger.info(f"Using num_vnets={num_vnets}, routes_per_vnet={routes_per_vnet}")
 
@@ -381,7 +388,9 @@ def vxlan_scale_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, tbinfo,
             routes_per_vnet,
             vnet_base,
             vxlan_port,
-            samples_per_vnet
+            samples_per_vnet,
+            vxlan_sport=vxlan_sport,
+            vxlan_mask=vxlan_mask
         )
     except Exception as e:
         logger.error("Exception raised in setup: {}".format(repr(e)))
@@ -451,7 +460,9 @@ def test_vxlan_scale_config_reload(vxlan_scale_setup_teardown, ptfhost, duthosts
     # Reconfigure VXLAN switch with correct MAC after reload
     logger.info("Reconfiguring VXLAN switch after config reload")
     vxlan_port = setup_params["vxlan_port"]
-    vxlan_router_mac = configure_vxlan_switch_with_mac(duthost, vxlan_port)
+    vxlan_router_mac = configure_vxlan_switch_with_mac(duthost, vxlan_port,
+                                                       vxlan_sport=setup_params.get("vxlan_sport"),
+                                                       vxlan_mask=setup_params.get("vxlan_mask"))
     setup_params["mac_switch"] = vxlan_router_mac
 
     logger.info("Running PTF traffic after config reload")

--- a/tests/vxlan/test_vxlan_tunnel_route_scale.py
+++ b/tests/vxlan/test_vxlan_tunnel_route_scale.py
@@ -181,6 +181,23 @@ def generate_routes_to_test_file(ptfhost, num_samples, num_routes, vnet, routes,
     return file_dest
 
 
+def get_vxlan_router_mac(duthost):
+    """Get VXLAN router MAC from SWITCH_TABLE or fall back to router_mac"""
+    res = duthost.shell("redis-cli -n 0 hget 'SWITCH_TABLE:switch' vxlan_router_mac")
+    vxlan_router_mac = res["stdout"].strip()
+    if not vxlan_router_mac:
+        vxlan_router_mac = duthost.facts["router_mac"]
+    return vxlan_router_mac
+
+
+def configure_vxlan_switch_with_mac(duthost, vxlan_port):
+    """Configure VXLAN switch and return the MAC address used"""
+    vxlan_router_mac = get_vxlan_router_mac(duthost)
+    logger.info(f"Using VXLAN router MAC: {vxlan_router_mac}")
+    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=vxlan_port, dutmac=vxlan_router_mac)
+    return vxlan_router_mac
+
+
 def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
                        tbinfo, num_vnets, routes_per_vnet, vnet_base, vxlan_port, samples_per_vnet):
     ports = get_available_vlan_id_and_ports(config_facts, num_vnets)
@@ -207,13 +224,6 @@ def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
     if duthost.facts.get("asic_type") == "cisco-8000":
         vxlan_tunnel_entry["ttl_mode"] = "pipe"
     apply_chunk(duthost, {"VXLAN_TUNNEL": {vxlan_tun: vxlan_tunnel_entry}}, "vxlan_tunnel")
-    res = duthost.shell("redis-cli -n 0 hget 'SWITCH_TABLE:switch' vxlan_router_mac")
-    vxlan_router_mac = res["stdout"].strip()
-
-    if not vxlan_router_mac:
-        vxlan_router_mac = duthost.facts["router_mac"]
-
-    logger.info(f"Using VXLAN router MAC: {vxlan_router_mac}")
 
     vnet_ptf_map = {}
 
@@ -306,7 +316,7 @@ def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
     pytest_assert(egress_ptf_if, "No egress PTF interfaces discovered from PortChannels")
     logger.info(f"Egress PTF interfaces: {egress_ptf_if}")
 
-    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=vxlan_port, dutmac=vxlan_router_mac)
+    vxlan_router_mac = configure_vxlan_switch_with_mac(duthost, vxlan_port)
 
     logger.info("Waiting for all VNET routes to appear in STATE_DB (max 120s)")
     ready_state = wait_until(
@@ -350,9 +360,9 @@ def vxlan_scale_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, tbinfo,
     try:
         cfg_facts = json.loads(duthost.shell("sonic-cfggen -d --print-data")["stdout"])
         config_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
-        num_vnets = scaled_vnet_params.get("num_vnet") or 5
-        routes_per_vnet = scaled_vnet_params.get("num_routes") or 1000
-        samples_per_vnet = request.config.getoption("num_samples") or -1
+        num_vnets = scaled_vnet_params.get("num_vnet")
+        routes_per_vnet = scaled_vnet_params.get("num_routes")
+        samples_per_vnet = request.config.getoption("num_samples")
         vnet_base = 10000
         duts_map = tbinfo["duts_map"]
         dut_indx = duts_map[duthost.hostname]
@@ -437,6 +447,13 @@ def test_vxlan_scale_config_reload(vxlan_scale_setup_teardown, ptfhost, duthosts
         pytest.fail("State DB VNET routes failed to repopulate after config reload")
 
     logger.info("All VNET routes restored in STATE_DB after reload")
+
+    # Reconfigure VXLAN switch with correct MAC after reload
+    logger.info("Reconfiguring VXLAN switch after config reload")
+    vxlan_port = setup_params["vxlan_port"]
+    vxlan_router_mac = configure_vxlan_switch_with_mac(duthost, vxlan_port)
+    setup_params["mac_switch"] = vxlan_router_mac
+
     logger.info("Running PTF traffic after config reload")
 
     ptf_runner(
@@ -517,7 +534,22 @@ def test_vxlan_scale_mac_vni(vxlan_scale_setup_teardown, ptfhost):
             vnis=all_vnis_for_vnet
         )
 
-    time.sleep(20)
+    # Two-stage verification: STATE_DB + Hardware programming delay
+    # Stage 1: Wait for STATE_DB (software layer)
+    ready = wait_until(
+        180, 15, 0,
+        all_vnet_routes_in_state_db,
+        duthost,
+        setup["num_vnets"],
+        routes_per_vnet
+    )
+    if not ready:
+        pytest.fail("Routes failed to update in STATE_DB after MAC/VNI change")
+
+    # Stage 2: Hardware programming delay (scale-aware)
+    total_routes = setup["num_vnets"] * routes_per_vnet
+    hw_delay = max(30, min(180, (total_routes // 500) * 10))
+    time.sleep(hw_delay)
 
     logger.info("All route MAC+VNI updates applied via batch cfggen.")
 
@@ -578,7 +610,19 @@ def test_vxlan_scale_mac_vni(vxlan_scale_setup_teardown, ptfhost):
             vnis=all_vnis_for_vnet
         )
 
-    time.sleep(20)
+    ready = wait_until(
+        180, 15, 0,
+        all_vnet_routes_in_state_db,
+        duthost,
+        setup["num_vnets"],
+        routes_per_vnet
+    )
+    if not ready:
+        pytest.fail("Routes failed to update in STATE_DB after second MAC/VNI change")
+
+    total_routes = setup["num_vnets"] * routes_per_vnet
+    hw_delay = max(30, min(180, (total_routes // 500) * 10))
+    time.sleep(hw_delay)
 
     logger.info("All route MAC+VNI updates applied via batch cfggen.")
 


### PR DESCRIPTION
### Description of PR
Summary:
Fixes # (issue)

Manual cherry-pick of two upstream VxLAN scale-test PRs to the `202605` branch, applied in upstream order so that `202605` converges with `master`:

1. #25063 — "Fixed VxLAN default parameters and scale limits" (commit 47f94f8015beef52e4b7833c621d948be21961e6)
2. #25839 — "[tests/vxlan]: Configure sport as part of vxlan switch configuration" (commit d3287627deb72647ff47d462a608e28102cc994d). The original PR requested a `202605` back port.

#25839 was the original target of this PR. #25063 is a prerequisite: it introduces the `get_vxlan_router_mac()` / `configure_vxlan_switch_with_mac()` helpers and the post `config reload` VxLAN switch reconfiguration block that #25839 then extends with the sport arguments. Picking #25839 alone left that reconfiguration missing on `202605`, so the sport range was silently dropped across `config reload`.

**#25063** aligns the VxLAN scale defaults with what the tests can actually sustain (`num_vnet` 8 -> 5, `num_endpoints` 4000 -> 511, `num_routes` 16000 -> 1000), adds platform-specific ECMP limits, adds a `clean_vnet_route` fixture, replaces fixed `time.sleep(20)` waits after MAC/VNI updates with STATE_DB polling plus a scale-aware hardware programming delay, and adds the post-reload VxLAN switch reconfiguration.

**#25839** fixes the outer UDP source port. That port is a hash derived value, and on some platforms the hash lands in the IANA assigned range, so the encapsulated packet never reaches PTF because of the OVS rules on the test server. This is especially visible in scale tests where the combination of inner fields is larger. The fix adds `vxlan_sport` / `vxlan_mask` to the VxLAN switch configuration (written to `SWITCH_TABLE`), exposes them as pytest runtime options, and passes default values from `test_scale_ecmp` and `test_vxlan_tunnel_route_scale`.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`202605` carries the same VxLAN scale tests as `master`, so it hits the same failure: the hash derived outer UDP source port can fall inside the IANA assigned range and the encapsulated packet gets dropped by the OVS rules on the test server before reaching PTF. Bringing #25063 along as well keeps the two branches on the same code, so future VxLAN cherry-picks apply cleanly instead of conflicting.

#### How did you do it?
The branch was built from the current `202605` head with `git cherry-pick -x`, in upstream order.

**1. #25063 (47f94f8)** — one conflict, in `tests/vxlan/test_vxlan_tunnel_route_scale.py`. #25063 removes the inline `SWITCH_TABLE` MAC lookup from `vxlan_setup_config()` (it moves into the new `get_vxlan_router_mac()` helper), but on `202605` the adjacent `apply_chunk(...)` call had been rewritten by #26620 to build a `vxlan_tunnel_entry` dict so it can set `ttl_mode=pipe` on cisco-8000. Resolved by keeping the `202605` `vxlan_tunnel_entry` block and dropping only the MAC lookup lines. `master` carries the same `ttl_mode` block via #26084, so the result matches.

**2. #25839 (d328762)** — three conflicts, all in `tests/vxlan/test_scale_ecmp.py`, and all the same cosmetic case. #25839 carried incidental `{i % 256:02x}` f-string whitespace touch-ups, but those literals were already converted to `str.format()` on `202605` by #26620 to dodge a flake8 false positive. The `202605` `str.format()` form was kept and the f-string variants dropped. Everything else, including the post-reload reconfiguration and all `vxlan_sport` / `vxlan_mask` plumbing, applied cleanly on top of #25063.

**3. flake8 compatibility** — the pre-commit `flake8` hook on `202605` is still pinned to `6.0.0`, whose `pycodestyle 2.10.0` does not understand the PEP 701 `FSTRING_*` tokens emitted by Python 3.12, so it reports a bogus `E231 missing whitespace after ','` for the comma inside the `ttl_entry` f-string literal in `create_vxlan_tunnel()`. That line is not touched by either cherry-pick, but pre-commit only runs on files changed by a PR, so it starts failing as soon as `vxlan_ecmp_utils.py` is modified. The literal is converted to an equivalent `str.format()` call so pycodestyle sees a single `STRING` token again; the produced string is byte-identical. (#26573 bumps the hook to `7.1.1` and would make this unnecessary, but it is not merged yet.)

#### How did you verify/test it?
* Both commits applied with `git cherry-pick -x`; each conflict resolution was reviewed hunk by hunk against the original commit.
* **Parity check against `master`.** After both picks, the only differences between this branch and `upstream/master` across the four touched files are five deliberate f-string -> `str.format()` conversions (four pre-existing from #26620, one added here), all needed only because `202605` pins flake8 `6.0.0`. `tests/vxlan/conftest.py` is byte-identical to `master`.
* Reproduced the CI pre-commit failure locally with `flake8 6.0.0` on Python 3.12 (matching the pinned hook) and confirmed it is clean after the `str.format()` conversion.
* `flake8 --max-line-length=120` clean on all four touched files under both `6.0.0`/Py3.12 and `7.3.0`/Py3.11.
* Verified the converted literal is byte-identical for empty, `pipe` and `uniform` `ttl_mode` values.
* `python -m py_compile` clean on all four touched files.
* #25839 was verified by its author on a Cisco 8223 platform.
* Test log: https://github.com/user-attachments/files/30481251/test_scale_ecmp_2026-07-28-06-46-45.log

#### Any platform specific information?
The sport problem is most visible on platforms whose VxLAN source port hash can land in the IANA assigned range. The new options default to `vxlan_sport=5120` / `vxlan_mask=7` for all platforms and can be overridden at runtime with `--vxlan_sport` / `--vxlan_mask`. #25063 additionally caps `num_endpoints` per platform (`8101`/`8102` -> 510, `8223` -> 4094).

#### Supported testbed topology if it's a new test case?
Not a new test case. Affects the existing VxLAN scale tests `tests/vxlan/test_scale_ecmp.py` and `tests/vxlan/test_vxlan_tunnel_route_scale.py`.

### Documentation
No documentation change required.
