### PR TITLE
[Test Framework] Add hardware-aware pytest deselection framework

### DIFF
--- a/tests/common/plugins/hardware_aware/README.md
+++ b/tests/common/plugins/hardware_aware/README.md
@@ -1,0 +1,61 @@
+# Hardware-Aware Collection Plugin
+
+This pytest plugin evaluates collected tests against hardware-aware test
+capabilities. It can either write a report or deselect tests during collection.
+
+The plugin is disabled by default.
+
+Report only:
+
+```bash
+--hardware-aware-report-only
+```
+
+Deselect during collection:
+
+```bash
+--hardware-aware-deselect
+```
+
+Normal catalog setup mode:
+
+```bash
+--hardware-aware-setup x86_64-8122_64ehf_o-r0:t0
+```
+
+Or provide a complete/override setup YAML:
+
+```bash
+--hardware-aware-setup-input my_setup.yaml
+```
+
+The plugin reads `hardware_aware/setup_profiles.yaml` and
+`hardware_aware/skip_rules.yaml` by default, then generates runtime
+`run_context` and `test_capabilities` rules internally.
+
+Explicit runtime files are still supported for debugging or backward
+compatibility:
+
+```bash
+--hardware-aware-run-context-file out/run_context.json
+--hardware-aware-test-capabilities-file out/test_capabilities.json
+```
+
+See `hardware_aware/README.md` for setup keys, override files, and catalog
+maintenance details.
+
+Optional report path:
+
+```bash
+--hardware-aware-report-path logs_hwaware/hardware_aware_report.json
+```
+
+Optional generated-rule filters:
+
+```bash
+--hardware-aware-min-confidence high
+--hardware-aware-candidate-status ready_for_report_only
+```
+
+The report includes `summary`, `collected_nodeids`, `filtered_test_capabilities`,
+and one decision entry for each matched test capability.

--- a/tests/common/plugins/hardware_aware/__init__.py
+++ b/tests/common/plugins/hardware_aware/__init__.py
@@ -1,0 +1,930 @@
+"""Hardware-aware collection recommendations and deselection.
+
+This plugin is intentionally disabled by default. When enabled, it evaluates
+collected pytest items against normalized test capabilities. It can either
+write a JSON report or deselect unsupported tests during collection.
+"""
+
+import importlib.util
+import json
+import logging
+import os
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RUN_CONTEXT_FILE = "hardware_aware/run_context.yaml"
+DEFAULT_TEST_CAPABILITIES_FILE = "hardware_aware/test_capabilities.yaml"
+DEFAULT_CATALOG_FILE = "hardware_aware/skip_rules.yaml"
+DEFAULT_SETUP_PROFILES_FILE = "hardware_aware/setup_profiles.yaml"
+DEFAULT_RUNTIME_INPUTS_GENERATOR = "hardware_aware/generate_runtime_inputs.py"
+DEFAULT_REPORT_PATH = "hardware_aware/pytest_collection_hardware_aware_report.json"
+CONFIDENCE_ORDER = {
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
+TOPOLOGY_MARKER_EVALUATION_MODES = (
+    "topology_marker",
+    "topology_marker_intersects_available_tags",
+)
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("hardware-aware")
+    group.addoption(
+        "--hardware-aware-report-only",
+        action="store_true",
+        default=False,
+        help="Evaluate hardware-aware test capabilities during collection and write a report without deselecting tests.",
+    )
+    group.addoption(
+        "--hardware-aware-deselect",
+        action="store_true",
+        default=False,
+        help="Deselect tests that do not satisfy hardware-aware test capabilities during collection and write a report.",
+    )
+    group.addoption(
+        "--hardware-aware-run-context-file",
+        "--hardware-aware-capabilities-file",
+        action="store",
+        dest="hardware_aware_run_context_file",
+        default=DEFAULT_RUN_CONTEXT_FILE,
+        help=(
+            "YAML or JSON file containing the current run context. "
+            "--hardware-aware-capabilities-file is accepted as a backward-compatible alias."
+        ),
+    )
+    group.addoption(
+        "--hardware-aware-test-capabilities-file",
+        "--hardware-aware-requirements-file",
+        action="store",
+        dest="hardware_aware_test_capabilities_file",
+        default=DEFAULT_TEST_CAPABILITIES_FILE,
+        help=(
+            "YAML or JSON file containing hardware-aware test capability rules. "
+            "--hardware-aware-requirements-file is accepted as a backward-compatible alias."
+        ),
+    )
+    group.addoption(
+        "--hardware-aware-catalog-file",
+        "--hardware-aware-catalog",
+        action="store",
+        dest="hardware_aware_catalog_file",
+        default=DEFAULT_CATALOG_FILE,
+        help=(
+            "YAML skip-rule catalog used with --hardware-aware-setup or "
+            "--hardware-aware-setup-input."
+        ),
+    )
+    group.addoption(
+        "--hardware-aware-setup-profiles-file",
+        "--hardware-aware-setup-profiles",
+        action="store",
+        dest="hardware_aware_setup_profiles_file",
+        default=DEFAULT_SETUP_PROFILES_FILE,
+        help=(
+            "YAML setup profiles used with --hardware-aware-setup or "
+            "--hardware-aware-setup-input."
+        ),
+    )
+    group.addoption(
+        "--hardware-aware-setup",
+        action="store",
+        help=(
+            "Setup key or alias from setup profiles. When provided, the plugin "
+            "generates run context and test capabilities from the YAML catalog."
+        ),
+    )
+    group.addoption(
+        "--hardware-aware-setup-input",
+        action="store",
+        help=(
+            "Optional user setup YAML. If --hardware-aware-setup is also provided, "
+            "this file overrides the selected setup profile. If --hardware-aware-setup "
+            "is omitted, this file must provide a complete setup."
+        ),
+    )
+    group.addoption(
+        "--hardware-aware-include-topology-rules",
+        action="store_true",
+        default=False,
+        help=(
+            "In catalog setup mode, temporarily include topology marker rules even "
+            "when skip_rules.yaml marks enabled=false. By default the "
+            "YAML catalog controls whether topology rules are generated."
+        ),
+    )
+    group.addoption(
+        "--hardware-aware-report-path",
+        action="store",
+        default=DEFAULT_REPORT_PATH,
+        help="Path to write the hardware-aware collection report JSON.",
+    )
+    group.addoption(
+        "--hardware-aware-min-confidence",
+        action="store",
+        default="none",
+        choices=("none", "low", "medium", "high"),
+        help=(
+            "Only evaluate test capabilities at or above this confidence. "
+            "Use high to run only high-confidence generated rules."
+        ),
+    )
+    group.addoption(
+        "--hardware-aware-candidate-status",
+        action="store",
+        default="any",
+        help=(
+            "Only evaluate test capabilities with this candidate_status, for example "
+            "ready_for_report_only. Use any to disable this filter."
+        ),
+    )
+    group.addoption(
+        "--hardware-aware-missing-run-context-policy",
+        "--hardware-aware-missing-capability-policy",
+        action="store",
+        dest="hardware_aware_missing_run_context_policy",
+        default="deselect",
+        choices=("deselect", "run"),
+        help=(
+            "How to handle test capability conditions whose run context path is not present. "
+            "Use run with partial run context files to avoid deselecting on unknown facts. "
+            "--hardware-aware-missing-capability-policy is accepted as a backward-compatible alias."
+        ),
+    )
+
+
+def _candidate_paths(config, user_path):
+    path = Path(user_path)
+    if path.is_absolute():
+        return [path]
+
+    candidates = [Path.cwd() / path]
+    root = Path(str(config.rootpath)).resolve()
+    for parent in [root] + list(root.parents):
+        candidates.append(parent / path)
+    return candidates
+
+
+def _resolve_path(config, user_path):
+    for candidate in _candidate_paths(config, user_path):
+        if candidate.exists():
+            return candidate
+    return _candidate_paths(config, user_path)[0]
+
+
+def _resolve_output_path(config, user_path):
+    candidates = _candidate_paths(config, user_path)
+    for candidate in candidates:
+        if candidate.exists() or candidate.parent.exists():
+            return candidate
+    return candidates[0]
+
+
+def _load_yaml(config, option_name):
+    user_path = config.getoption(option_name)
+    return _load_yaml_path(config, user_path)
+
+
+def _load_yaml_path(config, user_path):
+    path = _resolve_path(config, user_path)
+    if not path.exists():
+        raise pytest.UsageError("Hardware-aware file not found: {}".format(user_path))
+    with path.open() as f:
+        return yaml.safe_load(f), path
+
+
+def _catalog_setup_enabled(config):
+    return bool(
+        config.getoption("hardware_aware_setup")
+        or config.getoption("hardware_aware_setup_input")
+    )
+
+
+def _explicit_runtime_files_provided(config):
+    return (
+        config.getoption("hardware_aware_run_context_file") != DEFAULT_RUN_CONTEXT_FILE
+        or config.getoption("hardware_aware_test_capabilities_file") != DEFAULT_TEST_CAPABILITIES_FILE
+    )
+
+
+def _load_runtime_inputs_generator(config):
+    path = _resolve_path(config, DEFAULT_RUNTIME_INPUTS_GENERATOR)
+    if not path.exists():
+        raise pytest.UsageError(
+            "Hardware-aware runtime input generator not found: {}".format(
+                DEFAULT_RUNTIME_INPUTS_GENERATOR
+            )
+        )
+
+    spec = importlib.util.spec_from_file_location("hardware_aware_runtime_inputs", str(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module, path
+
+
+def _safe_getoption(config, name, default=None):
+    try:
+        return config.getoption(name)
+    except (AttributeError, ValueError):
+        return default
+
+
+def _runtime_parameter_overrides(config):
+    overrides = {}
+
+    py_saithrift_url = _safe_getoption(config, "py_saithrift_url")
+    if py_saithrift_url is not None:
+        overrides["resources.python_saithrift_package_url.available"] = bool(py_saithrift_url)
+
+    topology = _safe_getoption(config, "topology")
+    if topology:
+        topology = str(topology).lower()
+        overrides["topology.is_tgen"] = any(
+            token in topology
+            for token in ("tgen", "ixia", "nut")
+        )
+        overrides["topology.is_t0_backend"] = "t0-backend" in topology
+
+    mark_condition_files = _safe_getoption(config, "mark_conditions_files", []) or []
+    mark_condition_files = [str(path).lower() for path in mark_condition_files]
+    if any("cisco_sim" in path for path in mark_condition_files):
+        overrides["environment.is_sim"] = True
+        overrides["environment.is_vxr"] = True
+
+    return overrides
+
+
+def _load_catalog_runtime_inputs(config):
+    if _explicit_runtime_files_provided(config):
+        raise pytest.UsageError(
+            "Do not combine --hardware-aware-setup/--hardware-aware-setup-input with "
+            "--hardware-aware-run-context-file or --hardware-aware-test-capabilities-file. "
+            "Catalog setup mode generates those runtime inputs internally."
+        )
+
+    catalog_doc, catalog_path = _load_yaml(config, "hardware_aware_catalog_file")
+    setup_profiles_doc, setup_profiles_path = _load_yaml(config, "hardware_aware_setup_profiles_file")
+    setup_input_path = None
+    setup_input_doc = None
+    setup_input = config.getoption("hardware_aware_setup_input")
+    if setup_input:
+        setup_input_doc, setup_input_path = _load_yaml_path(config, setup_input)
+
+    generator, generator_path = _load_runtime_inputs_generator(config)
+    try:
+        test_capabilities_doc, run_context_doc, audit_doc, _ = generator.build_outputs(
+            catalog_doc,
+            setup_profiles_doc,
+            config.getoption("hardware_aware_setup"),
+            raw_skips=None,
+            setup_input_doc=setup_input_doc,
+            parameter_overrides=_runtime_parameter_overrides(config),
+            include_topology_rules=config.getoption("hardware_aware_include_topology_rules"),
+        )
+    except SystemExit as exc:
+        raise pytest.UsageError("Hardware-aware catalog setup failed: {}".format(exc))
+
+    audit_summary = audit_doc.get("summary", {}) if isinstance(audit_doc, dict) else {}
+    setup_key = audit_doc.get("setup") if isinstance(audit_doc, dict) else config.getoption("hardware_aware_setup")
+    source = {
+        "mode": "catalog_setup",
+        "catalog": str(catalog_path),
+        "setup_profiles": str(setup_profiles_path),
+        "setup": setup_key,
+        "setup_input": str(setup_input_path) if setup_input_path else None,
+        "runtime_inputs_generator": str(generator_path),
+        "include_topology_rules": config.getoption("hardware_aware_include_topology_rules"),
+        "audit_summary": audit_summary,
+    }
+
+    return (
+        run_context_doc,
+        "catalog:run_context:{}".format(setup_key or "setup_input"),
+        test_capabilities_doc,
+        "catalog:test_capabilities:{}".format(setup_key or "setup_input"),
+        source,
+    )
+
+
+def _load_runtime_inputs(config):
+    if _catalog_setup_enabled(config):
+        return _load_catalog_runtime_inputs(config)
+
+    run_context_doc, run_context_path = _load_yaml(config, "hardware_aware_run_context_file")
+    test_capabilities_doc, test_capabilities_path = _load_yaml(
+        config,
+        "hardware_aware_test_capabilities_file",
+    )
+    return run_context_doc, run_context_path, test_capabilities_doc, test_capabilities_path, None
+
+
+def _get_path(data, dotted_path):
+    cur = data
+    for part in dotted_path.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
+def _normalize_identifier(value):
+    return str(value).strip().lower().replace("_", "-").replace(" ", "-")
+
+
+def _normalized_values(value):
+    return [_normalize_identifier(item) for item in _as_list(value)]
+
+
+def _condition_passed(operator, actual, expected, test_capability_id):
+    if operator == "equals":
+        return actual == expected
+    if operator == "not_equals":
+        return actual != expected
+
+    actual_values = set(_normalized_values(actual))
+    expected_values = set(_normalized_values(expected))
+
+    if operator == "contains":
+        return bool(expected_values) and expected_values.issubset(actual_values)
+    if operator == "not_contains":
+        return not expected_values.intersection(actual_values)
+    if operator == "intersects":
+        return bool(expected_values.intersection(actual_values))
+    if operator == "excludes_any":
+        return not expected_values.intersection(actual_values)
+
+    raise pytest.UsageError(
+        "Unsupported hardware-aware operator for {}: {}".format(test_capability_id, operator)
+    )
+
+
+def _format_reason(template, run_context):
+    def replace(match):
+        value = _get_path(run_context, match.group(1))
+        if value is None:
+            return "unknown"
+        return str(value)
+
+    return re.sub(r"\{([^{}]+)\}", replace, template)
+
+
+def _clean_skip_reason(reason):
+    if not reason:
+        return None
+
+    text = str(reason).strip()
+    if text.startswith("^"):
+        text = text[1:]
+    if text.endswith("$"):
+        text = text[:-1]
+
+    replacements = {
+        "[- ]": "-",
+        "\\.": ".",
+        "\\'": "'",
+        '\\"': '"',
+        "\\ ": " ",
+        "\\-": "-",
+        "\\[": "[",
+        "\\]": "]",
+        "\\(": "(",
+        "\\)": ")",
+    }
+    for old, new in replacements.items():
+        text = text.replace(old, new)
+    return text
+
+
+def _format_condition_value(value):
+    if isinstance(value, list):
+        return "[" + ", ".join(str(item) for item in value) + "]"
+    return str(value)
+
+
+def _format_trigger(evaluated_condition):
+    path = evaluated_condition["path"]
+    operator = evaluated_condition["operator"]
+    actual = _format_condition_value(evaluated_condition.get("actual"))
+    expected = _format_condition_value(evaluated_condition.get("expected"))
+
+    if operator == "not_equals":
+        return "{}={} matches blocked value {}".format(path, actual, expected)
+    if operator == "excludes_any":
+        return "{}={} intersects unsupported values {}".format(path, actual, expected)
+    if operator == "intersects":
+        return "{}={} has no intersection with required values {}".format(path, actual, expected)
+    if operator == "equals":
+        return "{}={} did not match required value {}".format(path, actual, expected)
+    if operator == "contains":
+        return "{}={} does not contain required values {}".format(path, actual, expected)
+    if operator == "not_contains":
+        return "{}={} contains unsupported values {}".format(path, actual, expected)
+    return "{}={} failed {}".format(path, actual, operator)
+
+
+def _decision_triggers(decision):
+    return [
+        _format_trigger(condition)
+        for condition in decision.get("evaluated_run_context", [])
+        if not condition.get("passed")
+    ]
+
+
+def _normalized_nodeids(item, config):
+    nodeid = item.nodeid
+    root_prefix = os.path.basename(str(config.rootpath)) + "/"
+    candidates = [nodeid]
+
+    if nodeid.startswith(root_prefix):
+        candidates.append(nodeid[len(root_prefix):])
+
+    for candidate in list(candidates):
+        if not candidate.startswith("tests/"):
+            candidates.append("tests/" + candidate)
+
+    return list(dict.fromkeys(candidates))
+
+
+def _canonical_report_nodeid(item, config):
+    for nodeid in _normalized_nodeids(item, config):
+        if nodeid.startswith("tests/"):
+            return nodeid
+    return item.nodeid
+
+
+def _selector_matches(test_capability, item, config):
+    selector = test_capability["applies_to"]
+    selector_type = selector["type"]
+
+    if selector_type == "pytest_marker":
+        return any(item.iter_markers(name=selector["marker"]))
+
+    nodeids = _normalized_nodeids(item, config)
+    if selector_type == "path_prefix":
+        return any(nodeid.startswith(selector["prefix"]) for nodeid in nodeids)
+    if selector_type == "regex":
+        pattern = re.compile(selector["pattern"])
+        return any(pattern.search(nodeid) for nodeid in nodeids)
+
+    raise pytest.UsageError("Unsupported hardware-aware selector type: {}".format(selector_type))
+
+
+def _topology_marker_name(test_capability):
+    evaluation = test_capability.get("evaluation", {})
+    selector = test_capability.get("applies_to", {})
+    return evaluation.get("marker") or selector.get("marker") or "topology"
+
+
+def _evaluate_topology_marker(test_capability, item, run_context):
+    marker_name = _topology_marker_name(test_capability)
+    marks = list(item.iter_markers(name=marker_name))
+    if not marks:
+        return None
+
+    marker_args = [str(arg) for arg in marks[0].args]
+    raw_available_tags = _get_path(run_context, "topology.available_tags")
+    available_tags = raw_available_tags or []
+    available_tags = [str(tag) for tag in available_tags]
+    marker_allows_any = "any" in marker_args
+    matched = marker_allows_any or bool(set(marker_args).intersection(available_tags))
+
+    evaluated = [
+        {
+            "path": "marker.{}".format(marker_name),
+            "operator": "intersects",
+            "expected": available_tags,
+            "actual": marker_args,
+            "passed": matched,
+            "missing": False,
+        },
+        {
+            "path": "topology.available_tags",
+            "operator": "intersects",
+            "expected": marker_args,
+            "actual": available_tags,
+            "passed": matched,
+            "missing": raw_available_tags is None,
+        },
+        {
+            "path": "topology.name",
+            "actual": _get_path(run_context, "topology.name"),
+        },
+        {
+            "path": "topology.type",
+            "actual": _get_path(run_context, "topology.type"),
+        },
+    ]
+    return "run" if matched else "deselect", evaluated
+
+
+def _evaluate_test_capability(test_capability, item, run_context, missing_run_context_policy="deselect"):
+    evaluation = test_capability.get("evaluation", {})
+    selector = test_capability["applies_to"]
+
+    if evaluation.get("mode") in TOPOLOGY_MARKER_EVALUATION_MODES:
+        return _evaluate_topology_marker(test_capability, item, run_context)
+
+    if selector["type"] == "pytest_marker" and selector.get("marker") == "topology":
+        return _evaluate_topology_marker(test_capability, item, run_context)
+
+    if evaluation.get("mode") != "all":
+        raise pytest.UsageError(
+            "Unsupported hardware-aware evaluation mode for {}: {}".format(
+                test_capability["id"], evaluation.get("mode")
+            )
+        )
+
+    evaluated = []
+    all_passed = True
+    for condition in evaluation.get("conditions", []):
+        path = condition["path"]
+        operator = condition["operator"]
+        expected = condition["expected"]
+        actual = _get_path(run_context, path)
+        missing = actual is None
+        if missing and missing_run_context_policy == "run":
+            passed = True
+        else:
+            passed = _condition_passed(operator, actual, expected, test_capability["id"])
+        all_passed = all_passed and passed
+        evaluated.append({
+            "path": path,
+            "operator": operator,
+            "expected": expected,
+            "actual": actual,
+            "passed": passed,
+            "missing": missing,
+        })
+
+    return "run" if all_passed else "deselect", evaluated
+
+
+def _run_context_instance(run_context_doc):
+    if isinstance(run_context_doc, dict) and "example_current_run" in run_context_doc:
+        return run_context_doc["example_current_run"]
+    return run_context_doc
+
+
+def _test_capability_passes_confidence_filter(test_capability, min_confidence):
+    if min_confidence == "none":
+        return True
+    confidence = test_capability.get("confidence")
+    return CONFIDENCE_ORDER.get(confidence, 0) >= CONFIDENCE_ORDER[min_confidence]
+
+
+def _test_capability_passes_candidate_status_filter(test_capability, candidate_status):
+    if candidate_status == "any":
+        return True
+    return test_capability.get("candidate_status") == candidate_status
+
+
+def _test_capabilities_doc_items(test_capabilities_doc):
+    return test_capabilities_doc.get("test_capabilities", test_capabilities_doc.get("requirements", []))
+
+
+def _filter_test_capabilities(config, test_capabilities):
+    min_confidence = config.getoption("hardware_aware_min_confidence")
+    candidate_status = config.getoption("hardware_aware_candidate_status")
+    active = []
+    filtered = []
+
+    for test_capability in test_capabilities:
+        if not _test_capability_passes_confidence_filter(test_capability, min_confidence):
+            filtered.append({
+                "id": test_capability.get("id"),
+                "reason": "confidence_below_minimum",
+                "confidence": test_capability.get("confidence"),
+                "candidate_status": test_capability.get("candidate_status"),
+            })
+            continue
+        if not _test_capability_passes_candidate_status_filter(test_capability, candidate_status):
+            filtered.append({
+                "id": test_capability.get("id"),
+                "reason": "candidate_status_mismatch",
+                "confidence": test_capability.get("confidence"),
+                "candidate_status": test_capability.get("candidate_status"),
+            })
+            continue
+        active.append(test_capability)
+
+    return active, filtered, {
+        "min_confidence": min_confidence,
+        "candidate_status": candidate_status,
+    }
+
+
+def _build_report(
+    config,
+    items,
+    run_context_doc,
+    test_capabilities_doc,
+    run_context_path,
+    test_capabilities_path,
+    mode,
+    runtime_inputs_source=None,
+):
+    run_context = _run_context_instance(run_context_doc)
+    test_capabilities = _test_capabilities_doc_items(test_capabilities_doc)
+    active_test_capabilities, filtered_test_capabilities, test_capability_filters = _filter_test_capabilities(
+        config,
+        test_capabilities,
+    )
+    missing_run_context_policy = config.getoption("hardware_aware_missing_run_context_policy")
+    decisions = []
+
+    for item in items:
+        for test_capability in active_test_capabilities:
+            if not _selector_matches(test_capability, item, config):
+                continue
+
+            evaluated = _evaluate_test_capability(
+                test_capability,
+                item,
+                run_context,
+                missing_run_context_policy,
+            )
+            if evaluated is None:
+                continue
+
+            decision, evaluated_run_context = evaluated
+            decisions.append({
+                "nodeid": item.nodeid,
+                "decision": decision,
+                "reason": _format_reason(test_capability["decision"]["reason_template"], run_context),
+                "skip_reason": _clean_skip_reason(test_capability.get("raw_skip_reason")),
+                "test_capability_id": test_capability["id"],
+                "bucket_id": test_capability.get("bucket_id"),
+                "confidence": test_capability.get("confidence"),
+                "candidate_status": test_capability.get("candidate_status"),
+                "evaluated_run_context": evaluated_run_context,
+            })
+
+    by_decision = Counter(decision["decision"] for decision in decisions)
+    by_test_capability = Counter(decision["test_capability_id"] for decision in decisions)
+    by_bucket = Counter(decision["bucket_id"] for decision in decisions)
+    collected_nodeids = sorted(_canonical_report_nodeid(item, config) for item in items)
+
+    inputs = {
+        "run_context": str(run_context_path),
+        "test_capabilities": str(test_capabilities_path),
+    }
+    if runtime_inputs_source:
+        inputs["catalog_setup"] = runtime_inputs_source
+
+    return {
+        "version": "hardware-aware-pytest-collection-report/v0.1",
+        "mode": mode,
+        "inputs": inputs,
+        "test_capability_filters": test_capability_filters,
+        "summary": {
+            "collected_items": len(items),
+            "test_capabilities_total": len(test_capabilities),
+            "test_capabilities_active": len(active_test_capabilities),
+            "test_capabilities_filtered_out": len(filtered_test_capabilities),
+            "matched_items": len({decision["nodeid"] for decision in decisions}),
+            "decisions": len(decisions),
+            "deselect_recommendations": sum(1 for decision in decisions if decision["decision"] == "deselect"),
+            "by_decision": dict(sorted(by_decision.items())),
+            "by_test_capability": dict(sorted(by_test_capability.items())),
+            "by_bucket": dict(sorted(by_bucket.items())),
+            "missing_run_context_policy": missing_run_context_policy,
+        },
+        "collected_nodeids": collected_nodeids,
+        "filtered_test_capabilities": filtered_test_capabilities,
+        "decisions": decisions,
+    }
+
+
+def _write_report(config, report):
+    report_path = _resolve_output_path(config, config.getoption("hardware_aware_report_path"))
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    with report_path.open("w") as f:
+        json.dump(report, f, indent=2, sort_keys=True)
+        f.write("\n")
+    summary_path = _write_text_summary(report_path, report)
+    aggregate_summary_path = _write_aggregate_text_summary(report_path.parent)
+    return report_path, summary_path, aggregate_summary_path
+
+
+def _text_summary_path(report_path):
+    return report_path.with_name("{}_summary.txt".format(report_path.stem))
+
+
+def _write_text_summary(report_path, report):
+    summary_path = _text_summary_path(report_path)
+    summary = report.get("summary", {})
+    deselected = [
+        decision for decision in report.get("decisions", [])
+        if decision.get("decision") == "deselect"
+    ]
+
+    lines = [
+        "Hardware-aware deselect summary",
+        "JSON report: {}".format(report_path),
+        "mode: {}".format(report.get("mode")),
+        "collected_items: {}".format(summary.get("collected_items", 0)),
+        "deselected_items: {}".format(summary.get("deselected_items", 0)),
+        "",
+    ]
+
+    if not deselected:
+        lines.append("No tests were deselected.")
+    else:
+        reason_groups = defaultdict(list)
+        for decision in deselected:
+            reason = decision.get("skip_reason") or decision.get("reason")
+            triggers = _decision_triggers(decision)
+            key = (
+                reason,
+                decision.get("bucket_id"),
+                "; ".join(triggers),
+            )
+            reason_groups[key].append(decision.get("nodeid"))
+
+        lines.append("Deselect reasons:")
+        for key in sorted(reason_groups, key=lambda item: (item[0] or "", item[1] or "", item[2] or "")):
+            reason, bucket_id, trigger = key
+            lines.append("- reason: {}".format(reason))
+            lines.append("  bucket: {}".format(bucket_id))
+            if trigger:
+                lines.append("  trigger: {}".format(trigger))
+            lines.append("  tests:")
+            for nodeid in sorted(reason_groups[key]):
+                lines.append("    - {}".format(nodeid))
+            lines.append("")
+
+    with summary_path.open("w") as f:
+        f.write("\n".join(lines).rstrip())
+        f.write("\n")
+    return summary_path
+
+
+def _aggregate_text_summary_path(report_dir):
+    return report_dir / "hardware_aware_deselect_summary.txt"
+
+
+def _load_hardware_aware_reports(report_dir):
+    reports = []
+    for path in sorted(report_dir.glob("*_hardware_aware.json")):
+        try:
+            with path.open() as f:
+                report = json.load(f)
+        except (IOError, ValueError) as exc:
+            logger.warning("Unable to read hardware-aware report %s: %s", path, exc)
+            continue
+        reports.append((path, report))
+    return reports
+
+
+def _write_aggregate_text_summary(report_dir):
+    reports = _load_hardware_aware_reports(report_dir)
+    if not reports:
+        return None
+
+    total_collected = sum(
+        report.get("summary", {}).get("collected_items", 0)
+        for _, report in reports
+    )
+    total_deselected = sum(
+        report.get("summary", {}).get("deselected_items", 0)
+        for _, report in reports
+    )
+    total_decisions = sum(
+        report.get("summary", {}).get("decisions", 0)
+        for _, report in reports
+    )
+
+    lines = [
+        "Hardware-aware aggregate deselect summary",
+        "report_dir: {}".format(report_dir),
+        "report_files: {}".format(len(reports)),
+        "total_collected_items: {}".format(total_collected),
+        "total_decisions: {}".format(total_decisions),
+        "total_deselected_items: {}".format(total_deselected),
+        "",
+    ]
+
+    reason_groups = defaultdict(list)
+    for path, report in reports:
+        for decision in report.get("decisions", []):
+            if decision.get("decision") != "deselect":
+                continue
+            reason = decision.get("skip_reason") or decision.get("reason")
+            triggers = _decision_triggers(decision)
+            key = (
+                reason,
+                decision.get("bucket_id"),
+                "; ".join(triggers),
+            )
+            reason_groups[key].append((decision.get("nodeid"), path.name))
+
+    if not reason_groups:
+        lines.append("No tests were deselected.")
+    else:
+        lines.append("Deselect reasons:")
+        for key in sorted(reason_groups, key=lambda item: (item[0] or "", item[1] or "", item[2] or "")):
+            reason, bucket_id, trigger = key
+            entries = sorted(reason_groups[key])
+            lines.append("- reason: {}".format(reason))
+            lines.append("  bucket: {}".format(bucket_id))
+            if trigger:
+                lines.append("  trigger: {}".format(trigger))
+            lines.append("  tests:")
+            for nodeid, source_report in entries:
+                lines.append("    - {} ({})".format(nodeid, source_report))
+            lines.append("")
+
+    lines.append("Report file overview:")
+    for path, report in reports:
+        summary = report.get("summary", {})
+        lines.append(
+            "- {}: collected={}, deselected={}".format(
+                path.name,
+                summary.get("collected_items", 0),
+                summary.get("deselected_items", 0),
+            )
+        )
+
+    summary_path = _aggregate_text_summary_path(report_dir)
+    with summary_path.open("w") as f:
+        f.write("\n".join(lines).rstrip())
+        f.write("\n")
+    return summary_path
+
+
+def _deselect_items(config, items, report):
+    deselect_nodeids = {
+        decision["nodeid"]
+        for decision in report["decisions"]
+        if decision["decision"] == "deselect"
+    }
+    if not deselect_nodeids:
+        report["summary"]["deselected_items"] = 0
+        return
+
+    deselected_items = [item for item in items if item.nodeid in deselect_nodeids]
+    if not deselected_items:
+        report["summary"]["deselected_items"] = 0
+        return
+
+    items[:] = [item for item in items if item.nodeid not in deselect_nodeids]
+    config.hook.pytest_deselected(items=deselected_items)
+    report["summary"]["deselected_items"] = len(deselected_items)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(session, config, items):
+    report_only = config.getoption("hardware_aware_report_only")
+    deselect = config.getoption("hardware_aware_deselect")
+    if not report_only and not deselect:
+        return
+
+    (
+        run_context_doc,
+        run_context_path,
+        test_capabilities_doc,
+        test_capabilities_path,
+        runtime_inputs_source,
+    ) = _load_runtime_inputs(config)
+    mode = "deselect" if deselect else "report_only"
+    report = _build_report(
+        config,
+        items,
+        run_context_doc,
+        test_capabilities_doc,
+        run_context_path,
+        test_capabilities_path,
+        mode,
+        runtime_inputs_source=runtime_inputs_source,
+    )
+
+    if deselect:
+        _deselect_items(config, items, report)
+    else:
+        report["summary"]["deselected_items"] = 0
+
+    report_path, summary_path, aggregate_summary_path = _write_report(config, report)
+    logger.info(
+        "Hardware-aware %s report written to %s, summary written to %s, aggregate summary written to %s: %s",
+        mode,
+        report_path,
+        summary_path,
+        aggregate_summary_path,
+        report["summary"],
+    )

--- a/tests/common/plugins/hardware_aware/__init__.py
+++ b/tests/common/plugins/hardware_aware/__init__.py
@@ -42,13 +42,19 @@ def pytest_addoption(parser):
         "--hardware-aware-report-only",
         action="store_true",
         default=False,
-        help="Evaluate hardware-aware test capabilities during collection and write a report without deselecting tests.",
+        help=(
+            "Evaluate hardware-aware test capabilities during collection "
+            "and write a report without deselecting tests."
+        ),
     )
     group.addoption(
         "--hardware-aware-deselect",
         action="store_true",
         default=False,
-        help="Deselect tests that do not satisfy hardware-aware test capabilities during collection and write a report.",
+        help=(
+            "Deselect tests that do not satisfy hardware-aware test capabilities "
+            "during collection and write a report."
+        ),
     )
     group.addoption(
         "--hardware-aware-run-context-file",

--- a/tests/hardware_aware/.gitignore
+++ b/tests/hardware_aware/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+generated/
+run_context*.json
+test_capabilities*.json
+generation_audit*.json
+candidate_target_files*.txt
+selector_scope*.json
+audit*.json

--- a/tests/hardware_aware/README.md
+++ b/tests/hardware_aware/README.md
@@ -1,0 +1,207 @@
+# Hardware-Aware Pre-Run Deselect
+
+Hardware-aware deselect removes tests during pytest collection when the current
+platform/topology/run setup cannot satisfy the facts required by those tests.
+
+Users mainly work with two YAML files:
+
+```text
+setup_profiles.yaml
+  Current setup facts: platform, topology, run options, feature flags, and
+  resource availability.
+
+skip_rules.yaml
+  Skip rules: which setup facts make a rule apply, and which tests are affected.
+```
+
+The generated `run_context` and `test_capabilities` objects are internal plugin
+artifacts. Users should not create or edit them by hand.
+
+## Quick Start
+
+Run from `sonic-mgmt/tests` or `/data/tests`.
+
+### Option 1: Use A Known Setup
+
+Use this when the setup already exists in `setup_profiles.yaml`.
+
+```bash
+RUN_ID=ring4-5697-42221-t0-m6-28-superbolt
+
+./run_tests.sh ... \
+  -e "-p tests.common.plugins.hardware_aware" \
+  -e "--hardware-aware-deselect" \
+  -e "--hardware-aware-setup=8122-64EHF-O:t0" \
+  -e "--hardware-aware-missing-run-context-policy=deselect" \
+  -e "--hardware-aware-report-path=logs_hwaware/${RUN_ID}_hardware_aware.json" \
+  -e --collect-only
+```
+
+The plugin also writes a concise text summary next to the JSON report, for
+example `logs_hwaware/${RUN_ID}_hardware_aware_summary.txt`. When multiple
+reports named `*_hardware_aware.json` are written in the same log directory,
+the plugin also refreshes `hardware_aware_deselect_summary.txt` in that
+directory.
+
+View the readable summaries with:
+
+```bash
+cat logs_hwaware/${RUN_ID}_hardware_aware_summary.txt
+cat logs_hwaware/hardware_aware_deselect_summary.txt
+```
+
+Use report-only mode to inspect decisions without removing tests:
+
+```bash
+-e "--hardware-aware-report-only"
+```
+
+### Option 2: Override A Known Setup
+
+Use this when most setup facts are already correct, but one or two values differ
+for the current run.
+
+`my_override.yaml`:
+
+```yaml
+parameters:
+  features.nat.enabled: true
+```
+
+Command:
+
+```bash
+./run_tests.sh ... \
+  -e "-p tests.common.plugins.hardware_aware" \
+  -e "--hardware-aware-deselect" \
+  -e "--hardware-aware-setup=x86_64-8122_64ehf_o-r0:t0" \
+  -e "--hardware-aware-setup-input=my_override.yaml" \
+  -e --collect-only
+```
+
+### Option 3: Provide A New Setup File
+
+Use this when the platform/topology setup is not in `setup_profiles.yaml` yet.
+
+`my_setup.yaml`:
+
+```yaml
+key: FAS1000-32D:t0
+metadata:
+  platform: FAS1000-32D
+  topology: t0
+parameters:
+  run.options.include_long_tests: false
+  topology.type: t0
+  topology.available_tags:
+    - t0
+  topology.is_dualtor: false
+  topology.multi_dut.supported: false
+  topology.single_dut_multi_asic.supported: false
+  platform.is_multi_asic: false
+  features.nat.enabled: false
+  features.macsec.enabled: false
+  resources.tgen_port_info.available: false
+```
+
+Command:
+
+```bash
+./run_tests.sh ... \
+  -e "-p tests.common.plugins.hardware_aware" \
+  -e "--hardware-aware-deselect" \
+  -e "--hardware-aware-setup-input=my_setup.yaml" \
+  -e --collect-only
+```
+
+Prefer external identifiers such as SONiC platform, PID, or HwSKU. Cisco
+internal names such as `superbolt` are aliases only.
+
+The output report records the selected setup and generated rule counts under
+`inputs.catalog_setup`.
+
+## Maintaining The YAML Files
+
+### Add Setup Facts
+
+Add platform identity and validated setup facts in `setup_profiles.yaml`.
+
+```yaml
+setups:
+  x86_64-8122_64ehf_o-r0:t0:
+    aliases:
+      - superbolt:t0
+      - 8122-64EHF-O:t0
+    metadata:
+      platform: x86_64-8122_64ehf_o-r0
+      topology: t0
+    parameters:
+      topology.type: t0
+      topology.multi_dut.supported: false
+      platform.is_multi_asic: false
+      features.nat.enabled: false
+```
+
+### Add Skip Rules
+
+Add or refine skip rules in `skip_rules.yaml`.
+
+```yaml
+skip_rules:
+  nat_feature_disabled:
+    reason_patterns:
+      - "^nat feature is not enabled with image version .*$"
+    parameters:
+      features.nat.enabled: false
+    tests:
+      - tests/nat/
+```
+
+Readable test selectors can be folders, files, tests, or selected
+parametrizations:
+
+```yaml
+tests:
+  - tests/nat/
+  - tests/qos/test_buffer.py
+  - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark
+  - nodeid: tests/qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark
+    param_contains: multi_dut
+```
+
+## Internal Flow
+
+The plugin keeps the old capability comparison logic, but hides the generated
+files from users:
+
+```text
+user passes setup key or setup YAML
+-> plugin loads setup_profiles.yaml
+-> plugin loads skip_rules.yaml
+-> matching skip rules become internal test_capabilities
+-> selected setup facts become internal run_context
+-> plugin compares test requirements with current setup facts
+-> unsupported tests are reported or deselected
+```
+
+`generate_runtime_inputs.py` is the converter used by the plugin. It can also
+be run directly for debugging or report-seeded validation:
+
+```bash
+python3 hardware_aware/generate_runtime_inputs.py \
+  --catalog hardware_aware/skip_rules.yaml \
+  --setup-profiles hardware_aware/setup_profiles.yaml \
+  --setup x86_64-8122_64ehf_o-r0:t0 \
+  --test-capabilities-output out/test_capabilities.json \
+  --run-context-output out/run_context.json \
+  --audit-output out/audit.json
+```
+
+`audit_selector_scope.py` is optional. Use it to validate whether readable test
+selectors are too narrow or too broad against historical skipped-reason reports.
+
+By default, `topology_unavailable` has `enabled: false` in `skip_rules.yaml`
+because SONiC `custom_markers` already handles `pytest.mark.topology` when
+`--topology` is passed. Set that YAML value to `true` if hardware-aware should
+own topology gating. The `--hardware-aware-include-topology-rules` flag is only
+a temporary override for debugging.

--- a/tests/hardware_aware/audit_selector_scope.py
+++ b/tests/hardware_aware/audit_selector_scope.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Audit whether catalog test selectors are too narrow or too broad.
+
+This script does not generate runtime inputs and does not change deselection
+behavior. It compares the human-maintained tests selectors in
+skip_rules.yaml with observed skipped nodeids from an Allure
+extraction and, when available, collected nodeids from a hardware-aware
+report-only/deselect JSON.
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from generate_runtime_inputs import (  # noqa: E402
+    load_json,
+    load_yaml,
+    normalize_raw_skips,
+    reason_matches_rule,
+    selector_from_catalog_tests,
+    selector_from_observed_nodeids,
+    setup_matches_parameters,
+)
+
+
+def write_json(path, data):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def normalize_nodeid(nodeid):
+    nodeid = str(nodeid)
+    if nodeid.startswith("tests/"):
+        return nodeid
+    return "tests/" + nodeid
+
+
+def base_nodeid(nodeid):
+    """Return nodeid without the final parametrization bracket.
+
+    This is intentionally a secondary audit key. Exact nodeids catch parameter
+    over-selection, while base nodeids help distinguish real over-selection from
+    run-specific parameter labels such as sup-t0-dut vs superbolt-01.
+    """
+    return re.sub(r"\[[^\]]*\]$", "", normalize_nodeid(nodeid))
+
+
+def selector_matches(selector, nodeid):
+    nodeid = normalize_nodeid(nodeid)
+    candidates = [nodeid, nodeid[len("tests/"):]]
+
+    selector_type = selector["type"]
+    if selector_type == "path_prefix":
+        prefix = selector["prefix"]
+        return any(candidate.startswith(prefix) for candidate in candidates)
+    if selector_type == "regex":
+        pattern = re.compile(selector["pattern"])
+        return any(pattern.search(candidate) for candidate in candidates)
+    if selector_type == "pytest_marker":
+        return None
+
+    raise SystemExit("Unsupported selector type in audit: {}".format(selector_type))
+
+
+def resolve_setup(setup_profiles, setup_key):
+    setups = setup_profiles.get("setups", {})
+    if setup_key in setups:
+        return setup_key, setups[setup_key]
+
+    alias_matches = [
+        (key, setup)
+        for key, setup in setups.items()
+        if setup_key in (setup.get("aliases") or [])
+    ]
+    if len(alias_matches) == 1:
+        return alias_matches[0]
+    if not alias_matches:
+        raise SystemExit("setup not found in setup profiles: {}".format(setup_key))
+
+    raise SystemExit(
+        "setup alias matched multiple setups: {}".format(
+            ", ".join(key for key, _ in alias_matches)
+        )
+    )
+
+
+def load_collected_nodeids(report_paths):
+    collected = []
+    reports = []
+
+    for path in report_paths or []:
+        report = load_json(path)
+        nodeids = report.get("collected_nodeids")
+        source = "collected_nodeids"
+
+        if nodeids is None:
+            decisions = report.get("decisions") or []
+            nodeids = [decision["nodeid"] for decision in decisions if decision.get("nodeid")]
+            source = "decisions_nodeids_only"
+
+        nodeids = [normalize_nodeid(nodeid) for nodeid in nodeids or []]
+        collected.extend(nodeids)
+        reports.append({
+            "path": str(path),
+            "nodeids": len(nodeids),
+            "source": source,
+        })
+
+    return sorted(dict.fromkeys(collected)), reports
+
+
+def build_observed_by_rule(catalog, normalized_raw):
+    observed_by_rule = OrderedDict()
+    unmapped_reasons = []
+    ambiguous_reasons = []
+
+    for reason, nodeids in sorted(normalized_raw.items()):
+        matches = []
+        for rule_id, rule in sorted((catalog.get("skip_rules") or {}).items()):
+            pattern = reason_matches_rule(reason, rule)
+            if pattern:
+                matches.append((rule_id, rule, pattern))
+
+        if not matches:
+            unmapped_reasons.append({
+                "reason": reason,
+                "count": len(nodeids),
+                "sample_tests": nodeids[:5],
+            })
+            continue
+
+        if len(matches) > 1:
+            ambiguous_reasons.append({
+                "reason": reason,
+                "count": len(nodeids),
+                "matched_rules": [rule_id for rule_id, _, _ in matches],
+            })
+
+        rule_id, _, _ = matches[0]
+        bucket = observed_by_rule.setdefault(rule_id, {
+            "raw_reasons": [],
+            "nodeids": [],
+        })
+        bucket["raw_reasons"].append(reason)
+        bucket["nodeids"].extend(normalize_nodeid(nodeid) for nodeid in nodeids)
+
+    for bucket in observed_by_rule.values():
+        bucket["raw_reasons"] = sorted(dict.fromkeys(bucket["raw_reasons"]))
+        bucket["nodeids"] = sorted(dict.fromkeys(bucket["nodeids"]))
+
+    return observed_by_rule, unmapped_reasons, ambiguous_reasons
+
+
+def audit_rule(rule_id, rule, observed_nodeids, setup_parameters, collected_nodeids):
+    matched, missing, mismatched = setup_matches_parameters(
+        setup_parameters,
+        rule.get("parameters") or {},
+    )
+    selector, selector_strategy = selector_from_catalog_tests(rule)
+    if selector is None:
+        selector, selector_strategy = selector_from_observed_nodeids(observed_nodeids)
+
+    result = OrderedDict()
+    result["rule_id"] = rule_id
+    result["selector_strategy"] = selector_strategy
+    result["selector"] = selector
+    result["observed_skipped_nodeids"] = len(observed_nodeids)
+    result["setup_applicable"] = matched
+    result["missing_parameters"] = missing
+    result["mismatched_parameters"] = mismatched
+
+    if selector["type"] == "pytest_marker":
+        result["status"] = "marker_selector_not_checked_by_nodeid"
+        result["note"] = (
+            "Marker selectors need pytest collection metadata. Validate this rule "
+            "with the hardware-aware report decisions instead of nodeid prefix checks."
+        )
+        return result
+
+    under_matched = [
+        nodeid for nodeid in observed_nodeids
+        if not selector_matches(selector, nodeid)
+    ]
+    result["under_matched_observed_nodeids"] = len(under_matched)
+    result["under_matched_examples"] = under_matched[:10]
+
+    if collected_nodeids:
+        selected_collected = [
+            nodeid for nodeid in collected_nodeids
+            if selector_matches(selector, nodeid)
+        ]
+        observed_set = set(observed_nodeids)
+        observed_base_set = set(base_nodeid(nodeid) for nodeid in observed_nodeids)
+        over_selected = [
+            nodeid for nodeid in selected_collected
+            if nodeid not in observed_set
+        ]
+        base_over_selected = [
+            nodeid for nodeid in selected_collected
+            if base_nodeid(nodeid) not in observed_base_set
+        ]
+        result["selected_collected_nodeids"] = len(selected_collected)
+        result["over_selected_collected_nodeids"] = len(over_selected)
+        result["over_selected_examples"] = over_selected[:10]
+        result["base_over_selected_collected_nodeids"] = len(base_over_selected)
+        result["base_over_selected_examples"] = base_over_selected[:10]
+    else:
+        result["selected_collected_nodeids"] = None
+        result["over_selected_collected_nodeids"] = None
+        result["over_selected_examples"] = []
+        result["base_over_selected_collected_nodeids"] = None
+        result["base_over_selected_examples"] = []
+
+    if under_matched:
+        result["status"] = "under_match"
+    elif result["base_over_selected_collected_nodeids"]:
+        result["status"] = "over_select_review"
+    elif collected_nodeids:
+        result["status"] = "ok"
+    else:
+        result["status"] = "under_match_checked_only"
+
+    return result
+
+
+def build_audit(catalog, setup_profiles, setup_key, raw_skips, collected_nodeids, report_inputs):
+    setup_profiles = setup_profiles or catalog
+    resolved_setup_key, setup = resolve_setup(setup_profiles, setup_key)
+    setup_parameters = setup.get("parameters") or {}
+    normalized_raw = normalize_raw_skips(raw_skips)
+    observed_by_rule, unmapped, ambiguous = build_observed_by_rule(catalog, normalized_raw)
+
+    rules = []
+    skipped_not_applicable = []
+    for rule_id, observed in sorted(observed_by_rule.items()):
+        rule = (catalog.get("skip_rules") or {})[rule_id]
+        audit = audit_rule(
+            rule_id,
+            rule,
+            observed["nodeids"],
+            setup_parameters,
+            collected_nodeids,
+        )
+        audit["raw_reasons"] = observed["raw_reasons"]
+        rules.append(audit)
+
+        if not audit["setup_applicable"]:
+            skipped_not_applicable.append(rule_id)
+
+    status_counts = {}
+    for rule in rules:
+        status_counts[rule["status"]] = status_counts.get(rule["status"], 0) + 1
+
+    summary = OrderedDict()
+    summary["setup"] = resolved_setup_key
+    summary["raw_reasons"] = len(normalized_raw)
+    summary["rules_with_observed_skips"] = len(rules)
+    summary["rules_not_applicable_to_setup"] = len(skipped_not_applicable)
+    summary["collected_nodeids"] = len(collected_nodeids)
+    summary["status_counts"] = dict(sorted(status_counts.items()))
+    summary["under_match_rules"] = sum(1 for rule in rules if rule["status"] == "under_match")
+    summary["over_select_review_rules"] = sum(1 for rule in rules if rule["status"] == "over_select_review")
+    summary["exact_over_select_debug_rules"] = sum(
+        1 for rule in rules
+        if rule.get("over_selected_collected_nodeids")
+    )
+    summary["base_over_select_review_rules"] = sum(
+        1 for rule in rules
+        if rule.get("base_over_selected_collected_nodeids")
+    )
+    summary["marker_selector_rules"] = sum(
+        1 for rule in rules if rule["status"] == "marker_selector_not_checked_by_nodeid"
+    )
+    summary["unmapped_reasons"] = len(unmapped)
+    summary["ambiguous_reasons"] = len(ambiguous)
+
+    return OrderedDict([
+        ("version", "hardware-aware-selector-scope-audit/v0.1"),
+        ("summary", summary),
+        ("inputs", {
+            "setup": setup_key,
+            "resolved_setup": resolved_setup_key,
+            "catalog_schema": catalog.get("version"),
+            "setup_profiles_schema": setup_profiles.get("version"),
+            "collected_reports": report_inputs,
+        }),
+        ("rules", rules),
+        ("unmapped_reasons", unmapped),
+        ("ambiguous_reasons", ambiguous),
+    ])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", required=True, help="catalog YAML file.")
+    parser.add_argument(
+        "--setup-profiles",
+        help="Setup profiles YAML. If omitted, setups are read from --catalog for backward compatibility.",
+    )
+    parser.add_argument("--setup", required=True, help="Setup key or alias from setup profiles.")
+    parser.add_argument("--raw-skips", required=True, help="Raw skipped-reasons JSON from Allure extraction.")
+    parser.add_argument(
+        "--collected-report",
+        action="append",
+        default=[],
+        help="Hardware-aware report-only/deselect JSON containing collected_nodeids. Can be repeated.",
+    )
+    parser.add_argument("--output", required=True, help="Path to write selector scope audit JSON.")
+    args = parser.parse_args()
+
+    catalog = load_yaml(args.catalog)
+    setup_profiles = load_yaml(args.setup_profiles) if args.setup_profiles else None
+    raw_skips = load_json(args.raw_skips)
+    collected_nodeids, report_inputs = load_collected_nodeids(args.collected_report)
+    audit = build_audit(catalog, setup_profiles, args.setup, raw_skips, collected_nodeids, report_inputs)
+    write_json(args.output, audit)
+
+    print(json.dumps(audit["summary"], indent=2, sort_keys=True))
+    print("wrote {}".format(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hardware_aware/generate_runtime_inputs.py
+++ b/tests/hardware_aware/generate_runtime_inputs.py
@@ -1,0 +1,1292 @@
+#!/usr/bin/env python3
+"""Generate current hardware-aware inputs from catalog YAML files.
+
+This is intentionally a converter, not a new pytest plugin. It lets us test a
+human-readable catalog while continuing to use the existing hardware-aware
+plugin backend. Without --raw-skips it generates setup-only inputs from the
+selected setup profile. With --raw-skips it generates report-seeded inputs for
+historical validation and catalog coverage work.
+"""
+
+import argparse
+import copy
+import json
+import re
+from collections import OrderedDict
+from pathlib import Path
+
+import yaml
+
+
+def load_yaml(path):
+    with open(str(path)) as f:
+        return yaml.safe_load(f)
+
+
+def load_json(path):
+    with open(str(path)) as f:
+        return json.load(f)
+
+
+def write_json(path, data):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def write_lines(path, lines):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        for line in lines:
+            f.write(line)
+            f.write("\n")
+
+
+def safe_id(value):
+    return re.sub(r"[^a-zA-Z0-9_]+", "_", str(value)).strip("_").lower()
+
+
+def exact_nodeid_regex(nodeids):
+    escaped = [re.escape(nodeid) for nodeid in sorted(nodeids)]
+    return "^(?:{})$".format("|".join(escaped))
+
+
+def normalize_test_selector_path(value):
+    value = str(value).strip()
+    if value.startswith("tests/"):
+        return value
+    return "tests/" + value.lstrip("/")
+
+
+def regex_for_test_selector(value):
+    value = normalize_test_selector_path(value)
+    if value.endswith("/"):
+        return "^{}".format(re.escape(value))
+    if "::" in value:
+        if "[" in value:
+            return "^{}$".format(re.escape(value))
+        return "^{}(?:$|\\[|::)".format(re.escape(value))
+    if value.endswith(".py"):
+        return "^{}(?:::|$)".format(re.escape(value))
+    return "^{}".format(re.escape(value))
+
+
+def regex_for_param_selector(nodeid, param_contains=None, param_prefixes=None):
+    nodeid = normalize_test_selector_path(nodeid)
+    prefix = "^{}\\[".format(re.escape(nodeid))
+
+    if param_contains:
+        return "{}.*{}".format(prefix, re.escape(str(param_contains)))
+
+    if param_prefixes:
+        escaped = [re.escape(str(value)) for value in param_prefixes]
+        return "{}(?:{})".format(prefix, "|".join(escaped))
+
+    return regex_for_test_selector(nodeid)
+
+
+def regex_for_prefix_param_selector(prefix, param_contains=None, param_prefixes=None):
+    prefix = normalize_test_selector_path(prefix)
+    if prefix.endswith("/") or ("::" not in prefix and not prefix.endswith(".py")):
+        pattern = "^{}.*\\[".format(re.escape(prefix))
+        fallback = "^{}".format(re.escape(prefix))
+    else:
+        pattern = "^{}(?=$|\\[|::).*\\[".format(re.escape(prefix))
+        fallback = "^{}(?=$|\\[|::)".format(re.escape(prefix))
+
+    if param_contains:
+        return "{}.*{}".format(pattern, re.escape(str(param_contains)))
+
+    if param_prefixes:
+        escaped = [re.escape(str(value)) for value in param_prefixes]
+        return "{}(?:{})".format(pattern, "|".join(escaped))
+
+    return fallback
+
+
+def regex_for_path_prefix_with_excludes(path_prefix, exclude_nodeids):
+    path_prefix = normalize_test_selector_path(path_prefix)
+    relative_excludes = []
+    for nodeid in exclude_nodeids or []:
+        nodeid = normalize_test_selector_path(nodeid)
+        if not nodeid.startswith(path_prefix):
+            raise SystemExit(
+                "exclude_nodeid {} is not under path_prefix {}".format(nodeid, path_prefix)
+            )
+        relative_excludes.append(re.escape(nodeid[len(path_prefix):]))
+
+    if not relative_excludes:
+        return "^{}".format(re.escape(path_prefix))
+
+    return "^{}(?!(?:{})(?:$|\\[|::))".format(
+        re.escape(path_prefix),
+        "|".join(relative_excludes),
+    )
+
+
+def selector_from_catalog_tests(rule):
+    tests = rule.get("tests") or []
+    if not tests:
+        return None, None
+
+    markers = []
+    prefixes = []
+    regexes = []
+
+    for entry in tests:
+        if isinstance(entry, str):
+            value = normalize_test_selector_path(entry)
+            if value.endswith("/"):
+                prefixes.append(value)
+            else:
+                regexes.append(regex_for_test_selector(value))
+            continue
+
+        if not isinstance(entry, dict):
+            raise SystemExit("Unsupported tests selector entry in rule {}: {}".format(rule, entry))
+
+        if "marker" in entry:
+            markers.append(str(entry["marker"]))
+        elif "path_prefix" in entry:
+            if entry.get("param_contains") or entry.get("param_prefixes"):
+                regexes.append(regex_for_prefix_param_selector(
+                    entry["path_prefix"],
+                    param_contains=entry.get("param_contains"),
+                    param_prefixes=entry.get("param_prefixes"),
+                ))
+            elif entry.get("exclude_nodeids"):
+                regexes.append(regex_for_path_prefix_with_excludes(
+                    entry["path_prefix"],
+                    entry.get("exclude_nodeids"),
+                ))
+            else:
+                prefixes.append(normalize_test_selector_path(entry["path_prefix"]))
+        elif "nodeid_prefix" in entry:
+            regexes.append(regex_for_prefix_param_selector(
+                entry["nodeid_prefix"],
+                param_contains=entry.get("param_contains"),
+                param_prefixes=entry.get("param_prefixes"),
+            ))
+        elif "nodeid" in entry:
+            regexes.append(regex_for_param_selector(
+                entry["nodeid"],
+                param_contains=entry.get("param_contains"),
+                param_prefixes=entry.get("param_prefixes"),
+            ))
+        elif "nodeids" in entry:
+            for nodeid in entry["nodeids"]:
+                regexes.append(regex_for_param_selector(
+                    nodeid,
+                    param_contains=entry.get("param_contains"),
+                    param_prefixes=entry.get("param_prefixes"),
+                ))
+        elif "regex" in entry:
+            regexes.append(entry["regex"])
+        else:
+            raise SystemExit("Unsupported tests selector mapping in rule {}: {}".format(rule, entry))
+
+    if len(markers) == 1 and not prefixes and not regexes:
+        return {"type": "pytest_marker", "marker": markers[0]}, "catalog_pytest_marker"
+
+    if markers:
+        raise SystemExit("Cannot combine marker selectors with path/regex selectors: {}".format(markers))
+
+    if len(prefixes) == 1 and not regexes:
+        return {"type": "path_prefix", "prefix": prefixes[0]}, "catalog_path_prefix"
+
+    selector_patterns = ["^{}".format(re.escape(prefix)) for prefix in prefixes]
+    selector_patterns.extend(regexes)
+    return {
+        "type": "regex",
+        "pattern": "(?:{})".format("|".join(selector_patterns)),
+    }, "catalog_readable_tests"
+
+
+def selector_from_observed_nodeids(nodeids):
+    return {
+        "type": "regex",
+        "pattern": exact_nodeid_regex(nodeids),
+    }, "exact_observed_nodeids_from_report"
+
+
+def selector_for_setup_only_rule(rule):
+    selector, selector_strategy = selector_from_catalog_tests(rule)
+    if selector is not None:
+        return selector, selector_strategy
+
+    if evaluation_mode(rule) == "topology_marker_intersects_available_tags":
+        return {"type": "pytest_marker", "marker": "topology"}, "catalog_pytest_marker"
+
+    return None, None
+
+
+def resolve_setup(setup_profiles, setup_key):
+    if not setup_profiles:
+        raise SystemExit("--setup requires --setup-profiles or a catalog containing setups")
+
+    setups = setup_profiles.get("setups", {})
+    if setup_key in setups:
+        return setup_key, setups[setup_key]
+
+    alias_matches = [
+        (key, setup)
+        for key, setup in setups.items()
+        if setup_key in (setup.get("aliases") or [])
+    ]
+    if len(alias_matches) == 1:
+        return alias_matches[0]
+    if not alias_matches:
+        raise SystemExit("setup not found in setup profiles: {}".format(setup_key))
+
+    raise SystemExit(
+        "setup alias matched multiple setups: {}".format(
+            ", ".join(key for key, _ in alias_matches)
+        )
+    )
+
+
+def setup_from_input_doc(setup_input_doc, setup_key=None):
+    if not isinstance(setup_input_doc, dict):
+        raise SystemExit("--setup-input must be a YAML mapping")
+
+    if "setups" in setup_input_doc:
+        setups = setup_input_doc.get("setups") or {}
+        if setup_key and setup_key in setups:
+            return setup_key, setups[setup_key]
+
+        user_setup_keys = [key for key in setups if key != "_template"]
+        if len(user_setup_keys) == 1:
+            key = user_setup_keys[0]
+            return key, setups[key]
+
+        if setup_key:
+            raise SystemExit("--setup-input does not contain setup key: {}".format(setup_key))
+
+        raise SystemExit(
+            "--setup-input with setups must contain exactly one setup or be used with --setup"
+        )
+
+    if "parameters" in setup_input_doc or "metadata" in setup_input_doc:
+        key = setup_input_doc.get("key") or setup_key or "user_setup"
+        setup = {
+            k: v for k, v in setup_input_doc.items()
+            if k not in ("key", "version")
+        }
+        return key, setup
+
+    raise SystemExit(
+        "--setup-input must either contain top-level metadata/parameters or a setups mapping"
+    )
+
+
+def merge_setup(base_setup, override_setup):
+    merged = copy.deepcopy(base_setup or {})
+    override = copy.deepcopy(override_setup or {})
+
+    for key, value in override.items():
+        if key in ("metadata", "parameters"):
+            base_value = merged.get(key) or {}
+            if not isinstance(base_value, dict) or not isinstance(value, dict):
+                merged[key] = value
+                continue
+            updated = copy.deepcopy(base_value)
+            updated.update(value)
+            merged[key] = updated
+        else:
+            merged[key] = value
+
+    return merged
+
+
+def normalize_lookup_value(value):
+    if value is None:
+        return None
+    value = str(value).strip()
+    if not value:
+        return None
+    return value.lower()
+
+
+def as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def unique_values(values):
+    result = []
+    seen = set()
+    for value in values:
+        if value is None:
+            continue
+        value = str(value).strip()
+        if not value:
+            continue
+        key = value.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(value)
+    return result
+
+
+def split_setup_platform_key(setup_key):
+    if not setup_key:
+        return None
+    return str(setup_key).split(":", 1)[0]
+
+
+def platform_catalog_lookup_values(entry_key, entry):
+    values = [
+        entry_key,
+        entry.get("sonic_platform"),
+        entry.get("pid"),
+        entry.get("hwsku"),
+        entry.get("internal_name"),
+    ]
+    values.extend(as_list(entry.get("aliases")))
+    values.extend(as_list(entry.get("external_aliases")))
+    values.extend(as_list(entry.get("internal_aliases")))
+    return unique_values(values)
+
+
+def platform_catalog_rule_identifiers(entry_key, entry):
+    """Return identifiers safe to expose to skip rules.
+
+    Internal aliases such as Superbolt are intentionally excluded here. They are
+    accepted for setup resolution only, so external-facing rules can use SONiC
+    platform, PID, chip, ASIC type, or vendor family instead.
+    """
+    values = [
+        entry.get("sonic_platform"),
+        entry_key,
+        entry.get("pid"),
+        entry.get("hwsku"),
+        entry.get("chip"),
+    ]
+    values.extend(as_list(entry.get("identifiers")))
+    values.extend(as_list(entry.get("external_aliases")))
+    return unique_values(values)
+
+
+def setup_platform_candidates(setup_key, setup):
+    metadata = setup.get("metadata") or {}
+    parameters = setup.get("parameters") or {}
+    values = [
+        split_setup_platform_key(setup_key),
+        metadata.get("platform"),
+        metadata.get("sonic_platform"),
+        metadata.get("pid"),
+        metadata.get("hwsku"),
+        metadata.get("platform_alias"),
+        metadata.get("internal_platform"),
+        parameters.get("platform.sonic_platform"),
+        parameters.get("platform.pid"),
+        parameters.get("platform.hwsku"),
+    ]
+    values.extend(as_list(parameters.get("platform.identifiers")))
+    return unique_values(values)
+
+
+def resolve_platform_catalog_entry(setup_profiles, setup_key, setup):
+    catalog = (setup_profiles or {}).get("platform_catalog") or {}
+    if not catalog:
+        return None
+
+    lookup = {}
+    for entry_key, entry in sorted(catalog.items()):
+        entry = entry or {}
+        for value in platform_catalog_lookup_values(entry_key, entry):
+            norm = normalize_lookup_value(value)
+            if norm:
+                lookup.setdefault(norm, []).append((entry_key, entry))
+
+    matches = OrderedDict()
+    for value in setup_platform_candidates(setup_key, setup):
+        norm = normalize_lookup_value(value)
+        for entry_key, entry in lookup.get(norm, []):
+            matches[entry_key] = entry
+
+    if not matches:
+        return None
+    if len(matches) > 1:
+        raise SystemExit(
+            "setup platform matched multiple platform_catalog entries: {}".format(
+                ", ".join(matches.keys())
+            )
+        )
+
+    entry_key, entry = next(iter(matches.items()))
+    return entry_key, entry
+
+
+def fill_missing(mapping, key, value):
+    if value is None:
+        return
+    if key not in mapping or mapping.get(key) in (None, ""):
+        mapping[key] = value
+
+
+def merge_identifier_parameter(parameters, values):
+    existing = as_list(parameters.get("platform.identifiers"))
+    parameters["platform.identifiers"] = unique_values(existing + values)
+
+
+def apply_platform_catalog(setup_profiles, setup_key, setup):
+    setup = copy.deepcopy(setup or {})
+    resolved = resolve_platform_catalog_entry(setup_profiles, setup_key, setup)
+    if not resolved:
+        return setup, None
+
+    catalog_key, entry = resolved
+    sonic_platform = entry.get("sonic_platform")
+    platform_identity = sonic_platform or entry.get("pid") or catalog_key
+    platform_family = entry.get("platform_family") or entry.get("asic_type")
+
+    metadata = setup.setdefault("metadata", {})
+    parameters = setup.setdefault("parameters", {})
+
+    fill_missing(metadata, "platform", platform_identity)
+    fill_missing(metadata, "sonic_platform", sonic_platform)
+    fill_missing(metadata, "pid", entry.get("pid"))
+    fill_missing(metadata, "chip", entry.get("chip"))
+    fill_missing(metadata, "hwsku", entry.get("hwsku"))
+    fill_missing(metadata, "hbm", entry.get("hbm"))
+    fill_missing(metadata, "speed", entry.get("speed"))
+    fill_missing(metadata, "configuration", entry.get("configuration"))
+    fill_missing(metadata, "sonic_support_roles", entry.get("sonic_support_roles"))
+    fill_missing(metadata, "vendor_family", entry.get("vendor_family"))
+    fill_missing(metadata, "asic_type", entry.get("asic_type"))
+    fill_missing(metadata, "platform_family", platform_family)
+
+    fill_missing(parameters, "platform.sonic_platform", sonic_platform)
+    fill_missing(parameters, "platform.platform", sonic_platform or catalog_key)
+    fill_missing(parameters, "platform.pid", entry.get("pid"))
+    fill_missing(parameters, "platform.chip", entry.get("chip"))
+    fill_missing(parameters, "platform.hwsku", entry.get("hwsku"))
+    fill_missing(parameters, "platform.hbm", entry.get("hbm"))
+    fill_missing(parameters, "platform.speed", entry.get("speed"))
+    fill_missing(parameters, "platform.configuration", entry.get("configuration"))
+    fill_missing(parameters, "platform.sonic_support_roles", entry.get("sonic_support_roles"))
+    fill_missing(parameters, "platform.vendor_family", entry.get("vendor_family"))
+    fill_missing(parameters, "platform.asic_type", entry.get("asic_type"))
+    fill_missing(parameters, "platform.platform_family", platform_family)
+    merge_identifier_parameter(parameters, platform_catalog_rule_identifiers(catalog_key, entry))
+
+    return setup, {
+        "catalog_key": catalog_key,
+        "sonic_platform": sonic_platform,
+        "pid": entry.get("pid"),
+        "chip": entry.get("chip"),
+        "hbm": entry.get("hbm"),
+        "speed": entry.get("speed"),
+        "configuration": entry.get("configuration"),
+        "asic_type": entry.get("asic_type"),
+        "platform_family": platform_family,
+    }
+
+
+def setup_topology_candidates(setup_key, setup):
+    metadata = setup.get("metadata") or {}
+    parameters = setup.get("parameters") or {}
+    values = []
+
+    if setup_key and ":" in str(setup_key):
+        values.append(str(setup_key).split(":", 1)[1])
+
+    values.extend([
+        metadata.get("topology"),
+        parameters.get("topology.name"),
+        parameters.get("topology.type"),
+    ])
+    values.extend(as_list(parameters.get("topology.identifiers")))
+    values.extend(as_list(parameters.get("topology.available_tags")))
+    return unique_values(values)
+
+
+def infer_topology_fact_values(topology_candidates):
+    lowered = [str(value).lower() for value in topology_candidates]
+    return {
+        "topology.is_tgen": any(
+            token in value
+            for value in lowered
+            for token in ("tgen", "ixia", "nut")
+        ),
+        "topology.is_t0_backend": any("t0-backend" in value for value in lowered),
+    }
+
+
+def apply_topology_inferences(setup_key, setup):
+    setup = copy.deepcopy(setup or {})
+    parameters = setup.setdefault("parameters", {})
+    candidates = setup_topology_candidates(setup_key, setup)
+    if not candidates:
+        return setup, None
+
+    inferred = infer_topology_fact_values(candidates)
+    for path, value in sorted(inferred.items()):
+        fill_missing(parameters, path, value)
+
+    return setup, {
+        "topology_candidates": candidates,
+        "inferred": inferred,
+    }
+
+
+def apply_parameter_overrides(setup, parameter_overrides):
+    if not parameter_overrides:
+        return setup
+
+    return merge_setup(setup, {
+        "parameters": parameter_overrides,
+    })
+
+
+def materialize_setup(setup_profiles, setup_key=None, setup_input_doc=None):
+    if not setup_key and setup_input_doc is None:
+        raise SystemExit("provide --setup, --setup-input, or both")
+
+    resolved_key = setup_key
+    setup = None
+
+    if setup_key:
+        resolved_key, setup = resolve_setup(setup_profiles, setup_key)
+
+    if setup_input_doc is not None:
+        input_key, input_setup = setup_from_input_doc(setup_input_doc, resolved_key)
+        if setup is None:
+            resolved_key = input_key
+            setup = input_setup
+        else:
+            setup = merge_setup(setup, input_setup)
+
+    return resolved_key, setup
+
+
+def setup_profiles_for_resolution(catalog, setup_profiles, setup_key):
+    if setup_profiles is not None:
+        return setup_profiles
+    if setup_key:
+        return catalog
+    return {"version": None, "setups": {}}
+
+
+def evaluation_mode(rule):
+    evaluation = rule.get("evaluation")
+    if isinstance(evaluation, dict):
+        return evaluation.get("mode")
+    return evaluation
+
+
+def rule_enabled(rule):
+    if "enabled" not in rule:
+        return True
+    enabled = rule["enabled"]
+    if isinstance(enabled, bool):
+        return enabled
+    if isinstance(enabled, str):
+        return enabled.strip().lower() in ("1", "true", "yes", "on")
+    return bool(enabled)
+
+
+def rule_disabled_reason(rule):
+    return rule.get("disabled_reason") or "enabled is false"
+
+
+def is_topology_marker_rule(rule):
+    return evaluation_mode(rule) == "topology_marker_intersects_available_tags"
+
+
+def set_path(data, dotted_path, value):
+    cur = data
+    parts = dotted_path.split(".")
+    for part in parts[:-1]:
+        cur = cur.setdefault(part, {})
+    cur[parts[-1]] = value
+
+
+def build_run_context(
+    catalog,
+    setup_profiles,
+    setup_key,
+    setup,
+    setup_input_used=False,
+    setup_merge_mode="profile_only",
+    platform_decode=None,
+):
+    run_context = OrderedDict()
+    run_context["version"] = "hardware-aware-run-context/v0.1"
+    run_context["status"] = "resolved_from_catalog"
+    run_context["source"] = {
+        "catalog_schema": catalog.get("version"),
+        "setup_profiles_schema": setup_profiles.get("version"),
+        "setup": setup_key,
+        "setup_input_used": setup_input_used,
+        "setup_merge_mode": setup_merge_mode,
+        "platform_decode": platform_decode,
+    }
+
+    metadata = setup.get("metadata", {})
+    parameters = setup.get("parameters") or {}
+    if metadata or parameters:
+        run_context["run"] = {
+            "platform": metadata.get("platform"),
+            "sonic_platform": metadata.get("sonic_platform"),
+            "pid": metadata.get("pid"),
+            "chip": metadata.get("chip"),
+            "hwsku": metadata.get("hwsku"),
+            "hbm": metadata.get("hbm"),
+            "speed": metadata.get("speed"),
+            "configuration": metadata.get("configuration"),
+            "sonic_support_roles": metadata.get("sonic_support_roles"),
+            "vendor_family": metadata.get("vendor_family"),
+            "asic_type": metadata.get("asic_type"),
+            "platform_family": metadata.get("platform_family"),
+            "topology": metadata.get("topology"),
+            "branch": metadata.get("branch"),
+        }
+
+        run_parameter_overrides = {
+            "platform.sonic_platform": "sonic_platform",
+            "platform.pid": "pid",
+            "platform.chip": "chip",
+            "platform.hwsku": "hwsku",
+            "platform.hbm": "hbm",
+            "platform.speed": "speed",
+            "platform.configuration": "configuration",
+            "platform.sonic_support_roles": "sonic_support_roles",
+            "platform.vendor_family": "vendor_family",
+            "platform.asic_type": "asic_type",
+            "platform.platform_family": "platform_family",
+        }
+        for path, run_key in sorted(run_parameter_overrides.items()):
+            if path in parameters and parameters[path] is not None:
+                run_context["run"][run_key] = parameters[path]
+        if parameters.get("platform.sonic_platform") is not None:
+            run_context["run"]["platform"] = parameters["platform.sonic_platform"]
+
+    for path, value in sorted(parameters.items()):
+        set_path(run_context, path, value)
+
+    return run_context
+
+
+def values_equal(actual, expected):
+    if isinstance(expected, list):
+        if isinstance(actual, list):
+            return bool(set(str(v) for v in actual).intersection(str(v) for v in expected))
+        return str(actual) in set(str(v) for v in expected)
+    return actual == expected
+
+
+def setup_matches_parameters(setup_parameters, rule_parameters):
+    missing = []
+    mismatched = []
+    for path, expected in sorted((rule_parameters or {}).items()):
+        actual = setup_parameters.get(path)
+        if path not in setup_parameters:
+            missing.append({"path": path, "expected": expected})
+            continue
+        if not values_equal(actual, expected):
+            mismatched.append({"path": path, "expected": expected, "actual": actual})
+    return not missing and not mismatched, missing, mismatched
+
+
+def condition_from_trigger_parameter(path, value):
+    if isinstance(value, list):
+        return {
+            "path": path,
+            "operator": "excludes_any",
+            "expected": value,
+        }
+    return {
+        "path": path,
+        "operator": "not_equals",
+        "expected": value,
+    }
+
+
+def source_areas(nodeids):
+    areas = {}
+    for nodeid in nodeids:
+        path = nodeid.split("::", 1)[0]
+        if path.startswith("tests/"):
+            path = path[len("tests/"):]
+        area = path.split("/", 1)[0] if "/" in path else path.rsplit(".", 1)[0]
+        areas[area] = areas.get(area, 0) + 1
+    return dict(sorted(areas.items()))
+
+
+def reason_matches_rule(reason, rule):
+    for pattern in rule.get("reason_patterns", []):
+        if re.search(pattern, reason, flags=re.DOTALL):
+            return pattern
+    return None
+
+
+def normalize_raw_skips(raw):
+    """Accept raw reason -> nodeids or reason -> area -> nodeids."""
+    normalized = {}
+    for reason, value in raw.items():
+        nodeids = []
+        if isinstance(value, list):
+            nodeids = list(value)
+        elif isinstance(value, dict):
+            for area_nodeids in value.values():
+                if isinstance(area_nodeids, list):
+                    nodeids.extend(area_nodeids)
+        normalized[reason] = sorted(dict.fromkeys(nodeids))
+    return normalized
+
+
+def build_test_capability(
+    rule_id,
+    rule,
+    nodeids,
+    raw_reasons,
+    matched_patterns,
+    selector=None,
+    selector_strategy=None,
+    source_mode="report_seeded",
+):
+    confidence = rule.get("confidence", "high")
+    candidate_status = rule.get("candidate_status", "ready_for_report_only")
+    source_instances = len(nodeids)
+    if selector is None:
+        selector, selector_strategy = selector_from_catalog_tests(rule)
+    if selector is None:
+        selector, selector_strategy = selector_from_observed_nodeids(nodeids)
+
+    selector_note = (
+        "Generated from catalog setup-only rules."
+        if source_mode == "setup_only"
+        else "Generated from hardware-aware catalog readable tests when present; otherwise observed Allure nodeids."
+    )
+
+    if evaluation_mode(rule) == "topology_marker_intersects_available_tags":
+        conditions = [
+            {
+                "path": "topology.available_tags",
+                "operator": "intersects",
+                "expected_source": "pytest.mark.topology args or test-required topology tags",
+            }
+        ]
+        return {
+            "id": "candidate_{}_requires_topology_available_tags".format(safe_id(rule_id)),
+            "bucket_id": rule_id,
+            "source_normalized_reason_id": rule_id,
+            "raw_skip_reason": raw_reasons[0],
+            "raw_skip_reason_variants": raw_reasons if len(raw_reasons) > 1 else None,
+            "candidate_status": candidate_status,
+            "confidence": confidence,
+            "approved_for": "catalog",
+            "selector_strategy": "{}_with_dynamic_topology_marker".format(selector_strategy),
+            "selector_note": selector_note,
+            "source_areas": source_areas(nodeids),
+            "source_skipped_test_instances": source_instances,
+            "applies_to": selector,
+            "decision": {
+                "deselect_when": "pytest.mark.topology args do not intersect run_context.topology.available_tags",
+                "reason_template": (
+                    "requires pytest.mark.topology args to intersect topology.available_tags, "
+                    "current topology.available_tags={topology.available_tags}."
+                ),
+            },
+            "evaluation": {
+                "mode": "topology_marker_intersects_available_tags",
+                "marker": "topology",
+                "conditions": conditions,
+            },
+            "catalog": {
+                "source_mode": source_mode,
+                "matched_reason_patterns": sorted(matched_patterns),
+            },
+        }
+
+    conditions = [
+        condition_from_trigger_parameter(path, value)
+        for path, value in sorted((rule.get("parameters") or {}).items())
+    ]
+    reason_template = "matches hardware-aware catalog rule {}; current setup has triggering parameters.".format(rule_id)
+    if conditions:
+        first = conditions[0]
+        reason_template = "skip rule {} triggered by {{{}}}.".format(rule_id, first["path"])
+
+    return {
+        "id": "candidate_{}_from_catalog".format(safe_id(rule_id)),
+        "bucket_id": rule_id,
+        "source_normalized_reason_id": rule_id,
+        "raw_skip_reason": raw_reasons[0],
+        "raw_skip_reason_variants": raw_reasons if len(raw_reasons) > 1 else None,
+        "candidate_status": candidate_status,
+        "confidence": confidence,
+        "approved_for": "catalog",
+        "selector_strategy": selector_strategy,
+        "selector_note": selector_note,
+        "source_areas": source_areas(nodeids),
+        "source_skipped_test_instances": source_instances,
+        "applies_to": selector,
+        "decision": {
+            "deselect_when": "current run context matches hardware-aware catalog trigger parameters",
+            "reason_template": reason_template,
+        },
+        "evaluation": {
+            "mode": "all",
+            "conditions": conditions,
+        },
+        "catalog": {
+            "source_mode": source_mode,
+            "matched_reason_patterns": sorted(matched_patterns),
+        },
+    }
+
+
+def nodeid_to_file(nodeid):
+    path = nodeid.split("::", 1)[0]
+    if path.startswith("tests/"):
+        path = path[len("tests/"):]
+    return path
+
+
+def build_setup_only_outputs(
+    catalog,
+    setup_profiles,
+    setup_key,
+    setup_input_doc=None,
+    parameter_overrides=None,
+    run_id=None,
+    source_report_url=None,
+    include_topology_rules=False,
+):
+    setup_profiles = setup_profiles_for_resolution(catalog, setup_profiles, setup_key)
+    requested_setup_key = setup_key
+    setup_key, setup = materialize_setup(
+        setup_profiles,
+        setup_key=setup_key,
+        setup_input_doc=setup_input_doc,
+    )
+    setup_merge_mode = (
+        "override_profile" if setup_input_doc is not None and requested_setup_key
+        else "input_only" if setup_input_doc is not None
+        else "profile_only"
+    )
+    setup, platform_decode = apply_platform_catalog(setup_profiles, setup_key, setup)
+    setup, topology_inference = apply_topology_inferences(setup_key, setup)
+    setup = apply_parameter_overrides(setup, parameter_overrides)
+    setup_parameters = setup.get("parameters") or {}
+    rules = catalog.get("skip_rules", {})
+
+    test_capabilities = []
+    not_applicable = []
+    missing_selectors = []
+    skipped_topology_rules = []
+
+    for rule_id, rule in sorted(rules.items()):
+        if not rule_enabled(rule):
+            if is_topology_marker_rule(rule) and include_topology_rules:
+                pass
+            else:
+                skipped_topology_rules.append({
+                    "rule_id": rule_id,
+                    "reason": rule_disabled_reason(rule),
+                })
+                continue
+
+        if (
+            is_topology_marker_rule(rule)
+            and "enabled" not in rule
+            and not include_topology_rules
+        ):
+            skipped_topology_rules.append({
+                "rule_id": rule_id,
+                "reason": (
+                    "setup-only generation skips topology marker rules without explicit "
+                    "enabled=true because existing SONiC custom markers already "
+                    "handle topology gating"
+                ),
+            })
+            continue
+
+        matched, missing, mismatched = setup_matches_parameters(
+            setup_parameters,
+            rule.get("parameters") or {},
+        )
+        if not matched:
+            not_applicable.append({
+                "rule_id": rule_id,
+                "missing_parameters": missing,
+                "mismatched_parameters": mismatched,
+            })
+            continue
+
+        selector, selector_strategy = selector_for_setup_only_rule(rule)
+        if selector is None:
+            missing_selectors.append({
+                "rule_id": rule_id,
+                "reason_patterns": rule.get("reason_patterns") or [],
+                "note": "setup-only generation needs tests selectors or a supported structured evaluation mode",
+            })
+            continue
+
+        reason_patterns = sorted(rule.get("reason_patterns") or [rule_id])
+        test_capabilities.append(build_test_capability(
+            rule_id,
+            rule,
+            [],
+            reason_patterns,
+            reason_patterns,
+            selector=selector,
+            selector_strategy=selector_strategy,
+            source_mode="setup_only",
+        ))
+
+    test_capabilities_doc = OrderedDict()
+    test_capabilities_doc["version"] = "hardware-aware-test-capabilities/v0.1"
+    test_capabilities_doc["status"] = "candidate_test_capabilities_from_catalog_setup_only"
+    test_capabilities_doc["source"] = {
+        "mode": "setup_only",
+        "catalog_schema": catalog.get("version"),
+        "setup_profiles_schema": setup_profiles.get("version"),
+        "setup": setup_key,
+        "setup_input_used": setup_input_doc is not None,
+        "setup_merge_mode": setup_merge_mode,
+        "platform_decode": platform_decode,
+        "topology_inference": topology_inference,
+        "parameter_overrides": sorted((parameter_overrides or {}).keys()),
+        "run_id": run_id,
+        "allure_report_url": source_report_url,
+    }
+    test_capabilities_doc["notes"] = [
+        "Generated from catalog setup profiles and skip rules only.",
+        "No skipped-reason report was used. source_skipped_test_instances is 0 by design.",
+        "This is a compatibility artifact for the current hardware-aware pytest plugin.",
+    ]
+    test_capabilities_doc["summary"] = {
+        "generated_test_capabilities": len(test_capabilities),
+        "source_skipped_test_instances": 0,
+        "unmapped_reasons": 0,
+        "not_applicable_rules": len(not_applicable),
+        "missing_selector_rules": len(missing_selectors),
+        "skipped_topology_rules": len(skipped_topology_rules),
+        "ambiguous_reasons": 0,
+    }
+    test_capabilities_doc["test_capabilities"] = test_capabilities
+
+    run_context = build_run_context(
+        catalog,
+        setup_profiles,
+        setup_key,
+        setup,
+        setup_input_used=setup_input_doc is not None,
+        setup_merge_mode=setup_merge_mode,
+        platform_decode=platform_decode,
+    )
+    if run_id:
+        run_context.setdefault("run", {})
+        run_context["run"]["id"] = run_id
+
+    audit = {
+        "version": "hardware-aware-catalog-audit/v0.1",
+        "setup": setup_key,
+        "mode": "setup_only",
+        "setup_input_used": setup_input_doc is not None,
+        "platform_decode": platform_decode,
+        "topology_inference": topology_inference,
+        "parameter_overrides": sorted((parameter_overrides or {}).keys()),
+        "summary": {
+            "raw_reasons": 0,
+            "generated_test_capabilities": len(test_capabilities),
+            "generated_source_instances": 0,
+            "unmapped_reasons": 0,
+            "not_applicable_rules": len(not_applicable),
+            "missing_selector_rules": len(missing_selectors),
+            "skipped_topology_rules": len(skipped_topology_rules),
+            "ambiguous_reasons": 0,
+            "target_files": 0,
+        },
+        "not_applicable_rules": not_applicable,
+        "missing_selector_rules": missing_selectors,
+        "skipped_topology_rules": skipped_topology_rules,
+        "matched_rules": [
+            {
+                "rule_id": tc["bucket_id"],
+                "selector_strategy": tc["selector_strategy"],
+                "source_mode": "setup_only",
+            }
+            for tc in test_capabilities
+        ],
+    }
+
+    return test_capabilities_doc, run_context, audit, []
+
+
+def build_outputs(
+    catalog,
+    setup_profiles,
+    setup_key,
+    raw_skips,
+    setup_input_doc=None,
+    parameter_overrides=None,
+    run_id=None,
+    source_report_url=None,
+    include_topology_rules=False,
+):
+    if raw_skips is None:
+        return build_setup_only_outputs(
+            catalog,
+            setup_profiles,
+            setup_key,
+            setup_input_doc=setup_input_doc,
+            parameter_overrides=parameter_overrides,
+            run_id=run_id,
+            source_report_url=source_report_url,
+            include_topology_rules=include_topology_rules,
+        )
+
+    setup_profiles = setup_profiles_for_resolution(catalog, setup_profiles, setup_key)
+    requested_setup_key = setup_key
+    setup_key, setup = materialize_setup(
+        setup_profiles,
+        setup_key=setup_key,
+        setup_input_doc=setup_input_doc,
+    )
+    setup_merge_mode = (
+        "override_profile" if setup_input_doc is not None and requested_setup_key
+        else "input_only" if setup_input_doc is not None
+        else "profile_only"
+    )
+    setup, platform_decode = apply_platform_catalog(setup_profiles, setup_key, setup)
+    setup, topology_inference = apply_topology_inferences(setup_key, setup)
+    setup = apply_parameter_overrides(setup, parameter_overrides)
+    setup_parameters = setup.get("parameters") or {}
+    rules = catalog.get("skip_rules", {})
+    normalized_raw = normalize_raw_skips(raw_skips)
+
+    per_rule = {}
+    unmapped = []
+    not_applicable = []
+    ambiguous = []
+
+    for reason, nodeids in sorted(normalized_raw.items()):
+        matches = []
+        for rule_id, rule in sorted(rules.items()):
+            pattern = reason_matches_rule(reason, rule)
+            if pattern:
+                matches.append((rule_id, rule, pattern))
+
+        if not matches:
+            unmapped.append({
+                "reason": reason,
+                "count": len(nodeids),
+                "sample_tests": nodeids[:5],
+            })
+            continue
+        if len(matches) > 1:
+            ambiguous.append({
+                "reason": reason,
+                "count": len(nodeids),
+                "matched_rules": [rule_id for rule_id, _, _ in matches],
+            })
+
+        for rule_id, rule, pattern in matches[:1]:
+            matched, missing, mismatched = setup_matches_parameters(
+                setup_parameters,
+                rule.get("parameters") or {},
+            )
+            if not matched:
+                not_applicable.append({
+                    "reason": reason,
+                    "count": len(nodeids),
+                    "rule_id": rule_id,
+                    "missing_parameters": missing,
+                    "mismatched_parameters": mismatched,
+                })
+                continue
+
+            bucket = per_rule.setdefault(rule_id, {
+                "rule": rule,
+                "nodeids": [],
+                "raw_reasons": [],
+                "matched_patterns": [],
+            })
+            bucket["nodeids"].extend(nodeids)
+            if reason not in bucket["raw_reasons"]:
+                bucket["raw_reasons"].append(reason)
+            if pattern not in bucket["matched_patterns"]:
+                bucket["matched_patterns"].append(pattern)
+
+    test_capabilities = []
+    target_files = set()
+    for rule_id, bucket in sorted(per_rule.items()):
+        nodeids = sorted(dict.fromkeys(bucket["nodeids"]))
+        if not nodeids:
+            continue
+        for nodeid in nodeids:
+            target_files.add(nodeid_to_file(nodeid))
+        test_capabilities.append(build_test_capability(
+            rule_id,
+            bucket["rule"],
+            nodeids,
+            sorted(bucket["raw_reasons"]),
+            sorted(bucket["matched_patterns"]),
+        ))
+
+    test_capabilities_doc = OrderedDict()
+    test_capabilities_doc["version"] = "hardware-aware-test-capabilities/v0.1"
+    test_capabilities_doc["status"] = "candidate_test_capabilities_from_catalog"
+    test_capabilities_doc["source"] = {
+        "mode": "report_seeded",
+        "catalog_schema": catalog.get("version"),
+        "setup_profiles_schema": setup_profiles.get("version"),
+        "setup": setup_key,
+        "setup_input_used": setup_input_doc is not None,
+        "setup_merge_mode": setup_merge_mode,
+        "platform_decode": platform_decode,
+        "topology_inference": topology_inference,
+        "parameter_overrides": sorted((parameter_overrides or {}).keys()),
+        "run_id": run_id,
+        "allure_report_url": source_report_url,
+    }
+    test_capabilities_doc["notes"] = [
+        "Generated from catalog YAML and observed skipped-reason nodeids.",
+        "This is a compatibility artifact for the current hardware-aware pytest plugin.",
+    ]
+    test_capabilities_doc["summary"] = {
+        "generated_test_capabilities": len(test_capabilities),
+        "source_skipped_test_instances": sum(tc["source_skipped_test_instances"] for tc in test_capabilities),
+        "unmapped_reasons": len(unmapped),
+        "not_applicable_reasons": len(not_applicable),
+        "ambiguous_reasons": len(ambiguous),
+    }
+    test_capabilities_doc["test_capabilities"] = test_capabilities
+
+    run_context = build_run_context(
+        catalog,
+        setup_profiles,
+        setup_key,
+        setup,
+        setup_input_used=setup_input_doc is not None,
+        setup_merge_mode=setup_merge_mode,
+        platform_decode=platform_decode,
+    )
+    if run_id:
+        run_context.setdefault("run", {})
+        run_context["run"]["id"] = run_id
+
+    audit = {
+        "version": "hardware-aware-catalog-audit/v0.1",
+        "setup": setup_key,
+        "mode": "report_seeded",
+        "setup_input_used": setup_input_doc is not None,
+        "platform_decode": platform_decode,
+        "topology_inference": topology_inference,
+        "parameter_overrides": sorted((parameter_overrides or {}).keys()),
+        "summary": {
+            "raw_reasons": len(normalized_raw),
+            "generated_test_capabilities": len(test_capabilities),
+            "generated_source_instances": test_capabilities_doc["summary"]["source_skipped_test_instances"],
+            "unmapped_reasons": len(unmapped),
+            "not_applicable_reasons": len(not_applicable),
+            "ambiguous_reasons": len(ambiguous),
+            "target_files": len(target_files),
+        },
+        "unmapped_reasons": unmapped,
+        "not_applicable_reasons": not_applicable,
+        "ambiguous_reasons": ambiguous,
+        "matched_rules": [
+            {
+                "rule_id": tc["bucket_id"],
+                "source_skipped_test_instances": tc["source_skipped_test_instances"],
+                "raw_skip_reason": tc["raw_skip_reason"],
+            }
+            for tc in test_capabilities
+        ],
+    }
+
+    return test_capabilities_doc, run_context, audit, sorted(target_files)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", required=True, help="Hardware-aware skip-rule catalog YAML.")
+    parser.add_argument(
+        "--setup-profiles",
+        help="Setup profiles YAML. If omitted, setups are read from --catalog for backward compatibility.",
+    )
+    parser.add_argument(
+        "--setup",
+        help=(
+            "Setup key or setup alias from setup profiles. Optional when --setup-input "
+            "provides a complete setup."
+        ),
+    )
+    parser.add_argument(
+        "--setup-input",
+        help=(
+            "Optional user setup YAML. If --setup is also provided, this file overrides "
+            "the selected setup profile. If --setup is omitted, this file must provide a complete setup."
+        ),
+    )
+    parser.add_argument(
+        "--raw-skips",
+        help=(
+            "Optional raw skipped-reasons JSON from Allure extraction. "
+            "When omitted, generate setup-only inputs from setup profiles and skip rules."
+        ),
+    )
+    parser.add_argument(
+        "--include-topology-rules",
+        action="store_true",
+        help=(
+            "In setup-only mode, also generate topology marker rules. "
+            "By default these are skipped because SONiC custom markers already handle topology gating."
+        ),
+    )
+    parser.add_argument("--run-id", help="Run id recorded in generated artifacts.")
+    parser.add_argument("--source-report-url", help="Allure report URL recorded in generated artifacts.")
+    parser.add_argument("--test-capabilities-output", required=True)
+    parser.add_argument("--run-context-output")
+    parser.add_argument("--audit-output")
+    parser.add_argument("--target-files-output")
+    args = parser.parse_args()
+
+    catalog = load_yaml(args.catalog)
+    setup_profiles = load_yaml(args.setup_profiles) if args.setup_profiles else None
+    setup_input_doc = load_yaml(args.setup_input) if args.setup_input else None
+    raw_skips = load_json(args.raw_skips) if args.raw_skips else None
+    test_capabilities, run_context, audit, target_files = build_outputs(
+        catalog,
+        setup_profiles,
+        args.setup,
+        raw_skips,
+        setup_input_doc=setup_input_doc,
+        run_id=args.run_id,
+        source_report_url=args.source_report_url,
+        include_topology_rules=args.include_topology_rules,
+    )
+
+    write_json(args.test_capabilities_output, test_capabilities)
+    if args.run_context_output:
+        write_json(args.run_context_output, run_context)
+    if args.audit_output:
+        write_json(args.audit_output, audit)
+    if args.target_files_output:
+        write_lines(args.target_files_output, target_files)
+
+    print(json.dumps(audit["summary"], indent=2, sort_keys=True))
+    print("wrote {}".format(args.test_capabilities_output))
+    if args.run_context_output:
+        print("wrote {}".format(args.run_context_output))
+    if args.audit_output:
+        print("wrote {}".format(args.audit_output))
+    if args.target_files_output:
+        print("wrote {}".format(args.target_files_output))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hardware_aware/setup_profiles.yaml
+++ b/tests/hardware_aware/setup_profiles.yaml
@@ -1,0 +1,729 @@
+version: hardware-aware-setup-profiles/v0.1
+description: >
+  Human-readable setup profiles for hardware-aware pre-run deselection.
+  A setup profile records the current platform, topology, run options,
+  feature flags, and resource availability used by skip rules.
+
+parameter_schema:
+  run.options.include_long_tests:
+    type: boolean
+    description: Whether long tests were explicitly enabled for this run.
+    example: false
+  environment.is_sim:
+    type: boolean
+    description: Whether the run is using a simulated DUT environment.
+    example: false
+  environment.is_vxr:
+    type: boolean
+    description: Whether the run is using a VXR virtual test environment.
+    example: false
+  topology.type:
+    type: string
+    description: High-level topology family.
+    example: t0
+  topology.name:
+    type: string
+    description: Concrete topology name passed to the run.
+    example: t0-64
+  topology.available_tags:
+    type: list[string]
+    description: Topology tags considered available for pytest.mark.topology matching.
+    example:
+      - t0
+      - t0-64
+  topology.identifiers:
+    type: list[string]
+    description: Topology names or aliases used by skip rules.
+    example:
+      - t0
+      - t0-64
+  topology.is_dualtor:
+    type: boolean
+    description: Whether the run is on a dualtor topology.
+    example: false
+  topology.is_isolated_v6:
+    type: boolean
+    description: Whether the run uses an isolated IPv6-only topology.
+    example: false
+  topology.is_storage_backend:
+    type: boolean
+    description: Whether the topology is a storage backend topology.
+    example: false
+  topology.is_tgen:
+    type: boolean
+    description: Whether the topology has traffic generator support for tgen/ixia/nut tests.
+    example: false
+  topology.is_t0_backend:
+    type: boolean
+    description: Whether the topology is a T0 backend topology.
+    example: false
+  topology.is_t2:
+    type: boolean
+    description: Whether the run is on a T2 topology.
+    example: false
+  topology.multi_dut.supported:
+    type: boolean
+    description: Whether multi-DUT parametrized tests are supported.
+    example: false
+  topology.single_dut_multi_asic.supported:
+    type: boolean
+    description: Whether single-DUT multi-ASIC parametrized tests are supported.
+    example: false
+  topology.fanout.explicit_support:
+    type: boolean
+    description: Whether tests requiring explicit fanout support can run.
+    example: false
+  topology.rif_members.available:
+    type: boolean
+    description: Whether rif_members parameters are available.
+    example: false
+  topology.vlan_members.drop_counter_supported:
+    type: boolean
+    description: Whether drop counter tests support vlan_members parameters.
+    example: false
+  platform.vendor_family:
+    type: string
+    description: Optional broad vendor grouping. Prefer SONiC facts such as platform.asic_type when possible.
+    example: cisco
+  platform.asic_type:
+    type: string
+    description: SONiC ASIC type from show platform summary, not the hardware chip name.
+    example: cisco-8000
+  platform.platform_family:
+    type: string
+    description: Platform family after platform alias decoding.
+    example: cisco-8000
+  platform.sonic_platform:
+    type: string
+    description: SONiC platform string from duthost.facts["platform"].
+    example: x86_64-8122_64ehf_o-r0
+  platform.platform:
+    type: string
+    description: Compatibility alias for the SONiC platform string used by some source skips.
+    example: x86_64-8122_64ehf_o-r0
+  platform.platform_asic:
+    type: string
+    description: Finer ASIC family from duthost facts when available.
+    example: cisco-8000
+  platform.pid:
+    type: string
+    description: External hardware PID or model identifier.
+    example: 8122-64EHF-O
+  platform.chip:
+    type: string
+    description: Hardware chip generation used for chip-level grouping.
+    example: G200
+  platform.hwsku:
+    type: string|null
+    description: Optional SONiC HwSKU from duthost.facts["hwsku"].
+    example: null
+  platform.hbm:
+    type: boolean|null
+    description: Whether the platform has HBM, when known.
+    example: false
+  platform.speed:
+    type: string|null
+    description: Platform aggregate speed from hardware identity data.
+    example: 51.2T
+  platform.configuration:
+    type: string|null
+    description: Port configuration from hardware identity data.
+    example: 64x800G
+  platform.sonic_support_roles:
+    type: list[string]
+    description: SONiC roles listed for the platform, when known.
+    example:
+      - BT0
+      - BT1
+  platform.identifiers:
+    type: list[string]
+    description: External platform identifiers available to skip rules. Internal aliases are resolved separately.
+    example:
+      - x86_64-8122_64ehf_o-r0
+      - 8122-64EHF-O
+      - G200
+  platform.is_multi_asic:
+    type: boolean
+    description: Whether the DUT is a multi-ASIC system.
+    example: false
+  platform.is_smartswitch:
+    type: boolean
+    description: Whether the DUT is a SmartSwitch platform.
+    example: false
+  platform.is_dpu:
+    type: boolean
+    description: Whether the DUT is a DPU node.
+    example: false
+  platform.is_modular_chassis:
+    type: boolean
+    description: Whether the DUT is a modular chassis.
+    example: false
+  platform.chassis.modules.available:
+    type: boolean
+    description: Whether chassis module APIs report at least one module.
+    example: false
+  platform.chassis.status_led.controllable:
+    type: boolean
+    description: Whether chassis status LED can be controlled by platform APIs.
+    example: false
+  platform.role:
+    type: string|null
+    description: Optional chassis role such as LC/RP when relevant.
+    example: null
+  image.os_version:
+    type: string|null
+    description: SONiC image branch or release used by image-gated skips.
+    example: 202505c
+  image.kernel_version:
+    type: string|null
+    description: DUT kernel version when image-age skips apply.
+    example: null
+  features.acl.ipv6.supported:
+    type: boolean
+    description: Whether IPv6 ACL tests are supported.
+    example: false
+  features.bgp.idf_isolation.supported:
+    type: boolean
+    description: Whether BGP IDF isolation is supported by the image.
+    example: false
+  features.bgp.tsa_persistence.supported:
+    type: boolean
+    description: Whether startup TSA/TSB persistence is supported by the image.
+    example: false
+  features.console_switch.enabled:
+    type: boolean
+    description: Whether console switch tests are enabled for the DUT.
+    example: false
+  features.dhcp_relay.enabled:
+    type: boolean
+    description: Whether DHCP relay is enabled for the run.
+    example: true
+  features.eventd.enabled:
+    type: boolean
+    description: Whether eventd is enabled on the system.
+    example: true
+  features.everflow.cross_direction_acl_mirroring.supported:
+    type: boolean
+    description: Whether cross-direction ACL mirroring is supported.
+    example: false
+  features.everflow.ipv6_erspan_cli.supported:
+    type: boolean
+    description: Whether CLI-based IPv6 ERSPAN mirror session creation is supported.
+    example: false
+  features.macsec.enabled:
+    type: boolean
+    description: Whether MACsec tests are applicable.
+    example: false
+  features.nat.enabled:
+    type: boolean
+    description: Whether NAT feature tests are enabled.
+    example: false
+  features.sflow.enabled:
+    type: boolean
+    description: Whether sFlow feature tests are enabled.
+    example: false
+  resources.tgen_port_info.available:
+    type: boolean
+    description: Whether tgen_port_info parameters are available.
+    example: false
+  resources.psu.minimum_count_2.available:
+    type: boolean
+    description: Whether the DUT has at least two healthy PSUs for PSU on/off testing.
+    example: false
+  resources.python_saithrift_package_url.available:
+    type: boolean
+    description: Whether --py_saithrift_url is available for pretest PTF setup.
+    example: false
+  resources.sensor_mocker.available:
+    type: boolean
+    description: Whether platform sensor mockers are available for fan and thermal tests.
+    example: false
+  resources.counterpoll_cpu_usage_program.available:
+    type: boolean
+    description: Whether a vendor-specific program is defined for counterpoll CPU usage checks.
+    example: false
+  test.platform_or_asic.supported:
+    type: boolean
+    description: Generic flag for tests whose source says this platform or ASIC is unsupported.
+    example: false
+  run.neighbor_type:
+    type: string|null
+    description: Neighbor type passed to the run, such as sonic or eos.
+    example: sonic
+  run.uses_topology_filter:
+    type: boolean
+    description: Whether run_tests.sh passes --topology.
+    example: true
+  run.uses_asic_filter:
+    type: boolean
+    description: Whether pytest is invoked with --asic.
+    example: false
+  run.enable_macsec:
+    type: boolean|null
+    description: Whether the MACsec run option is enabled.
+    example: false
+
+platform_catalog:
+  x86_64-8102_64h_o-r0:
+    description: External/canonical identity for the Cisco internal Matilda-64 platform.
+    sonic_platform: x86_64-8102_64h_o-r0
+    pid: 8102-64H-O
+    chip: Q200
+    hbm: false
+    speed: 6.4T
+    configuration: 64x100G
+    sonic_support_roles:
+      - T0
+      - T1
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    aliases:
+      - 8102-64H-O
+    internal_aliases:
+      - matilda
+      - Matilda-64
+      - m64
+      - mth64
+
+  x86_64-8101_32fh_o-r0:
+    description: External/canonical identity for the Cisco internal Churchill Mono platform.
+    sonic_platform: x86_64-8101_32fh_o-r0
+    pid: 8101-32FH-O
+    chip: Q200
+    hbm: false
+    speed: 12.8T
+    configuration: 32x400G
+    sonic_support_roles:
+      - T1
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    aliases:
+      - 8101-32FH-O
+    internal_aliases:
+      - churchill-mono
+      - Churchill Mono
+
+  x86_64-8201_32fh_o-r0:
+    description: External/canonical identity for the Cisco internal Churchill HBM platform.
+    sonic_platform: x86_64-8201_32fh_o-r0
+    pid: 8201-32FH-O
+    chip: Q200
+    hbm: true
+    speed: 12.8T
+    configuration: 32x400G
+    sonic_support_roles:
+      - T1
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    aliases:
+      - 8201-32FH-O
+    internal_aliases:
+      - churchill-hbm
+      - Churchill HBM
+
+  x86_64-8111_32eh_o-r0:
+    description: External/canonical identity for the Cisco internal Crocodile platform.
+    sonic_platform: x86_64-8111_32eh_o-r0
+    pid: 8111-32EH-O
+    chip: G100
+    hbm: false
+    speed: 25.6T
+    configuration: 32x800G
+    sonic_support_roles:
+      - BT0
+      - BT1
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    aliases:
+      - 8111-32EH-O
+    internal_aliases:
+      - crocodile
+      - Crocodile
+
+  x86_64-8122_64eh_o-r0:
+    description: External/canonical identity for the Cisco internal Lightning platform.
+    sonic_platform: x86_64-8122_64eh_o-r0
+    pid: 8122-64EH-O
+    chip: G200
+    hbm: false
+    speed: 51.2T
+    configuration: 64x800G
+    sonic_support_roles:
+      - BT0
+      - BT1
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    aliases:
+      - 8122-64EH-O
+    internal_aliases:
+      - lightning
+      - Lightning
+
+  x86_64-8122_64ehf_o-r0:
+    description: External/canonical identity for the Cisco internal Superbolt platform.
+    sonic_platform: x86_64-8122_64ehf_o-r0
+    pid: 8122-64EHF-O
+    chip: G200
+    hbm: false
+    speed: 51.2T
+    configuration: 64x800G
+    sonic_support_roles:
+      - BT0
+      - BT1
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    aliases:
+      - 8122-64EHF-O
+    internal_aliases:
+      - superbolt
+      - Superbolt
+
+  x86_64-8102_28fh_dpu_o-r0:
+    description: External/canonical identity for the Cisco internal Mt. Fuji platform.
+    sonic_platform: x86_64-8102_28fh_dpu_o-r0
+    pid: 8102-28FH-DPU-O
+    chip: Q200 + DPU
+    hbm: false
+    speed: 12.8T
+    configuration: 28x400G
+    sonic_support_roles:
+      - T1
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    aliases:
+      - 8102-28FH-DPU-O
+    internal_aliases:
+      - mt-fuji
+      - Mt. Fuji
+
+  8524-64EH-O:
+    description: External identity for the Cisco internal McKenzie platform. SONiC platform string is not confirmed here.
+    pid: 8524-64EH-O
+    chip: G200
+    hbm: false
+    speed: 51.2T
+    configuration: 64x800G
+    sonic_support_roles: []
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    internal_aliases:
+      - mckenzie
+      - McKenzie
+
+  8800-LC-48H:
+    description: External identity for the Cisco internal Gauntlet platform. SONiC platform string is not confirmed here.
+    pid: 8800-LC-48H
+    chip: Q100
+    hbm: true
+    speed: 4.8T
+    configuration: 48x100G
+    hwsku: Cisco-8800-LC-48H-C48
+    sonic_support_roles:
+      - T2
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    internal_aliases:
+      - gauntlet
+      - Gauntlet
+
+  x86_64-88_lc0_36fh_m-r0:
+    description: External/canonical identity for the Cisco internal Vanguard platform.
+    sonic_platform: x86_64-88_lc0_36fh_m-r0
+    pid: 88-LC0-36FH-M
+    chip: Q200
+    hbm: true
+    speed: 14.4T
+    configuration: 36x400G
+    hwsku: Cisco-88-LC0-36FH-M-O36
+    sonic_support_roles:
+      - T2
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    aliases:
+      - 88-LC0-36FH-M
+      - x86_64-88_lc0_36fh_mo-r0
+    internal_aliases:
+      - vanguard
+      - Vanguard
+
+  x86_64-88_lc0_36fh-r0:
+    description: External/canonical identity for the Cisco internal Lancer platform.
+    sonic_platform: x86_64-88_lc0_36fh-r0
+    pid: 88-LC0-36FH
+    chip: Q200
+    hbm: true
+    speed: 14.4T
+    configuration: 36x400G
+    hwsku: Cisco-88-LC0-36FH-O36
+    sonic_support_roles:
+      - T2
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    aliases:
+      - 88-LC0-36FH
+      - x86_64-88_lc0_36fh_o-r0
+    internal_aliases:
+      - lancer
+      - Lancer
+
+  FAS1000-32D:
+    description: External identity for Carib, rebranded from Churchill Mono. SONiC platform string is not confirmed here.
+    pid: FAS1000-32D
+    chip: Q200
+    hbm: false
+    speed: 12.8T
+    configuration: 32x400G
+    sonic_support_roles:
+      - T1
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    internal_aliases:
+      - carib
+      - Carib
+
+  FAS1000-60L4D:
+    description: External identity for Siren. SONiC platform string is not confirmed here.
+    pid: FAS1000-60L4D
+    chip: Q200
+    hbm: false
+    speed: 12.8T
+    configuration: 64x50G + 4x400G
+    sonic_support_roles:
+      - T0
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    internal_aliases:
+      - siren
+      - Siren
+
+  x86_64-8101_32fh_o_c01-r0:
+    description: External/canonical identity for the Cisco internal Tornado platform.
+    sonic_platform: x86_64-8101_32fh_o_c01-r0
+    pid: 8101-32FH-C01
+    chip: Q200
+    hbm: false
+    speed: 12.8T
+    configuration: 32x400G
+    sonic_support_roles:
+      - T0
+    vendor_family: cisco
+    asic_type: cisco-8000
+    platform_family: cisco-8000
+    aliases:
+      - 8101-32FH-C01
+    internal_aliases:
+      - tornado
+      - Tornado
+
+setups:
+  _template:
+    description: Copy this profile when adding a new setup.
+    metadata:
+      platform: null
+      sonic_platform: null
+      pid: null
+      chip: null
+      hwsku: null
+      hbm: null
+      speed: null
+      configuration: null
+      sonic_support_roles: []
+      vendor_family: null
+      asic_type: null
+      platform_family: null
+      topology: null
+      branch: null
+    parameters:
+      run.options.include_long_tests: null
+      environment.is_sim: null
+      environment.is_vxr: null
+      topology.type: null
+      topology.name: null
+      topology.available_tags: []
+      topology.identifiers: []
+      topology.is_dualtor: null
+      topology.is_isolated_v6: null
+      topology.is_storage_backend: null
+      topology.is_tgen: null
+      topology.is_t0_backend: null
+      topology.is_t2: null
+      topology.multi_dut.supported: null
+      topology.single_dut_multi_asic.supported: null
+      topology.fanout.explicit_support: null
+      topology.rif_members.available: null
+      topology.vlan_members.drop_counter_supported: null
+      platform.sonic_platform: null
+      platform.platform: null
+      platform.platform_asic: null
+      platform.pid: null
+      platform.chip: null
+      platform.hwsku: null
+      platform.hbm: null
+      platform.speed: null
+      platform.configuration: null
+      platform.sonic_support_roles: []
+      platform.vendor_family: null
+      platform.asic_type: null
+      platform.platform_family: null
+      platform.identifiers: []
+      platform.is_multi_asic: null
+      platform.is_smartswitch: null
+      platform.is_dpu: null
+      platform.is_modular_chassis: null
+      platform.chassis.modules.available: null
+      platform.chassis.status_led.controllable: null
+      platform.role: null
+      image.os_version: null
+      image.kernel_version: null
+      features.acl.ipv6.supported: null
+      features.bgp.idf_isolation.supported: null
+      features.bgp.tsa_persistence.supported: null
+      features.console_switch.enabled: null
+      features.dhcp_relay.enabled: null
+      features.eventd.enabled: null
+      features.everflow.cross_direction_acl_mirroring.supported: null
+      features.everflow.ipv6_erspan_cli.supported: null
+      features.macsec.enabled: null
+      features.nat.enabled: null
+      features.sflow.enabled: null
+      resources.tgen_port_info.available: null
+      resources.psu.minimum_count_2.available: null
+      resources.python_saithrift_package_url.available: null
+      resources.sensor_mocker.available: null
+      resources.counterpoll_cpu_usage_program.available: null
+      test.platform_or_asic.supported: null
+      run.neighbor_type: null
+      run.uses_topology_filter: true
+      run.uses_asic_filter: false
+      run.enable_macsec: null
+
+  x86_64-8122_64ehf_o-r0:t0:
+    aliases:
+      - superbolt:t0
+      - 8122-64EHF-O:t0
+    description: Cisco 8000 T0 setup seeded from the internal Superbolt T0 report.
+    metadata:
+      platform: x86_64-8122_64ehf_o-r0
+      topology: t0
+    parameters:
+      run.options.include_long_tests: false
+      topology.type: t0
+      topology.name: t0
+      topology.available_tags:
+        - t0
+        - t0-m6-28
+      topology.identifiers:
+        - t0
+        - t0-m6-28
+      topology.is_dualtor: false
+      topology.is_isolated_v6: false
+      topology.is_storage_backend: false
+      topology.is_tgen: false
+      topology.is_t0_backend: false
+      topology.is_t2: false
+      topology.multi_dut.supported: false
+      topology.single_dut_multi_asic.supported: false
+      topology.fanout.explicit_support: false
+      topology.rif_members.available: false
+      platform.platform: x86_64-8122_64ehf_o-r0
+      platform.platform_asic: cisco-8000
+      platform.is_multi_asic: false
+      platform.is_smartswitch: false
+      platform.is_dpu: false
+      platform.role: null
+      image.os_version: 202505c
+      image.kernel_version: null
+      features.bgp.idf_isolation.supported: false
+      features.bgp.tsa_persistence.supported: false
+      features.console_switch.enabled: false
+      features.dhcp_relay.enabled: true
+      features.eventd.enabled: true
+      features.everflow.cross_direction_acl_mirroring.supported: false
+      features.macsec.enabled: false
+      features.nat.enabled: false
+      resources.tgen_port_info.available: false
+      resources.python_saithrift_package_url.available: false
+      test.platform_or_asic.supported: false
+      run.neighbor_type: sonic
+      run.uses_topology_filter: true
+      run.uses_asic_filter: false
+      run.enable_macsec: false
+
+  x86_64-8102_64h_o-r0:t0-64:
+    aliases:
+      - matilda:t0-64
+      - matilda-64:t0-64
+      - mth64:t0-64
+      - m64:t0-64
+      - 8102-64H-O:t0-64
+    description: Cisco 8000 T0-64 setup seeded from the Matilda/M64 report.
+    metadata:
+      platform: x86_64-8102_64h_o-r0
+      topology: t0-64
+    parameters:
+      run.options.include_long_tests: false
+      environment.is_sim: false
+      environment.is_vxr: false
+      topology.type: t0
+      topology.name: t0-64
+      topology.available_tags:
+        - t0
+        - t0-64
+      topology.identifiers:
+        - t0
+        - t0-64
+      topology.is_dualtor: false
+      topology.is_isolated_v6: false
+      topology.is_storage_backend: false
+      topology.is_tgen: false
+      topology.is_t0_backend: false
+      topology.is_t2: false
+      topology.multi_dut.supported: false
+      topology.single_dut_multi_asic.supported: false
+      topology.fanout.explicit_support: false
+      topology.rif_members.available: false
+      topology.vlan_members.drop_counter_supported: false
+      platform.platform: x86_64-8102_64h_o-r0
+      platform.platform_asic: cisco-8000
+      platform.is_multi_asic: false
+      platform.is_smartswitch: false
+      platform.is_dpu: false
+      platform.is_modular_chassis: false
+      platform.chassis.modules.available: false
+      platform.chassis.status_led.controllable: null
+      platform.role: null
+      image.os_version: 202405c
+      image.kernel_version: null
+      features.acl.ipv6.supported: false
+      features.bgp.idf_isolation.supported: false
+      features.bgp.tsa_persistence.supported: false
+      features.console_switch.enabled: false
+      features.dhcp_relay.enabled: true
+      features.eventd.enabled: true
+      features.everflow.cross_direction_acl_mirroring.supported: false
+      features.everflow.ipv6_erspan_cli.supported: false
+      features.macsec.enabled: false
+      features.nat.enabled: false
+      features.sflow.enabled: false
+      resources.psu.minimum_count_2.available: null
+      resources.python_saithrift_package_url.available: false
+      resources.sensor_mocker.available: false
+      resources.counterpoll_cpu_usage_program.available: false
+      test.platform_or_asic.supported: false
+      run.neighbor_type: sonic
+      run.uses_topology_filter: true
+      run.uses_asic_filter: false
+      run.enable_macsec: false

--- a/tests/hardware_aware/skip_rules.yaml
+++ b/tests/hardware_aware/skip_rules.yaml
@@ -1,0 +1,660 @@
+version: hardware-aware-skip-catalog/v0.1
+description: >
+  Human-readable skip-rule catalog for hardware-aware pre-run deselection.
+  A skip rule applies when its reason_patterns match an Allure skipped reason
+  and its parameters match the selected setup profile parameters.
+
+skip_rules:
+  nat_feature_disabled:
+    reason_patterns:
+      - "^nat feature is not enabled with image version .*$"
+    parameters:
+      features.nat.enabled: false
+    tests:
+      - tests/nat/
+
+  dhcp_relay_feature_disabled:
+    reason_patterns:
+      - "^dhcp_relay is not enabled$"
+      - "^dhcp_relay is not enabled, skipping dhcp_relay events$"
+    parameters:
+      features.dhcp_relay.enabled: false
+    tests:
+      - tests/dhcp_relay/
+      - tests/telemetry/events/dhcp-relay_events.py::test_event
+
+  voq_not_supported:
+    reason_patterns:
+      - "^Cisco 8800 doesn't support voq tests$"
+    parameters:
+      platform.asic_type: cisco-8000
+      topology.is_t2: false
+    tests:
+      - tests/voq/
+
+  multi_dut_not_supported_on_t0:
+    reason_patterns:
+      - "^multi-dut is not supported on T0 topologies$"
+    parameters:
+      topology.multi_dut.supported: false
+    tests:
+      - nodeids:
+          - tests/cisco/qos/test_qos_sai.py::TestQosSai::testQosSaiFullMeshTrafficSanity
+          - tests/cisco/qos/test_qos_sai.py::TestQosSai::testQosSaiTrafficSanity
+          - tests/qos/test_oq_watchdog.py::TestOqWatchdog::testOqWatchdog
+          - tests/qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog
+          - tests/qos/test_qos_sai.py::TestQosSai::testParameter
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpQueueMapping
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpToPgMapping
+        param_contains: multi_dut
+
+  multi_dut_not_supported_on_t1:
+    reason_patterns:
+      - "^multi-dut is not supported on T1 topologies$"
+    parameters:
+      topology.type: t1
+    tests:
+      - path_prefix: tests/qos/
+        param_contains: multi_dut
+      - path_prefix: tests/cisco/qos/
+        param_contains: multi_dut
+
+  include_long_tests_not_enabled:
+    reason_patterns:
+      - "^This test runs only when '--include_long_tests=True' is provided$"
+      - "^This test will be run only if '--include_long_tests=True' is provided\\.$"
+      - "^This test will be run only if'--include_long_tests=True' is provided\\.$"
+    parameters:
+      run.options.include_long_tests: false
+    tests:
+      - tests/vxlan/test_vxlan_ecmp.py::Test_VxLAN_ecmp_random_hash
+      - tests/vxlan/test_vxlan_ecmp.py::Test_VxLAN_entropy
+      - tests/vxlan/test_vxlan_ecmp.py::Test_VxLAN_underlay_ecmp
+
+  single_dut_multi_asic_not_supported_on_t0:
+    reason_patterns:
+      - "^single_dut_multi_asic is not supported on T0 topologies$"
+    parameters:
+      topology.single_dut_multi_asic.supported: false
+    tests:
+      - nodeids:
+          - tests/cisco/qos/test_qos_sai.py::TestQosSai::testQosSaiFullMeshTrafficSanity
+          - tests/cisco/qos/test_qos_sai.py::TestQosSai::testQosSaiTrafficSanity
+          - tests/qos/test_oq_watchdog.py::TestOqWatchdog::testOqWatchdog
+          - tests/qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog
+          - tests/qos/test_qos_sai.py::TestQosSai::testParameter
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpQueueMapping
+          - tests/qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpToPgMapping
+        param_contains: single_dut_multi_asic
+
+  console_switch_feature_disabled:
+    reason_patterns:
+      - "^Skip test due to the console switch feature is not enabled for current DUT\\.$"
+    parameters:
+      features.console_switch.enabled: false
+    tests:
+      - tests/console/test_console_availability.py::test_console_availability
+      - tests/console/test_console_driver.py::test_console_driver
+      - tests/console/test_console_loopback.py::test_console_loopback_echo
+      - tests/console/test_console_loopback.py::test_console_loopback_pingpong
+      - tests/console/test_console_reversessh.py::test_console_reversessh_connectivity
+      - tests/console/test_console_reversessh.py::test_console_reversessh_force_interrupt
+      - tests/console/test_console_udevrule.py::test_console_port_mapping
+
+  unsupported_platform_or_asic:
+    confidence: low
+    reason_patterns:
+      - "^Unsupported platform or asic$"
+    parameters:
+      test.platform_or_asic.supported: false
+    tests:
+      - tests/sub_port_interfaces/test_show_subinterface.py::test_subinterface_status
+      - tests/sub_port_interfaces/test_sub_port_interfaces.py::TestSubPortStress::test_max_numbers_of_sub_ports
+      - tests/sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_admin_status_down_disables_forwarding
+      - tests/sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_balancing_sub_ports
+      - tests/sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_mtu_inherited_from_parent_port
+      - tests/sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_valid_vlan
+      - tests/sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports
+      - tests/sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port
+      - tests/sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_unaffected_by_sub_ports_removal
+      - tests/sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_untagged_packet_not_routed
+      - tests/sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_vlan_config_impact
+      - tests/sub_port_interfaces/test_sub_port_interfaces.py::TestSubPortsNegative::test_packet_routed_with_invalid_vlan
+      - tests/sub_port_interfaces/test_sub_port_l2_forwarding.py::test_sub_port_l2_forwarding
+
+  rif_members_unavailable:
+    reason_patterns:
+      - "^No rif_members available$"
+    parameters:
+      topology.rif_members.available: false
+    tests:
+      - nodeids:
+          - tests/cisco/platform_tests/test_serviceability_packet_capture.py::test_packet_capture
+          - tests/drop_packets/test_drop_counters.py::test_absent_ip_header
+          - tests/drop_packets/test_drop_counters.py::test_acl_drop
+          - tests/drop_packets/test_drop_counters.py::test_acl_egress_drop
+          - tests/drop_packets/test_drop_counters.py::test_broken_ip_header
+          - tests/drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop
+          - tests/drop_packets/test_drop_counters.py::test_ip_pkt_with_exceeded_mtu
+          - tests/drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl
+          - tests/drop_packets/test_drop_counters.py::test_multicast_smac_drop
+          - tests/drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link
+          - tests/drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts
+          - tests/drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop
+          - tests/drop_packets/test_drop_counters.py::test_reserved_dmac_drop
+          - tests/drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr
+          - tests/drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr
+          - tests/drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst
+        param_prefixes:
+          - rif_members
+
+  drop_counter_vlan_members_unsupported:
+    reason_patterns:
+      - "^Test case is not supported on VLAN interface$"
+    parameters:
+      topology.vlan_members.drop_counter_supported: false
+    tests:
+      - nodeid: tests/drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst
+        param_prefixes:
+          - vlan_members
+
+  requires_t2_topology:
+    reason_patterns:
+      - "^Only support T2$"
+      - "^Skip the test\\. This is only for T2 and Cisco T2 does not support it\\.$"
+    parameters:
+      topology.is_t2: false
+    tests:
+      - nodeids:
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_components
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_fans
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_base_mac
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_description
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_maximum_consumed_power
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_midplane_ip
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_model
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_name
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_oper_status
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_position_in_parent
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_presence
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_serial
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_slot
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_status
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_system_eeprom_info
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_get_type
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_is_midplane_reachable
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_is_replaceable
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_psus
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_reboot
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_sfps
+          - tests/platform_tests/api/test_module.py::TestModuleApi::test_thermals
+
+  requires_modular_chassis:
+    reason_patterns:
+      - "^Test skipped applicable to modular chassis only$"
+      - "^skipped as this test is applicable to modular chassis only$"
+    parameters:
+      platform.is_modular_chassis: false
+    tests:
+      - nodeids:
+          - tests/platform_tests/api/test_chassis.py::TestChassisApi::test_get_my_slot
+          - tests/platform_tests/api/test_chassis.py::TestChassisApi::test_get_supervisor_slot
+          - tests/platform_tests/test_thermal_state_db.py::test_thermal_global_state_db
+          - tests/platform_tests/test_thermal_state_db.py::test_thermal_state_db
+
+  chassis_modules_unavailable:
+    reason_patterns:
+      - "^No modules found on device$"
+    parameters:
+      platform.chassis.modules.available: false
+    tests:
+      - tests/platform_tests/api/test_chassis.py::TestChassisApi::test_modules
+
+  chassis_status_led_not_controllable:
+    reason_patterns:
+      - "^skipped as chassis's status led is not controllable$"
+    parameters:
+      platform.chassis.status_led.controllable: false
+    tests:
+      - tests/platform_tests/api/test_chassis.py::TestChassisApi::test_status_led
+
+  requires_multi_asic_cisco_lc:
+    confidence: medium
+    reason_patterns:
+      - "^Only supported on multi-asic system & Cisco LCs\\.$"
+    parameters:
+      platform.is_multi_asic: false
+      platform.role: null
+    tests:
+      - nodeids:
+          - tests/bfd/test_bfd_static_route.py::TestBfdStaticRoute::test_bfd_config_reload
+          - tests/bfd/test_bfd_static_route.py::TestBfdStaticRoute::test_bfd_flap
+          - tests/bfd/test_bfd_static_route.py::TestBfdStaticRoute::test_bfd_lc_asic_shutdown
+          - tests/bfd/test_bfd_static_route.py::TestBfdStaticRoute::test_bfd_portchannel_member_flap
+          - tests/bfd/test_bfd_static_route.py::TestBfdStaticRoute::test_bfd_remote_link_flap
+          - tests/bfd/test_bfd_static_route.py::TestBfdStaticRoute::test_bfd_static_route_deletion
+          - tests/bfd/test_bfd_static_route.py::TestBfdStaticRoute::test_bfd_with_bad_fc_asic
+          - tests/bfd/test_bfd_static_route.py::TestBfdStaticRoute::test_bfd_with_lc_reboot
+          - tests/bfd/test_bfd_static_route.py::TestBfdStaticRoute::test_bfd_with_rp_config_reload
+          - tests/bfd/test_bfd_static_route.py::TestBfdStaticRoute::test_bfd_with_rp_reboot
+
+  requires_multi_asic_system:
+    reason_patterns:
+      - "^Only supported on multi-asic system\\.$"
+    parameters:
+      platform.is_multi_asic: false
+    tests:
+      - tests/generic_config_updater/test_multiasic_addcluster.py
+      - tests/generic_config_updater/test_multiasic_idf.py
+      - tests/generic_config_updater/test_multiasic_linkcrc.py
+
+  not_applicable_on_cisco_8000_t2_m0_mx:
+    confidence: medium
+    reason_patterns:
+      - "^These tests don't apply to cisco 8000 platforms or T2 or m0/mx, since they support only traditional model\\.$"
+      - "^These tests don't apply to cisco 8000 platforms or T2 or M\\* since they support only traditional model\\.?$"
+      - "^These tests don't apply to cisco 8000 platforms or T2 or M\\* since they support only traditional model and it is skipped for '202412' for now$"
+    parameters:
+      platform.asic_type: cisco-8000
+    tests:
+      - nodeids:
+          - tests/qos/test_buffer.py::test_buffer_deployment
+          - tests/qos/test_buffer.py::test_change_speed_cable
+          - tests/qos/test_buffer.py::test_exceeding_headroom
+          - tests/qos/test_buffer.py::test_headroom_override
+          - tests/qos/test_buffer.py::test_lossless_pg
+          - tests/qos/test_buffer.py::test_port_admin_down
+          - tests/qos/test_buffer.py::test_port_auto_neg
+          - tests/qos/test_buffer.py::test_shared_headroom_pool_configure
+
+  cross_direction_acl_mirroring_not_supported:
+    reason_patterns:
+      - "^Cross-direction ACL mirroring is not supported$"
+      - "^egress ACL w/ ingress Mirroring not supported, skipping$"
+      - "^ingress ACL w/ egress Mirroring not supported, skipping$"
+    parameters:
+      features.everflow.cross_direction_acl_mirroring.supported: false
+    tests:
+      - nodeids:
+          - tests/everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_basic_forwarding
+          - tests/everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_dscp_with_policer
+          - tests/everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_frwd_with_bkg_trf
+          - tests/everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_neighbor_mac_change
+          - tests/everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop
+          - tests/everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop
+          - tests/everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_basic_forwarding
+          - tests/everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_dscp_with_policer
+          - tests/everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_frwd_with_bkg_trf
+          - tests/everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_neighbor_mac_change
+          - tests/everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop
+          - tests/everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop
+
+  everflow_ipv6_erspan_cli_not_supported:
+    reason_patterns:
+      - "^Cannot create mirror session: both legacy and erspan CLI commands failed\\."
+    parameters:
+      features.everflow.ipv6_erspan_cli.supported: false
+    tests:
+      - nodeid_prefix: tests/everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6
+        param_contains: erspan_ipv6-cli
+      - nodeid_prefix: tests/everflow/test_everflow_ipv6.py::TestEgressEverflowIPv6
+        param_contains: erspan_ipv6-cli
+
+  requires_explicit_fanout_support:
+    reason_patterns:
+      - "^Test case requires explicit fanout support$"
+    parameters:
+      topology.fanout.explicit_support: false
+    tests:
+      - nodeids:
+          - tests/drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop
+          - tests/drop_packets/test_drop_counters.py::test_multicast_smac_drop
+          - tests/drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts
+          - tests/drop_packets/test_drop_counters.py::test_reserved_dmac_drop
+        param_prefixes:
+          - port_channel_members
+          - vlan_members
+
+  macsec_tests_not_applicable:
+    confidence: medium
+    reason_patterns:
+      - "^macsec test cases$"
+    parameters:
+      features.macsec.enabled: false
+    tests:
+      - tests/macsec/
+
+  sflow_feature_disabled:
+    reason_patterns:
+      - "^sflow feature is not enabled$"
+    parameters:
+      features.sflow.enabled: false
+    tests:
+      - tests/sflow/
+
+  bgp_tsa_persistence_not_supported:
+    reason_patterns:
+      - "^TSA persistence not supported in the image$"
+    parameters:
+      features.bgp.tsa_persistence.supported: false
+    tests:
+      - tests/bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_consistency
+      - tests/bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_dut_abnormal_reboot
+      - tests/bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_dut_cold_reboot
+      - tests/bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_supervisor_abnormal_reboot
+      - tests/bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_supervisor_cold_reboot
+      - tests/bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_tsa_on_sup
+      - tests/bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_user_init_tsa
+      - tests/bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_timer_efficiency
+      - tests/bgp/test_startup_tsa_tsb_service.py::test_user_init_tsa_while_service_run_on_dut
+      - tests/bgp/test_startup_tsa_tsb_service.py::test_user_init_tsb_on_sup_while_service_run_on_dut
+      - tests/bgp/test_startup_tsa_tsb_service.py::test_user_init_tsb_while_service_run_on_dut
+      - tests/bgp/test_traffic_shift.py::test_TSA_TSB_with_config_reload
+      - tests/bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away
+      - tests/bgp/test_traffic_shift_lc.py::test_load_minigraph_with_traffic_shift_away
+      - tests/bgp/test_traffic_shift_lc.py::test_tsa_tsb_with_config_reload
+
+  bgp_idf_isolation_not_supported:
+    reason_patterns:
+      - "^IDF isolation is not supported in the image$"
+      - "^Sequential IDF isolation is not supported in the image$"
+    parameters:
+      features.bgp.idf_isolation.supported: false
+    tests:
+      - tests/bgp/test_seq_idf_isolation.py::test_idf_isolated_no_export
+      - tests/bgp/test_seq_idf_isolation.py::test_idf_isolated_withdraw_all
+      - tests/bgp/test_seq_idf_isolation.py::test_idf_isolation_no_export_with_config_reload
+      - tests/bgp/test_seq_idf_isolation.py::test_idf_isolation_withdraw_all_with_config_reload
+
+  requires_dualtor:
+    reason_patterns:
+      - "^Only run on dualtor testbed\\.$"
+      - "^Testcase could only be executed on dualtor testbed\\.$"
+      - "^DualTOR is MSFT specific$"
+      - "^KVM testbed do not support shutdown fanout interface action / Testcase could only be executed on dualtor testbed\\.$"
+      - "^Skip on non-dualtor testbed$"
+      - "^This is only applicable for dualtor topology$"
+    parameters:
+      topology.is_dualtor: false
+    tests:
+      - tests/dualtor/
+      - tests/dualtor_mgmt/
+      - path_prefix: tests/dualtor_io/
+        exclude_nodeids:
+          - tests/dualtor_io/test_normal_op.py::test_upstream_standby_rx_drop_check
+          - tests/dualtor_io/test_switchover_impact.py::test_tor_switchover_impact_bulk
+
+  acl_multibinding_requires_dualtor:
+    reason_patterns:
+      - "^MultiBinding only supports dualtor topo$"
+    parameters:
+      topology.is_dualtor: false
+    tests:
+      - tests/acl/test_acl.py::TestMultiBindingAcl
+
+  pretest_snappi_metadata_requires_tgen:
+    reason_patterns:
+      - "^Skip snappi metadata generation for non-tgen testbed$"
+    parameters:
+      topology.is_tgen: false
+    tests:
+      - tests/test_pretest.py::test_update_snappi_testbed_metadata
+      - tests/test_pretest/test_pre1.py::test_update_snappi_testbed_metadata
+
+  pretest_saithrift_url_missing:
+    reason_patterns:
+      - "^No URL specified for python saithrift package$"
+    parameters:
+      resources.python_saithrift_package_url.available: false
+    tests:
+      - tests/test_pretest.py::test_update_saithrift_ptf
+      - tests/test_pretest/test_pre1.py::test_update_saithrift_ptf
+
+  pretest_backend_acl_requires_t0_backend:
+    reason_patterns:
+      - "^Skip 'test_backend_acl_load' on non[- ]t0-backend testbeds\\.$"
+    parameters:
+      topology.is_t0_backend: false
+    tests:
+      - tests/test_pretest.py::test_backend_acl_load
+      - tests/test_pretest/test_pre2.py::test_backend_acl_load
+
+  pretest_dpu_recovery_requires_smartswitch:
+    reason_patterns:
+      - "^DPU module recovery is only applicable to SmartSwitch testbeds$"
+    parameters:
+      platform.is_smartswitch: false
+    tests:
+      - tests/test_pretest.py::test_recover_admin_up_offline_dpu_modules
+
+  sensor_mocker_unavailable:
+    reason_patterns:
+      - "^No mocker defined for this platform .*$"
+      - "^No FanStatusMocker for .*, skip rest of the testing in this case$"
+      - "^No ThermalStatusMocker for .*, skip rest of the testing in this case$"
+    parameters:
+      resources.sensor_mocker.available: false
+    tests:
+      - nodeids:
+          - tests/platform_tests/test_platform_info.py::test_show_platform_fanstatus_mocked
+          - tests/platform_tests/test_platform_info.py::test_show_platform_temperature_mocked
+          - tests/platform_tests/test_platform_info.py::test_thermal_control_fan_status
+
+  psu_minimum_count_2_unavailable:
+    reason_patterns:
+      - "^At least 2 PSUs required for rest of the testing in this case$"
+    parameters:
+      resources.psu.minimum_count_2.available: false
+    tests:
+      - tests/platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_psustatus
+
+  counterpoll_cpu_usage_program_unavailable:
+    reason_patterns:
+      - "^Skip no program is offered to check$"
+    parameters:
+      resources.counterpoll_cpu_usage_program.available: false
+    tests:
+      - tests/platform_tests/test_cpu_memory_usage.py::test_cpu_memory_usage_counterpoll
+
+  sim_sfp_low_power_mode_not_supported:
+    reason_patterns:
+      - "^Skip the test for sim$"
+      - "^Skip the test for sim, will be revisited later$"
+    parameters:
+      environment.is_sim: true
+    tests:
+      - tests/platform_tests/api/test_sfp.py::TestSfpApi::test_lpmode
+      - tests/platform_tests/sfp/test_sfputil.py::test_check_sfputil_low_power_mode
+
+  vxr_chassis_identity_unstable:
+    reason_patterns:
+      - "^Test is skipped on vxr since the model is not set in the ansible inventory properly$"
+      - "^Test is skipped on vxr since the serail is generated randomly in each run$"
+      - "^Test is skipped on vxr since the mac is generated randomly in each run$"
+    parameters:
+      environment.is_vxr: true
+    tests:
+      - nodeids:
+          - tests/platform_tests/api/test_chassis.py::TestChassisApi::test_get_base_mac
+          - tests/platform_tests/api/test_chassis.py::TestChassisApi::test_get_model
+          - tests/platform_tests/api/test_chassis.py::TestChassisApi::test_get_serial
+
+  vxr_chassis_eeprom_and_thermal_unavailable:
+    reason_patterns:
+      - "^Test is skipped on vxr, will be revisited later$"
+    parameters:
+      environment.is_vxr: true
+    tests:
+      - nodeids:
+          - tests/platform_tests/api/test_chassis.py::TestChassisApi::test_get_system_eeprom_info
+          - tests/platform_tests/api/test_chassis.py::TestChassisApi::test_thermals
+
+  everflow_multibinding_requires_dualtor:
+    reason_patterns:
+      - "^Multi-binding ACL is not supported for non-dualtor testbed$"
+    parameters:
+      topology.is_dualtor: false
+    tests:
+      - tests/everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_multi_binding_acl
+      - tests/everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_multi_binding_acl
+      - tests/everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_multi_binding_acl
+      - tests/everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_multi_binding_acl
+
+  ipv4_acl_not_supported_on_isolated_v6:
+    reason_patterns:
+      - "^IPV4 ACL test not supported on isolated-v6 testbeds$"
+    parameters:
+      topology.is_isolated_v6: true
+    tests:
+      - nodeid_prefix: tests/acl/test_acl.py::TestAclWithPortToggle
+        param_contains: ipv4
+      - nodeid_prefix: tests/acl/test_acl.py::TestAclWithReboot
+        param_contains: ipv4
+      - nodeid_prefix: tests/acl/test_acl.py::TestBasicAcl
+        param_contains: ipv4
+      - nodeid_prefix: tests/acl/test_acl.py::TestIncrementalAcl
+        param_contains: ipv4
+
+  ipv6_acl_not_supported_on_t0:
+    reason_patterns:
+      - "^IPV6 ACL test not currently supported on t0 testbeds$"
+    parameters:
+      topology.type: t0
+      topology.is_isolated_v6: false
+    tests:
+      - nodeid_prefix: tests/acl/test_acl.py::TestAclWithPortToggle
+        param_contains: ipv6
+      - nodeid_prefix: tests/acl/test_acl.py::TestAclWithReboot
+        param_contains: ipv6
+      - nodeid_prefix: tests/acl/test_acl.py::TestBasicAcl
+        param_contains: ipv6
+      - nodeid_prefix: tests/acl/test_acl.py::TestIncrementalAcl
+        param_contains: ipv6
+
+  ipfwd_mtu_unsupported_topology:
+    reason_patterns:
+      - "^Unsupported topology\\.$"
+    parameters:
+      topology.type:
+        - t0
+        - m0
+        - mx
+    tests:
+      - tests/ipfwd/test_mtu.py::test_mtu
+      - tests/cisco/ipfwd/test_mtu.py::test_mtu
+
+  topology_unavailable:
+    description: >
+      Historical skipped reason for pytest.mark.topology mismatch. This rule is
+      kept for report coverage and future hardware-aware topology experiments,
+      but hardware-aware skips it by default because SONiC custom_markers
+      already handles topology gating when --topology is provided. Set enabled
+      to true only if hardware-aware should evaluate pytest.mark.topology
+      itself.
+    handled_by_default: sonic_custom_markers
+    enabled: false
+    disabled_reason: SONiC custom_markers already handles topology gating.
+    reason_patterns:
+      - "^Test requires a topology that is not available in this run$"
+    evaluation:
+      mode: topology_marker_intersects_available_tags
+      marker: topology
+      actual: pytest.mark.topology args
+      expected: topology.available_tags
+      operator: intersects
+
+  tgen_port_info_unavailable:
+    reason_patterns:
+      - "^got empty parameter set \\['tgen_port_info'\\]$"
+      - "^got empty parameter set for \\(tgen_port_info\\)$"
+    parameters:
+      resources.tgen_port_info.available: false
+    tests:
+      - tests/snappi_tests/ecn/test_multidut_dequeue_ecn_brcm_dnx.py::test_dequeue_ecn
+      - tests/snappi_tests/pfc/test_lossless_response_to_external_pause_storms.py::test_lossless_response_to_external_pause_storms_test
+      - tests/snappi_tests/pfc/test_lossless_response_to_throttling_pause_storms.py::test_lossless_response_to_throttling_pause_storms
+      - tests/snappi_tests/pfc/test_m2o_fluctuating_lossless.py::test_m2o_fluctuating_lossless
+      - tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless.py::test_m2o_oversubscribe_lossless
+      - tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless_lossy.py::test_m2o_oversubscribe_lossless_lossy
+      - tests/snappi_tests/pfc/test_m2o_oversubscribe_lossy.py::test_m2o_oversubscribe_lossy
+      - tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_counter_check
+      - tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio
+      - tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot
+      - tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio
+      - tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot
+      - tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_multi_lossy_prio
+      - tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_multi_lossy_prio_reboot
+      - tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio
+      - tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot
+      - tests/snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all
+      - tests/snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py::test_pfcwd_burst_storm_single_lossless_prio
+      - tests/snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py::test_pfcwd_many_to_one
+      - tests/snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py::test_pfcwd_runtime_traffic
+      - tests/snappi_tests/test_multidut_snappi.py
+
+  mellanox_2700_v6_underlay_not_supported:
+    reason_patterns:
+      - "^Skipping test\\. v6 underlay is not supported on Mlnx 2700$"
+    parameters:
+      platform.platform:
+        - x86_64-mlnx_msn2700-r0
+        - x86_64-mlnx_msn2700a1-r0
+    tests:
+      - path_prefix: tests/vxlan/test_vxlan_bfd_tsa.py
+        param_prefixes:
+          - v4_in_v6
+          - v6_in_v6
+      - path_prefix: tests/vxlan/test_vxlan_ecmp.py
+        param_prefixes:
+          - v4_in_v6
+          - v6_in_v6
+      - path_prefix: tests/vxlan/test_vxlan_ecmp_switchover.py
+        param_prefixes:
+          - v4_in_v6
+          - v6_in_v6
+
+  requires_mellanox_platform:
+    reason_patterns:
+      - "^Non-Mellanox platforms doesn't support fwutil for now$"
+      - "^This test is only for Mellanox\\.$"
+    parameters:
+      platform.vendor_family: cisco
+    tests:
+      - nodeids:
+          - tests/platform_tests/fwutil/test_fwutil.py::test_fwutil_install_bad_name
+          - tests/platform_tests/fwutil/test_fwutil.py::test_fwutil_install_bad_path
+          - tests/platform_tests/fwutil/test_fwutil.py::test_fwutil_install_file
+          - tests/platform_tests/fwutil/test_fwutil.py::test_fwutil_install_url
+          - tests/platform_tests/fwutil/test_fwutil.py::test_fwutil_show
+          - tests/platform_tests/fwutil/test_fwutil.py::test_fwutil_update_bad_config
+          - tests/platform_tests/fwutil/test_fwutil.py::test_fwutil_update_current
+          - tests/platform_tests/fwutil/test_fwutil.py::test_fwutil_update_next
+      - tests/qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Summary:
Add a hardware-aware pytest deselection framework for SONiC management tests.

This PR introduces a collection-time pytest plugin that uses centralized setup facts and skip rules to deselect tests that are known to be unsupported on the current platform/topology before runtime fixtures execute.

The framework also writes JSON and human-readable text reports explaining which tests were deselected and why.

Reviewer starting points:
  - `tests/hardware_aware/README.md`
  - `tests/hardware_aware/setup_profiles.yaml`
  - `tests/hardware_aware/skip_rules.yaml`
  - `tests/common/plugins/hardware_aware/__init__.py`

Fixes # (issue) N/A
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: <!-- day-one issue / regression / other --> N/A

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

- master: validated with VXR collect-only workflow and Cisco Jenkins sanity runs on `x86_64-8122_64ehf_o-r0:t0` (this platform and topology combination).                                                        
                                                                                
Example validated deselections:                                               
  - `test_pretest.py::test_update_snappi_testbed_metadata` on non-TGEN setup    
  - `test_pretest.py::test_update_saithrift_ptf` when python saithrift package URL is unavailable                                                            
  - `test_pretest.py::test_backend_acl_load` on non-T0-backend setup            
  - `test_pretest.py::test_recover_admin_up_offline_dpu_modules` on non-SmartSwitch setup                                                             
  - `ipfwd/test_mtu.py` unsupported T0 parametrizations   

### Approach
#### What is the motivation for this PR?
SONiC management validation runs across different platforms, ASICs, SKUs, and topologies. Some tests require setup capabilities such as traffic generator support, backend topology, feature support, package availability, or platform-specific behavior.                                                            
                                                                                
Today, known unsupported cases may still be collected and only skipped after runtime fixtures start. This mixes expected unsupported cases with real regressions and makes reports harder to analyze.                              
                                                                                
This PR moves known unsupported cases into centralized collection-time deselection with readable reasons.  

#### How did you do it?
  - Added a hardware-aware pytest plugin under `tests/common/plugins/hardware_aware`.                                                              
  - Added `tests/hardware_aware/setup_profiles.yaml` for centralized platform/topology/setup facts.                                                         
  - Added `tests/hardware_aware/skip_rules.yaml` for unsupported conditions and affected tests.                                                               
  - Added runtime input generation from the YAML catalogs.                      
  - Added JSON and readable text summaries for deselect decisions.              
  - Added documentation for setup profiles, setup overrides, skip rules, and report usage.                                                                 
                                                                                
Deselect logic:                                                               
Each skip rule describes an unsupported setup condition. During pytest collection, if the current setup facts match that condition, the plugin deselects the affected tests and records the reason.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Validated in VXR collect-only mode and Cisco Jenkins sanity runs using `x86_64-8122_64ehf_o-r0:t0`.

The collect-only validation confirmed pytest collection-time deselection andgenerated readable summaries in the format: reason -> affected tests -> triggering setup fact

Cisco Jenkins sanity validation confirmed the plugin can run in a real sanity workflow and generate hardware-aware reports.

#### Any platform specific information?
Initial setup profiles include validated Cisco platform/topology examples and aliases.

The framework is catalog-driven. Additional platforms and topologies can be supported by extending:
  - tests/hardware_aware/setup_profiles.yaml
  - tests/hardware_aware/skip_rules.yaml 

The plugin is not automatically enabled for every setup by this PR. Users must explicitly pass hardware-aware options, or CI integration can enable it only for known setup profiles.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Yes. Added documentation under:
  - tests/hardware_aware/README.md
  - tests/common/plugins/hardware_aware/README.md