### PR TITLE
[layer1]: Filter ports without RX disable support in test_port_error

### DIFF
--- a/tests/layer1/test_port_error.py
+++ b/tests/layer1/test_port_error.py
@@ -1,9 +1,11 @@
+import ast
 import logging
 import pytest
 import random
 import time
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.interface_utils import get_physical_port_indices
 from tests.common.utilities import skip_release
 
 pytestmark = [
@@ -44,6 +46,34 @@ class TestMACFault(object):
     def get_interface_status(dut, interface):
         return dut.show_and_parse("show interfaces status {}".format(interface))[0].get("oper", "unknown")
 
+    @staticmethod
+    def filter_rx_disable_supported_interfaces(dut, interfaces):
+        """Exclude interfaces whose module does not support RX disable"""
+        port_index_map = get_physical_port_indices(dut, interfaces)
+        indexes = sorted({idx for idx in port_index_map.values() if idx is not None})
+        cmd = """
+cat << EOF > get_rx_disable_supported_indexes.py
+from sonic_platform.chassis import Chassis
+c = Chassis()
+supported = []
+for i in {indexes}:
+    try:
+        api = c.get_sfp(i).get_xcvr_api()
+        if api and api.get_rx_disable_support() is True:
+            supported.append(i)
+    except Exception:
+        pass
+print(supported)
+EOF
+""".format(indexes=indexes)
+        dut.shell(cmd)
+        out = dut.shell("python3 get_rx_disable_supported_indexes.py")["stdout"].strip()
+        supported_indexes = set(ast.literal_eval(out))
+        supported = [intf for intf in interfaces if port_index_map.get(intf) in supported_indexes]
+        logging.info("Excluded interfaces without RX disable support: {}".format(
+            [intf for intf in interfaces if intf not in supported]))
+        return supported
+
     @pytest.fixture
     def select_random_interfaces(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         dut = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
@@ -58,6 +88,11 @@ class TestMACFault(object):
         ]
 
         pytest_assert(available_interfaces, "No interfaces with SFP detected. Cannot proceed with tests.")
+
+        # Local fault uses sfputil rx-output; skip modules that cannot disable RX.
+        available_interfaces = self.filter_rx_disable_supported_interfaces(dut, available_interfaces)
+        if not available_interfaces:
+            pytest.skip("No interfaces available for this test were found.")
 
         # Select 5 random interfaces (or fewer if not enough available)
         selected_interfaces = random.sample(available_interfaces, min(5, len(available_interfaces)))


### PR DESCRIPTION
### Description of PR
Summary:
Filter out interfaces whose optics do not support RX disable before random
port selection in `test_port_error`, so local-fault testing does not pick
unsupported modules.
* Exclude modules where `get_rx_disable_support()` is False before random
  port selection used by `test_mac_local_fault_increment`
* Skip the test when no RX-disable-capable interfaces remain

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement
### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:
### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Approach
#### What is the motivation for this PR?
`test_mac_local_fault_increment` uses `sfputil debug rx-output` to toggle RX.
Random selection can pick modules that do not support RX disable, which leads
to false failures.
#### How did you do it?
Added `filter_rx_disable_supported_interfaces`, which maps logical ports to
physical indices via `get_physical_port_indices` and keeps only modules where
`get_rx_disable_support()` is True. Applied that filter in
`select_random_interfaces` and skip when no capable interfaces remain.

#### Any platform specific information?
Relevant for platforms that exercise RX disable via sfputil.
#### Supported testbed topology if it's a new test case?
Not a new test case.
