### PR TITLE
[dualtor] Load minigraph before golden config generation

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -882,7 +882,7 @@
       - name: Apply minigraph prior to generating golden_config_db.json
         become: true
         shell: config load_minigraph -y
-        when: "'lt2' in topo or 'ft2' in topo"
+        when: "'lt2' in topo or 'ft2' in topo or 'dualtor' in topo"
 
       - name: Extract port speeds and hwsku from lab CSV files for PORT override
         delegate_to: localhost


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
PR #26376 added dual-ToR golden config generation support for `prober_type`
  and `neighbor_mode`. As part of that change, dualtor topologies started
  generating `golden_config_db.json` with a `PORT` table copied from minigraph.

  The deploy flow already runs `config load_minigraph -y` before golden config
  generation for `lt2` and `ft2`, because those topologies modify/copy `PORT`
  and need the DUT config to reflect testbed-specific interface admin state
  first. The new dualtor golden config path missed this preload step.

  Without the preload, unused routed ports can be preserved as `admin up` in
  `golden_config_db.json`. These ports have no link, remain `oper down`, and
  pretest interface sanity fails.

  This PR extends the existing preload condition to include dualtor.

Summary:
Fixes #26673
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

202605 

**Failure Results** 
  - SONiC image: branch.202605-ars.e7f59890-buildimage.de4f9f0baae9667c05bfe9fdeb1a4fdf4bd19d6c-nightly-2026.07.28.16.40
  - SONiC build commit: 0a4101e99
  - Build date: Tue Jul 28 21:11:40 UTC 2026
[test_pretest.log](https://github.com/user-attachments/files/30528920/test_pretest.log)
[test_pretest.xml](https://github.com/user-attachments/files/30528921/test_pretest.xml)

**Pass Results (after fix)**
  - SONiC image: branch.202605-ars.e7f59890-buildimage.de4f9f0baae9667c05bfe9fdeb1a4fdf4bd19d6c-nightly-2026.07.28.16.40
  - SONiC build commit: 0a4101e99
  - Build date: Tue Jul 28 21:11:40 UTC 2026
[test_pretest.log](https://github.com/user-attachments/files/30528954/test_pretest.log)
[test_pretest.xml](https://github.com/user-attachments/files/30528955/test_pretest.xml)

sonic-mgmt change under test:
  - PR head commit: f0c462b86ee7257451aede547b4d099a778678ef

  Note: Both before and after tests used the same SONiC image/build; the validated change is in sonic-mgmt.



### Approach
#### What is the motivation for this PR?

Fix a regression introduced when dualtor was added to the golden config
  generation path. dualtor golden config now copies `PORT`, so it needs the
  same minigraph preload step that already exists for `lt2` and `ft2`.

#### How did you do it?

 Updated `ansible/config_sonic_basedon_testbed.yml` so the existing
  `config load_minigraph -y` step runs for dualtor before
  `golden_config_db.json` is generated.

```
  -        when: "'lt2' in topo or 'ft2' in topo"
  +        when: "'lt2' in topo or 'ft2' in topo or 'dualtor' in topo"
```


#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Inspected failed pretest logs from tst-esx-31. 
All failed during pretest setup sanity with unused routed ports
  left as admin up / oper down. 
Applied the fix and sanitized the duts , ran deploy-mg and  pret-tests

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A