### PR TITLE
PFC-WD mmu-change auto-detect static vs dynamic profile

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -4,7 +4,6 @@ import os
 import pytest
 import time
 import six
-import re
 
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      # noqa: F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
@@ -64,13 +63,29 @@ def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost.command("pfcwd stop")
 
 
-def is_longlink(dut, profile):
-    if dut.sonichost._facts['platform'] in \
-            ["x86_64-88_lc0_36fh_mo-r0", "x86_64-88_lc0_36fh_m-r0"]:
-        match = re.search("_([0-9]*)m_", profile)
-        if match:
-            return int(match.group(1)) > 2000
-    return False
+def is_static_profile(asic, profile):
+    """
+    Determine whether a buffer profile uses a static threshold.
+
+    Args:
+        asic : asic instance used to run redis commands
+        profile(string) : buffer profile name
+
+    Returns:
+        bool : True if the profile uses a static threshold, False otherwise
+    """
+    if PfcCmd.isBufferInApplDb(asic):
+        db = "0"
+        table_template = BF_PROFILE_TABLE
+    else:
+        db = "4"
+        table_template = BF_PROFILE
+    result = asic.run_redis_cmd(
+        argv=[
+            "redis-cli", "-n", db, "HGET", table_template.format(profile), "static_th"
+        ]
+    )
+    return bool(result) and result[0] not in (None, "")
 
 
 class PfcCmd(object):
@@ -158,7 +173,7 @@ class PfcCmd(object):
             db = "4"
         table_template = BF_PROFILE if db == "4" else BF_PROFILE_TABLE
 
-        if is_longlink(dut, profile):
+        if is_static_profile(asic, profile):
             asic.run_redis_cmd(
                 argv=[
                     "redis-cli", "-n", db, "HSET", table_template.format(profile), "static_th", static_th
@@ -212,7 +227,7 @@ class PfcCmd(object):
 
         alpha = 0
         static_th = 0
-        if is_longlink(dut, pg_profile):
+        if is_static_profile(asic, pg_profile):
             static_th = six.text_type(asic.run_redis_cmd(
                 argv=[
                     "redis-cli", "-n", db, "HGET", table_template.format(pg_profile), "static_th"
@@ -420,7 +435,8 @@ class SetupPfcwdFunc(object):
         """
         new_alpha = self.alpha
         new_static_th = self.static_th
-        if is_longlink(dut, self.pg_profile):
+        asic = dut.get_port_asic_instance(port)
+        if is_static_profile(asic, self.pg_profile):
             if int(self.static_th) > 0:
                 new_static_th = int(int(self.static_th) / 2)
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes Cisco-8223 T2 issue with missing static profile detection due to a hardcoded list of platforms. 
Removes the harcoded list in favor of proper dynamic detection of the profile type. 

Fixes test:
- pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change

Sample error:
```
>           alpha = six.text_type(asic.run_redis_cmd(
                argv=[
                    "redis-cli", "-n", db, "HGET", table_template.format(pg_profile), "dynamic_th"
                ]
            )[0])
E           IndexError: list index out of range
```
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

- master: 3fc093f5c62b00cba0dfda673378375c89bfde7d - Cisco-8223 T2 - pass
```
================================================================================ short test summary info =========================================================
XPASS pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[IPv6-titan-t2-dut] - Xfail due to https://github.com/sonic-net/sonic-mgmt/issues/21082   
                                                                                                                                                                  
Results (1037.20s (0:17:17)):                                                                                                                                     
       1 passed                                                                                                                                                   
       1 xpassed                                                                                                                                                  
```
Confirms the new static profile detection works. 

- master: 3fc093f5c62b00cba0dfda673378375c89bfde7d - Cisco-8223 T0 - pass
Confirms dynamic profiles are still detected correctly. 

- 202605: 114762feb plus cherry-pick of final merge-commit in this PR (no conflicts), on Cisco-8223 T2, pass:
```
____________ TestPfcwdFunc.test_pfcwd_mmu_change[IPv6-titan-t2-dut] ____________                                                                                        
- generated xml file: /run_logs/test_logs_ttn-t2/pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change.xml -                                               
INFO:root:Can not get Allure report URL. Please check logs                                                                                                              
=========================== short test summary info ============================                                                                                        
XPASS pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[IPv6-titan-t2-dut] - Xfail due to https://github.com/sonic-net/sonic-mgmt/issues/21082         
                                                                                                                                                                        
Results (1089.83s (0:18:09)):                                                                                                                                           
       1 passed                                                                                                                                                         
       1 xpassed                                                                                                                                                        
```

git log for reference:
```
sonic-net/sonic-mgmt/tests/pfcwd$ git log --oneline -n 2                         
e47754285 (HEAD -> 202605_plus_54bdb28) PFC-WD mmu-change auto-detect static vs dynamic profile (#26660)        
114762feb (origin/202605, 202605) [action] [PR:26821] Skip test_vxlan_decap.py for TH4/5 on 202605 (#27031)     
```

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

Cisco-8223 T2 and T0 master branch on sha 3fc093f5c62b00cba0dfda673378375c89bfde7d, ran the test:
- pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change

#### Any platform specific information?

Somewhat Cisco-specific, though not explicitly. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
