### PR TITLE
[snappi] Fix get_queue_scheduler_weight_dict for VOQ chassis QUEUE keys

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1487,6 +1487,27 @@ def get_pfcQueueGroupSize(default=8):
     return default
 
 
+def _parse_queue_table_key(queue_key):
+    """
+    Parse a QUEUE table entry key into (asic_namespace, interface, queue_index).
+
+    Pizza-box DUTs use numeric queue keys (e.g. ``"3"``). VOQ multi-asic linecards
+    use ``<asic_ns>|<interface>|<queue>`` (e.g. ``asic1|Ethernet144|0``).
+    """
+    parts = str(queue_key).split('|')
+    if len(parts) == 1:
+        try:
+            return None, None, int(parts[0])
+        except ValueError:
+            return None, None, None
+    if len(parts) == 3 and parts[0].startswith('asic') and parts[1].startswith('Ethernet'):
+        try:
+            return parts[0], parts[1], int(parts[2])
+        except ValueError:
+            return None, None, None
+    return None, None, None
+
+
 def get_queue_scheduler_weight_dict(host_ans, asic_value=None, port=None,
                                     qos_map_profile=None):
     """
@@ -1547,21 +1568,39 @@ def get_queue_scheduler_weight_dict(host_ans, asic_value=None, port=None,
     if not queue_cfg_all:
         return result
 
+    requested_port = port
+    interface_filter = None
     if port is None:
         port = next(iter(queue_cfg_all))
     if port not in queue_cfg_all:
-        raise KeyError("Port {} not found in QUEUE config (available: {})".format(port, sorted(queue_cfg_all)))
+        # On VOQ chassis platforms the QUEUE table is keyed by linecard
+        # hostname (e.g. ixre-egl-board74) rather than front-panel interface
+        # name (e.g. Ethernet40).
+        if host_ans.hostname in queue_cfg_all:
+            if requested_port and str(requested_port).startswith('Ethernet'):
+                interface_filter = requested_port
+            port = host_ans.hostname
+        else:
+            raise KeyError("Port {} not found in QUEUE config (available: {})".format(
+                requested_port, sorted(queue_cfg_all)))
 
-    for q, value in queue_cfg_all[port].items():
+    for queue_key, value in queue_cfg_all[port].items():
+        asic_ns, interface_name, queue_idx = _parse_queue_table_key(queue_key)
+        if queue_idx is None:
+            continue
+        if asic_value not in (None, "None") and asic_ns and asic_ns != asic_value:
+            continue
+        if interface_filter and interface_name and interface_name != interface_filter:
+            continue
         scheduler = value.get("scheduler")
         if scheduler is None or scheduler not in scheduler_cfg:
             continue
         sched = scheduler_cfg[scheduler]
-        result[int(q)] = {
+        result[queue_idx] = {
             "scheduler": scheduler,
             "type": sched.get("type"),
             "weight": int(sched["weight"]),
-            "dscp": queue_to_dscp.get(int(q)),
+            "dscp": queue_to_dscp.get(queue_idx),
         }
     return result
 


### PR DESCRIPTION
Fix get_queue_scheduler_weight_dict for VOQ chassis QUEUE keys

On VOQ chassis platforms, CONFIG_DB QUEUE is keyed by linecard hostname and queue entries use asic|interface|queue format. Parse both layouts so m2o_fluctuating_lossless can read DWRR scheduler weights.

Tested on VOQ chassis testbed.

Signed-off-by: Varun Aiyaswamy Kannan <varun.aiyaswamy_kannan@nokia.com>

### Description of PR

`test_m2o_fluctuating_lossless` calls `get_queue_scheduler_weight_dict()` during
post-traffic verification to read DWRR queue scheduler weights from CONFIG_DB
(`QUEUE` + `SCHEDULER`). On pizza-box DUTs, `QUEUE` is keyed by interface name
and queue entries use numeric keys (e.g. `Ethernet40` / `"3"`). On VOQ chassis
platforms, `QUEUE` is keyed by linecard hostname and queue entries use
`asic|interface|queue` format (e.g. `<linecard4>` / `asic1|Ethernet144|0`).
Traffic generation completed successfully; verification failed with:

```
KeyError: Port Ethernet40 not found in QUEUE config
(available: ['<linecard1>', '<linecard2>', '<linecard3>', '<linecard4>']
```

This PR adds `_parse_queue_table_key()` and updates
`get_queue_scheduler_weight_dict()` to handle both layouts. Pizza-box behaviour
is unchanged. Validated on a VOQ chassis testbed.

**Reviewer starting point:** `get_queue_scheduler_weight_dict()` and
`_parse_queue_table_key()` in `tests/common/snappi_tests/common_helpers.py`.

**Dependencies:** None.

Summary:
Fix `get_queue_scheduler_weight_dict()` to parse VOQ chassis CONFIG_DB `QUEUE`
table layout (linecard hostname key, `asic|interface|queue` entries).


### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement



### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A

Failure type: N/A


### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `<internal-image-build>` on `<voq-chassis-testbed>` (`multidut-tgen`,
  DUTs `<linecard1>`, `<linecard3>`, `<linecard4>`) —
  `test_m2o_fluctuating_lossless.py` — 6 passed, 0 failed

### Approach
#### What is the motivation for this PR?
`m2o_fluctuating_lossless` computes expected background loss from runtime DWRR
weights. On VOQ chassis, `get_queue_scheduler_weight_dict()` could not read
`QUEUE` because it assumed a pizza-box key layout.

#### How did you do it?
- Added `_parse_queue_table_key()` for numeric keys (`"3"`) and VOQ keys
  (`asic1|Ethernet144|0`).
- When the requested port is not a top-level `QUEUE` key, fall back to
  `host_ans.hostname` and filter by Ethernet interface and `asic_value`.

#### How did you verify/test it?
Ran `test_m2o_fluctuating_lossless` on a VOQ chassis testbed — 6/6 pass. Before
the fix, verification failed with `KeyError: Port Ethernet40 not found in QUEUE
config`.


#### Any platform specific information?

Validated on a VOQ chassis platform (`switch_type: voq`). 3-part queue keys
(`asic<N>|Ethernet<M>|<queue>`) are supported; other formats are skipped.


#### Supported testbed topology if it's a new test case?
N/A — existing test, topology `multidut-tgen`.

### Documentation
N/A
