### PR TITLE
[smartswitch]: Fix DPU discovery from DPUS table

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -1423,6 +1423,25 @@ def get_configured_dpu_indices(duthost, include_admin_down=False):
     return sorted(set(indices))
 
 
+def resolve_upgrade_dpu_indices(duthost, ss_target_indices=None):
+    """
+    Resolve which DPU indices a SmartSwitch upgrade should target.
+
+    Precedence: an explicit --ss_target_indices selection always wins and is
+    honored exactly as given; only when it is absent do we fall back to the
+    admin-up DPUs auto-discovered from CONFIG_DB.
+
+    ss_target_indices is the raw option value (comma-separated string such as
+    "0,3,5"); returns a list of ints. Kept as a standalone helper so this
+    precedence is unit-testable without importing the pytest test module.
+    """
+    # Operator explicitly selected DPUs -> honor exactly that selection, never override.
+    if ss_target_indices:
+        return [int(x.strip()) for x in ss_target_indices.split(",") if x.strip()]
+    # No explicit selection -> upgrade the actual admin-up DPUs discovered from CONFIG_DB.
+    return get_configured_dpu_indices(duthost)
+
+
 def check_dpu_reachable_from_npu(duthost, dpuhost_name, dpu_index):
     # Check DPU ping status
     logging.info("Checking DPU ping status")

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -1378,8 +1378,11 @@ def get_configured_dpu_indices(duthost, include_admin_down=False):
 
     Indices are parsed from the real DPU identities, not a positional count,
     so a non-contiguous table (dpu1, dpu3) yields [1, 3] rather than [0, 1].
-    By default admin-down DPUs (CHASSIS_MODULE admin_status='down') are skipped;
-    pass include_admin_down=True to return every configured index.
+    By default only DPUs whose CHASSIS_MODULE admin_status is affirmatively
+    'up' are returned (fail closed): entries that are admin-down, missing
+    from CHASSIS_MODULE, or missing admin_status are skipped so unverified
+    DPUs are never selected implicitly. Pass include_admin_down=True to
+    return every configured index regardless of admin state.
     """
     # Reuse the DPU/DPUS table selection + ordering from get_configured_dpu_names.
     names = get_configured_dpu_names(duthost)
@@ -1398,11 +1401,21 @@ def get_configured_dpu_indices(duthost, include_admin_down=False):
             logger.warning("Skipping DPU entry without a numeric index: %r", name)
             continue
         idx = int(m.group(1))
-        # Look up admin state; treat a missing entry as 'up' (enabled by default).
-        admin_status = chassis_modules.get('DPU{}'.format(idx), {}).get('admin_status', 'up')
-        # Skip administratively-down DPUs unless the caller wants them all.
-        if not include_admin_down and str(admin_status).lower() == 'down':
-            logger.info("Skipping admin-down DPU%d", idx)
+        if include_admin_down:
+            # Caller explicitly asked for every configured index.
+            indices.append(idx)
+            continue
+        # Fail closed: only an affirmative admin_status == 'up' selects a DPU
+        # for discovery. A missing CHASSIS_MODULE entry or missing/unexpected
+        # admin_status means the DPU's state cannot be verified, and it must
+        # not be picked up implicitly (e.g. for a firmware upgrade); use
+        # include_admin_down=True or explicit target indices to override.
+        admin_status = chassis_modules.get('DPU{}'.format(idx), {}).get('admin_status')
+        if admin_status is None:
+            logger.warning("Skipping DPU%d: no admin_status in CHASSIS_MODULE; state cannot be verified", idx)
+            continue
+        if str(admin_status).lower() != 'up':
+            logger.info("Skipping DPU%d with admin_status=%r", idx, admin_status)
             continue
         indices.append(idx)
 

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -1306,24 +1306,37 @@ def get_dpu_ip(duthost, dpu_index):
 
 
 def get_dpu_port(duthost, dpu_index):
+    """Return the gNMI port for a DPU index from the CONFIG_DB 'DPU' table.
+
+    gnmi_port is a 'DPU' table attribute; 'DPUS' is only the name-to-midplane
+    mapping and never carries gnmi_port. So gNMI-port lookup uses 'DPU'
+    exclusively, kept separate from inventory discovery.
+    """
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     if not config_facts:
         logger.error("Failed to retrieve config_facts from DUT")
         return None
 
-    dpu_section = config_facts.get('DPU') or config_facts.get('DPUS') or {}
+    # gnmi_port lives only in the 'DPU' table; do not fall back to 'DPUS'.
+    dpu_section = config_facts.get('DPU') or {}
     if not dpu_section:
-        logger.error("DPU section not found in config_facts")
+        logger.error("DPU table not found in config_facts (gnmi_port needs 'DPU')")
         return None
 
-    dpu_key = 'dpu{}'.format(dpu_index)
-    # Check if the DPU exists in the configuration
-    if dpu_key not in dpu_section:
-        logger.error("DPU '{}' not found in config_facts. Available DPUs: {}".format(
-            dpu_key, list(dpu_section.keys())))
+    # DPU keys may be plain (dpu0) or hostname-prefixed (<host>-dpu0) -> match trailing index.
+    dpu_config = None
+    for name, cfg in dpu_section.items():
+        # Grab the trailing number of the key (dpu3 / <host>-dpu3 -> 3).
+        m = re.search(r'(\d+)$', str(name))
+        if m and int(m.group(1)) == int(dpu_index):
+            dpu_config = cfg
+            break
+    if dpu_config is None:
+        logger.error("DPU index %s not found in DPU table. Available: %s",
+                     dpu_index, list(dpu_section.keys()))
         return None
 
-    dpu_config = dpu_section[dpu_key]
+    # Extract the gNMI port for this DPU.
     port = dpu_config.get('gnmi_port', None)
     if port is None:
         logger.error("gnmi_port not found in config_facts for dpu_index {}".format(dpu_index))
@@ -1357,6 +1370,44 @@ def get_configured_dpu_names(duthost):
 
     names = [str(k) for k in dpu_section.keys()]
     return sorted(names, key=_dpu_sort_key)
+
+
+def get_configured_dpu_indices(duthost, include_admin_down=False):
+    """
+    Return the actual DPU indices configured on the DUT (e.g. dpu3 -> 3).
+
+    Indices are parsed from the real DPU identities, not a positional count,
+    so a non-contiguous table (dpu1, dpu3) yields [1, 3] rather than [0, 1].
+    By default admin-down DPUs (CHASSIS_MODULE admin_status='down') are skipped;
+    pass include_admin_down=True to return every configured index.
+    """
+    # Reuse the DPU/DPUS table selection + ordering from get_configured_dpu_names.
+    names = get_configured_dpu_names(duthost)
+    if not names:
+        return []
+
+    # Admin state lives in the CHASSIS_MODULE table, keyed by 'DPU<index>'.
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    chassis_modules = (config_facts or {}).get('CHASSIS_MODULE') or {}
+
+    indices = []
+    for name in names:
+        # Parse the trailing number so dpu3 / <host>-dpu3 both map to 3.
+        m = re.search(r'(\d+)$', str(name))
+        if not m:
+            logger.warning("Skipping DPU entry without a numeric index: %r", name)
+            continue
+        idx = int(m.group(1))
+        # Look up admin state; treat a missing entry as 'up' (enabled by default).
+        admin_status = chassis_modules.get('DPU{}'.format(idx), {}).get('admin_status', 'up')
+        # Skip administratively-down DPUs unless the caller wants them all.
+        if not include_admin_down and str(admin_status).lower() == 'down':
+            logger.info("Skipping admin-down DPU%d", idx)
+            continue
+        indices.append(idx)
+
+    # Deduplicate and keep deterministic ascending order.
+    return sorted(set(indices))
 
 
 def check_dpu_reachable_from_npu(duthost, dpuhost_name, dpu_index):

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -1311,7 +1311,7 @@ def get_dpu_port(duthost, dpu_index):
         logger.error("Failed to retrieve config_facts from DUT")
         return None
 
-    dpu_section = config_facts.get('DPU', {})
+    dpu_section = config_facts.get('DPU') or config_facts.get('DPUS') or {}
     if not dpu_section:
         logger.error("DPU section not found in config_facts")
         return None
@@ -1344,7 +1344,9 @@ def get_configured_dpu_names(duthost):
         logger.error("Failed to retrieve config_facts from DUT")
         return []
 
-    dpu_section = config_facts.get('DPU', {})
+    # DPU names may live under the singular 'DPU' table or the plural 'DPUS'
+    # table depending on the platform/config schema (e.g. Cisco 8102 uses 'DPUS').
+    dpu_section = config_facts.get('DPU') or config_facts.get('DPUS') or {}
     if not dpu_section:
         return []
 

--- a/tests/common/unit_tests/unit_test_dpu_discovery.py
+++ b/tests/common/unit_tests/unit_test_dpu_discovery.py
@@ -1,0 +1,191 @@
+"""Unit tests for SmartSwitch DPU discovery helpers in device_utils.
+
+Covers the edge cases that drove the review:
+  * explicit --ss_target_indices override wins over discovery
+  * sparse / non-contiguous DPU IDs (dpu1, dpu3 -> [1, 3])
+  * admin-down and missing admin_status DPUs are skipped (fail closed)
+  * DPUS-only config (no gnmi_port) -> get_dpu_port returns None
+"""
+
+import os
+import sys
+from unittest.mock import Mock
+
+import logging
+
+# The repo's pytest log_format uses a custom 'funcNamewithModule' record field that
+# is normally injected by a conftest-loaded plugin; --noconftest skips it, so add it
+# here to keep these tests runnable via `pytest --noconftest`.
+_old_record_factory = logging.getLogRecordFactory()
+
+
+def _record_factory(*args, **kwargs):
+    record = _old_record_factory(*args, **kwargs)
+    record.funcNamewithModule = "%s.%s" % (record.module, record.funcName)
+    return record
+
+
+logging.setLogRecordFactory(_record_factory)
+
+_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(_TEST_DIR))
+)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from tests.common.platform.device_utils import (  # noqa: E402
+    get_configured_dpu_indices,
+    get_configured_dpu_names,
+    get_dpu_port,
+    resolve_upgrade_dpu_indices,
+)
+
+
+def _make_duthost(config_db):
+    """Build a fake duthost whose config_facts() returns the given CONFIG_DB dict."""
+    duthost = Mock()
+    duthost.hostname = "test-dut"
+    # device_utils reads duthost.config_facts(...)['ansible_facts'].
+    duthost.config_facts.return_value = {"ansible_facts": config_db}
+    return duthost
+
+
+# ---------------------------------------------------------------------------
+# get_configured_dpu_indices: sparse IDs
+# ---------------------------------------------------------------------------
+def test_sparse_dpu_indices_parsed_from_identities():
+    # DPU table has non-contiguous ids dpu1 and dpu3 (both admin-up).
+    duthost = _make_duthost({
+        "DPU": {"dpu1": {"gnmi_port": 50052}, "dpu3": {"gnmi_port": 50052}},
+        "CHASSIS_MODULE": {"DPU1": {"admin_status": "up"}, "DPU3": {"admin_status": "up"}},
+    })
+    # Real identities -> [1, 3], not a positional [0, 1].
+    assert get_configured_dpu_indices(duthost) == [1, 3]
+
+
+# ---------------------------------------------------------------------------
+# get_configured_dpu_indices: admin state filtering
+# ---------------------------------------------------------------------------
+def test_admin_down_dpu_is_skipped():
+    # DPU1 is admin-down and must be excluded from discovery.
+    duthost = _make_duthost({
+        "DPU": {"dpu0": {}, "dpu1": {}, "dpu2": {}},
+        "CHASSIS_MODULE": {
+            "DPU0": {"admin_status": "up"},
+            "DPU1": {"admin_status": "down"},
+            "DPU2": {"admin_status": "up"},
+        },
+    })
+    assert get_configured_dpu_indices(duthost) == [0, 2]
+
+
+def test_missing_chassis_module_entry_is_skipped():
+    # DPU1 has no CHASSIS_MODULE entry -> state unverifiable -> fail closed (skip).
+    duthost = _make_duthost({
+        "DPU": {"dpu0": {}, "dpu1": {}},
+        "CHASSIS_MODULE": {"DPU0": {"admin_status": "up"}},
+    })
+    assert get_configured_dpu_indices(duthost) == [0]
+
+
+def test_missing_admin_status_key_is_skipped():
+    # CHASSIS_MODULE entry exists but has no admin_status -> fail closed (skip).
+    duthost = _make_duthost({
+        "DPU": {"dpu0": {}, "dpu1": {}},
+        "CHASSIS_MODULE": {"DPU0": {"admin_status": "up"}, "DPU1": {}},
+    })
+    assert get_configured_dpu_indices(duthost) == [0]
+
+
+def test_include_admin_down_returns_all_indices():
+    # include_admin_down=True bypasses the admin-state filter entirely.
+    duthost = _make_duthost({
+        "DPU": {"dpu0": {}, "dpu1": {}, "dpu2": {}},
+        "CHASSIS_MODULE": {
+            "DPU0": {"admin_status": "up"},
+            "DPU1": {"admin_status": "down"},
+            # DPU2 intentionally absent.
+        },
+    })
+    assert get_configured_dpu_indices(duthost, include_admin_down=True) == [0, 1, 2]
+
+
+# ---------------------------------------------------------------------------
+# DPUS-only configuration (name-to-midplane mapping, no gnmi_port)
+# ---------------------------------------------------------------------------
+def test_dpus_only_config_discovers_names_and_indices():
+    # 'DPUS' carries only midplane mapping; discovery must still resolve identities.
+    duthost = _make_duthost({
+        "DPUS": {"dpu0": {"midplane_interface": "dpu0"}, "dpu1": {"midplane_interface": "dpu1"}},
+        "CHASSIS_MODULE": {"DPU0": {"admin_status": "up"}, "DPU1": {"admin_status": "up"}},
+    })
+    assert get_configured_dpu_names(duthost) == ["dpu0", "dpu1"]
+    assert get_configured_dpu_indices(duthost) == [0, 1]
+
+
+def test_dpus_only_config_has_no_gnmi_port():
+    # gnmi_port lives only in 'DPU'; a DPUS-only config -> get_dpu_port returns None.
+    duthost = _make_duthost({
+        "DPUS": {"dpu0": {"midplane_interface": "dpu0"}},
+    })
+    assert get_dpu_port(duthost, 0) is None
+
+
+# ---------------------------------------------------------------------------
+# get_dpu_port: hostname-prefixed keys
+# ---------------------------------------------------------------------------
+def test_get_dpu_port_matches_hostname_prefixed_key():
+    # DPU keys may be prefixed with the hostname; match on the trailing index.
+    duthost = _make_duthost({
+        "DPU": {
+            "test-dut-dpu0": {"gnmi_port": 50051},
+            "test-dut-dpu3": {"gnmi_port": 50054},
+        },
+    })
+    assert get_dpu_port(duthost, 3) == 50054
+    assert get_dpu_port(duthost, 0) == 50051
+
+
+def test_get_dpu_port_unknown_index_returns_none():
+    # An index not present in the DPU table yields None.
+    duthost = _make_duthost({"DPU": {"dpu0": {"gnmi_port": 50051}}})
+    assert get_dpu_port(duthost, 7) is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_upgrade_dpu_indices: explicit override precedence
+# ---------------------------------------------------------------------------
+def test_explicit_override_wins_over_discovery():
+    # Explicit --ss_target_indices is honored exactly; discovery is not consulted.
+    duthost = _make_duthost({
+        "DPU": {"dpu0": {}, "dpu1": {}},
+        "CHASSIS_MODULE": {"DPU0": {"admin_status": "up"}, "DPU1": {"admin_status": "up"}},
+    })
+    assert resolve_upgrade_dpu_indices(duthost, "0,3,5") == [0, 3, 5]
+    # config_facts must never be read when an explicit selection is given.
+    duthost.config_facts.assert_not_called()
+
+
+def test_explicit_override_tolerates_whitespace():
+    # Spaces around comma-separated indices are stripped.
+    duthost = _make_duthost({})
+    assert resolve_upgrade_dpu_indices(duthost, "1, 2 ,  4") == [1, 2, 4]
+
+
+def test_no_override_falls_back_to_discovery():
+    # Absent --ss_target_indices -> fall back to admin-up discovered indices.
+    duthost = _make_duthost({
+        "DPU": {"dpu0": {}, "dpu1": {}},
+        "CHASSIS_MODULE": {"DPU0": {"admin_status": "up"}, "DPU1": {"admin_status": "down"}},
+    })
+    assert resolve_upgrade_dpu_indices(duthost, None) == [0]
+
+
+def test_empty_override_string_falls_back_to_discovery():
+    # An empty string is treated as "no explicit selection".
+    duthost = _make_duthost({
+        "DPU": {"dpu2": {}},
+        "CHASSIS_MODULE": {"DPU2": {"admin_status": "up"}},
+    })
+    assert resolve_upgrade_dpu_indices(duthost, "") == [2]

--- a/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
@@ -241,7 +241,8 @@ def test_upgrade_smartswitch_all_dpus_then_npu(
 
     if not dpu_indices:
         pytest.fail(
-            "Could not determine DPU indices: CONFIG_DB DPU(S) table is empty and "
+            "Could not determine DPU indices: CONFIG_DB DPU(S) table is empty or no "
+            "configured DPU has a verifiable CHASSIS_MODULE admin_status of 'up', and "
             "--ss_target_indices was not provided. Pass e.g. --ss_target_indices=0,1,2,3"
         )
 

--- a/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
@@ -14,7 +14,7 @@ from tests.common.helpers.upgrade_helpers import (
 )
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.platform.device_utils import get_configured_dpu_indices
+from tests.common.platform.device_utils import resolve_upgrade_dpu_indices
 
 logger = logging.getLogger(__name__)
 
@@ -67,12 +67,8 @@ def smartswitch_upgrade_params(request, duthost):
     ss_max_workers = request.config.getoption("ss_max_workers")
 
     ss_target_indices = request.config.getoption("ss_target_indices")
-    if ss_target_indices:
-        # Operator explicitly selected DPUs -> honor exactly that selection, never override.
-        dpu_indices = [int(x.strip()) for x in ss_target_indices.split(",") if x.strip()]
-    else:
-        # No explicit selection -> upgrade the actual admin-up DPUs discovered from CONFIG_DB.
-        dpu_indices = get_configured_dpu_indices(duthost)
+    # Explicit --ss_target_indices wins; otherwise auto-discover admin-up DPUs from CONFIG_DB.
+    dpu_indices = resolve_upgrade_dpu_indices(duthost, ss_target_indices)
     logger.debug("smartswitch_upgrade_params: dpu_indices=%s", dpu_indices)
 
     return SmartSwitchUpgradeParams(

--- a/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
@@ -1,4 +1,6 @@
 import logging
+from collections import namedtuple
+
 import pytest
 
 from tests.common.fixtures.grpc_fixtures import (  # noqa: F401
@@ -30,55 +32,61 @@ def _build_dpu_metadata(dpu_index: int):
     ]
 
 
+# Unified parameter set shared by all SmartSwitch upgrade tests.
+#   DPU image/version : --target_image_list / --target_version
+#   NPU image/version : --ss_npu_target_image / --ss_npu_target_version
+#   ss_target_index   : single DPU index (default 3)
+#   dpu_indices       : all DPU indices (from CONFIG_DB, else --ss_target_indices)
+SmartSwitchUpgradeParams = namedtuple("SmartSwitchUpgradeParams", [
+    "upgrade_type",
+    "from_image",
+    "dpu_to_image",
+    "dpu_to_version",
+    "npu_to_image",
+    "npu_to_version",
+    "dut_image_path",
+    "ss_target_index",
+    "dpu_indices",
+    "reboot_ready_timeout",
+    "max_workers",
+])
+
+
 @pytest.fixture(scope="module")
-def smartswitch_gnoi_upgrade_lists(request, duthost):
+def smartswitch_upgrade_params(request, duthost):
+    """Unified parameters for all SmartSwitch upgrade tests.
+
+    DPU indices are derived from the CONFIG_DB DPU(S) table; if that is empty
+    they fall back to the comma-separated --ss_target_indices option.
     """
-    Same style as tests/upgrade_path/test_upgrade_gnoi.py:
-      - upgrade_type: warm/cold -> passed into cfg.upgrade_type (helper maps to reboot method)
-      - target_image_list: used for TransferToRemote remote_download.path
-      - target_version: used for SetPackage package.version
-    SmartSwitch-only:
-      - ss_target_index: single DPU index
-      - ss_target_indices: comma-separated list for parallel
-      - ss_dut_image_path: local_path on DPU
-      - ss_reboot_ready_timeout: wait for gNOI Time back
-      - ss_max_workers: thread count for parallel
-    """
-    upgrade_type = request.config.getoption("upgrade_type")          # "warm" / "cold"
-    from_image = request.config.getoption("base_image_list")
-    to_image = request.config.getoption("target_image_list")
-    to_version = request.config.getoption("target_version")
-
-    ss_target_index = request.config.getoption("ss_target_index")          # int
-    ss_target_indices = request.config.getoption("ss_target_indices")      # "0,1,2,3"
-    ss_reboot_ready_timeout = 600
-    ss_max_workers = request.config.getoption("ss_max_workers")
-
-    ss_dut_image_path = "/var/tmp/sonic_image.bin"
-
-    # defaults
+    ss_target_index = request.config.getoption("ss_target_index")
     if ss_target_index in (None, ""):
         ss_target_index = 3
 
-    names = get_configured_dpu_names(duthost)
-    parsed_indices = None
-    if not ss_target_indices:
-        parsed_indices = list(range(len(names)))        # 4 -> [0, 1, 2, 3]]
-    else:
-        parsed_indices = [int(x.strip()) for x in ss_target_indices.split(",") if x.strip()]
-        if not parsed_indices:
-            parsed_indices = None
+    ss_max_workers = request.config.getoption("ss_max_workers")
 
-    return (
-        upgrade_type,
-        from_image,
-        to_image,
-        to_version,
-        ss_dut_image_path,
-        int(ss_target_index),
-        parsed_indices,
-        int(ss_reboot_ready_timeout),
-        int(ss_max_workers) if ss_max_workers else None,
+    names = get_configured_dpu_names(duthost)
+    ss_target_indices = request.config.getoption("ss_target_indices")
+    if names:
+        dpu_indices = list(range(len(names)))               # 4 -> [0, 1, 2, 3]
+    elif ss_target_indices:
+        dpu_indices = [int(x.strip()) for x in ss_target_indices.split(",") if x.strip()]
+    else:
+        dpu_indices = []
+    logger.debug("smartswitch_upgrade_params: dpu names=%r -> dpu_indices=%s", names, dpu_indices)
+
+    return SmartSwitchUpgradeParams(
+        upgrade_type=request.config.getoption("upgrade_type"),
+        from_image=request.config.getoption("base_image_list"),
+        dpu_to_image=request.config.getoption("target_image_list"),
+        dpu_to_version=request.config.getoption("target_version"),
+        npu_to_image=request.config.getoption("ss_npu_target_image"),
+        npu_to_version=request.config.getoption("ss_npu_target_version"),
+        dut_image_path="/var/tmp/sonic_image.bin",
+        ss_target_index=int(ss_target_index),
+        dpu_indices=dpu_indices,
+        reboot_ready_timeout=600,
+        max_workers=int(ss_max_workers) if ss_max_workers else None,
     )
 
 
@@ -86,17 +94,21 @@ def smartswitch_gnoi_upgrade_lists(request, duthost):
 def test_upgrade_one_dpu_via_gnoi(
     localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname,
     tbinfo, request,
-    smartswitch_gnoi_upgrade_lists, ptf_gnoi  # noqa: F811
+    smartswitch_upgrade_params, ptf_gnoi  # noqa: F811
 ):
     """
     SmartSwitch: upgrade ONE DPU via gNOI (plaintext + DPU routing headers).
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-    (
-        upgrade_type, from_image, to_image, to_version,
-        dut_image_path, dpu_index, _, reboot_ready_timeout, _
-    ) = smartswitch_gnoi_upgrade_lists
+    p = smartswitch_upgrade_params
+    upgrade_type = p.upgrade_type
+    from_image = p.from_image
+    to_image = p.dpu_to_image
+    to_version = p.dpu_to_version
+    dut_image_path = p.dut_image_path
+    dpu_index = p.ss_target_index
+    reboot_ready_timeout = p.reboot_ready_timeout
 
     assert to_image, "target_image_list must be set (used as TransferToRemote remote_download.path)"
     assert to_version, "target_version must be set (used as SetPackage package.version)"
@@ -134,7 +146,7 @@ def test_upgrade_one_dpu_via_gnoi(
 def test_upgrade_multiple_dpus_via_gnoi_parallel(
     localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname,
     tbinfo, request,
-    smartswitch_gnoi_upgrade_lists, ptf_gnoi  # noqa: F811
+    smartswitch_upgrade_params, ptf_gnoi  # noqa: F811
 ):
     """
     SmartSwitch: upgrade MULTIPLE DPUs via gNOI in parallel.
@@ -144,10 +156,14 @@ def test_upgrade_multiple_dpus_via_gnoi_parallel(
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-    (
-        upgrade_type, from_image, to_image, to_version,
-        dut_image_path, _, dpu_indices, reboot_ready_timeout, max_workers
-    ) = smartswitch_gnoi_upgrade_lists
+    p = smartswitch_upgrade_params
+    upgrade_type = p.upgrade_type
+    to_image = p.dpu_to_image
+    to_version = p.dpu_to_version
+    dut_image_path = p.dut_image_path
+    dpu_indices = p.dpu_indices
+    reboot_ready_timeout = p.reboot_ready_timeout
+    max_workers = p.max_workers
 
     if not dpu_indices:
         pytest.skip("--ss-target-indices not set; skipping parallel multi-DPU gNOI upgrade")
@@ -187,43 +203,11 @@ def test_upgrade_multiple_dpus_via_gnoi_parallel(
     )
 
 
-@pytest.fixture(scope="module")
-def smartswitch_full_upgrade_lists(request, duthost):
-    """
-    Parameters for the full SmartSwitch upgrade test.
-    DPU image/version come from --target_image_list / --target_version.
-    NPU image/version come from --ss_npu_target_image / --ss_npu_target_version.
-    """
-    upgrade_type = request.config.getoption("upgrade_type")
-    dpu_to_image = request.config.getoption("target_image_list")
-    dpu_to_version = request.config.getoption("target_version")
-    npu_to_image = request.config.getoption("ss_npu_target_image")
-    npu_to_version = request.config.getoption("ss_npu_target_version")
-    ss_reboot_ready_timeout = 600
-
-    # Try to get DPU indices from CONFIG_DB first.
-    # If that returns empty (DPU table not populated), fall back to --ss_target_indices.
-    names = get_configured_dpu_names(duthost)
-    if names:
-        dpu_indices = list(range(len(names)))
-    else:
-        ss_target_indices = request.config.getoption("ss_target_indices")
-        if not ss_target_indices:
-            pytest.fail(
-                "Could not determine DPU indices: CONFIG_DB DPU table is empty and "
-                "--ss_target_indices was not provided. Pass e.g. --ss_target_indices=0,1,2,3"
-            )
-        dpu_indices = [int(x.strip()) for x in ss_target_indices.split(",") if x.strip()]
-
-    return (upgrade_type, dpu_to_image, dpu_to_version, npu_to_image, npu_to_version,
-            dpu_indices, ss_reboot_ready_timeout)
-
-
 @pytest.mark.device_type("smartswitch")
 def test_upgrade_smartswitch_all_dpus_then_npu(
     localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname,
     tbinfo, conn_graph_facts, xcvr_skip_list, request,
-    smartswitch_full_upgrade_lists, gnmi_tls  # noqa: F811
+    smartswitch_upgrade_params, gnmi_tls  # noqa: F811
 ):
     """
     Full SmartSwitch upgrade: stage all DPUs first, then upgrade the NPU.
@@ -245,14 +229,24 @@ def test_upgrade_smartswitch_all_dpus_then_npu(
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-    (upgrade_type, dpu_to_image, dpu_to_version,
-     npu_to_image, npu_to_version,
-     dpu_indices, reboot_ready_timeout) = smartswitch_full_upgrade_lists
+    p = smartswitch_upgrade_params
+    upgrade_type = p.upgrade_type
+    dpu_to_image = p.dpu_to_image
+    dpu_to_version = p.dpu_to_version
+    npu_to_image = p.npu_to_image
+    npu_to_version = p.npu_to_version
+    dpu_indices = p.dpu_indices
+    reboot_ready_timeout = p.reboot_ready_timeout
+    dut_image_path = p.dut_image_path
+
+    if not dpu_indices:
+        pytest.fail(
+            "Could not determine DPU indices: CONFIG_DB DPU(S) table is empty and "
+            "--ss_target_indices was not provided. Pass e.g. --ss_target_indices=0,1,2,3"
+        )
 
     assert dpu_to_image, "--target_image_list is required (DPU image URL)"
     assert npu_to_image, "--ss_npu_target_image is required (NPU image URL)"
-
-    dut_image_path = "/var/tmp/sonic_image.bin"
 
     # ------------------------------------------------------------------
     # Phase 1: Stage image on all DPUs in parallel (no reboot yet).

--- a/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
@@ -14,7 +14,7 @@ from tests.common.helpers.upgrade_helpers import (
 )
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.platform.device_utils import get_configured_dpu_names
+from tests.common.platform.device_utils import get_configured_dpu_indices
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ def _build_dpu_metadata(dpu_index: int):
 #   DPU image/version : --target_image_list / --target_version
 #   NPU image/version : --ss_npu_target_image / --ss_npu_target_version
 #   ss_target_index   : single DPU index (default 3)
-#   dpu_indices       : all DPU indices (from CONFIG_DB, else --ss_target_indices)
+#   dpu_indices       : DPU indices to upgrade (--ss_target_indices if given, else admin-up DPUs from CONFIG_DB)
 SmartSwitchUpgradeParams = namedtuple("SmartSwitchUpgradeParams", [
     "upgrade_type",
     "from_image",
@@ -56,8 +56,9 @@ SmartSwitchUpgradeParams = namedtuple("SmartSwitchUpgradeParams", [
 def smartswitch_upgrade_params(request, duthost):
     """Unified parameters for all SmartSwitch upgrade tests.
 
-    DPU indices are derived from the CONFIG_DB DPU(S) table; if that is empty
-    they fall back to the comma-separated --ss_target_indices option.
+    DPU indices come from the explicit --ss_target_indices option when provided;
+    otherwise they are the admin-up DPU indices discovered from the CONFIG_DB
+    DPU(S) table (parsed from the actual DPU identities).
     """
     ss_target_index = request.config.getoption("ss_target_index")
     if ss_target_index in (None, ""):
@@ -65,15 +66,14 @@ def smartswitch_upgrade_params(request, duthost):
 
     ss_max_workers = request.config.getoption("ss_max_workers")
 
-    names = get_configured_dpu_names(duthost)
     ss_target_indices = request.config.getoption("ss_target_indices")
-    if names:
-        dpu_indices = list(range(len(names)))               # 4 -> [0, 1, 2, 3]
-    elif ss_target_indices:
+    if ss_target_indices:
+        # Operator explicitly selected DPUs -> honor exactly that selection, never override.
         dpu_indices = [int(x.strip()) for x in ss_target_indices.split(",") if x.strip()]
     else:
-        dpu_indices = []
-    logger.debug("smartswitch_upgrade_params: dpu names=%r -> dpu_indices=%s", names, dpu_indices)
+        # No explicit selection -> upgrade the actual admin-up DPUs discovered from CONFIG_DB.
+        dpu_indices = get_configured_dpu_indices(duthost)
+    logger.debug("smartswitch_upgrade_params: dpu_indices=%s", dpu_indices)
 
     return SmartSwitchUpgradeParams(
         upgrade_type=request.config.getoption("upgrade_type"),


### PR DESCRIPTION
Support platforms that store DPU configuration in either the DPU or DPUS CONFIG_DB table.

Consolidate SmartSwitch gNOI upgrade parameters into one fixture and derive DPU indices consistently across the upgrade tests.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

  Fixes DPU discovery in the SmartSwitch gNOI upgrade test on platforms whose CONFIG_DB stores DPU config under the plural  DPUS   get_configured_dpu_names()  and  get_dpu_port()  only looked up  config_facts['DPU'] . On platforms using the  DPUS  table, that   lookup returned empty, so the upgrade fixture discovered zero DPUs and the test failed with a misleading gNOI error instead of  upgrading anything. This PR falls back to the  DPUS  table when  DPU  is absent.                                                     
                                                                                                                                       
   It also unifies the two overlapping SmartSwitch upgrade fixtures (gNOI-only and full NPU+DPU) into a single                         
 smartswitch_upgrade_params  fixture (a  SmartSwitchUpgradeParams  namedtuple) to reduce duplication.                                
   Where to start:  tests/common/platform/device_utils.py  (the fix) and  tests/upgrade_path/test_upgrade_smart_switch_gnoi.py     

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
https://msazure.visualstudio.com/One/_workitems/edit/38896351/

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->


tests/upgrade_path/test_upgrade_smart_switch_gnoi.py::test_upgrade_smartswitch_all_dpus_then_npu[str3-cisco-8102-E04-U26]
tests/upgrade_path/test_upgrade_smart_switch_gnoi.py::test_upgrade_smartswitch_all_dpus_then_npu[str3-cisco-8102-E04-U26]
tests/upgrade_path/test_upgrade_smart_switch_gnoi.py::test_upgrade_smartswitch_all_dpus_then_npu[str3-cisco-8102-E04-U26]
tests/upgrade_path/test_upgrade_smart_switch_gnoi.py::test_upgrade_smartswitch_all_dpus_then_npu[str3-cisco-8102-E04-U26]
tests/upgrade_path/test_upgrade_smart_switch_gnoi.py::test_upgrade_smartswitch_all_dpus_then_npu[str3-cisco-8102-E04-U26]
tests/upgrade_path/test_upgrade_smart_switch_gnoi.py::test_upgrade_smartswitch_all_dpus_then_npu[str3-cisco-8102-E04-U26]
  /opt/venv/lib/python3.12/site-packages/ansible/plugins/loader.py:1485: UserWarning: AnsibleCollectionFinder has already been configured
    warnings.warn('AnsibleCollectionFinder has already been configured')

tests/upgrade_path/test_upgrade_smart_switch_gnoi.py: 145 warnings
  /usr/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=16159) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

tests/upgrade_path/test_upgrade_smart_switch_gnoi.py::test_upgrade_smartswitch_all_dpus_then_npu[str3-cisco-8102-E04-U26]
  /var/src/sonic-mgmt-int/tests/conftest.py:1608: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    record_testsuite_property("timestamp", datetime.utcnow())

tests/upgrade_path/test_upgrade_smart_switch_gnoi.py::test_upgrade_smartswitch_all_dpus_then_npu[str3-cisco-8102-E04-U26]
  /opt/venv/lib/python3.12/site-packages/passlib/utils/__init__.py:854: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
    from crypt import crypt as _crypt

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- generated xml file: /var/src/sonic-mgmt-int/tests/logs/upgrade_path/test_upgrade_smart_switch_gnoi.py::test_upgrade_smartswitch_all_dpus_then_npu.xml -
---------------------------- live log sessionfinish ----------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_upgrade_smartswitch_all_dpus_then_npu[str3-cisco-8102-E04-U26]>
DEBUG:root:[Parallel Fixture] Terminate parallel manager after teardown
INFO:root:[Parallel Fixture] Terminating parallel fixture manager
DEBUG:root:[Parallel Fixture] Running tasks to be terminated: []
DEBUG:root:[Parallel Fixture] Current worker threads: []
DEBUG:root:[Parallel Fixture] Current worker threads: []
DEBUG:root:[Parallel Fixture] The fixture manager is terminated:
stopped tasks [],
canceled tasks [],
pending tasks [],
done tasks [].
INFO:root:Can not get Allure report URL. Please check logs
================= 1 passed, 159 warnings in 1501.31s (0:25:01) =================
EXIT_CODE=0

### Approach
#### What is the motivation for this PR?
DPU upgrades were failing when DPU index was not specified.

#### How did you do it?
Fixed using the correct table.

#### How did you verify/test it?
For verification you can note: Validated on hardware             ┃
    str3-cisco-8102-E04-U26  —  test_upgrade_smartswitch_all_dpus_then_npu  upgraded all 8 DPUs  .31→.32  and the NPU to  .34 , passed  ┃
   (25 min).                                                            
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
