### PR TITLE
[testbed]: Support hyphenated topology removal

### DIFF
--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -63,9 +63,12 @@
 
   - set_fact:
       base_topo: "{{ topo.split('_') | first }}"
+  - set_fact:
+      base_topo: "{{ base_topo.split('-') | first }}"
+    when: base_topo not in topologies
 
-  - name: Check that variable topo is defined
-    fail: msg="Define topo variable with -e topo=something"
+  - name: Check that topo is a known topology
+    fail: msg="Unknown topology {{ topo }} in {{ topologies }}"
     when: base_topo not in topologies
 
   - name: Check that variable ptf_imagename is defined


### PR DESCRIPTION

Summary:

Fix topology removal for hyphenated topology variants such as `t1-isolated-d32u1s2`.

The following recovery test plan failed during `remove-topo` because the playbook treated the complete hyphenated name as the base topology:

https://elastictest.org/scheduler/testplan/6a6adb7eb63289adaeeedda9

The failure was:

fatal: FAILED! => "Define topo variable with -e topo=something" 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Validation pipeline:

https://dev.azure.com/mssonic/internal/_build/results?buildId=1178991&view=logs&j=e3185f07-de69-5b1b-9717-37f5a1612de2

Approach

What is the motivation for this PR?

 testbed_remove_vm_topology.yml  only handles underscore-separated topology variants. For  t1-isolated-d32u1s2 , it derives the base topology as the complete value and rejects it because it is not in the supported  topologies  list.

 testbed_add_vm_topology.yml  already supports hyphenated topology variants, but the equivalent normalization was missing from the remove-topology playbook.

How did you do it?

Added the same conditional hyphen normalization used by the add-topology playbook:

t1-isolated-d32u1s2 -> t1

The validation error was also corrected to report an unknown topology instead of incorrectly stating that the  topo  variable is undefined.

How did you verify/test it?

Verified that:

•  t1-isolated-d32u1s2  resolves to  t1 
•  t1_64  continues to resolve to  t1 
•  t0  remains unchanged

The validation pipeline is linked above.

Any platform specific information?

The failure was observed on a physical NVIDIA SN5640 T1 testbed. The fix applies to all hyphenated topology variants.

Supported testbed topology if it's a new test case?

N/A

Documentation

N/A

