### PR TITLE
[dhcp_relay] Remove DHCPv4/v6 relay modules from KVM PR checks

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1289,7 +1289,7 @@ dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[request:
 
 dhcp_relay/test_dhcpv4_relay.py:
   skip:
-    reason: "Test is not stable for KVM PR checks or sonic dhcpv4 is unsupported before 202511"
+    reason: "Test skipped: sonic dhcpv4 is not supported in the DUT image version < 202511 / Test is not stable for KVM PR checks"
     conditions_logical_operator: or
     conditions:
       - "release < '202511'"
@@ -1303,7 +1303,7 @@ dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_option82_suboptions[server_id_o
 
 dhcp_relay/test_dhcpv6_relay.py:
   skip:
-    reason: "Test is not stable for KVM PR checks or unsupported on the Cisco backend platform"
+    reason: "Need to skip for platform x86_64-8111_32eh_o-r0 / Test is not stable for KVM PR checks"
     conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0']"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1293,7 +1293,7 @@ dhcp_relay/test_dhcpv4_relay.py:
     conditions_logical_operator: or
     conditions:
       - "release < '202511'"
-      - "asic_type in ['vs']"
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/26645"
 
 dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_option82_suboptions[server_id_override-sonic-relay-agent]:
   skip:
@@ -1307,7 +1307,7 @@ dhcp_relay/test_dhcpv6_relay.py:
     conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0']"
-      - "asic_type in ['vs']"
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/26645"
 
 dhcp_relay/test_dhcpv6_relay.py::TestDhcpv6RelayWithMultipleVlan:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1289,9 +1289,11 @@ dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[request:
 
 dhcp_relay/test_dhcpv4_relay.py:
   skip:
-    reason: "Test skipped: sonic dhcpv4 is not supported in the DUT image version < 202511"
+    reason: "Test is not stable for KVM PR checks or sonic dhcpv4 is unsupported before 202511"
+    conditions_logical_operator: or
     conditions:
       - "release < '202511'"
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/26645"
 
 dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_option82_suboptions[server_id_override-sonic-relay-agent]:
   skip:
@@ -1301,9 +1303,11 @@ dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_option82_suboptions[server_id_o
 
 dhcp_relay/test_dhcpv6_relay.py:
   skip:
-    reason: "Need to skip for platform x86_64-8111_32eh_o-r0"
+    reason: "Test is not stable for KVM PR checks or unsupported on the Cisco backend platform"
+    conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0']"
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/26645"
 
 dhcp_relay/test_dhcpv6_relay.py::TestDhcpv6RelayWithMultipleVlan:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1293,7 +1293,7 @@ dhcp_relay/test_dhcpv4_relay.py:
     conditions_logical_operator: or
     conditions:
       - "release < '202511'"
-      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/26645"
+      - "asic_type in ['vs']"
 
 dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_option82_suboptions[server_id_override-sonic-relay-agent]:
   skip:
@@ -1307,7 +1307,7 @@ dhcp_relay/test_dhcpv6_relay.py:
     conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0']"
-      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/26645"
+      - "asic_type in ['vs']"
 
 dhcp_relay/test_dhcpv6_relay.py::TestDhcpv6RelayWithMultipleVlan:
   skip:

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -443,7 +443,8 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "uplink_mac": str(dhcp_relay['uplink_mac']),
                            "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
-                           "is_dualtor": str(dhcp_relay['is_dualtor'])},
+                           "is_dualtor": str(dhcp_relay['is_dualtor']),
+                           "kvm_support": True},
                    log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
 
 
@@ -485,7 +486,8 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "uplink_mac": str(dhcp_relay['uplink_mac']),
                            "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
-                           "is_dualtor": str(dhcp_relay['is_dualtor'])},
+                           "is_dualtor": str(dhcp_relay['is_dualtor']),
+                           "kvm_support": True},
                    log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
 
 
@@ -538,7 +540,8 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "uplink_mac": str(dhcp_relay['uplink_mac']),
                            "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
-                           "is_dualtor": str(dhcp_relay['is_dualtor'])},
+                           "is_dualtor": str(dhcp_relay['is_dualtor']),
+                           "kvm_support": True},
                    log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
 
 
@@ -596,5 +599,6 @@ class TestDhcpv6RelayWithMultipleVlan:
                                "vlan_ip": str(exp_link_addr),
                                "uplink_mac": str(common_dhcp_relay_data['uplink_mac']),
                                "loopback_ipv6": str(common_dhcp_relay_data['loopback_ipv6']),
-                               "is_dualtor": str(common_dhcp_relay_data['is_dualtor'])},
+                               "is_dualtor": str(common_dhcp_relay_data['is_dualtor']),
+                               "kvm_support": True},
                        log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)


### PR DESCRIPTION
### Description of PR

Summary:
Remove the actively changing DHCPv4 and DHCPv6 relay modules from KVM PR checks. Use conditional marks as the single KVM skip point and make every DHCPv6 PTF call explicitly set `kvm_support=True`.

Fixes #26645

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A (no backport requested)
Failure type: other

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: Python compilation, YAML validation, `git diff --check`, and targeted pre-commit checks passed. An AST check confirmed every `dhcpv6_relay_test.DHCPTest` call explicitly sets `kvm_support`.
- internal-202605: Same as above.

### Approach
#### What is the motivation for this PR?

The DHCPv4 and DHCPv6 relay modules are still unstable and actively being updated, so they are not suitable KVM PR gates. DHCPv6 previously skipped only inside `ptf_runner`, after fixtures and disruptive setup could already run.

#### How did you do it?

Add VS/KVM conditional skips for both modules and add `kvm_support=True` to the four DHCPv6 functional PTF calls that previously relied on the late `ptf_runner` skip.

#### How did you verify/test it?

Ran the targeted syntax, YAML, AST, diff, and pre-commit checks listed above.

#### Any platform specific information?

The skip applies only to VS/KVM. Physical test coverage is unchanged.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

Not applicable.

##### Work item tracking
- Microsoft ADO (number only): 39018779