### PR TITLE
Skip test_qos_dscp_mapping.py if ip_decap is disabled in SYSTEM_DEFAULTS

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -91,6 +91,10 @@ def dscp_config(dscp_mode, rand_selected_dut, loganalyzer):
     """
     duthost = rand_selected_dut
     asic_type = duthost.facts['asic_type']
+    ip_decap_status = duthost.shell("sonic-cfggen -d -v 'SYSTEM_DEFAULTS.ip_decap.status'",
+                                    module_ignore_errors=True)["stdout"].strip()
+    if ip_decap_status == 'disabled':
+        pytest.skip("ip_decap is not enabled in SYSTEM_DEFAULTS")
 
     # global DSCP_TO_TC_MAP update is not supported on Broadcom platforms
     # Broadcom ASICs do not support inner DSCP-based queue remapping for IPIP pipe mode.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
SYSTEM_DEFAULTS['ip_decap']['status'] is added in https://github.com/sonic-net/sonic-buildimage/pull/28693 to control enabling/disabling IPINIP decap.
Skip test_qos_dscp_mapping.py if ip_decap is disabled in SYSTEM_DEFAULTS
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
test_qos_dscp_mapping.py is skipped for SYSTEM_DEFAULTS['ip_decap']['status'] == 'disabled'

### Approach
#### What is the motivation for this PR?
Follow the proposal in https://github.com/sonic-net/sonic-buildimage/issues/28305 to skip the test for unsupported platforms

#### How did you do it?
Skip test_qos_dscp_mapping.py if ip_decap is disabled in SYSTEM_DEFAULTS

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
test_qos_dscp_mapping.py is skipped for SYSTEM_DEFAULTS['ip_decap']['status'] == 'disabled', and is passed on enabled platforms

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
