### PR TITLE
pfcwd: fix LAG isolation leaving the PortChannel oper-down

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -12,6 +12,7 @@ from tests.common import constants
 from tests.common import config_reload
 from tests.common.cisco_data import is_cisco_device
 from tests.common.devices.eos import EosHost
+from tests.common.utilities import wait_until
 from tests.common.mellanox_data import is_mellanox_device
 
 # If the version of the Python interpreter is greater or equal to 3, set the unicode variable to the str class.
@@ -964,9 +965,7 @@ def shutdown_lag_members(duthost, selected_port, tbinfo, nbrhosts, ports):
     Multi-asic-aware: uses minigraph_portchannels (frontend port names on both
     single-asic and multi-asic) instead of config_facts['PORTCHANNEL_MEMBER']
     (which on multi-asic is keyed by asic-internal names like Ethernet1/1
-    that don't match the frontend names in test_ports/vm_neighbors). All DUT
-    config edits go through namespace-aware CLI/sonic-db-cli; no on-disk
-    config_db.json edits, so restore can revert via config_reload.
+    that don't match the frontend names in test_ports/vm_neighbors).
     """
     if ports[selected_port]['test_port_type'] != 'portchannel':
         return None, None, None
@@ -998,29 +997,40 @@ def shutdown_lag_members(duthost, selected_port, tbinfo, nbrhosts, ports):
                     neigh_port_channel = po_name
                     min_links = len(po_config['activePorts'])
                     break
+        if neigh_port_channel is None:
+            # EOS Po had no active ports, pushing 'int None' would corrupt the neighbor config
+            pytest.fail("Could not resolve neighbor port-channel for {} on {}".format(
+                peer_port, peer_device))
         vm_host.eos_config(lines=['port-channel min-links 1'],
                            parents=[f'int {neigh_port_channel}'])
 
-    # Namespace-aware CLI option: '' on single-asic, '-n asicN' on multi-asic.
-    ns = duthost.get_port_asic_instance(selected_port).cli_ns_option
-    # Drop min-links to 1 so the LAG stays up while N-1 members are shut.
-    duthost.shell(
-        f"sonic-db-cli {ns} CONFIG_DB hset 'PORTCHANNEL|{portChannel}' min_links 1")
+    cmd_data = f'.PORTCHANNEL.{portChannel}.min_links = "1"'
+
     for port in portChannelMembers:
         if port == selected_port:
             continue
-        duthost.shell(f"sudo config interface {ns} shutdown {port}")
+        cmd_data += f' | .PORT.{port}.admin_status="down"'
+
+    cmd = f"""jq '{cmd_data}' /etc/sonic/config_db.json > /tmp/config_db.json"""
+
+    duthost.command("cp /etc/sonic/config_db.json /tmp/config_db_backup.json", _uses_shell=True)
+    duthost.command(cmd, _uses_shell=True)
+    duthost.command("sudo cp /tmp/config_db.json /etc/sonic/config_db.json", _uses_shell=True)
+    config_reload(duthost, config_source='config_db', safe_reload=True,
+                  check_intf_up_ports=True, wait_for_bgp=True)
+
+    # Isolation must leave the LAG oper-up on the selected member (sonic-mgmt issue
+    # #26060). Fail fast here instead of cryptic traffic failures later.
+    if not wait_until(120, 10, 0,
+                      lambda: duthost.get_interfaces_status()
+                      .get(portChannel, {}).get('oper', '').lower() == 'up'):
+        pytest.fail("{} not oper-up after LAG isolation (min_links + member shutdown)"
+                    .format(portChannel))
 
     return vm_host, neigh_port_channel, min_links
 
 
 def restore_original_config(duthost, selected_port, vm_host, neigh_port_channel, min_links, ports):
-    """Revert LAG/min-links edits made by shutdown_lag_members.
-
-    Since shutdown_lag_members modifies running CONFIG_DB only (no on-disk
-    edits), config_reload from the on-disk config_db is sufficient to bring
-    members back up and restore the original min_links.
-    """
     if ports[selected_port]['test_port_type'] != 'portchannel':
         return
 
@@ -1028,6 +1038,7 @@ def restore_original_config(duthost, selected_port, vm_host, neigh_port_channel,
         vm_host.eos_config(lines=[f'port-channel min-links {min_links}'],
                            parents=[f'int {neigh_port_channel}'])
 
+    duthost.command("sudo mv /tmp/config_db_backup.json /etc/sonic/config_db.json", _uses_shell=True)
     config_reload(duthost, config_source='config_db', safe_reload=True,
                   check_intf_up_ports=True, wait_for_bgp=True)
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #26060

The manage_lag_config fixture isolates a multi-member LAG by setting min_links to 1 with a live sonic-db-cli hset and shutting the other members. teammgrd reads min_links only when the teamd instance is created (teammgr.cpp notes min_links cannot be changed after the LAG is created), so the live update is never applied to the running LAG. Shutting a member then drops the LAG below the old minimum and the port-channel stays oper-down for the rest of the run, producing failures like "Did not receive expected packet on any of ports".

Changes:
- stage min_links together with the member admin_status changes in the config file and apply them atomically with config_reload, which recreates teamd with the new minimum (the config file is backed up and restored on teardown)
- fail fast if the port-channel is not oper-up after isolation, instead of cryptic traffic failures later
- fail fast when the EOS neighbor port-channel lookup returns None, instead of pushing "int None" into the neighbor config session

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
PFCWD tests on multi-member portchannel topologies fail because the LAG isolation fixture leaves the port-channel oper-down (issue #26060).

#### How did you do it?
Apply min_links via a staged config file edit plus config_reload so teamd is recreated with the new minimum, then verify the port-channel is oper-up before yielding to the test. Added a fail-fast for the EOS neighbor lookup.

#### How did you verify/test it?
Validated on a Broadcom DNX T2 testbed with a 2-member portchannel, including on a teammgrd without any local LAG patches (stock create-time-only min_links behavior):
- reproduced the reported bug exactly on the stock-behavior teammgrd, a live "sonic-db-cli hset min_links 1" is ignored, and after shutting the sibling member the port-channel is stuck LACP(Dw) with the remaining member selected-but-not-synced
- with this change, the staged config plus reload gives the recreated teamd min_ports 1 (verified via teamdctl on the running instance) and the port-channel stays oper-up on the selected member with the sibling shut
- test_pfcwd_port_toggle passed on both IP versions with the reload-based fixture
- the EOS neighbor min-links must also be lowered (already done by the fixture); otherwise the peer suspends the lone member and the LAG stays down regardless of the DUT side

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
N/A
