### PR TITLE
Fix bmx test_bmc_firmware_update issue

### DIFF
--- a/tests/platform_tests/api/test_bmc.py
+++ b/tests/platform_tests/api/test_bmc.py
@@ -33,11 +33,18 @@ OLD_BMC_VERSION_IDX = 1
 EROT_BUSY_MSG = "ERoT is busy"
 EROT_STABLE_TIMEOUT = 600
 WAIT_TIME = 30
+WAIT_TIME_INTERVAL_BETWEEN_ATTEMPTS = 30
+BMC_DISABLE_BACKGROUND_COPY_TIMEOUT = 30
+BMC_DISABLE_BACKGROUND_COPY_INTERVAL = 5
 BMC_COMPONENT_NAME = 'BMC'
 BMC_UPDATE_COMMAND = "sudo config platform firmware {} chassis component BMC fw -y"
 BMC_INSTALL_COMMAND = "sudo config platform firmware {} chassis component BMC fw -y {}"
-BMC_GET_STATUS_COMMAND = "curl -k -u {}:{} -X GET https://{}/redfish/v1/Chassis/MGX_ERoT_BMC_0"
-BMC_COMPLETE_STATUS = "Completed"
+BMC_GET_STATUS_COMMAND = "curl -k -u {}:{} --request GET --location https://{}/redfish/v1/Chassis/MGX_ERoT_BMC_0"
+BMC_DISABLE_BACKGROUND_COPY_COMMAND = (
+    "curl -k -u {}:{} -H \"Content-Type: application/json\" -X PATCH "
+    "https://{}/redfish/v1/Chassis/MGX_ERoT_BMC_0 "
+    "-d '{{\"Oem\": {{\"Nvidia\": {{\"AutomaticBackgroundCopyEnabled\": false}}}}}}'"
+)
 
 # BMC session test commands
 BMC_OPEN_SESSION_COMMAND = "sudo config bmc open-session"
@@ -58,6 +65,102 @@ CURL_BASIC_AUTH_GET = "curl -k -u {}:{} -X GET https://{}{}"
 CURL_BASIC_AUTH_GET_WITH_HEADERS = "curl -k -i -u {}:{} -X GET https://{}{}"
 CURL_BASIC_AUTH_PATCH = "curl -k -i -u {}:{} -H \"Content-Type: application/json\" -X PATCH https://{}{} -d '{}'"
 CURL_BASIC_AUTH_DELETE = "curl -k -u {}:{} -X DELETE https://{}{}"
+
+
+def _get_bmc_background_copy_enabled(duthost, bmc_ip, bmc_root_user, bmc_root_password):
+    """
+    Query the ERoT-BMC Chassis endpoint and return Oem.Nvidia.AutomaticBackgroundCopyEnabled.
+
+    Args:
+        duthost: DUT host object
+        bmc_ip: BMC IP address
+        bmc_root_user: BMC root username
+        bmc_root_password: BMC root password
+    Returns:
+        bool: value of AutomaticBackgroundCopyEnabled (defaults to True if missing/unparsable)
+    """
+    res = duthost.command(BMC_GET_STATUS_COMMAND.format(bmc_root_user, bmc_root_password, bmc_ip))["stdout"]
+    pytest_assert(res is not None, "Failed to query BMC status")
+
+    try:
+        response_json = json.loads(res)
+        background_copy_enabled = response_json.get("Oem", {}).get("Nvidia", {}).get(
+            "AutomaticBackgroundCopyEnabled", True)
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        logger.warning(f"Failed to parse BMC status response: {e}, response: {res}")
+        return True
+
+    logger.info(f"BMC AutomaticBackgroundCopyEnabled: {background_copy_enabled}")
+    return background_copy_enabled
+
+
+def _disable_bmc_background_copy(duthost, bmc_ip, bmc_root_user, bmc_root_password):
+    """
+    Disable automatic background copy on the ERoT-BMC via Redfish PATCH.
+
+    Sends:
+        PATCH /redfish/v1/Chassis/MGX_ERoT_BMC_0
+        -d '{"Oem": {"Nvidia": {"AutomaticBackgroundCopyEnabled": false}}}'
+
+    Args:
+        duthost: DUT host object
+        bmc_ip: BMC IP address
+        bmc_root_user: BMC root username
+        bmc_root_password: BMC root password
+    Returns:
+        str: raw response body from the PATCH request
+    """
+    logger.info("Disabling BMC AutomaticBackgroundCopyEnabled via Redfish PATCH")
+    res = duthost.command(
+        BMC_DISABLE_BACKGROUND_COPY_COMMAND.format(bmc_root_user, bmc_root_password, bmc_ip))["stdout"]
+    logger.info(f"BMC disable background copy response: {res}")
+    return res
+
+
+def _is_bmc_busy(duthost, bmc_ip, bmc_root_user, bmc_root_password):
+    """
+    Check if BMC/ERoT is busy.
+
+    Logic:
+        1. Query the Chassis Redfish endpoint for Oem.Nvidia.AutomaticBackgroundCopyEnabled.
+           - If False -> automatic background copy is disabled -> BMC is NOT busy.
+           - If True  -> PATCH the Chassis endpoint to disable AutomaticBackgroundCopyEnabled,
+                         then poll (re-query) for up to BMC_DISABLE_BACKGROUND_COPY_TIMEOUT
+                         seconds until it becomes False. If it becomes False, BMC is NOT busy;
+                         otherwise (timeout) it is still busy.
+
+    Args:
+        duthost: DUT host object
+        bmc_ip: BMC IP address
+        bmc_root_user: BMC root username
+        bmc_root_password: BMC root password
+    Returns:
+        bool: True if BMC is busy, False otherwise
+    """
+    background_copy_enabled = _get_bmc_background_copy_enabled(
+        duthost, bmc_ip, bmc_root_user, bmc_root_password)
+
+    if not background_copy_enabled:
+        # AutomaticBackgroundCopyEnabled is False -> BMC is not busy
+        return False
+
+    # AutomaticBackgroundCopyEnabled is True -> disable it via PATCH
+    _disable_bmc_background_copy(duthost, bmc_ip, bmc_root_user, bmc_root_password)
+
+    # Poll until AutomaticBackgroundCopyEnabled becomes False (up to timeout).
+    start_time = time.time()
+    while True:
+        background_copy_enabled = _get_bmc_background_copy_enabled(
+            duthost, bmc_ip, bmc_root_user, bmc_root_password)
+        if not background_copy_enabled:
+            # Confirmed disabled -> BMC is not busy
+            return False
+        if time.time() - start_time > BMC_DISABLE_BACKGROUND_COPY_TIMEOUT:
+            logger.warning(
+                f"AutomaticBackgroundCopyEnabled still True after "
+                f"{BMC_DISABLE_BACKGROUND_COPY_TIMEOUT}s -> BMC is still busy")
+            return True
+        time.sleep(BMC_DISABLE_BACKGROUND_COPY_INTERVAL)
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/platform_tests/api/test_bmc.py
+++ b/tests/platform_tests/api/test_bmc.py
@@ -67,6 +67,20 @@ CURL_BASIC_AUTH_PATCH = "curl -k -i -u {}:{} -H \"Content-Type: application/json
 CURL_BASIC_AUTH_DELETE = "curl -k -u {}:{} -X DELETE https://{}{}"
 
 
+def _get_bmc_version(duthost, timeout=120):
+    """Get BMC firmware version from 'show platform firmware status' output."""
+    start_time = time.time()
+    while True:
+        if time.time() - start_time > timeout:
+            logger.warning(f"Timeout after {timeout}s while getting BMC version")
+            return None
+        res = duthost.show_and_parse('sudo show platform firmware status')
+        for entry in res:
+            if entry['component'] == 'BMC' and entry['version'] != 'N/A':
+                return entry['version']
+        time.sleep(5)
+
+
 def _get_bmc_background_copy_enabled(duthost, bmc_ip, bmc_root_user, bmc_root_password):
     """
     Query the ERoT-BMC Chassis endpoint and return Oem.Nvidia.AutomaticBackgroundCopyEnabled.
@@ -92,6 +106,75 @@ def _get_bmc_background_copy_enabled(duthost, bmc_ip, bmc_root_user, bmc_root_pa
 
     logger.info(f"BMC AutomaticBackgroundCopyEnabled: {background_copy_enabled}")
     return background_copy_enabled
+
+
+def _disable_bmc_background_copy(duthost, bmc_ip, bmc_root_user, bmc_root_password):
+    """
+    Disable automatic background copy on the ERoT-BMC via Redfish PATCH.
+
+    Sends:
+        PATCH /redfish/v1/Chassis/MGX_ERoT_BMC_0
+        -d '{"Oem": {"Nvidia": {"AutomaticBackgroundCopyEnabled": false}}}'
+
+    Args:
+        duthost: DUT host object
+        bmc_ip: BMC IP address
+        bmc_root_user: BMC root username
+        bmc_root_password: BMC root password
+    Returns:
+        str: raw response body from the PATCH request
+    """
+    logger.info("Disabling BMC AutomaticBackgroundCopyEnabled via Redfish PATCH")
+    res = duthost.command(
+        BMC_DISABLE_BACKGROUND_COPY_COMMAND.format(bmc_root_user, bmc_root_password, bmc_ip))["stdout"]
+    logger.info(f"BMC disable background copy response: {res}")
+    return res
+
+
+def _is_bmc_busy(duthost, bmc_ip, bmc_root_user, bmc_root_password):
+    """
+    Check if BMC/ERoT is busy.
+
+    Logic:
+        1. Query the Chassis Redfish endpoint for Oem.Nvidia.AutomaticBackgroundCopyEnabled.
+           - If False -> automatic background copy is disabled -> BMC is NOT busy.
+           - If True  -> PATCH the Chassis endpoint to disable AutomaticBackgroundCopyEnabled,
+                         then poll (re-query) for up to BMC_DISABLE_BACKGROUND_COPY_TIMEOUT
+                         seconds until it becomes False. If it becomes False, BMC is NOT busy;
+                         otherwise (timeout) it is still busy.
+
+    Args:
+        duthost: DUT host object
+        bmc_ip: BMC IP address
+        bmc_root_user: BMC root username
+        bmc_root_password: BMC root password
+    Returns:
+        bool: True if BMC is busy, False otherwise
+    """
+    background_copy_enabled = _get_bmc_background_copy_enabled(
+        duthost, bmc_ip, bmc_root_user, bmc_root_password)
+
+    if not background_copy_enabled:
+        # AutomaticBackgroundCopyEnabled is False -> BMC is not busy
+        return False
+
+    # AutomaticBackgroundCopyEnabled is True -> disable it via PATCH
+    _disable_bmc_background_copy(duthost, bmc_ip, bmc_root_user, bmc_root_password)
+
+    # Poll until AutomaticBackgroundCopyEnabled becomes False (up to timeout).
+    start_time = time.time()
+    while True:
+        background_copy_enabled = _get_bmc_background_copy_enabled(
+            duthost, bmc_ip, bmc_root_user, bmc_root_password)
+        if not background_copy_enabled:
+            # Confirmed disabled -> BMC is not busy
+            return False
+        if time.time() - start_time > BMC_DISABLE_BACKGROUND_COPY_TIMEOUT:
+            logger.warning(
+                f"AutomaticBackgroundCopyEnabled still True after "
+                f"{BMC_DISABLE_BACKGROUND_COPY_TIMEOUT}s -> BMC is still busy")
+            return True
+        time.sleep(BMC_DISABLE_BACKGROUND_COPY_INTERVAL)
 
 
 def _disable_bmc_background_copy(duthost, bmc_ip, bmc_root_user, bmc_root_password):


### PR DESCRIPTION
### Description of PR

Because of a design change, BMC busy detection now works as follows:
   - Query /redfish/v1/Chassis/MGX_ERoT_BMC_0 for Oem.Nvidia.AutomaticBackgroundCopyEnabled. 
    * If False -> automatic background copy is disabled -> BMC is NOT busy.
    * If True  -> PATCH /redfish/v1/Chassis/MGX_ERoT_BMC_0 with {"Oem": {"Nvidia": {"AutomaticBackgroundCopyEnabled": false}}} to disable automatic background copy, then poll (re-query) for up to 30s until it becomes False. If it becomes False, BMC is NOT busy; otherwise (timeout) it is still busy.

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
master: pass
202605: pass

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Query /redfish/v1/Chassis/MGX_ERoT_BMC_0 for Oem.Nvidia.AutomaticBackgroundCopyEnabled. * If False -> automatic background copy is disabled -> BMC is NOT busy. * If True  -> PATCH /redfish/v1/Chassis/MGX_ERoT_BMC_0 with {"Oem": {"Nvidia": {"AutomaticBackgroundCopyEnabled": false}}} to disable automatic background copy, then poll (re-query) for up to 30s until it becomes False. If it becomes False, BMC is NOT busy; otherwise (timeout) it is still busy.

#### How did you verify/test it?
Run the test

#### Any platform specific information?
Platform with bmc

#### Supported testbed topology if it's a new test case?
Any

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
