### PR TITLE
Fix asymmetric lower-bound margin for wm_pg_shared_lossy on SPC4 and later

### DIFF
--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -310,6 +310,9 @@ class QosParamMellanox(object):
             self.qos_params_mlnx['wm_pg_shared_lossy']['pkts_num_margin'] = max(
                 self.qos_params_mlnx['wm_pg_shared_lossy']['pkts_num_margin'],
                 int(self.qos_params_mlnx['wm_pg_shared_lossy']['pkts_num_trig_egr_drp'] * wm_margin_ratio))
+            self.qos_params_mlnx['wm_pg_shared_lossy']['pkts_num_margin_lower_bound'] = max(
+                self.qos_params_mlnx['wm_pg_shared_lossy'].get('pkts_num_margin_lower_bound', 0),
+                int(self.qos_params_mlnx['wm_pg_shared_lossy']['pkts_num_trig_egr_drp'] * wm_margin_ratio))
             self.qos_params_mlnx['wm_q_shared_lossy']['pkts_num_margin'] = max(
                 self.qos_params_mlnx['wm_q_shared_lossy']['pkts_num_margin'],
                 int(self.qos_params_mlnx['wm_q_shared_lossy']['pkts_num_trig_egr_drp'] * wm_margin_ratio))


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
On SPC4+ ASICs the upper-bound margin for wm_pg_shared_lossy is set to int(pkts_num_trig_egr_drp * 0.002), but pkts_num_margin_lower_bound was never populated, defaulting to 0 in the PTF test. This causes a spurious failure when the hardware watermark snapshot is a few cells below the expected fill level due to hardware sampling granularity. Set pkts_num_margin_lower_bound to the same ratio so the assertion is symmetric on both sides.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
