### PR TITLE
Test DHCP relay process configuration matrix

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -126,15 +126,15 @@ def _set_dhcp_relay_server_state(duthost, vlan_name, vlan_names, backend, v4_ser
         _set_config_db_list_field(
             duthost, "VLAN", current_vlan, "dhcp_servers", isc_v4_servers)
 
-        native_v4 = {}
+        native_v4 = dict(original_native_v4[current_vlan])
+        native_v4.pop("dhcpv4_servers", None)
         if backend == "sonic" and current_vlan == vlan_name and v4_servers:
-            native_v4 = dict(original_native_v4[current_vlan])
             native_v4["dhcpv4_servers"] = v4_servers
         _replace_config_db_hash(duthost, "DHCPV4_RELAY", current_vlan, native_v4)
 
-        v6_config = {}
+        v6_config = dict(original_v6[current_vlan])
+        v6_config.pop("dhcpv6_servers", None)
         if current_vlan == vlan_name and v6_servers:
-            v6_config = dict(original_v6[current_vlan])
             v6_config["dhcpv6_servers"] = v6_servers
         _replace_config_db_hash(duthost, "DHCP_RELAY", current_vlan, v6_config)
 
@@ -295,6 +295,7 @@ def test_dhcp_relay_process_layout(duthosts, rand_one_dut_hostname, dut_dhcp_rel
     """Verify the DHCP relay process matrix as server configuration changes."""
     duthost = duthosts[rand_one_dut_hostname]
     backend = "sonic" if relay_agent == "sonic-relay-agent" else "isc"
+    pytest_assert(dut_dhcp_relay_data, "No DHCP relay data is available for the process matrix")
     selected_relay = dut_dhcp_relay_data[0]
     vlan_name = selected_relay["downlink_vlan_iface"]["name"]
     match = re.fullmatch(r"Vlan(\d+)", vlan_name)
@@ -334,7 +335,7 @@ def test_dhcp_relay_process_layout(duthosts, rand_one_dut_hostname, dut_dhcp_rel
     original_backend = "sonic" if str(original_flag).lower() == "true" else "isc"
 
     feature_state = original_config.get("FEATURE", {}).get("dhcp_relay", {}).get("state")
-    pytest_assert(feature_state == "enabled",
+    pytest_assert(feature_state in ["enabled", "always_enabled"],
                   "dhcp_relay feature must remain enabled, got {}".format(feature_state))
 
     states = [
@@ -367,7 +368,7 @@ def test_dhcp_relay_process_layout(duthosts, rand_one_dut_hostname, dut_dhcp_rel
 
             current_feature_state = duthost.shell(
                 'sonic-db-cli CONFIG_DB hget "FEATURE|dhcp_relay" "state"')["stdout"].strip()
-            pytest_assert(current_feature_state == "enabled",
+            pytest_assert(current_feature_state in ["enabled", "always_enabled"],
                           "dhcp_relay feature changed in state {}: {}"
                           .format(state_name, current_feature_state))
             critical_status = duthost.critical_process_status("dhcp_relay")

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -193,7 +193,7 @@ def _assert_dhcp_relay_process_layout(duthost, vlan_name, backend, has_v4, has_v
             return [state for name, state in entries if name == program]
 
         expected_dhcp6relay = ["RUNNING"] if has_v6 else []
-        expected_dhcp4relay = ["RUNNING"] if backend == "sonic" and has_v4 else []
+        expected_dhcp4relay = ["RUNNING"] if backend == "sonic" else []
         expected_isc = [
             ("isc-dhcpv4-relay-{}".format(vlan_name), "RUNNING")
         ] if backend == "isc" and has_v4 else []
@@ -358,7 +358,7 @@ def test_dhcp_relay_process_layout(duthosts, rand_one_dut_hostname, dut_dhcp_rel
                 duthost, vlan_name, vlan_names, backend, expected_v4, expected_v6)
 
             relay_types = []
-            if has_v4:
+            if backend == "sonic" or has_v4:
                 relay_types.append(backend)
             if has_v6:
                 relay_types.append("v6")
@@ -386,12 +386,9 @@ def test_dhcp_relay_process_layout(duthosts, rand_one_dut_hostname, dut_dhcp_rel
             duthost, original_flag if original_flag_present else None)
         original_relay_types = []
         if original_backend == "sonic":
-            original_has_v4 = any(
-                config.get("dhcpv4_servers") for config in original_native_v4.values())
-        else:
-            original_has_v4 = any(original_isc_v4.values())
-        if original_has_v4:
-            original_relay_types.append(original_backend)
+            original_relay_types.append("sonic")
+        elif any(original_isc_v4.values()):
+            original_relay_types.append("isc")
         if any(config.get("dhcpv6_servers") for config in original_v6.values()):
             original_relay_types.append("v6")
         _restart_dhcp_relay_for_process_layout(duthost, original_relay_types)

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -3,6 +3,7 @@ import random
 import time
 import logging
 import re
+import shlex
 
 from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmon_counters
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
@@ -77,6 +78,133 @@ def check_interface_status(duthost, relay_agent="isc-relay-agent"):
     return False
 
 
+def _replace_config_db_hash(duthost, table, name, values):
+    """Replace one CONFIG_DB hash using sonic-db-cli."""
+    key = "{}|{}".format(table, name)
+    commands = ["sonic-db-cli CONFIG_DB del {}".format(shlex.quote(key))]
+    for field, value in sorted(values.items()):
+        if isinstance(value, list):
+            field = "{}@".format(field)
+            value = ",".join(value)
+        commands.append(
+            "sonic-db-cli CONFIG_DB hset {} {} {}".format(
+                shlex.quote(key), shlex.quote(field), shlex.quote(str(value))))
+    duthost.shell_cmds(cmds=commands)
+
+
+def _set_config_db_list_field(duthost, table, name, field, values):
+    """Set or remove one CONFIG_DB list field using sonic-db-cli."""
+    key = "{}|{}".format(table, name)
+    field = "{}@".format(field)
+    if values:
+        command = "sonic-db-cli CONFIG_DB hset {} {} {}".format(
+            shlex.quote(key), shlex.quote(field), shlex.quote(",".join(values)))
+    else:
+        command = "sonic-db-cli CONFIG_DB hdel {} {}".format(
+            shlex.quote(key), shlex.quote(field))
+    duthost.shell(command)
+
+
+def _set_sonic_dhcpv4_relay_flag(duthost, value):
+    """Set the native DHCPv4 relay flag, or remove it when value is None."""
+    key = "DEVICE_METADATA|localhost"
+    field = "has_sonic_dhcpv4_relay"
+    if value is None:
+        command = "sonic-db-cli CONFIG_DB hdel {} {}".format(
+            shlex.quote(key), shlex.quote(field))
+    else:
+        command = "sonic-db-cli CONFIG_DB hset {} {} {}".format(
+            shlex.quote(key), shlex.quote(field), shlex.quote(value))
+    duthost.shell(command)
+
+
+def _set_dhcp_relay_server_state(duthost, vlan_name, backend, v4_servers, v6_servers,
+                                 original_native_v4, original_v6):
+    """Configure the selected VLAN without triggering an implicit service restart."""
+    if backend == "isc":
+        _set_config_db_list_field(duthost, "VLAN", vlan_name, "dhcp_servers", v4_servers)
+        _replace_config_db_hash(duthost, "DHCPV4_RELAY", vlan_name, {})
+    else:
+        _set_config_db_list_field(duthost, "VLAN", vlan_name, "dhcp_servers", [])
+        native_v4 = dict(original_native_v4) if v4_servers else {}
+        if v4_servers:
+            native_v4["dhcpv4_servers"] = v4_servers
+        _replace_config_db_hash(duthost, "DHCPV4_RELAY", vlan_name, native_v4)
+
+    v6_config = dict(original_v6) if v6_servers else {}
+    if v6_servers:
+        v6_config["dhcpv6_servers"] = v6_servers
+    _replace_config_db_hash(duthost, "DHCP_RELAY", vlan_name, v6_config)
+
+
+def _assert_dhcp_relay_server_state(duthost, vlan_name, backend, v4_servers, v6_servers):
+    """Verify the selected VLAN server configuration before restarting the container."""
+    config = duthost.get_running_config_facts()
+    if backend == "isc":
+        actual_v4 = config.get("VLAN", {}).get(vlan_name, {}).get("dhcp_servers", [])
+    else:
+        actual_v4 = config.get("DHCPV4_RELAY", {}).get(vlan_name, {}).get("dhcpv4_servers", [])
+    actual_v6 = config.get("DHCP_RELAY", {}).get(vlan_name, {}).get("dhcpv6_servers", [])
+
+    pytest_assert(sorted(actual_v4) == sorted(v4_servers),
+                  "Unexpected DHCPv4 servers for {}: expected {}, got {}"
+                  .format(vlan_name, v4_servers, actual_v4))
+    pytest_assert(sorted(actual_v6) == sorted(v6_servers),
+                  "Unexpected DHCPv6 servers for {}: expected {}, got {}"
+                  .format(vlan_name, v6_servers, actual_v6))
+
+
+def _assert_dhcp_relay_process_layout(duthost, vlan_name, backend, has_v4, has_v6):
+    """Assert the global and selected-VLAN supervisor process layout."""
+    output = duthost.shell(
+        "docker exec dhcp_relay supervisorctl status", module_ignore_errors=True)
+    entries = []
+    for line in output["stdout_lines"]:
+        parts = line.split()
+        if len(parts) >= 2:
+            entries.append((parts[0].split(":")[-1], parts[1]))
+
+    pytest_assert(entries, "No dhcp_relay supervisor processes found: {}".format(output))
+
+    def _matching(program):
+        return [state for name, state in entries if name == program]
+
+    def _assert_running_once(program):
+        states = _matching(program)
+        pytest_assert(states == ["RUNNING"],
+                      "Expected exactly one RUNNING {}, got {} from {}"
+                      .format(program, states, entries))
+
+    _assert_running_once("dhcprelayd")
+    _assert_running_once("dhcp6relay")
+
+    if backend == "sonic":
+        _assert_running_once("dhcp4relay")
+    else:
+        pytest_assert(not _matching("dhcp4relay"),
+                      "dhcp4relay unexpectedly present for ISC backend: {}".format(entries))
+
+    isc_program = "isc-dhcpv4-relay-{}".format(vlan_name)
+    isc_states = _matching(isc_program)
+    if backend == "isc" and has_v4:
+        pytest_assert(isc_states == ["RUNNING"],
+                      "Expected exactly one RUNNING {}, got {} from {}"
+                      .format(isc_program, isc_states, entries))
+    else:
+        pytest_assert(not isc_states,
+                      "{} unexpectedly present for selected VLAN: {}".format(isc_program, entries))
+
+    monitor_program = "dhcpmon-{}".format(vlan_name)
+    monitor_states = _matching(monitor_program)
+    if has_v4 or has_v6:
+        pytest_assert(monitor_states == ["RUNNING"],
+                      "Expected exactly one RUNNING {}, got {} from {}"
+                      .format(monitor_program, monitor_states, entries))
+    else:
+        pytest_assert(not monitor_states,
+                      "{} unexpectedly present for selected VLAN: {}".format(monitor_program, entries))
+
+
 @pytest.fixture(scope="function")
 def enable_source_port_ip_in_relay(duthosts, rand_one_dut_hostname, tbinfo, request):
     duthost = duthosts[rand_one_dut_hostname]
@@ -145,6 +273,80 @@ def enable_source_port_ip_in_relay(duthosts, rand_one_dut_hostname, tbinfo, requ
             delete_checkpoint(duthost, check_point)
             restart_dhcp_service(duthost, ['isc'])
             pytest_assert(wait_until(60, 2, 0, dhcp_ready, False), "Source port ip in relay is not disabled!")
+
+
+@pytest.mark.skip_config_dhcpv4_relay_agent
+def test_dhcp_relay_process_layout(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
+                                   tbinfo, relay_agent):
+    """Verify the DHCP relay process matrix as selected-VLAN server configuration changes."""
+    duthost = duthosts[rand_one_dut_hostname]
+    backend = "sonic" if relay_agent == "sonic-relay-agent" else "isc"
+    selected_relay = dut_dhcp_relay_data[0]
+    vlan_name = selected_relay["downlink_vlan_iface"]["name"]
+    match = re.fullmatch(r"Vlan(\d+)", vlan_name)
+    pytest_assert(match, "Unexpected VLAN interface name {}".format(vlan_name))
+
+    v4_servers = list(selected_relay["downlink_vlan_iface"]["dhcp_server_addrs"])
+    minigraph_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    v6_servers = list(minigraph_facts.get("dhcpv6_servers", []))
+    pytest_assert(v4_servers, "No DHCPv4 server is available for {}".format(vlan_name))
+    pytest_assert(v6_servers, "No DHCPv6 server is available for {}".format(vlan_name))
+
+    original_config = duthost.get_running_config_facts()
+    original_vlan = original_config.get("VLAN", {}).get(vlan_name, {})
+    original_isc_v4 = list(original_vlan.get("dhcp_servers", []))
+    original_native_v4 = dict(original_config.get("DHCPV4_RELAY", {}).get(vlan_name, {}))
+    original_v6 = dict(original_config.get("DHCP_RELAY", {}).get(vlan_name, {}))
+    metadata = original_config.get("DEVICE_METADATA", {}).get("localhost", {})
+    original_flag_present = "has_sonic_dhcpv4_relay" in metadata
+    original_flag = metadata.get("has_sonic_dhcpv4_relay")
+    original_backend = "sonic" if str(original_flag).lower() == "true" else "isc"
+
+    feature_state = original_config.get("FEATURE", {}).get("dhcp_relay", {}).get("state")
+    pytest_assert(feature_state == "enabled",
+                  "dhcp_relay feature must remain enabled, got {}".format(feature_state))
+
+    states = [
+        ("no-v4-no-v6", False, False),
+        ("v4-only", True, False),
+        ("v6-only", False, True),
+        ("v4-and-v6", True, True),
+    ]
+
+    try:
+        _set_sonic_dhcpv4_relay_flag(duthost, "True" if backend == "sonic" else None)
+        for state_name, has_v4, has_v6 in states:
+            logger.info("Checking DHCP relay process state %s for %s on %s",
+                        state_name, vlan_name, backend)
+            expected_v4 = v4_servers if has_v4 else []
+            expected_v6 = v6_servers if has_v6 else []
+            _set_dhcp_relay_server_state(
+                duthost, vlan_name, backend, expected_v4, expected_v6,
+                original_native_v4, original_v6)
+            _assert_dhcp_relay_server_state(
+                duthost, vlan_name, backend, expected_v4, expected_v6)
+
+            restart_dhcp_service(duthost, [backend, "v6"])
+            _assert_dhcp_relay_process_layout(duthost, vlan_name, backend, has_v4, has_v6)
+
+            current_feature_state = duthost.shell(
+                'sonic-db-cli CONFIG_DB hget "FEATURE|dhcp_relay" "state"')["stdout"].strip()
+            pytest_assert(current_feature_state == "enabled",
+                          "dhcp_relay feature changed in state {}: {}"
+                          .format(state_name, current_feature_state))
+            critical_status = duthost.critical_process_status("dhcp_relay")
+            pytest_assert(critical_status["status"] and not critical_status["exited_critical_process"],
+                          "dhcp_relay critical processes are unhealthy in state {}: {}"
+                          .format(state_name, critical_status))
+    finally:
+        _set_config_db_list_field(
+            duthost, "VLAN", vlan_name, "dhcp_servers", original_isc_v4)
+        _replace_config_db_hash(
+            duthost, "DHCPV4_RELAY", vlan_name, original_native_v4)
+        _replace_config_db_hash(duthost, "DHCP_RELAY", vlan_name, original_v6)
+        _set_sonic_dhcpv4_relay_flag(
+            duthost, original_flag if original_flag_present else None)
+        restart_dhcp_service(duthost, [original_backend, "v6"])
 
 
 def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data, relay_agent):

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -165,14 +165,8 @@ def _assert_dhcp_relay_server_state(duthost, vlan_name, vlan_names, backend, v4_
 
 
 def _restart_dhcp_relay_for_process_layout(duthost, relay_types):
-    """Restart the container when no relay agent exists or use the shared readiness helper."""
-    if relay_types:
-        restart_dhcp_service(duthost, relay_types)
-        return
-
-    duthost.shell("systemctl reset-failed dhcp_relay")
-    duthost.shell("systemctl restart dhcp_relay")
-    duthost.shell("systemctl reset-failed dhcp_relay")
+    """Restart the container and wait for the requested or empty ISC layout."""
+    restart_dhcp_service(duthost, relay_types or ["isc"])
 
 
 def _assert_dhcp_relay_process_layout(duthost, vlan_name, backend, has_v4, has_v6):
@@ -301,9 +295,11 @@ def test_dhcp_relay_process_layout(duthosts, rand_one_dut_hostname, dut_dhcp_rel
     match = re.fullmatch(r"Vlan(\d+)", vlan_name)
     pytest_assert(match, "Unexpected VLAN interface name {}".format(vlan_name))
 
-    v4_servers = list(selected_relay["downlink_vlan_iface"]["dhcp_server_addrs"])
+    v4_servers = [
+        server for server in selected_relay["downlink_vlan_iface"]["dhcp_server_addrs"] if server
+    ]
     minigraph_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    v6_servers = list(minigraph_facts.get("dhcpv6_servers", []))
+    v6_servers = [server for server in minigraph_facts.get("dhcpv6_servers", []) if server]
     pytest_assert(v4_servers, "No DHCPv4 server is available for {}".format(vlan_name))
     pytest_assert(v6_servers, "No DHCPv6 server is available for {}".format(vlan_name))
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -118,91 +118,105 @@ def _set_sonic_dhcpv4_relay_flag(duthost, value):
     duthost.shell(command)
 
 
-def _set_dhcp_relay_server_state(duthost, vlan_name, backend, v4_servers, v6_servers,
+def _set_dhcp_relay_server_state(duthost, vlan_name, vlan_names, backend, v4_servers, v6_servers,
                                  original_native_v4, original_v6):
-    """Configure the selected VLAN without triggering an implicit service restart."""
-    if backend == "isc":
-        _set_config_db_list_field(duthost, "VLAN", vlan_name, "dhcp_servers", v4_servers)
-        _replace_config_db_hash(duthost, "DHCPV4_RELAY", vlan_name, {})
-    else:
-        _set_config_db_list_field(duthost, "VLAN", vlan_name, "dhcp_servers", [])
-        native_v4 = dict(original_native_v4) if v4_servers else {}
-        if v4_servers:
+    """Configure only the selected VLAN without triggering an implicit service restart."""
+    for current_vlan in vlan_names:
+        isc_v4_servers = v4_servers if backend == "isc" and current_vlan == vlan_name else []
+        _set_config_db_list_field(
+            duthost, "VLAN", current_vlan, "dhcp_servers", isc_v4_servers)
+
+        native_v4 = {}
+        if backend == "sonic" and current_vlan == vlan_name and v4_servers:
+            native_v4 = dict(original_native_v4[current_vlan])
             native_v4["dhcpv4_servers"] = v4_servers
-        _replace_config_db_hash(duthost, "DHCPV4_RELAY", vlan_name, native_v4)
+        _replace_config_db_hash(duthost, "DHCPV4_RELAY", current_vlan, native_v4)
 
-    v6_config = dict(original_v6) if v6_servers else {}
-    if v6_servers:
-        v6_config["dhcpv6_servers"] = v6_servers
-    _replace_config_db_hash(duthost, "DHCP_RELAY", vlan_name, v6_config)
+        v6_config = {}
+        if current_vlan == vlan_name and v6_servers:
+            v6_config = dict(original_v6[current_vlan])
+            v6_config["dhcpv6_servers"] = v6_servers
+        _replace_config_db_hash(duthost, "DHCP_RELAY", current_vlan, v6_config)
 
 
-def _assert_dhcp_relay_server_state(duthost, vlan_name, backend, v4_servers, v6_servers):
-    """Verify the selected VLAN server configuration before restarting the container."""
+def _assert_dhcp_relay_server_state(duthost, vlan_name, vlan_names, backend, v4_servers, v6_servers):
+    """Verify that only the selected VLAN has the requested server configuration."""
     config = duthost.get_running_config_facts()
-    if backend == "isc":
-        actual_v4 = config.get("VLAN", {}).get(vlan_name, {}).get("dhcp_servers", [])
-    else:
-        actual_v4 = config.get("DHCPV4_RELAY", {}).get(vlan_name, {}).get("dhcpv4_servers", [])
-    actual_v6 = config.get("DHCP_RELAY", {}).get(vlan_name, {}).get("dhcpv6_servers", [])
+    for current_vlan in vlan_names:
+        expected_isc_v4 = v4_servers if backend == "isc" and current_vlan == vlan_name else []
+        expected_sonic_v4 = v4_servers if backend == "sonic" and current_vlan == vlan_name else []
+        expected_v6 = v6_servers if current_vlan == vlan_name else []
+        actual_isc_v4 = config.get("VLAN", {}).get(
+            current_vlan, {}).get("dhcp_servers", [])
+        actual_sonic_v4 = config.get("DHCPV4_RELAY", {}).get(
+            current_vlan, {}).get("dhcpv4_servers", [])
+        actual_v6 = config.get("DHCP_RELAY", {}).get(
+            current_vlan, {}).get("dhcpv6_servers", [])
 
-    pytest_assert(sorted(actual_v4) == sorted(v4_servers),
-                  "Unexpected DHCPv4 servers for {}: expected {}, got {}"
-                  .format(vlan_name, v4_servers, actual_v4))
-    pytest_assert(sorted(actual_v6) == sorted(v6_servers),
-                  "Unexpected DHCPv6 servers for {}: expected {}, got {}"
-                  .format(vlan_name, v6_servers, actual_v6))
+        pytest_assert(sorted(actual_isc_v4) == sorted(expected_isc_v4),
+                      "Unexpected ISC DHCPv4 servers for {}: expected {}, got {}"
+                      .format(current_vlan, expected_isc_v4, actual_isc_v4))
+        pytest_assert(sorted(actual_sonic_v4) == sorted(expected_sonic_v4),
+                      "Unexpected SONiC DHCPv4 servers for {}: expected {}, got {}"
+                      .format(current_vlan, expected_sonic_v4, actual_sonic_v4))
+        pytest_assert(sorted(actual_v6) == sorted(expected_v6),
+                      "Unexpected DHCPv6 servers for {}: expected {}, got {}"
+                      .format(current_vlan, expected_v6, actual_v6))
+
+
+def _restart_dhcp_relay_for_process_layout(duthost, relay_types):
+    """Restart the container when no relay agent exists or use the shared readiness helper."""
+    if relay_types:
+        restart_dhcp_service(duthost, relay_types)
+        return
+
+    duthost.shell("systemctl reset-failed dhcp_relay")
+    duthost.shell("systemctl restart dhcp_relay")
+    duthost.shell("systemctl reset-failed dhcp_relay")
 
 
 def _assert_dhcp_relay_process_layout(duthost, vlan_name, backend, has_v4, has_v6):
     """Assert the global and selected-VLAN supervisor process layout."""
-    output = duthost.shell(
-        "docker exec dhcp_relay supervisorctl status", module_ignore_errors=True)
-    entries = []
-    for line in output["stdout_lines"]:
-        parts = line.split()
-        if len(parts) >= 2:
-            entries.append((parts[0].split(":")[-1], parts[1]))
+    last_entries = {"value": []}
 
-    pytest_assert(entries, "No dhcp_relay supervisor processes found: {}".format(output))
+    def _has_expected_layout():
+        output = duthost.shell(
+            "docker exec dhcp_relay supervisorctl status", module_ignore_errors=True)
+        entries = []
+        for line in output["stdout_lines"]:
+            parts = line.split()
+            if len(parts) >= 2:
+                entries.append((parts[0].split(":")[-1], parts[1]))
+        last_entries["value"] = entries
 
-    def _matching(program):
-        return [state for name, state in entries if name == program]
+        def _matching(program):
+            return [state for name, state in entries if name == program]
 
-    def _assert_running_once(program):
-        states = _matching(program)
-        pytest_assert(states == ["RUNNING"],
-                      "Expected exactly one RUNNING {}, got {} from {}"
-                      .format(program, states, entries))
+        expected_dhcp6relay = ["RUNNING"] if has_v6 else []
+        expected_dhcp4relay = ["RUNNING"] if backend == "sonic" and has_v4 else []
+        expected_isc = [
+            ("isc-dhcpv4-relay-{}".format(vlan_name), "RUNNING")
+        ] if backend == "isc" and has_v4 else []
+        expected_monitors = [
+            ("dhcpmon-{}".format(vlan_name), "RUNNING")
+        ] if has_v4 or has_v6 else []
+        actual_isc = sorted(
+            (name, state) for name, state in entries if name.startswith("isc-dhcpv4-relay-"))
+        actual_monitors = sorted(
+            (name, state) for name, state in entries if name.startswith("dhcpmon-"))
 
-    _assert_running_once("dhcprelayd")
-    _assert_running_once("dhcp6relay")
+        return (
+            _matching("dhcprelayd") == ["RUNNING"]
+            and _matching("dhcp6relay") == expected_dhcp6relay
+            and _matching("dhcp4relay") == expected_dhcp4relay
+            and actual_isc == expected_isc
+            and actual_monitors == expected_monitors
+        )
 
-    if backend == "sonic":
-        _assert_running_once("dhcp4relay")
-    else:
-        pytest_assert(not _matching("dhcp4relay"),
-                      "dhcp4relay unexpectedly present for ISC backend: {}".format(entries))
-
-    isc_program = "isc-dhcpv4-relay-{}".format(vlan_name)
-    isc_states = _matching(isc_program)
-    if backend == "isc" and has_v4:
-        pytest_assert(isc_states == ["RUNNING"],
-                      "Expected exactly one RUNNING {}, got {} from {}"
-                      .format(isc_program, isc_states, entries))
-    else:
-        pytest_assert(not isc_states,
-                      "{} unexpectedly present for selected VLAN: {}".format(isc_program, entries))
-
-    monitor_program = "dhcpmon-{}".format(vlan_name)
-    monitor_states = _matching(monitor_program)
-    if has_v4 or has_v6:
-        pytest_assert(monitor_states == ["RUNNING"],
-                      "Expected exactly one RUNNING {}, got {} from {}"
-                      .format(monitor_program, monitor_states, entries))
-    else:
-        pytest_assert(not monitor_states,
-                      "{} unexpectedly present for selected VLAN: {}".format(monitor_program, entries))
+    pytest_assert(
+        wait_until(120, 5, 0, _has_expected_layout),
+        "Unexpected dhcp_relay supervisor layout for backend={} v4={} v6={}: {}"
+        .format(backend, has_v4, has_v6, last_entries["value"]))
 
 
 @pytest.fixture(scope="function")
@@ -278,7 +292,7 @@ def enable_source_port_ip_in_relay(duthosts, rand_one_dut_hostname, tbinfo, requ
 @pytest.mark.skip_config_dhcpv4_relay_agent
 def test_dhcp_relay_process_layout(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
                                    tbinfo, relay_agent):
-    """Verify the DHCP relay process matrix as selected-VLAN server configuration changes."""
+    """Verify the DHCP relay process matrix as server configuration changes."""
     duthost = duthosts[rand_one_dut_hostname]
     backend = "sonic" if relay_agent == "sonic-relay-agent" else "isc"
     selected_relay = dut_dhcp_relay_data[0]
@@ -293,10 +307,27 @@ def test_dhcp_relay_process_layout(duthosts, rand_one_dut_hostname, dut_dhcp_rel
     pytest_assert(v6_servers, "No DHCPv6 server is available for {}".format(vlan_name))
 
     original_config = duthost.get_running_config_facts()
-    original_vlan = original_config.get("VLAN", {}).get(vlan_name, {})
-    original_isc_v4 = list(original_vlan.get("dhcp_servers", []))
-    original_native_v4 = dict(original_config.get("DHCPV4_RELAY", {}).get(vlan_name, {}))
-    original_v6 = dict(original_config.get("DHCP_RELAY", {}).get(vlan_name, {}))
+    vlan_names = {vlan_name}
+    for table, field in [
+            ("VLAN", "dhcp_servers"),
+            ("DHCPV4_RELAY", "dhcpv4_servers"),
+            ("DHCP_RELAY", "dhcpv6_servers")]:
+        vlan_names.update(
+            name for name, values in original_config.get(table, {}).items()
+            if values.get(field))
+    vlan_names = sorted(vlan_names)
+    original_isc_v4 = {
+        name: list(original_config.get("VLAN", {}).get(name, {}).get("dhcp_servers", []))
+        for name in vlan_names
+    }
+    original_native_v4 = {
+        name: dict(original_config.get("DHCPV4_RELAY", {}).get(name, {}))
+        for name in vlan_names
+    }
+    original_v6 = {
+        name: dict(original_config.get("DHCP_RELAY", {}).get(name, {}))
+        for name in vlan_names
+    }
     metadata = original_config.get("DEVICE_METADATA", {}).get("localhost", {})
     original_flag_present = "has_sonic_dhcpv4_relay" in metadata
     original_flag = metadata.get("has_sonic_dhcpv4_relay")
@@ -321,12 +352,17 @@ def test_dhcp_relay_process_layout(duthosts, rand_one_dut_hostname, dut_dhcp_rel
             expected_v4 = v4_servers if has_v4 else []
             expected_v6 = v6_servers if has_v6 else []
             _set_dhcp_relay_server_state(
-                duthost, vlan_name, backend, expected_v4, expected_v6,
+                duthost, vlan_name, vlan_names, backend, expected_v4, expected_v6,
                 original_native_v4, original_v6)
             _assert_dhcp_relay_server_state(
-                duthost, vlan_name, backend, expected_v4, expected_v6)
+                duthost, vlan_name, vlan_names, backend, expected_v4, expected_v6)
 
-            restart_dhcp_service(duthost, [backend, "v6"])
+            relay_types = []
+            if has_v4:
+                relay_types.append(backend)
+            if has_v6:
+                relay_types.append("v6")
+            _restart_dhcp_relay_for_process_layout(duthost, relay_types)
             _assert_dhcp_relay_process_layout(duthost, vlan_name, backend, has_v4, has_v6)
 
             current_feature_state = duthost.shell(
@@ -339,14 +375,26 @@ def test_dhcp_relay_process_layout(duthosts, rand_one_dut_hostname, dut_dhcp_rel
                           "dhcp_relay critical processes are unhealthy in state {}: {}"
                           .format(state_name, critical_status))
     finally:
-        _set_config_db_list_field(
-            duthost, "VLAN", vlan_name, "dhcp_servers", original_isc_v4)
-        _replace_config_db_hash(
-            duthost, "DHCPV4_RELAY", vlan_name, original_native_v4)
-        _replace_config_db_hash(duthost, "DHCP_RELAY", vlan_name, original_v6)
+        for current_vlan in vlan_names:
+            _set_config_db_list_field(
+                duthost, "VLAN", current_vlan, "dhcp_servers", original_isc_v4[current_vlan])
+            _replace_config_db_hash(
+                duthost, "DHCPV4_RELAY", current_vlan, original_native_v4[current_vlan])
+            _replace_config_db_hash(
+                duthost, "DHCP_RELAY", current_vlan, original_v6[current_vlan])
         _set_sonic_dhcpv4_relay_flag(
             duthost, original_flag if original_flag_present else None)
-        restart_dhcp_service(duthost, [original_backend, "v6"])
+        original_relay_types = []
+        if original_backend == "sonic":
+            original_has_v4 = any(
+                config.get("dhcpv4_servers") for config in original_native_v4.values())
+        else:
+            original_has_v4 = any(original_isc_v4.values())
+        if original_has_v4:
+            original_relay_types.append(original_backend)
+        if any(config.get("dhcpv6_servers") for config in original_v6.values()):
+            original_relay_types.append("v6")
+        _restart_dhcp_relay_for_process_layout(duthost, original_relay_types)
 
 
 def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data, relay_agent):

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -3,6 +3,8 @@ import random
 import time
 import logging
 import sys
+import re
+import shlex
 
 from _pytest.outcomes import OutcomeException
 
@@ -79,6 +81,141 @@ def check_interface_status(duthost, relay_agent="isc-relay-agent"):
     return False
 
 
+def _replace_config_db_hash(duthost, table, name, values):
+    """Replace one CONFIG_DB hash using sonic-db-cli."""
+    key = "{}|{}".format(table, name)
+    commands = ["sonic-db-cli CONFIG_DB del {}".format(shlex.quote(key))]
+    for field, value in sorted(values.items()):
+        if isinstance(value, list):
+            field = "{}@".format(field)
+            value = ",".join(value)
+        commands.append(
+            "sonic-db-cli CONFIG_DB hset {} {} {}".format(
+                shlex.quote(key), shlex.quote(field), shlex.quote(str(value))))
+    duthost.shell_cmds(cmds=commands)
+
+
+def _set_config_db_list_field(duthost, table, name, field, values):
+    """Set or remove one CONFIG_DB list field using sonic-db-cli."""
+    key = "{}|{}".format(table, name)
+    field = "{}@".format(field)
+    if values:
+        command = "sonic-db-cli CONFIG_DB hset {} {} {}".format(
+            shlex.quote(key), shlex.quote(field), shlex.quote(",".join(values)))
+    else:
+        command = "sonic-db-cli CONFIG_DB hdel {} {}".format(
+            shlex.quote(key), shlex.quote(field))
+    duthost.shell(command)
+
+
+def _set_sonic_dhcpv4_relay_flag(duthost, value):
+    """Set the native DHCPv4 relay flag, or remove it when value is None."""
+    key = "DEVICE_METADATA|localhost"
+    field = "has_sonic_dhcpv4_relay"
+    if value is None:
+        command = "sonic-db-cli CONFIG_DB hdel {} {}".format(
+            shlex.quote(key), shlex.quote(field))
+    else:
+        command = "sonic-db-cli CONFIG_DB hset {} {} {}".format(
+            shlex.quote(key), shlex.quote(field), shlex.quote(value))
+    duthost.shell(command)
+
+
+def _set_dhcp_relay_server_state(duthost, vlan_name, vlan_names, backend, v4_servers, v6_servers,
+                                 original_native_v4, original_v6):
+    """Configure only the selected VLAN without triggering an implicit service restart."""
+    for current_vlan in vlan_names:
+        isc_v4_servers = v4_servers if backend == "isc" and current_vlan == vlan_name else []
+        _set_config_db_list_field(
+            duthost, "VLAN", current_vlan, "dhcp_servers", isc_v4_servers)
+
+        native_v4 = dict(original_native_v4[current_vlan])
+        native_v4.pop("dhcpv4_servers", None)
+        if backend == "sonic" and current_vlan == vlan_name and v4_servers:
+            native_v4["dhcpv4_servers"] = v4_servers
+        _replace_config_db_hash(duthost, "DHCPV4_RELAY", current_vlan, native_v4)
+
+        v6_config = dict(original_v6[current_vlan])
+        v6_config.pop("dhcpv6_servers", None)
+        if current_vlan == vlan_name and v6_servers:
+            v6_config["dhcpv6_servers"] = v6_servers
+        _replace_config_db_hash(duthost, "DHCP_RELAY", current_vlan, v6_config)
+
+
+def _assert_dhcp_relay_server_state(duthost, vlan_name, vlan_names, backend, v4_servers, v6_servers):
+    """Verify that only the selected VLAN has the requested server configuration."""
+    config = duthost.get_running_config_facts()
+    for current_vlan in vlan_names:
+        expected_isc_v4 = v4_servers if backend == "isc" and current_vlan == vlan_name else []
+        expected_sonic_v4 = v4_servers if backend == "sonic" and current_vlan == vlan_name else []
+        expected_v6 = v6_servers if current_vlan == vlan_name else []
+        actual_isc_v4 = config.get("VLAN", {}).get(
+            current_vlan, {}).get("dhcp_servers", [])
+        actual_sonic_v4 = config.get("DHCPV4_RELAY", {}).get(
+            current_vlan, {}).get("dhcpv4_servers", [])
+        actual_v6 = config.get("DHCP_RELAY", {}).get(
+            current_vlan, {}).get("dhcpv6_servers", [])
+
+        pytest_assert(sorted(actual_isc_v4) == sorted(expected_isc_v4),
+                      "Unexpected ISC DHCPv4 servers for {}: expected {}, got {}"
+                      .format(current_vlan, expected_isc_v4, actual_isc_v4))
+        pytest_assert(sorted(actual_sonic_v4) == sorted(expected_sonic_v4),
+                      "Unexpected SONiC DHCPv4 servers for {}: expected {}, got {}"
+                      .format(current_vlan, expected_sonic_v4, actual_sonic_v4))
+        pytest_assert(sorted(actual_v6) == sorted(expected_v6),
+                      "Unexpected DHCPv6 servers for {}: expected {}, got {}"
+                      .format(current_vlan, expected_v6, actual_v6))
+
+
+def _restart_dhcp_relay_for_process_layout(duthost, relay_types):
+    """Restart the container and wait for the requested or empty ISC layout."""
+    restart_dhcp_service(duthost, relay_types or ["isc"])
+
+
+def _assert_dhcp_relay_process_layout(duthost, vlan_name, backend, has_v4, has_v6):
+    """Assert the global and selected-VLAN supervisor process layout."""
+    last_entries = {"value": []}
+
+    def _has_expected_layout():
+        output = duthost.shell(
+            "docker exec dhcp_relay supervisorctl status", module_ignore_errors=True)
+        entries = []
+        for line in output["stdout_lines"]:
+            parts = line.split()
+            if len(parts) >= 2:
+                entries.append((parts[0].split(":")[-1], parts[1]))
+        last_entries["value"] = entries
+
+        def _matching(program):
+            return [state for name, state in entries if name == program]
+
+        expected_dhcp6relay = ["RUNNING"] if has_v6 else []
+        expected_dhcp4relay = ["RUNNING"] if backend == "sonic" else []
+        expected_isc = [
+            ("isc-dhcpv4-relay-{}".format(vlan_name), "RUNNING")
+        ] if backend == "isc" and has_v4 else []
+        expected_monitors = [
+            ("dhcpmon-{}".format(vlan_name), "RUNNING")
+        ] if has_v4 or has_v6 else []
+        actual_isc = sorted(
+            (name, state) for name, state in entries if name.startswith("isc-dhcpv4-relay-"))
+        actual_monitors = sorted(
+            (name, state) for name, state in entries if name.startswith("dhcpmon-"))
+
+        return (
+            _matching("dhcprelayd") == ["RUNNING"]
+            and _matching("dhcp6relay") == expected_dhcp6relay
+            and _matching("dhcp4relay") == expected_dhcp4relay
+            and actual_isc == expected_isc
+            and actual_monitors == expected_monitors
+        )
+
+    pytest_assert(
+        wait_until(120, 5, 0, _has_expected_layout),
+        "Unexpected dhcp_relay supervisor layout for backend={} v4={} v6={}: {}"
+        .format(backend, has_v4, has_v6, last_entries["value"]))
+
+
 @pytest.fixture(scope="function")
 def enable_source_port_ip_in_relay(duthosts, rand_one_dut_hostname, tbinfo, request):
     duthost = duthosts[rand_one_dut_hostname]
@@ -147,6 +284,114 @@ def enable_source_port_ip_in_relay(duthosts, rand_one_dut_hostname, tbinfo, requ
             delete_checkpoint(duthost, check_point)
             restart_dhcp_service(duthost, ['isc'])
             pytest_assert(wait_until(60, 2, 0, dhcp_ready, False), "Source port ip in relay is not disabled!")
+
+
+@pytest.mark.skip_config_dhcpv4_relay_agent
+def test_dhcp_relay_process_layout(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
+                                   tbinfo, relay_agent):
+    """Verify the DHCP relay process matrix as server configuration changes."""
+    duthost = duthosts[rand_one_dut_hostname]
+    backend = "sonic" if relay_agent == "sonic-relay-agent" else "isc"
+    pytest_assert(dut_dhcp_relay_data, "No DHCP relay data is available for the process matrix")
+    selected_relay = dut_dhcp_relay_data[0]
+    vlan_name = selected_relay["downlink_vlan_iface"]["name"]
+    match = re.fullmatch(r"Vlan(\d+)", vlan_name)
+    pytest_assert(match, "Unexpected VLAN interface name {}".format(vlan_name))
+
+    v4_servers = [
+        server for server in selected_relay["downlink_vlan_iface"]["dhcp_server_addrs"] if server
+    ]
+    minigraph_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    v6_servers = [server for server in minigraph_facts.get("dhcpv6_servers", []) if server]
+    pytest_assert(v4_servers, "No DHCPv4 server is available for {}".format(vlan_name))
+    pytest_assert(v6_servers, "No DHCPv6 server is available for {}".format(vlan_name))
+
+    original_config = duthost.get_running_config_facts()
+    vlan_names = {vlan_name}
+    for table, field in [
+            ("VLAN", "dhcp_servers"),
+            ("DHCPV4_RELAY", "dhcpv4_servers"),
+            ("DHCP_RELAY", "dhcpv6_servers")]:
+        vlan_names.update(
+            name for name, values in original_config.get(table, {}).items()
+            if values.get(field))
+    vlan_names = sorted(vlan_names)
+    original_isc_v4 = {
+        name: list(original_config.get("VLAN", {}).get(name, {}).get("dhcp_servers", []))
+        for name in vlan_names
+    }
+    original_native_v4 = {
+        name: dict(original_config.get("DHCPV4_RELAY", {}).get(name, {}))
+        for name in vlan_names
+    }
+    original_v6 = {
+        name: dict(original_config.get("DHCP_RELAY", {}).get(name, {}))
+        for name in vlan_names
+    }
+    metadata = original_config.get("DEVICE_METADATA", {}).get("localhost", {})
+    original_flag_present = "has_sonic_dhcpv4_relay" in metadata
+    original_flag = metadata.get("has_sonic_dhcpv4_relay")
+    original_backend = "sonic" if str(original_flag).lower() == "true" else "isc"
+
+    feature_state = original_config.get("FEATURE", {}).get("dhcp_relay", {}).get("state")
+    pytest_assert(feature_state in ["enabled", "always_enabled"],
+                  "dhcp_relay feature must remain enabled, got {}".format(feature_state))
+
+    states = [
+        ("no-v4-no-v6", False, False),
+        ("v4-only", True, False),
+        ("v6-only", False, True),
+        ("v4-and-v6", True, True),
+    ]
+
+    try:
+        _set_sonic_dhcpv4_relay_flag(duthost, "True" if backend == "sonic" else None)
+        for state_name, has_v4, has_v6 in states:
+            logger.info("Checking DHCP relay process state %s for %s on %s",
+                        state_name, vlan_name, backend)
+            expected_v4 = v4_servers if has_v4 else []
+            expected_v6 = v6_servers if has_v6 else []
+            _set_dhcp_relay_server_state(
+                duthost, vlan_name, vlan_names, backend, expected_v4, expected_v6,
+                original_native_v4, original_v6)
+            _assert_dhcp_relay_server_state(
+                duthost, vlan_name, vlan_names, backend, expected_v4, expected_v6)
+
+            relay_types = []
+            if backend == "sonic" or has_v4:
+                relay_types.append(backend)
+            if has_v6:
+                relay_types.append("v6")
+            _restart_dhcp_relay_for_process_layout(duthost, relay_types)
+            _assert_dhcp_relay_process_layout(duthost, vlan_name, backend, has_v4, has_v6)
+
+            current_feature_state = duthost.shell(
+                'sonic-db-cli CONFIG_DB hget "FEATURE|dhcp_relay" "state"')["stdout"].strip()
+            pytest_assert(current_feature_state in ["enabled", "always_enabled"],
+                          "dhcp_relay feature changed in state {}: {}"
+                          .format(state_name, current_feature_state))
+            critical_status = duthost.critical_process_status("dhcp_relay")
+            pytest_assert(critical_status["status"] and not critical_status["exited_critical_process"],
+                          "dhcp_relay critical processes are unhealthy in state {}: {}"
+                          .format(state_name, critical_status))
+    finally:
+        for current_vlan in vlan_names:
+            _set_config_db_list_field(
+                duthost, "VLAN", current_vlan, "dhcp_servers", original_isc_v4[current_vlan])
+            _replace_config_db_hash(
+                duthost, "DHCPV4_RELAY", current_vlan, original_native_v4[current_vlan])
+            _replace_config_db_hash(
+                duthost, "DHCP_RELAY", current_vlan, original_v6[current_vlan])
+        _set_sonic_dhcpv4_relay_flag(
+            duthost, original_flag if original_flag_present else None)
+        original_relay_types = []
+        if original_backend == "sonic":
+            original_relay_types.append("sonic")
+        elif any(original_isc_v4.values()):
+            original_relay_types.append("isc")
+        if any(config.get("dhcpv6_servers") for config in original_v6.values()):
+            original_relay_types.append("v6")
+        _restart_dhcp_relay_for_process_layout(duthost, original_relay_types)
 
 
 def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data, relay_agent):


### PR DESCRIPTION
### Description of PR

Summary:

Add sequential process-layout coverage for ISC and SONiC DHCPv4 backends across no-server, IPv4-only, IPv6-only, and dual-stack configuration.

The test isolates the selected VLAN, verifies the complete supervisor layout, and restores all original relay configuration afterward. It preserves the current SONiC behavior where `dhcp4relay` remains present when the backend is enabled without external servers; changing that default is covered by a separate image PR.

Dependency: https://github.com/sonic-net/sonic-buildimage/pull/27277

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: head `4c38b26a6`; the t0 run used `SONiC.master.1178622-6453caefd`, which predates dependency #27277, so the v6-only state correctly exposed the missing `dhcpmon`. Refresh after an image containing final #27277 exists.

### Approach
#### What is the motivation for this PR?

The relay container combines global daemons with per-VLAN ISC and monitor processes. Existing coverage did not verify the full process matrix or prevent configuration on unrelated VLANs from masking duplicate or stale processes.

#### How did you do it?

- Clear relay server configuration from every originally configured VLAN except the selected test VLAN.
- Exercise all four IPv4/IPv6 configuration combinations for both backends.
- Poll until the exact expected process set is present.
- Verify the `dhcp_relay` feature remains enabled and critical processes remain healthy.
- Restore every modified table and the original backend flag in cleanup.

#### How did you verify/test it?

Commit hooks passed. Public PR checks provide functional validation against the image dependency.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

Existing DHCP relay topologies selected by the module's current markers and fixtures.

### Documentation

N/A
