### PR TITLE
[Mellanox] Add xfail for SN4280 due to sonic-mgmt issue#26455

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5171,6 +5171,18 @@ smartswitch:
     conditions:
       - *lossyTopos
 
+smartswitch/platform_tests/test_reload_dpu.py::test_dpu_status_post_switch_kernel_panic:
+  xfail:
+    reason: "Testcase ignored on sn4280 due to issue: https://github.com/sonic-net/sonic-mgmt/issues/26455"
+    conditions:
+    - "https://github.com/sonic-net/sonic-mgmt/issues/26455 and 'sn4280' in platform"
+
+smartswitch/platform_tests/test_reload_dpu.py::test_dpu_status_post_switch_mem_exhaustion:
+  xfail:
+    reason: "Testcase ignored on sn4280 due to issue: https://github.com/sonic-net/sonic-mgmt/issues/26455"
+    conditions:
+    - "https://github.com/sonic-net/sonic-mgmt/issues/26455 and 'sn4280' in platform"
+
 #######################################
 #####         snappi_tests        #####
 #######################################


### PR DESCRIPTION
### Description of PR

Summary:
This is to xfail the test cases affected by https://github.com/sonic-net/sonic-mgmt/issues/26455 on Nvidia SN4280 smartswitch.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: test regression

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
The test cases are xfailed correctly:
<img width="357" height="71" alt="image" src="https://github.com/user-attachments/assets/aef1db31-10ab-4f19-aa3f-4d2b361f79f7" />


### Approach
#### What is the motivation for this PR?
Add xfail for SN4280 due to sonic-mgmt issue#26455
#### How did you do it?
Add to the tests_mark_conditions.yaml, smartswitch section.
#### How did you verify/test it?
Run the test on SN4280, master branch
#### Any platform specific information?
only for SN4280
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
