### PR TITLE
LogAnalyzer: ignore repeated imrelp errors

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -335,7 +335,8 @@ r, ".* ERR syncd\d*#syncd:.* SAI_API_SWITCH:brcm_sai_get_switch_attribute.* Get 
 
 # Ignore rsyslog librelp error if rsyslogd on host or container is down or going down
 r, ".* ERR .*#rsyslogd: librelp error 10008 forwarding to server .* - suspending.*"
-r, ".* ERR rsyslogd: imrelp.*error 'error when receiving data, session broken', object .* - input may not work as intended.*"
+# The same imrelp session-broken error may be compressed as "message repeated N times".
+r, ".* ERR rsyslogd:\s*(message repeated \d+ times: \[)?imrelp.*error 'error when receiving data, session broken', object\s+.* - input may not work as intended.*"
 # Ignore related rsyslog librelp error, which is caused by the session closed by peer when receiving data, and it will cause the input not work as intended, but it is safe to ignore the error for now to unblock the test, and we will address the root cause later. (PBI https://msazure.visualstudio.com/One/_workitems/edit/37879332)
 r, ".* ERR rsyslogd: imrelp.*error 'server closed relp session, session broken', object .* - input may not work as intended.*"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
LogAnalyzer already ignores the direct rsyslog imrelp
 "error when receiving data, session broken" message.

  Recent runs can emit the same condition in rsyslog's duplicate-message
  reduction format:

`  ERR rsyslogd: message repeated N times: [imrelp...]`

  The existing ignore regex does not match this compressed form, so tests can
  fail in teardown with a LogAnalyzer error even though the test logic itself
  passed.

  This PR updates the common LogAnalyzer ignore regex to match both the direct
  imrelp message and the optional repeated-message wrapper.



Summary:
  Fixes #26641
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
- 202605 
 Image : branch.202605-ars.3213bfab-buildimage.63f17ae505b85275482fef3274201014c07fed91-nightly-2026.07.15.21.40
 Failure Logs  
[test_link_failure.xml](https://github.com/user-attachments/files/30488089/test_link_failure.xml)
[test_pfcwd_cli.xml](https://github.com/user-attachments/files/30488098/test_pfcwd_cli.xml)

### Approach
#### What is the motivation for this PR?
 Tests were failing in teardown because LogAnalyzer treated rsyslog's compressed
  duplicate-message form as a new unexpected ERR log. The direct imrelp
  session-broken message is already ignored, but the equivalent repeated form was
  not covered.

#### How did you do it?
Updated the common LogAnalyzer ignore regex for the rsyslog imrelp
  session-broken message to allow an optional:

  `message repeated N times: [`

  prefix before `imrelp`.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Verified the updated regex matches both forms:
  - `ERR rsyslogd: imrelp...error 'error when receiving data, session broken'...`
  - `ERR rsyslogd: message repeated N times: [imrelp...error 'error when receiving data, session broken'...]`

  Verified it does not match unrelated repeated rsyslog messages.

  Validated against failed 202605 logs where LogAnalyzer matched the repeated
  imrelp line, and against later passing 202605 runs for `pfcwd` and
  `dualtor_io`.

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A