### PR TITLE
Add cdb_supported to expected keys in test_sfp.py

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -121,7 +121,8 @@ class TestSfpApi(PlatformApiTestBase):
                                         'media_lane_count',
                                         'cmis_rev',
                                         'media_interface_technology',
-                                        'vdm_supported']
+                                        'vdm_supported',
+                                        'cdb_supported']
 
     EXPECTED_XCVR_NEW_CMIS_FIRMWARE_INFO_KEYS = ['active_firmware',
                                                  'inactive_firmware']


### PR DESCRIPTION
### Description of PR
https://github.com/sonic-net/sonic-platform-common/pull/721 adds a new key to `get_transceiver_info` called `cdb_supported` that indicates whether a transceiver advertises CDB support.

Summary:
Once https://github.com/sonic-net/sonic-platform-common/pull/721 merges, `cdb_supported` will always be returned by `CmisApi.get_transceiver_info`. This test needs to be updated to reflect that or else it will fail.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
The test passes.

### Approach
#### What is the motivation for this PR?
Making this change to ensure the tests within `test_sfp.py` continue to pass.

#### How did you do it?
Added `cdb_supported` as a key that the test expects to see.

#### How did you verify/test it?
Ran the test.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
