### PR TITLE
[packet_trimming]: Fix trim counter polling wait

### DIFF
--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import time
 
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from tests.common.helpers.assertions import pytest_assert
@@ -283,7 +284,7 @@ class BasePacketTrimming:
         with allure.step("Verify packet trimming counter"):
             for egress_port in test_params['egress_ports']:
                 for port in egress_port['dut_members']:
-                    pytest_assert(wait_until(5 * TRIMMING_COUNTER_INTERVAL, TRIMMING_COUNTER_INTERVAL, 0,
+                    pytest_assert(wait_until(5 * TRIMMING_COUNTER_INTERVAL / 1000, TRIMMING_COUNTER_INTERVAL / 1000, 0,
                                              has_non_zero_trim_counters, duthost, port),
                                   f"port level trim counters are zero for {port}")
                     verify_queue_and_port_trim_counter_consistency(duthost, port)
@@ -339,7 +340,7 @@ class BasePacketTrimming:
         with allure.step("Verify packet trimming counter"):
             for egress_port in test_params['egress_ports']:
                 for port in egress_port['dut_members']:
-                    pytest_assert(wait_until(5 * TRIMMING_COUNTER_INTERVAL, TRIMMING_COUNTER_INTERVAL, 0,
+                    pytest_assert(wait_until(5 * TRIMMING_COUNTER_INTERVAL / 1000, TRIMMING_COUNTER_INTERVAL / 1000, 0,
                                              has_non_zero_trim_counters, duthost, port),
                                   f"port level trim counters are zero for {port}")
                     verify_queue_and_port_trim_counter_consistency(duthost, port)
@@ -368,7 +369,7 @@ class BasePacketTrimming:
             # Verify the consistency of the trim counter on the queue and the port level
             for egress_port in test_params['egress_ports']:
                 for port in egress_port['dut_members']:
-                    pytest_assert(wait_until(5 * TRIMMING_COUNTER_INTERVAL, TRIMMING_COUNTER_INTERVAL, 0,
+                    pytest_assert(wait_until(5 * TRIMMING_COUNTER_INTERVAL / 1000, TRIMMING_COUNTER_INTERVAL / 1000, 0,
                                              has_non_zero_trim_counters, duthost, port),
                                   f"port level trim counters are zero for {port}")
                     verify_queue_and_port_trim_counter_consistency(duthost, port)
@@ -476,6 +477,10 @@ class BasePacketTrimming:
             verify_trimmed_packet(**counter_kwargs)
 
         with allure.step("Verify trimming counter when trimming feature toggles"):
+            sleep_time = TRIMMING_COUNTER_INTERVAL / 1000 + 1
+            logger.info(f"Waiting {sleep_time} seconds for the trim counter to be updated")
+            time.sleep(sleep_time)
+
             trim_queue = 'UC' + str(PacketTrimmingConfig.get_trim_queue(duthost))
 
             # Get queue level and port level counter when trimming is enabled


### PR DESCRIPTION
### Description of PR
Summary: Packet trimming improve for counter polling wait
Fixes # (issue)


### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: case pass
- 202605: case pass

### Approach
#### What is the motivation for this PR?
Issue1:
In the `test_trimming_counters_with_feature_toggle` function, the counter is read immediately after a data packet is sent. However, the counter's polling interval is 2 seconds, which may cause the counter to be queried before it is ready.

Issue2:
TRIMMING_COUNTER_INTERVAL is in milliseconds, but wait_until is in seconds, so the actual wait time for wait_until is 2000 seconds. Need fix


#### How did you do it?
1. Add a counterpoll wait in `test_trimming_counters_with_feature_toggle` before reading the counter snapshots. Without it the port level TRIM_PKTS might be read before counterpoll flushed it. Need add sleep before read counter

2. Fix the unit mismatch in the wait_until calls: TRIMMING_COUNTER_INTERVAL is in milliseconds while wait_until takes seconds.

#### How did you verify/test it?
Regression pass

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
