### PR TITLE
[tests/vxlan]: Set VXLAN tunnel ttl_mode=pipe for cisco-8000 platforms

### DIFF
--- a/tests/common/vxlan_ecmp_utils.py
+++ b/tests/common/vxlan_ecmp_utils.py
@@ -74,6 +74,11 @@ class Ecmp_Utils(object):
         if src_ip is None:
             src_ip = self.get_dut_loopback_address(duthost, minigraph_data, af)
 
+        # On cisco-8000, base topology IP-in-IP decap tunnels use pipe TTL mode.
+        # Auto-default to "pipe" so orchagent passes DECAP_TTL_MODE consistently.
+        if ttl_mode is None and duthost.facts.get("asic_type") == "cisco-8000":
+            ttl_mode = "pipe"
+
         ttl_entry = ""
         if ttl_mode:
             ttl_entry = f',\n"ttl_mode": "{ttl_mode}"\n'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #26669
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
On cisco-8000, the base topology IP-in-IP decap tunnels already use pipe TTL mode. When VxLAN DECAP_TTL_MODE is not set consistently, orchagent fails to program the tunnel correctly. Set the ttl mode during vxlan tunnel creation if platform is cisco-8000.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/sonic-net/sonic-mgmt/issues/26669
Failure type: day-one issue

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Tested on Cisco 8101 platform.
[test_vxlan_multi_tunnel_2026-07-29-18-27-25.log](https://github.com/user-attachments/files/30519990/test_vxlan_multi_tunnel_2026-07-29-18-27-25.log)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
