### PR TITLE
Fix EOS fanout speed parser for forced mode

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -690,11 +690,11 @@ class EosHost(AnsibleHostBase):
 
     def get_speed(self, interface_name):
         output = self.eos_command(commands=['show interfaces %s transceiver properties' % interface_name])
-        found_txt = re.search(r'Operational Speed: (\S+)', output['stdout'][0])
+        found_txt = re.search(r'Operational speed: (\S+)', output['stdout'][0], re.IGNORECASE)
         if found_txt is None:
             _raise_err('Not able to extract interface %s speed from output: %s' % (interface_name, output['stdout']))
 
-        v = found_txt.groups()[0]
+        v = found_txt.groups()[0].split('(')[0]
         return v[:-1] + '000'
 
     def _has_cli_cmd_failed(self, cmd_output_obj):


### PR DESCRIPTION
### Description of PR

Summary:
Fix the EOS fanout speed parser used by auto-negotiation tests so it accepts current EOS output such as `Operational speed: 100G(forced)`.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/39003747

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39003747
Failure type: regression

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- Verified parser conversion locally for `Operational Speed: 100G`, `Operational speed: 100G(forced)`, `Operational speed: 25G`, and `Operational speed: 10G(auto)`.
- Ran `python -m pre_commit run --files tests/common/devices/eos.py` successfully.

### Approach
#### What is the motivation for this PR?

Nightly auto-negotiation tests fail during setup when saving EOS fanout port state because the parser only matches `Operational Speed:` and assumes the speed token is exactly like `100G`. Current EOS output can be `Operational speed: 100G(forced)`.

#### How did you do it?

Make the `Operational speed` match case-insensitive and strip the optional parenthesized mode suffix before converting the EOS speed token to Mbps.

#### How did you verify/test it?

Validated the parser behavior with representative EOS output strings and ran pre-commit on the changed file.

#### Any platform specific information?

Observed on Mellanox-SN2700 T0 nightly with EOS fanout `str-7260-24`; the change is limited to EOS fanout speed parsing.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A