### PR TITLE
[memory_checker] stop the memory allocation when the test fails part way through

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -246,6 +246,11 @@ def test_setup_and_cleanup(memory_checker_dut_and_container, request):
 
     yield
 
+    # test_memory_checker relies on a container restart to clear its allocation, so it
+    # leaks the same way if it fails before that happens. Stop any allocation still
+    # running before handing the device to the next test.
+    container.stop_consume_memory()
+
     restore_monit_config_files(duthost)
     restart_monit_service(duthost)
 
@@ -683,9 +688,15 @@ def test_memory_checker_recover(memory_checker_dut_and_container, test_setup_and
         timeout_status_change = 30
 
     container.start_consume_memory()
-    container.wait_monit_mem_last_failed(timeout_status_change)
+    try:
+        container.wait_monit_mem_last_failed(timeout_status_change)
+    finally:
+        # If the wait above fails we are still holding the allocation, and nothing else
+        # in this test stops it. Leaving it running keeps the container inflated into the
+        # next test, which then gets failed by the memory utilization plugin for memory it
+        # never allocated.
+        container.stop_consume_memory()
 
-    container.stop_consume_memory()
     container.wait_monit_mem_last_ok(timeout_status_change)
 
     analysis = loganalyzer.analyze(marker, fail=False)


### PR DESCRIPTION
### Description of PR

Summary:

Ensure memory allocations started by the memory-checker tests are stopped even
when a test fails before its normal cleanup path. This prevents a failed test
from leaving the container inflated and causing unrelated teardown or
next-test memory alarms.

ADO: 38927892

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): ADO 38927892

Failure type: day-one test cleanup defect

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: `SONiC.master.1178343-a93656a54` - PR CI build 1178989 completed
  four ElasticTest jobs with 66 passed, 30 skipped, 0 failed and 0 errors.
  Testplan IDs: `6a6ae5c3101ed2146e8096d9`,
  `6a6ae7cdf481df03c4e59dff`, `6a6ae7e6c4dbc22bce9ce19c`,
  `6a6ae7ebeb2c1b23503d2765`.
- 202605: `SONiC.20260510.08` - physical Nokia 7215 M0 A/B with three
  module executions per arm and retries disabled.
  - Baseline Testplan ID: `6a69d9cb101ed2146e809524`. The observed
    `test_memory_checker_recover` failure left the allocation running, producing
    two teardown/next-test memory errors.
  - Patched Testplan ID: `6a6aebe0b63289adaeeeddcd`. The first two module
    executions passed 4/4. The third retained the same primary recover failure,
    but completed with 3 passed, 1 failed and **0 errors**; the following
    `test_monit_reset_counter_failure` passed. Pretest and posttest also passed.
- 202511: `SONiC.HEAD.0-6163597e65` - Testplan ID:
  `6aa8f5b99b3845c93d5a163e`. The complete memory-checker module passed
  4/4 in each of three retry-free repetitions. Overall: 28 passed, 4 skipped,
  0 failed and 0 errors; pretest and posttest passed.

### Approach
#### What is the motivation for this PR?

`test_memory_checker_recover` starts a background allocation that pushes a
container over its Monit limit. If the test fails while waiting for Monit, the
normal stop call is skipped. The process continues running and can fail the
next test for memory that test did not allocate.

The module has the same cleanup risk in paths that rely on container restart
to terminate the allocation.

#### How did you do it?

Stop the allocation in a `finally` in `test_memory_checker_recover`, preserving
the existing successful sequence while covering its failure path. Also perform
a best-effort stop in the function-scoped fixture teardown as a safety net for
the other memory-checker cases.

#### How did you verify/test it?

The master PR CI passed. The 202511 module passed 4/4 in three consecutive
retry-free KVM repetitions. On 202605 hardware, the baseline and patched runs
reproduced the same primary recover failure. The baseline added two collateral
memory errors; the patched run added none and the next test passed. Two healthy
patched repeats passed 4/4.

#### Any platform specific information?

None. The cleanup is platform independent. The failure is visible on platforms
where a memory-checker wait fails after starting the allocation.

#### Supported testbed topology if it's a new test case?

N/A - no new test case.

### Documentation

N/A - no user-visible interface change.