### PR TITLE
[configlet]: Restore interface state after T0 removal

### DIFF
--- a/tests/configlet/util/generic_patch.py
+++ b/tests/configlet/util/generic_patch.py
@@ -128,6 +128,26 @@ def _list_patch_files(patch_dir):
     return sorted(fnmatch.filter(os.listdir(patch_dir), "patch_[0-9]_*.json"))
 
 
+def _restore_interface_admin_status(duthost, target_dir):
+    with open(os.path.join(target_dir, "config_db.json"), "r") as stream:
+        target_ports = json.load(stream).get("PORT", {})
+
+    for link in tor_data["links"]:
+        interface = link["local"]["sonic_name"]
+            port_config = target_ports.get(interface)
+            assert isinstance(port_config, dict), \
+                "Missing PORT configuration for interface {}".format(interface)
+
+            admin_status = port_config.get("admin_status", "down")
+            assert admin_status in ("up", "down"), \
+                "Unexpected admin_status '{}' for interface {}".format(admin_status, interface)
+
+        action = "startup" if admin_status == "up" else "shutdown"
+        pause = PAUSE_INTF_UP if admin_status == "up" else PAUSE_INTF_DOWN
+        duthost.shell("config interface {} {}".format(action, interface))
+        do_pause(pause, "pause upon i/f {} {} after remove patch".format(interface, action))
+
+
 def generic_patch_add_t0(duthost, skip_load=False, hack_apply=False):
     # Load config w/o T0
     #
@@ -221,13 +241,10 @@ def generic_patch_rm_t0(duthost, skip_load=False, hack_apply=False):
         # We can ignore rc, as DB comp is the final check. So skip it.
         # assert res["rc"] == 0, "Failed to apply patch"
 
-    # Manual shutdown needed because the removal of admin_status won't operate shutdown. It will
-    # by default keep the previous admin_status state. Thus making app-db comparison fail.
-    for link in tor_data["links"]:
-        tor_ifname = link["local"]["sonic_name"]
-        duthost.shell("config interface shutdown {}".format(tor_ifname))
-        do_pause(PAUSE_INTF_DOWN, "pause upon i/f {} shutdown before add patch".format(tor_ifname))
+    # Applying a remove patch can preserve a transient interface state when admin_status
+    # is removed or reordered. Restore the state captured from the no-T0 configuration.
+    _restore_interface_admin_status(duthost, no_t0_db_dir)
 
     assert wait_until(DB_COMP_WAIT_TIME, 20, 0, db_comp, duthost, patch_rm_t0_dir,
                       no_t0_db_dir, "generic_patch_rm_t0"), \
-        "DB compare failed after adding T0 via generic patch updater"
+        "DB compare failed after removing T0 via generic patch updater"

--- a/tests/configlet/util/generic_patch.py
+++ b/tests/configlet/util/generic_patch.py
@@ -134,13 +134,13 @@ def _restore_interface_admin_status(duthost, target_dir):
 
     for link in tor_data["links"]:
         interface = link["local"]["sonic_name"]
-            port_config = target_ports.get(interface)
-            assert isinstance(port_config, dict), \
-                "Missing PORT configuration for interface {}".format(interface)
+        port_config = target_ports.get(interface)
+        assert isinstance(port_config, dict), \
+            "Missing PORT configuration for interface {}".format(interface)
 
-            admin_status = port_config.get("admin_status", "down")
-            assert admin_status in ("up", "down"), \
-                "Unexpected admin_status '{}' for interface {}".format(admin_status, interface)
+        admin_status = port_config.get("admin_status", "down")
+        assert admin_status in ("up", "down"), \
+            "Unexpected admin_status '{}' for interface {}".format(admin_status, interface)
 
         action = "startup" if admin_status == "up" else "shutdown"
         pause = PAUSE_INTF_UP if admin_status == "up" else PAUSE_INTF_DOWN


### PR DESCRIPTION
### Description of PR

Summary:
Restore removed-rack interfaces to the admin state captured in the generated no-T0 reference configuration before comparing databases. The previous unconditional shutdown left interfaces down even when the reference expected them up, causing persistent CONFIG_DB and APP_DB mismatches across Cisco, Arista, and Mellanox 202605 testbeds.

Fixes #26098

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/sonic-net/sonic-mgmt/issues/26098
Failure type: day-one issue on 202605

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: all PR checks passed, including `impacted-area-kvmtest-t1-lag` and `impacted-area-kvmtest-multi-asic-t1`.
- 202605: SONiC.20260510.08 - `configlet/test_add_rack.py` passed on the first attempt on all representative platforms:
  - Cisco-8102-C64: https://elastictest.org/scheduler/testplan/6a6b41d0101ed2146e809781
  - Arista-7260CX3-C64: https://elastictest.org/scheduler/testplan/6a6b41e1101ed2146e809784
  - Mellanox-SN4600C-C64: https://elastictest.org/scheduler/testplan/6a6b41f7c738d690ad9c1bbf

### Approach
#### What is the motivation for this PR?

In 202605 nightly results, the remove-T0 phase of `configlet/test_add_rack.py` repeatedly fails after the generated patch is applied. The no-T0 reference CONFIG_DB expects the selected physical interface to be up, while `generic_patch_rm_t0()` unconditionally shuts it down. The resulting state mismatch keeps the LAG member down and prevents the expected APP_DB routes and neighbors from returning.

The same failure signature was observed across Cisco-8000, Broadcom, and Mellanox platforms. PR #24658 forces the target state down, but that contradicts the current generated no-T0 reference state and its exact `test_add_rack` CI did not pass.

#### How did you do it?

Read the target interface state from `no_t0_db_dir/config_db.json` after applying the remove patch, then explicitly start or shut down each removed-rack interface to match that reference. If `admin_status` is omitted, preserve SONiC's default-down behavior. Also correct the remove-path assertion message.

#### How did you verify/test it?

Ran the repository pre-commit checks for the changed file, Python syntax validation, and a focused behavior check covering target `admin_status=up` and omitted/default-down states. The full PR pipeline passed, including both targeted T1 KVM jobs. Physical 202605 validation passed on Cisco-8102-C64, Arista-7260CX3-C64, and Mellanox-SN4600C-C64.

#### Any platform specific information?

The failure is not platform-specific. It has reproduced on Cisco-8102/8101, Arista-7260CX3, Mellanox-SN4600C, and Mellanox-SN4700.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
