### PR TITLE
[ansible/vm_set] Add dormant GoBGP PTF speaker shim engine

### DIFF
--- a/ansible/roles/vm_set/files/gobgp/__init__.py
+++ b/ansible/roles/vm_set/files/gobgp/__init__.py
@@ -1,0 +1,9 @@
+"""GoBGP PTF speaker: ExaBGP-compatible HTTP shim over per-neighbor gobgpd.
+
+Nothing in the ansible or test paths imports this package, so it cannot affect
+the ExaBGP speaker that remains the default; the vm_set wiring lands in a
+follow-up change. The shim itself runs as a pool of processes, one per core
+and portmap-sharded -- see :mod:`gobgp.shim`.
+
+Design: https://github.com/sonic-net/sonic-mgmt/pull/26382
+"""

--- a/ansible/roles/vm_set/files/gobgp/shardmap.py
+++ b/ansible/roles/vm_set/files/gobgp/shardmap.py
@@ -1,0 +1,86 @@
+"""Portmap sharding -- the single source of truth for how per-neighbor HTTP
+ports are partitioned across the shim process pool.
+
+The shim entrypoint imports this module to select the ports it owns; the
+ansible module that launches one supervisord program per shard will import the
+same helpers, so the two can never disagree on which shim owns which port.
+
+The layout follows the design (https://github.com/sonic-net/sonic-mgmt/pull/26382
+-> "Daemon topology and the shim", "Memory consumption"):
+
+* one gobgpd per (neighbor, family) -- untouched here, that is the manager's job;
+* ``k = min(core_count, session_count)`` **shim** processes (the POOL config),
+  each owning a disjoint shard of the per-neighbor ports. This keeps shim memory
+  ``O(cores)`` instead of ``O(sessions)`` and avoids GIL-serializing the
+  CPU-bound protobuf build in a single process (the rejected CONS config).
+
+A "portmap" is the JSON object the manager renders::
+
+    {
+      "5000": {"grpc": "127.0.0.1:50052", "family": "v4", "name": "ARISTA01T1"},
+      "6000": {"grpc": "127.0.0.1:50052", "family": "v6", "name": "ARISTA01T1"},
+      ...
+    }
+
+Ports are the stable contract (``filters.py`` port math: ``5000+off`` v4 /
+``6000+off`` v6), so sharding is defined purely in terms of ports and never
+perturbs that math.
+"""
+from __future__ import division
+
+
+def num_shards(core_count, session_count):
+    """Number of shim processes in the pool: ``min(cores, sessions)``, >= 1.
+
+    ``session_count`` is the number of ports to serve (each (neighbor, family)
+    port is one intake slot). Capping at the port count avoids spawning idle
+    shims when there are fewer ports than cores.
+    """
+    core_count = int(core_count)
+    session_count = int(session_count)
+    if session_count <= 0:
+        return 1
+    return max(1, min(max(core_count, 1), session_count))
+
+
+def _sorted_ports(portmap):
+    """Deterministic port ordering so shard assignment is stable across the
+    manager and every shim (numeric sort; ports are ints-as-strings in JSON)."""
+    return sorted(portmap, key=int)
+
+
+def partition(portmap, k):
+    """Split ``portmap`` into disjoint sub-portmaps (shards).
+
+    Returns one dict per effective shard, where ``k`` is clamped to
+    ``[1, len(portmap)]`` so callers can pass a raw core count without
+    special-casing tiny portmaps and no shard comes back empty; an empty
+    ``portmap`` yields a single empty shard. The shards' union is ``portmap``
+    and their pairwise intersection is empty (every port owned by exactly one
+    shard). Assignment is round-robin over numerically sorted ports, which
+    spreads the two families of one neighbor across shards and keeps shard
+    sizes balanced to within one port.
+    """
+    ports = _sorted_ports(portmap)
+    if not ports:
+        return [{}]
+    k = max(1, min(int(k), len(ports)))
+    shards = [dict() for _ in range(k)]
+    for idx, port in enumerate(ports):
+        shards[idx % k][port] = portmap[port]
+    return shards
+
+
+def shard_for(portmap, k, shard_index):
+    """Convenience: the single sub-portmap owned by ``shard_index`` of ``k``.
+
+    Raises ``IndexError`` if ``shard_index`` is out of range for the effective
+    (clamped) shard count, so a mis-launched shim fails loudly instead of
+    silently serving nothing.
+    """
+    shards = partition(portmap, k)
+    if not 0 <= shard_index < len(shards):
+        raise IndexError(
+            "shard_index %d out of range for %d shard(s)"
+            % (shard_index, len(shards)))
+    return shards[shard_index]

--- a/ansible/roles/vm_set/files/gobgp/shim/__init__.py
+++ b/ansible/roles/vm_set/files/gobgp/shim/__init__.py
@@ -1,0 +1,11 @@
+"""ExaBGP-compatible HTTP shim over per-neighbor gobgpd (gRPC).
+
+Public surface:
+
+* :mod:`gobgp.shim.parser` -- ExaBGP text grammar -> command dicts (pure).
+* :mod:`gobgp.shim.translator` -- command dicts -> batched gRPC (``NeighborClient``).
+* :mod:`gobgp.shim.receive` -- ADJ_IN structured receive view.
+* :mod:`gobgp.shim.server` -- per-port HTTP front end.
+
+Run as ``python -m gobgp.shim --portmap <file> --shard i/k`` (see ``__main__``).
+"""

--- a/ansible/roles/vm_set/files/gobgp/shim/__main__.py
+++ b/ansible/roles/vm_set/files/gobgp/shim/__main__.py
@@ -1,0 +1,91 @@
+"""Shard-aware shim entrypoint.
+
+Run one shim process of the POOL::
+
+    python -m gobgp.shim --portmap /etc/gobgp/portmap.json --shard 0/4
+
+``--shard i/k`` means "this is shim ``i`` of ``k``": the process serves only the
+ports :func:`gobgp.shardmap.shard_for` assigns to shard ``i`` of a ``k``-way
+split of the full portmap. The manager (``gobgp`` ansible module, landing in a
+follow-up change) launches ``k = min(cores, sessions)`` supervisord programs, one per shard, so the pool
+collectively covers every neighbor port with no overlap and no single-process
+GIL bottleneck. ``--shard`` defaults to ``0/1`` (serve the whole portmap), which
+is handy for local testing.
+"""
+import argparse
+import json
+import logging
+import sys
+import threading
+import time
+
+from .. import shardmap
+from .server import make_server
+
+LOG = logging.getLogger("gobgp_shim")
+
+
+def _parse_shard(spec):
+    """``"i/k"`` -> ``(i, k)`` with ``0 <= i < k`` and ``k >= 1``."""
+    try:
+        i_str, k_str = spec.split("/")
+        i, k = int(i_str), int(k_str)
+    except (ValueError, AttributeError):
+        raise argparse.ArgumentTypeError(
+            "shard must be 'i/k' (e.g. 0/4), got %r" % spec)
+    if k < 1 or not 0 <= i < k:
+        raise argparse.ArgumentTypeError(
+            "shard 'i/k' needs k>=1 and 0<=i<k, got %r" % spec)
+    return i, k
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog="gobgp.shim")
+    ap.add_argument("--portmap", required=True,
+                    help="JSON file: {port: {grpc, family, name, self_nexthop}}")
+    ap.add_argument("--shard", type=_parse_shard, default=(0, 1),
+                    help="this shim's slot as 'i/k' (default 0/1 = all ports)")
+    ap.add_argument("--debug", action="store_true")
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+    with open(args.portmap) as f:
+        full_portmap = json.load(f)
+
+    shard_index, k = args.shard
+    my_ports = shardmap.shard_for(full_portmap, k, shard_index)
+
+    # Bind all ports up front so a bind failure is fatal (exit non-zero ->
+    # supervisord restarts) instead of a serve thread dying silently.
+    servers = []
+    for port, spec in my_ports.items():
+        try:
+            servers.append((port, spec, make_server(port, spec)))
+        except Exception:
+            LOG.exception("shard %d/%d: failed to bind port %s", shard_index, k,
+                          port)
+            return 1
+
+    threads = []
+    for port, spec, httpd in servers:
+        t = threading.Thread(target=httpd.serve_forever, daemon=True)
+        t.start()
+        threads.append(t)
+        LOG.info("shim listening on :%s -> %s (%s, neighbor %s)",
+                 port, spec["grpc"], spec["family"], spec.get("name"))
+    LOG.info("gobgp_shim shard %d/%d up: %d of %d port(s)",
+             shard_index, k, len(servers), len(full_portmap))
+
+    try:
+        while True:
+            time.sleep(3600)
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ansible/roles/vm_set/files/gobgp/shim/_gbapi.py
+++ b/ansible/roles/vm_set/files/gobgp/shim/_gbapi.py
@@ -1,0 +1,36 @@
+"""Import shim for the gobgp gRPC stubs.
+
+The stubs live in the PTF image at ``/usr/local/lib/gobgp-api``, generated when
+the image is built from the same gobgp checkout that produces ``gobgpd``, so the
+stubs and the daemon always describe the same gobgp version. ``GOBGP_API_PATH``
+overrides the location. Centralising the path setup here gives the rest of the
+package a single import surface::
+
+    from ._gbapi import grpc, gb, gbg, attr, nlri, common, extcom
+
+NLRIs come from ``nlri`` (``nlri_pb2``), path attributes from ``attr``/``extcom``,
+and the address family from ``common``.
+"""
+import os
+import sys
+
+_GBAPI_DIR = os.environ.get("GOBGP_API_PATH", "/usr/local/lib/gobgp-api")
+if _GBAPI_DIR not in sys.path:
+    sys.path.insert(0, _GBAPI_DIR)
+
+import grpc  # noqa: E402
+from api import gobgp_pb2 as gb  # noqa: E402
+from api import gobgp_pb2_grpc as gbg  # noqa: E402
+from api import attribute_pb2 as attr  # noqa: E402
+from api import nlri_pb2 as nlri  # noqa: E402
+from api import common_pb2 as common  # noqa: E402
+from api import extcom_pb2 as extcom  # noqa: E402
+
+
+def family_msg(family):
+    """``common.Family`` for ``"v4"``/``"v6"`` (AFI + unicast SAFI)."""
+    afi = common.Family.AFI_IP if family == "v4" else common.Family.AFI_IP6
+    return common.Family(afi=afi, safi=common.Family.SAFI_UNICAST)
+
+
+__all__ = ["grpc", "gb", "gbg", "attr", "nlri", "common", "extcom", "family_msg"]

--- a/ansible/roles/vm_set/files/gobgp/shim/parser.py
+++ b/ansible/roles/vm_set/files/gobgp/shim/parser.py
@@ -1,0 +1,180 @@
+"""ExaBGP text-command grammar parser.
+
+Pure functions, **no gRPC/protobuf imports**, so the grammar can be unit-tested
+(U1/U3) without a gobgpd or the generated stubs. Translates the exact ExaBGP
+command grammar that ``announce_routes.py`` and the test helpers emit into
+plain structured dicts; :mod:`gobgp.shim.translator` turns those into gRPC paths.
+
+Grammar handled (superset of what sonic-mgmt emits)::
+
+    announce route <prefix> next-hop <nh> [as-path [ <asns> ]]
+        [community [ <c> ]] [large-community [ <c> ]] [extended-community [ <c> ]]
+        [local-preference <n>] [med <n>] [origin igp|egp|incomplete]
+    withdraw route <prefix> [next-hop <nh>] ...
+    announce attributes <same attrs> nlri <p1> <p2> ...
+    withdraw attributes ... nlri <p1> <p2> ...
+"""
+from __future__ import print_function
+
+ORIGIN_MAP = {"igp": 0, "egp": 1, "incomplete": 2}
+
+_WELL_KNOWN_COMMUNITIES = {
+    "no-export": 0xFFFFFF01,
+    "no-advertise": 0xFFFFFF02,
+    "no-export-subconfed": 0xFFFFFF03,
+    "local-as": 0xFFFFFF03,
+}
+
+
+def _bracket_list(tokens, i):
+    """Parse ``[ a b c ]`` starting at ``tokens[i] == '['``.
+
+    Returns ``(items, next_i)``. Also tolerates a single bare token, because
+    ExaBGP allows the un-bracketed form (e.g. ``community 65000:1``).
+    """
+    if i >= len(tokens):
+        return [], i
+    if tokens[i] == "[":
+        items = []
+        i += 1
+        while i < len(tokens) and tokens[i] != "]":
+            items.append(tokens[i])
+            i += 1
+        i += 1  # skip ']'
+        return items, i
+    return [tokens[i]], i + 1
+
+
+def parse_community(tok):
+    """``'65000:100'`` -> packed 32-bit community int; well-known names mapped."""
+    if tok in _WELL_KNOWN_COMMUNITIES:
+        return _WELL_KNOWN_COMMUNITIES[tok]
+    if ":" in tok:
+        hi, lo = tok.split(":")
+        return (int(hi) << 16) | int(lo)
+    return int(tok)
+
+
+def parse_large_community(tok):
+    """``'a:b:c'`` -> ``(a, b, c)`` tuple of ints."""
+    a, b, c = tok.split(":")
+    return (int(a), int(b), int(c))
+
+
+def parse_ext_community(tok):
+    """``'target:65000:100'`` or ``'65000:100'`` -> ``(as_num, local_admin)``."""
+    t = tok.split(":")
+    if len(t) == 3:
+        _, a, b = t
+    else:
+        a, b = t
+    return (int(a), int(b))
+
+
+def parse_attrs(tokens, i):
+    """Parse the shared attribute tail (next-hop/as-path/community/...).
+
+    Returns ``(attrs_dict, next_i)``. Stops at the ``nlri`` keyword or end of
+    input. Truncated (value-less) and unknown tokens are skipped defensively; a
+    malformed scalar value (e.g. a non-integer ``med``) raises ``ValueError``,
+    which ``parse_command`` catches to keep the U3 no-op contract.
+    """
+    a = {"nexthop": None, "aspath": None, "communities": None,
+         "large_communities": None, "ext_communities": None,
+         "local_pref": None, "med": None, "origin": None}
+    n = len(tokens)
+    while i < n:
+        t = tokens[i]
+        if t == "nlri":
+            break
+        elif t == "next-hop":
+            if i + 1 >= n:
+                break
+            a["nexthop"] = tokens[i + 1]
+            i += 2
+        elif t == "as-path":
+            items, i = _bracket_list(tokens, i + 1)
+            a["aspath"] = [int(x) for x in items]
+        elif t == "community":
+            items, i = _bracket_list(tokens, i + 1)
+            a["communities"] = [parse_community(x) for x in items]
+        elif t == "large-community":
+            items, i = _bracket_list(tokens, i + 1)
+            a["large_communities"] = [parse_large_community(x) for x in items]
+        elif t == "extended-community":
+            items, i = _bracket_list(tokens, i + 1)
+            a["ext_communities"] = [parse_ext_community(x) for x in items]
+        elif t in ("local-preference", "local-pref"):
+            if i + 1 >= n:
+                break
+            a["local_pref"] = int(tokens[i + 1])
+            i += 2
+        elif t == "med":
+            if i + 1 >= n:
+                break
+            a["med"] = int(tokens[i + 1])
+            i += 2
+        elif t == "origin":
+            if i + 1 >= n:
+                break
+            a["origin"] = ORIGIN_MAP.get(tokens[i + 1], 0)
+            i += 2
+        else:
+            i += 1
+    return a, i
+
+
+def parse_command(cmd):
+    """Parse one ExaBGP command line into an operation dict.
+
+    Returns ``{op, is_withdraw, prefixes: [...], **attrs}`` for announce/withdraw
+    of ``route``/``attributes`` forms, or ``{"op": "noop"}`` for commands we
+    intentionally ignore (route-refresh, session-level teardown, blanks),
+    truncated commands (e.g. ``announce route`` with no prefix), and commands
+    whose attribute values are malformed (e.g. a non-integer ``med``), so a bad
+    line from an untrusted body degrades to a no-op instead of raising.
+    """
+    tokens = cmd.strip().split()
+    if not tokens:
+        return {"op": "noop"}
+    op = tokens[0]
+    if op not in ("announce", "withdraw"):
+        return {"op": "noop", "raw": cmd}
+    is_withdraw = (op == "withdraw")
+
+    kind = tokens[1] if len(tokens) > 1 else ""
+    try:
+        if kind == "route":
+            if len(tokens) < 3:  # 'announce route' with no prefix
+                return {"op": "noop", "raw": cmd}
+            prefix = tokens[2]
+            attrs, _ = parse_attrs(tokens, 3)
+            return dict(op=op, is_withdraw=is_withdraw, prefixes=[prefix], **attrs)
+        elif kind == "attributes":
+            attrs, i = parse_attrs(tokens, 2)
+            prefixes = tokens[i + 1:] if i < len(tokens) else []  # tokens[i] == 'nlri'
+            return dict(op=op, is_withdraw=is_withdraw, prefixes=prefixes, **attrs)
+    except ValueError:  # malformed attribute value -> safe no-op
+        return {"op": "noop", "raw": cmd}
+    return {"op": "noop", "raw": cmd}
+
+
+def commands_from_body(body):
+    """Split an HTTP POST body into individual command strings.
+
+    Accepts ExaBGP form-encoding (``command=`` / ``commands=`` where the latter
+    is ``;``-separated) **and** raw text (one command or ``;``-separated), so
+    every existing caller works unchanged.
+    """
+    from urllib.parse import parse_qs
+
+    cmds = []
+    if "command=" in body or "commands=" in body:
+        form = parse_qs(body, keep_blank_values=True)
+        for c in form.get("command", []):
+            cmds.append(c)
+        for blob in form.get("commands", []):
+            cmds.extend(blob.split(";"))
+    else:
+        cmds.extend(body.split(";"))
+    return [c.strip() for c in cmds if c.strip()]

--- a/ansible/roles/vm_set/files/gobgp/shim/receive.py
+++ b/ansible/roles/vm_set/files/gobgp/shim/receive.py
@@ -1,0 +1,29 @@
+"""Structured receive path -- prefixes the DUT advertised to us (BGP ADJ_IN).
+
+This replaces the ExaBGP text ``dump`` process that bgpmon-style tests scraped:
+instead of parsing free-form text, tests GET ``/adj-in`` and read a JSON prefix
+list sourced directly from gobgpd's per-neighbor ADJ_IN RIB. Kept in its own
+module (no HTTP, no parser) so U6 can exercise it against a fake stub.
+"""
+from ._gbapi import gb, family_msg
+
+
+def adj_in_prefixes(stub, family):
+    """Return the ADJ_IN prefixes for ``family`` across ``stub``'s peers.
+
+    gobgpd's ADJ_IN table is per-neighbor, so we enumerate peers (each shim
+    gobgpd holds exactly one neighbor -- the DUT/cEOS VM) and collect their
+    ADJ_IN prefixes for this address family. ``stub`` is injected so the caller
+    (and U6) controls the gRPC endpoint / fake.
+    """
+    out = []
+    for peer in stub.ListPeer(gb.ListPeerRequest()):
+        addr = (peer.peer.conf.neighbor_address
+                or peer.peer.state.neighbor_address)
+        if not addr:
+            continue
+        req = gb.ListPathRequest(table_type=gb.TABLE_TYPE_ADJ_IN, name=addr,
+                                 family=family_msg(family))
+        for dst in stub.ListPath(req):
+            out.append(dst.destination.prefix)
+    return out

--- a/ansible/roles/vm_set/files/gobgp/shim/server.py
+++ b/ansible/roles/vm_set/files/gobgp/shim/server.py
@@ -1,0 +1,167 @@
+"""HTTP front end -- one ExaBGP-compatible server per neighbor port.
+
+Ties the pure pieces together: :mod:`parser` turns the POST body into command
+dicts, :class:`~gobgp.shim.translator.NeighborClient` batches them into one
+gRPC stream, and GET ``/adj-in`` returns the structured receive view. The wire
+contract (per-neighbor port, ``command=``/``commands=`` form-encoding, ``done``/
+``error`` text responses) is identical to the ExaBGP ``http_api.py`` it
+replaces, so no caller in sonic-mgmt changes.
+
+Each port gets its own app and :class:`NeighborClient`, so neighbours share no
+state and a shard adds no cross-port serialization beyond the GIL it already
+has. Flask parses the request; the shim owns the body cap and the command
+semantics.
+"""
+import json
+import logging
+import time
+
+from flask import Flask, Response, request
+from werkzeug.exceptions import HTTPException
+from werkzeug.serving import WSGIRequestHandler
+from werkzeug.serving import make_server as _make_wsgi_server
+
+from . import parser
+from .translator import NeighborClient
+
+LOG = logging.getLogger("gobgp_shim")
+
+# Cap on a POST body; announce_routes.py batches 200 commands (~25 KB).
+MAX_BODY_BYTES = 16 * 1024 * 1024
+
+
+def _sanitize(value):
+    """Strip CR/LF so untrusted text cannot forge log records."""
+    return str(value).replace("\r", " ").replace("\n", " ")
+
+
+def _reason(exc):
+    """Failure category for the response body.
+
+    The full message goes to the shim log; the reply carries only the
+    exception type, so a failing route is still attributable without
+    returning interpreter detail to the caller.
+    """
+    return type(exc).__name__
+
+
+class _RequestHandler(WSGIRequestHandler):
+    """Route werkzeug's access and error logs through the shim logger."""
+
+    def log(self, type_, message, *args):
+        LOG.debug("%s %s", self.address_string(), _sanitize(message % args))
+
+
+def _read_body():
+    """Return the request body, or ``None`` if it exceeds the cap.
+
+    Reads at most one byte past the cap, so an oversized body is refused
+    without ever being buffered -- for both ``Content-Length`` and chunked
+    framing, and independently of the werkzeug version. werkzeug's own limit
+    sits one byte higher so that overshoot stays visible here: at the cap it
+    would truncate the stream silently instead, and old werkzeug ignores the
+    limit altogether.
+    """
+    declared = request.content_length
+    if declared is not None and declared > MAX_BODY_BYTES:
+        return None
+    raw = request.stream.read(MAX_BODY_BYTES + 1)
+    if len(raw) > MAX_BODY_BYTES:
+        return None
+    return raw.decode("utf-8", "replace")
+
+
+def make_app(client):
+    """Build the Flask app that serves one neighbor ``client``."""
+    app = Flask("gobgp_shim", static_folder=None)
+    app.config["MAX_CONTENT_LENGTH"] = MAX_BODY_BYTES + 1
+
+    def _text(code, body):
+        return Response(body, status=code, mimetype="text/plain")
+
+    def _reject_too_large():
+        LOG.error("[%s:%s] POST body over %d byte cap, rejected",
+                  client.name, client.family, MAX_BODY_BYTES)
+        return _text(413, "error: request body too large\n")
+
+    @app.errorhandler(413)
+    def _too_large(exc):
+        return _reject_too_large()
+
+    @app.errorhandler(Exception)
+    def _unhandled(exc):
+        # Keeps the plain-text error contract, and stops Flask from logging
+        # the untrusted request path itself.
+        if isinstance(exc, HTTPException):
+            return exc
+        LOG.error("[%s:%s] %s FAILED: %s", client.name, client.family,
+                  _sanitize(request.path), _sanitize(exc))
+        return _text(500, "error: %s\n" % _reason(exc))
+
+    @app.post("/", defaults={"path": ""})
+    @app.post("/<path:path>")
+    def apply_commands(path):
+        """Apply every command in the body; 200 iff all of them applied."""
+        body = _read_body()
+        if body is None:
+            return _reject_too_large()
+        cmds = parser.commands_from_body(body)
+        parsed_list, errors = [], []
+        for raw in cmds:
+            try:
+                parsed_list.append(parser.parse_command(raw))
+            except Exception as exc:  # parser degrades to noop; guard anyway
+                LOG.error("[%s:%s] parse cmd=%r FAILED: %s", client.name,
+                          client.family, _sanitize(raw), _sanitize(exc))
+                errors.append("%s: %s" % (raw, _reason(exc)))
+        n_add = sum(len(p.get("prefixes", [])) for p in parsed_list
+                    if p.get("op") != "noop" and not p.get("is_withdraw"))
+        n_del = sum(len(p.get("prefixes", [])) for p in parsed_list
+                    if p.get("op") != "noop" and p.get("is_withdraw"))
+        t0 = time.time()
+        try:
+            # best-effort: good routes still apply; failures return as strings.
+            errors.extend(client.apply_many(parsed_list))
+        except Exception as exc:  # gRPC transport / backend down
+            LOG.error("[%s:%s] apply_many FAILED: %s", client.name,
+                      client.family, _sanitize(exc))
+            errors.append("apply_many: %s" % _reason(exc))
+        LOG.info("[%s:%s] POST: %d cmds -> +%d/-%d prefixes in %.2fs (%d err)",
+                 client.name, client.family, len(cmds), n_add, n_del,
+                 time.time() - t0, len(errors))
+        # AddPath is idempotent per NLRI, so retry-on-500 is safe.
+        if errors:
+            return _text(500, "error\n" + "\n".join(errors))
+        return _text(200, "done\n" if parsed_list else "OK\n")
+
+    @app.get("/adj-in", strict_slashes=False)
+    def adj_in():
+        """Structured ADJ_IN view of the prefixes this neighbor received."""
+        return Response(
+            json.dumps({"prefixes": client.adj_in_prefixes()}) + "\n",
+            mimetype="application/json")
+
+    @app.get("/", defaults={"path": ""})
+    @app.get("/<path:path>")
+    def liveness(path):
+        return _text(200, "OK\n")
+
+    return app
+
+
+def make_server(port, spec):
+    """Create (but do not start) the HTTP server for one neighbor ``port``.
+
+    ``spec`` is one portmap entry: ``{grpc, family, name, self_nexthop}``. The
+    socket is bound here so a shard fails fast on a port clash; the caller runs
+    ``serve_forever``.
+    """
+    client = NeighborClient(spec["grpc"], spec["family"], spec.get("name", "?"),
+                            spec.get("self_nexthop"))
+    try:
+        return _make_wsgi_server("0.0.0.0", int(port), make_app(client),
+                                 threaded=True, request_handler=_RequestHandler)
+    except SystemExit as exc:
+        # werkzeug exits the process itself when the socket will not bind;
+        # surface it as an error the caller can attribute to this port.
+        raise OSError("cannot bind port %s" % port) from exc

--- a/ansible/roles/vm_set/files/gobgp/shim/translator.py
+++ b/ansible/roles/vm_set/files/gobgp/shim/translator.py
@@ -1,0 +1,210 @@
+"""Command-dict -> gobgp gRPC translation and the per-neighbor client.
+
+This module owns the two things that turn parsed commands into BGP state:
+
+* :func:`build_path` -- one parsed prefix + attributes -> a ``gb.Path`` protobuf
+  (typed-oneof NLRI + path attributes), and
+* :class:`NeighborClient` -- batches every prefix from one HTTP POST into a
+  **single** ``AddPathStream`` (chunked), never a unary call per route. That
+  batching is the whole point of R6 and is guarded by unit test U4.
+
+Withdrawals reuse the same stream: gobgp has no ``DeletePathStream``, but
+``AddPathStream`` honours each ``Path.is_withdraw`` flag, so a bulk withdraw is
+one streamed call exactly like a bulk announce.
+
+The gRPC stub is injectable (``NeighborClient(..., stub=...)``) so U2/U4/U5 can
+drive the batching logic with a fake stub and no real gobgpd.
+"""
+import threading
+
+from ._gbapi import gb, gbg, attr, nlri, extcom, grpc, family_msg
+from . import receive
+
+ORIGIN_DEFAULT = 0
+_AS_SEGMENT_MAX = 255  # one AS_PATH segment length field is a single octet
+_STREAM_CHUNK = 1000   # paths per AddPathStreamRequest message
+
+
+def _nlri(prefix_len, prefix):
+    return nlri.NLRI(prefix=nlri.IPAddressPrefix(prefix_len=prefix_len,
+                                                 prefix=prefix))
+
+
+def build_path(prefix, family, nexthop=None, aspath=None, communities=None,
+               large_communities=None, ext_communities=None, local_pref=None,
+               med=None, origin=None, is_withdraw=False):
+    """Build one ``gb.Path`` from parsed command fields.
+
+    ``family`` is ``"v4"`` or ``"v6"``; for v6 the next hop is carried in an
+    ``MpReachNLRIAttribute`` rather than a plain ``NextHopAttribute``.
+    """
+    fam = family_msg(family)
+    if not is_withdraw and not nexthop:
+        raise ValueError("announce %s has no next-hop "
+                         "('next-hop self' needs self_nexthop in the port spec)"
+                         % prefix)
+    if "/" not in prefix:
+        raise ValueError("malformed prefix %r (expected addr/len)" % prefix)
+    addr, plen = prefix.split("/", 1)
+    if not plen.isdigit():
+        raise ValueError("malformed prefix %r (bad length)" % prefix)
+    plen_i = int(plen)
+    max_plen = 32 if family == "v4" else 128
+    if plen_i > max_plen:
+        raise ValueError("prefix %r length exceeds /%d max for %s"
+                         % (prefix, max_plen, family))
+    route = _nlri(plen_i, addr)
+
+    pattrs = [attr.Attribute(origin=attr.OriginAttribute(
+        origin=origin if origin is not None else ORIGIN_DEFAULT))]
+
+    if aspath:
+        # >255 ASNs overflow gobgpd's one-octet segment length and panic the
+        # backend; reject with a clear error instead.
+        if len(aspath) > _AS_SEGMENT_MAX:
+            raise ValueError(
+                "as-path too long (%d ASNs > %d per-segment limit) for %s"
+                % (len(aspath), _AS_SEGMENT_MAX, prefix))
+        seg = attr.AsSegment(type=attr.AsSegment.TYPE_AS_SEQUENCE, numbers=aspath)
+        pattrs.append(attr.Attribute(as_path=attr.AsPathAttribute(segments=[seg])))
+
+    if local_pref is not None:
+        pattrs.append(attr.Attribute(
+            local_pref=attr.LocalPrefAttribute(local_pref=local_pref)))
+    if med is not None:
+        pattrs.append(attr.Attribute(
+            multi_exit_disc=attr.MultiExitDiscAttribute(med=med)))
+    if communities:
+        pattrs.append(attr.Attribute(
+            communities=attr.CommunitiesAttribute(communities=communities)))
+    if large_communities:
+        lcs = [attr.LargeCommunity(global_admin=g, local_data1=d1, local_data2=d2)
+               for (g, d1, d2) in large_communities]
+        pattrs.append(attr.Attribute(
+            large_communities=attr.LargeCommunitiesAttribute(communities=lcs)))
+    if ext_communities:
+        exts = [
+            extcom.ExtendedCommunity(
+                two_octet_as_specific=extcom.TwoOctetAsSpecificExtended(
+                    is_transitive=True, sub_type=2, asn=as_num,
+                    local_admin=local_admin))
+            for (as_num, local_admin) in ext_communities]
+        pattrs.append(attr.Attribute(
+            extended_communities=attr.ExtendedCommunitiesAttribute(communities=exts)))
+
+    if family == "v4":
+        if nexthop:
+            pattrs.append(attr.Attribute(
+                next_hop=attr.NextHopAttribute(next_hop=nexthop)))
+    else:
+        nh = [nexthop] if nexthop else []
+        pattrs.append(attr.Attribute(mp_reach=attr.MpReachNLRIAttribute(
+            family=fam, next_hops=nh, nlris=[route])))
+
+    return gb.Path(nlri=route, pattrs=pattrs, family=fam, is_withdraw=is_withdraw)
+
+
+def stream_requests(paths, chunk=_STREAM_CHUNK):
+    """Yield ``AddPathStreamRequest`` messages carrying ``paths`` in ``chunk``-sized
+    batches against the GLOBAL table.
+
+    Factored out of :class:`NeighborClient` so U4 can assert that N prefixes
+    produce ``ceil(N/chunk)`` stream messages (i.e. batched, not per-route).
+    """
+    for j in range(0, len(paths), chunk):
+        yield gb.AddPathStreamRequest(table_type=gb.TABLE_TYPE_GLOBAL,
+                                      paths=paths[j:j + chunk])
+
+
+class NeighborClient(object):
+    """gRPC client for one (neighbor, family) gobgpd behind an HTTP port."""
+
+    def __init__(self, grpc_endpoint, family, name, self_nexthop=None,
+                 stub=None):
+        self.endpoint = grpc_endpoint
+        self.family = family
+        self.name = name
+        self.self_nexthop = self_nexthop  # ptf local ip, for 'next-hop self'
+        self._lock = threading.Lock()
+        if stub is not None:  # dependency injection for tests
+            self._chan = None
+            self._stub = stub
+        else:
+            self._chan = grpc.insecure_channel(grpc_endpoint)
+            self._stub = gbg.GoBgpServiceStub(self._chan)
+
+    @property
+    def stub(self):
+        return self._stub
+
+    def _resolve_nh(self, nh):
+        # Only an explicit 'next-hop self' maps to the local IP. A missing
+        # next-hop (None) is left as-is so build_path fails an announce fast and
+        # a bare withdraw carries no NEXT_HOP.
+        if nh == "self":
+            return self.self_nexthop
+        return nh
+
+    def build_paths(self, parsed_list):
+        """Flatten parsed commands into ``(add_paths, del_paths, errors)``.
+
+        Each command is translated independently: one malformed prefix or an
+        as-path-too-long only drops *that* command (its message is appended to
+        ``errors``) instead of aborting the whole POST, so a single bad route in
+        a full-table announce never discards the thousands of good ones -- the
+        best-effort behaviour ExaBGP callers expect. ``errors`` is empty on a
+        clean batch.
+        """
+        add_paths, del_paths, errors = [], [], []
+        for parsed in parsed_list:
+            if not parsed or parsed.get("op") == "noop":
+                continue
+            nh = self._resolve_nh(parsed.get("nexthop"))
+            for prefix in parsed["prefixes"]:
+                try:
+                    p = build_path(
+                        prefix, self.family, nexthop=nh,
+                        aspath=parsed.get("aspath"),
+                        communities=parsed.get("communities"),
+                        large_communities=parsed.get("large_communities"),
+                        ext_communities=parsed.get("ext_communities"),
+                        local_pref=parsed.get("local_pref"),
+                        med=parsed.get("med"), origin=parsed.get("origin"),
+                        is_withdraw=parsed["is_withdraw"])
+                except Exception as exc:  # bad single route -- skip, keep the rest
+                    errors.append("%s: %s" % (prefix, exc))
+                    continue
+                (del_paths if parsed["is_withdraw"] else add_paths).append(p)
+        return add_paths, del_paths, errors
+
+    def apply_many(self, parsed_list):
+        """Apply every command from one HTTP POST, streaming adds and
+        withdrawals as one ``AddPathStream`` per direction.
+
+        ``announce_routes`` emits one ``announce route <prefix>`` per prefix, so
+        a full-table announce arrives as one POST of thousands of one-prefix
+        commands -- all one direction, sent as a single chunked stream. Building
+        all paths first turns thousands of round-trips into one streamed call --
+        the behaviour that lets gobgp match/beat exabgp convergence. A POST that
+        mixes adds and withdrawals uses one stream per direction (two calls).
+
+        Returns the list of per-route error strings (empty on success). Good
+        routes are always applied even when some routes errored; because
+        AddPath is idempotent per NLRI, a caller may safely retry on a non-empty
+        result without duplicating state.
+        """
+        add_paths, del_paths, errors = self.build_paths(parsed_list)
+        if not add_paths and not del_paths:
+            return errors
+        with self._lock:
+            if add_paths:
+                self._stub.AddPathStream(stream_requests(add_paths))
+            if del_paths:
+                # is_withdraw already set by build_path -> same stream API
+                self._stub.AddPathStream(stream_requests(del_paths))
+        return errors
+
+    def adj_in_prefixes(self):
+        """Prefixes the DUT advertised to us (this neighbor's ADJ_IN RIB)."""
+        with self._lock:
+            return receive.adj_in_prefixes(self._stub, self.family)

--- a/ansible/roles/vm_set/files/gobgp/tests/__init__.py
+++ b/ansible/roles/vm_set/files/gobgp/tests/__init__.py
@@ -1,0 +1,1 @@
+# Unit tests for the GoBGP PTF speaker shim (HLD U1-U6 + shardmap).

--- a/ansible/roles/vm_set/files/gobgp/tests/conftest.py
+++ b/ansible/roles/vm_set/files/gobgp/tests/conftest.py
@@ -1,0 +1,13 @@
+"""pytest bootstrap: make the ``gobgp`` package importable with no install.
+
+Put the package parent (``ansible/roles/vm_set/files``) on ``sys.path`` so the
+tests can ``import gobgp`` whether run from the repo root, this directory, or CI.
+The gRPC fakes live in :mod:`gobgp.tests.fakes`.
+"""
+import os
+import sys
+
+_FILES_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+if _FILES_DIR not in sys.path:
+    sys.path.insert(0, _FILES_DIR)

--- a/ansible/roles/vm_set/files/gobgp/tests/fakes.py
+++ b/ansible/roles/vm_set/files/gobgp/tests/fakes.py
@@ -1,0 +1,58 @@
+"""gRPC fakes for the shim unit tests (no gobgpd, no network).
+
+:class:`FakeStub` stands in for ``GoBgpServiceStub`` and records what the shim would
+have sent, so tests assert on batching / targeting / receive behaviour directly.
+"""
+
+
+class _Namespace(object):
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+class FakeStub(object):
+    """Records ``AddPathStream`` traffic; replays canned ADJ_IN for receive.
+
+    * ``AddPathStream(request_iterator)`` drains the generator and stores every
+      ``AddPathStreamRequest`` so tests can count stream calls, request
+      messages, and total paths (U4 batching), returning ``None`` like the real
+      unary-stream RPC.
+    * ``ListPeer`` / ``ListPath`` replay ``adj_in`` keyed by neighbor for U6.
+    """
+
+    def __init__(self, peers=None, adj_in=None):
+        self.add_calls = []           # list of [AddPathStreamRequest, ...] per call
+        self._peers = peers or []
+        self._adj_in = adj_in or {}   # {neighbor_address: [prefix, ...]}
+
+    # --- announce/withdraw path ---
+    def AddPathStream(self, request_iterator):
+        self.add_calls.append(list(request_iterator))
+        return None
+
+    @property
+    def call_count(self):
+        return len(self.add_calls)
+
+    @property
+    def request_messages(self):
+        return sum(len(reqs) for reqs in self.add_calls)
+
+    @property
+    def total_paths(self):
+        return sum(len(r.paths) for reqs in self.add_calls for r in reqs)
+
+    def withdraw_flags(self):
+        return [p.is_withdraw for reqs in self.add_calls for r in reqs
+                for p in r.paths]
+
+    # --- receive path (U6) ---
+    def ListPeer(self, req):
+        for addr in self._peers:
+            yield _Namespace(peer=_Namespace(
+                conf=_Namespace(neighbor_address=addr),
+                state=_Namespace(neighbor_address=addr)))
+
+    def ListPath(self, req):
+        for prefix in self._adj_in.get(req.name, []):
+            yield _Namespace(destination=_Namespace(prefix=prefix))

--- a/ansible/roles/vm_set/files/gobgp/tests/test_parser.py
+++ b/ansible/roles/vm_set/files/gobgp/tests/test_parser.py
@@ -1,0 +1,113 @@
+"""U1 grammar parity + U3 negative parsing -- pure parser, no gRPC.
+
+U1: every ExaBGP command form sonic-mgmt emits parses into the expected
+structured dict. U3 (parse half): malformed / unknown / empty inputs degrade to
+a safe no-op instead of raising, so a bad line never takes the shim down.
+"""
+from gobgp.shim import parser
+
+
+# --------------------------------------------------------------------------- #
+# U1 -- grammar parity
+# --------------------------------------------------------------------------- #
+def test_u1_announce_route_full_attrs():
+    d = parser.parse_command(
+        "announce route 10.0.0.0/24 next-hop 1.1.1.1 as-path [ 65000 65001 ] "
+        "community [ 65000:1 no-export ] local-preference 200 med 5 origin igp")
+    assert d["op"] == "announce" and d["is_withdraw"] is False
+    assert d["prefixes"] == ["10.0.0.0/24"]
+    assert d["nexthop"] == "1.1.1.1"
+    assert d["aspath"] == [65000, 65001]
+    assert d["communities"] == [(65000 << 16) | 1, 0xFFFFFF01]
+    assert d["local_pref"] == 200 and d["med"] == 5 and d["origin"] == 0
+
+
+def test_u1_withdraw_route():
+    d = parser.parse_command("withdraw route 2001:db8::/48 next-hop fe80::1")
+    assert d["op"] == "withdraw" and d["is_withdraw"] is True
+    assert d["prefixes"] == ["2001:db8::/48"] and d["nexthop"] == "fe80::1"
+
+
+def test_u1_announce_attributes_multi_nlri():
+    d = parser.parse_command(
+        "announce attributes next-hop 1.1.1.1 origin egp "
+        "nlri 10.0.0.0/24 10.0.1.0/24 10.0.2.0/24")
+    assert d["prefixes"] == ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"]
+    assert d["nexthop"] == "1.1.1.1" and d["origin"] == 1
+
+
+def test_u1_large_and_ext_community():
+    d = parser.parse_command(
+        "announce route 10.0.0.0/24 next-hop 1.1.1.1 "
+        "large-community [ 65000:1:2 ] extended-community [ target:65000:100 ]")
+    assert d["large_communities"] == [(65000, 1, 2)]
+    assert d["ext_communities"] == [(65000, 100)]
+
+
+def test_u1_bare_unbracketed_community():
+    d = parser.parse_command(
+        "announce route 10.0.0.0/24 next-hop 1.1.1.1 community 65000:7")
+    assert d["communities"] == [(65000 << 16) | 7]
+
+
+def test_u1_origin_variants_and_localpref_alias():
+    assert parser.parse_command(
+        "announce route 10.0.0.0/24 origin incomplete")["origin"] == 2
+    assert parser.parse_command(
+        "announce route 10.0.0.0/24 local-pref 150")["local_pref"] == 150
+
+
+def test_u1_commands_from_body_forms():
+    assert parser.commands_from_body("command=announce+route+10.0.0.0%2F24") == \
+        ["announce route 10.0.0.0/24"]
+    assert parser.commands_from_body("commands=a+1;b+2") == ["a 1", "b 2"]
+    assert parser.commands_from_body("announce route 10.0.0.0/24") == \
+        ["announce route 10.0.0.0/24"]
+
+
+# --------------------------------------------------------------------------- #
+# U3 -- negative parsing (never raises)
+# --------------------------------------------------------------------------- #
+def test_u3_unknown_verb_is_noop():
+    assert parser.parse_command("frobnicate route 1.2.3.0/24")["op"] == "noop"
+
+
+def test_u3_empty_and_blank():
+    assert parser.parse_command("")["op"] == "noop"
+    assert parser.parse_command("   ")["op"] == "noop"
+    assert parser.commands_from_body("") == []
+
+
+def test_u3_unknown_attr_token_skipped():
+    d = parser.parse_command(
+        "announce route 10.0.0.0/24 next-hop 1.1.1.1 wat 9 origin igp")
+    assert d["nexthop"] == "1.1.1.1" and d["origin"] == 0
+
+
+def test_u3_truncated_commands_are_noop_not_raise():
+    # W3: partial lines must degrade to a safe no-op, never raise IndexError.
+    for cmd in ("announce route",
+                "announce",
+                "withdraw route",
+                "announce route 10.0.0.0/24 next-hop",
+                "announce route 10.0.0.0/24 med",
+                "announce route 10.0.0.0/24 local-pref",
+                "announce route 10.0.0.0/24 origin"):
+        d = parser.parse_command(cmd)
+        assert d.get("op") in ("announce", "withdraw", "noop")
+        # trailing-valueless attr keyword just yields a None attr, never a crash
+        if d.get("op") != "noop":
+            assert d["prefixes"] == ["10.0.0.0/24"]
+
+
+def test_u3_truncated_route_no_prefix_is_noop():
+    assert parser.parse_command("announce route")["op"] == "noop"
+    assert parser.parse_command("withdraw route")["op"] == "noop"
+
+
+def test_u3_malformed_scalar_is_noop():
+    # W3: non-integer med/local-pref (untrusted body) degrade to noop, never raise.
+    for cmd in ("announce route 10.0.0.0/24 med abc",
+                "announce route 10.0.0.0/24 local-pref xyz",
+                "announce route 10.0.0.0/24 local-preference NaN"):
+        assert parser.parse_command(cmd)["op"] == "noop"

--- a/ansible/roles/vm_set/files/gobgp/tests/test_receive.py
+++ b/ansible/roles/vm_set/files/gobgp/tests/test_receive.py
@@ -1,0 +1,46 @@
+"""U6 -- structured receive endpoint returns ADJ_IN prefixes per neighbor.
+
+The shim's ``/adj-in`` replaces ExaBGP's text dump. Here the FakeStub replays a
+neighbor advertising a known prefix set; the receive path must return exactly
+that set for the requested family, sourced from the ADJ_IN table.
+"""
+import pytest
+
+pytest.importorskip("gobgp.shim._gbapi",
+                    reason="gobgp gRPC stubs are generated into the PTF image")
+
+from gobgp.shim import receive  # noqa: E402
+from gobgp.shim.translator import NeighborClient  # noqa: E402
+from gobgp.shim._gbapi import common  # noqa: E402
+from gobgp.tests.fakes import FakeStub  # noqa: E402
+
+
+def test_u6_adj_in_prefixes_match_advertisement():
+    stub = FakeStub(peers=["10.0.0.57"],
+                    adj_in={"10.0.0.57": ["100.0.0.0/24", "100.0.1.0/24"]})
+    assert receive.adj_in_prefixes(stub, "v4") == ["100.0.0.0/24", "100.0.1.0/24"]
+
+
+def test_u6_adj_in_empty_when_no_peer():
+    assert receive.adj_in_prefixes(FakeStub(), "v4") == []
+
+
+def test_u6_adj_in_uses_correct_family_afi():
+    seen = {}
+    stub = FakeStub(peers=["fc00::1"], adj_in={"fc00::1": ["2064:100::/64"]})
+    orig = stub.ListPath
+
+    def spy(req):
+        seen["afi"] = req.family.afi
+        return orig(req)
+
+    stub.ListPath = spy
+    out = receive.adj_in_prefixes(stub, "v6")
+    assert out == ["2064:100::/64"]
+    assert seen["afi"] == common.Family.AFI_IP6
+
+
+def test_u6_neighborclient_delegates_to_receive():
+    stub = FakeStub(peers=["10.0.0.57"], adj_in={"10.0.0.57": ["100.0.0.0/24"]})
+    c = NeighborClient("127.0.0.1:50052", "v4", "ARISTA01T1", stub=stub)
+    assert c.adj_in_prefixes() == ["100.0.0.0/24"]

--- a/ansible/roles/vm_set/files/gobgp/tests/test_server.py
+++ b/ansible/roles/vm_set/files/gobgp/tests/test_server.py
@@ -1,0 +1,182 @@
+"""HTTP front end wire behaviour.
+
+Covers the framing the shim relies on rather than the command semantics the
+parser and translator tests already own: the body cap under both framings
+`requests` can emit, ``/adj-in`` routing, the plain-text error contract, and
+fail-fast binding.
+"""
+import json
+import socket
+import threading
+
+import pytest
+
+pytest.importorskip("gobgp.shim._gbapi",
+                    reason="gobgp gRPC stubs are generated into the PTF image")
+pytest.importorskip("flask", reason="flask ships in the PTF image")
+
+from werkzeug.serving import make_server  # noqa: E402
+
+from gobgp.shim import server as shim_server  # noqa: E402
+from gobgp.shim.server import make_app, MAX_BODY_BYTES, _RequestHandler  # noqa: E402
+from gobgp.shim.translator import NeighborClient  # noqa: E402
+from gobgp.tests.fakes import FakeStub  # noqa: E402
+
+ANNOUNCE = b"command=announce route 100.0.0.0/24 next-hop 10.0.0.57"
+
+
+@pytest.fixture
+def serve():
+    """Factory starting a shim server on an ephemeral port; returns the port."""
+    servers = []
+
+    def _start(stub):
+        client = NeighborClient("127.0.0.1:50052", "v4", "ARISTA01T1", stub=stub)
+        srv = make_server("127.0.0.1", 0, make_app(client), threaded=True,
+                          request_handler=_RequestHandler)
+        servers.append(srv)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        return srv.server_address[1]
+
+    yield _start
+    for srv in servers:
+        srv.shutdown()
+        srv.server_close()
+
+
+def _send(port, raw):
+    """Send a raw request; return the response, read to end of connection."""
+    sock = socket.create_connection(("127.0.0.1", port), timeout=10)
+    try:
+        sock.sendall(raw)
+        chunks = []
+        while True:
+            buf = sock.recv(65536)
+            if not buf:
+                break
+            chunks.append(buf)
+        return b"".join(chunks).decode("utf-8", errors="replace")
+    finally:
+        sock.close()
+
+
+def _post_sized(port, body, content_length):
+    """POST ``body`` under a chosen ``Content-Length``."""
+    head = ("POST / HTTP/1.1\r\n"
+            "Host: 127.0.0.1\r\n"
+            "Content-Type: application/x-www-form-urlencoded\r\n"
+            "Connection: close\r\n"
+            "Content-Length: %d\r\n\r\n" % content_length)
+    return _send(port, head.encode() + body)
+
+
+def _post_chunked(port, body):
+    """POST ``body`` as a single chunk, with no ``Content-Length``."""
+    head = ("POST / HTTP/1.1\r\n"
+            "Host: 127.0.0.1\r\n"
+            "Content-Type: application/x-www-form-urlencoded\r\n"
+            "Connection: close\r\n"
+            "Transfer-Encoding: chunked\r\n\r\n")
+    frame = b"%x\r\n%s\r\n0\r\n\r\n" % (len(body), body)
+    return _send(port, head.encode() + frame)
+
+
+def test_oversized_content_length_rejected(serve):
+    stub = FakeStub()
+    resp = _post_sized(serve(stub), b"", MAX_BODY_BYTES + 1)
+    assert "413" in resp.splitlines()[0]
+    assert stub.call_count == 0
+
+
+def test_oversized_chunked_body_rejected(serve, monkeypatch):
+    """An over-cap chunked body must be refused, not truncated and applied.
+
+    werkzeug caps the stream at ``MAX_CONTENT_LENGTH`` without raising, so
+    without the shim's own check this returns 200 for a body cut mid-command.
+    """
+    monkeypatch.setattr(shim_server, "MAX_BODY_BYTES", 1000)
+    stub = FakeStub()
+    resp = _post_chunked(serve(stub), ANNOUNCE + b"\n" + b"x" * 2000)
+    assert "413" in resp.splitlines()[0]
+    assert stub.call_count == 0
+
+
+def test_body_within_cap_applies(serve):
+    stub = FakeStub()
+    resp = _post_sized(serve(stub), ANNOUNCE, len(ANNOUNCE))
+    assert "200" in resp.splitlines()[0]
+    assert stub.total_paths == 1
+
+
+def test_chunked_body_applies(serve):
+    """A body framed by ``Transfer-Encoding`` must apply, not silently no-op."""
+    stub = FakeStub()
+    resp = _post_chunked(serve(stub), ANNOUNCE)
+    assert "200" in resp.splitlines()[0]
+    assert resp.rstrip().endswith("done")
+    assert stub.total_paths == 1
+
+
+@pytest.mark.parametrize("target", ["/adj-in", "/adj-in/", "/adj-in?debug=1"])
+def test_adj_in_returns_received_prefixes(serve, target):
+    """A trailing slash or query string must not fall through to liveness."""
+    stub = FakeStub(peers=["10.0.0.57"], adj_in={"10.0.0.57": ["100.0.0.0/24"]})
+    resp = _send(serve(stub), ("GET %s HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+                               "Connection: close\r\n\r\n" % target).encode())
+    assert "200" in resp.splitlines()[0]
+    body = json.loads(resp.split("\r\n\r\n", 1)[1])
+    assert body == {"prefixes": ["100.0.0.0/24"]}
+
+
+@pytest.mark.parametrize("target", ["/", "/anything", "/static/x"])
+def test_other_gets_return_liveness(serve, target):
+    """Every non-``/adj-in`` GET is liveness, including flask's static path."""
+    resp = _send(serve(FakeStub()), ("GET %s HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+                                     "Connection: close\r\n\r\n" % target).encode())
+    assert "200" in resp.splitlines()[0]
+    assert resp.split("\r\n\r\n", 1)[1] == "OK\n"
+
+
+def test_unexpected_error_stays_plain_text(serve, monkeypatch):
+    """An unhandled error must keep the text contract, not render an HTML page.
+
+    The handler owns the log record, so werkzeug never logs the untrusted
+    request path, and the reply names only the failure type.
+    """
+    def _boom(_body):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(shim_server.parser, "commands_from_body", _boom)
+    resp = _post_sized(serve(FakeStub()), ANNOUNCE, len(ANNOUNCE))
+    assert "500" in resp.splitlines()[0]
+    assert "<!doctype" not in resp.lower()
+    body = resp.split("\r\n\r\n", 1)[1]
+    assert body == "error: RuntimeError\n"
+    assert "boom" not in body
+
+
+def test_bind_clash_fails_the_shard(tmp_path):
+    """An unbindable port must fail the shard, not leave a dead serve thread."""
+    from gobgp.shim.__main__ import main
+
+    held = socket.socket()
+    # loopback is enough to collide with the shim's 0.0.0.0 bind
+    held.bind(("127.0.0.1", 0))
+    held.listen(1)
+    port = held.getsockname()[1]
+    portmap = tmp_path / "portmap.json"
+    portmap.write_text(json.dumps(
+        {str(port): {"grpc": "127.0.0.1:50052", "family": "v4", "name": "N1"}}))
+
+    result = []
+    # main() serves forever once bound, so a regression would hang the suite.
+    runner = threading.Thread(
+        target=lambda: result.append(main(["--portmap", str(portmap)])),
+        daemon=True)
+    try:
+        runner.start()
+        runner.join(timeout=30)
+        assert not runner.is_alive(), "shard kept running despite a bound port"
+        assert result == [1]
+    finally:
+        held.close()

--- a/ansible/roles/vm_set/files/gobgp/tests/test_shardmap.py
+++ b/ansible/roles/vm_set/files/gobgp/tests/test_shardmap.py
@@ -1,0 +1,58 @@
+"""Sharding invariants -- the POOL layout the HLD mandates.
+
+The pool is only correct if every neighbor port is owned by exactly one shim
+(disjoint) and no port is dropped (covering). These properties are what let the
+manager launch ``k`` independent shims with no coordination beyond this map.
+"""
+from gobgp import shardmap
+
+
+def _portmap(n):
+    return {str(5000 + i): {"grpc": "127.0.0.1:5005%d" % i, "family": "v4",
+                            "name": "N%d" % i} for i in range(n)}
+
+
+def test_num_shards_min_cores_sessions():
+    assert shardmap.num_shards(8, 4) == 4      # capped by sessions
+    assert shardmap.num_shards(2, 100) == 2    # capped by cores
+    assert shardmap.num_shards(8, 0) == 1      # floor of 1
+    assert shardmap.num_shards(0, 5) == 1      # cores floored to 1
+
+
+def test_partition_disjoint_and_covering():
+    pm = _portmap(7)
+    shards = shardmap.partition(pm, 4)
+    assert len(shards) == 4
+    seen = []
+    for s in shards:
+        seen.extend(s.keys())
+    assert sorted(seen) == sorted(pm)          # covering
+    assert len(seen) == len(set(seen))         # disjoint
+
+
+def test_partition_balanced_within_one():
+    shards = shardmap.partition(_portmap(7), 4)
+    sizes = sorted(len(s) for s in shards)
+    assert sizes[-1] - sizes[0] <= 1
+
+
+def test_partition_k_clamped_to_port_count():
+    shards = shardmap.partition(_portmap(3), 10)
+    assert len(shards) == 3 and all(len(s) == 1 for s in shards)
+
+
+def test_partition_empty_portmap():
+    assert shardmap.partition({}, 4) == [{}]
+
+
+def test_shard_for_matches_partition():
+    pm = _portmap(7)
+    parts = shardmap.partition(pm, 3)
+    for i in range(3):
+        assert shardmap.shard_for(pm, 3, i) == parts[i]
+
+
+def test_shard_for_out_of_range_raises():
+    import pytest
+    with pytest.raises(IndexError):
+        shardmap.shard_for(_portmap(3), 3, 5)

--- a/ansible/roles/vm_set/files/gobgp/tests/test_translator.py
+++ b/ansible/roles/vm_set/files/gobgp/tests/test_translator.py
@@ -1,0 +1,231 @@
+"""U2 translation correctness, U3 as-path guard, U4 batching, U5 targeting.
+
+All against :class:`FakeStub` -- no gobgpd. U2 asserts N parsed prefixes become
+N gb.Path messages with the right family/next-hop encoding. U4 asserts a POST of
+N routes issues ONE AddPathStream (chunked), never a unary call per route
+(guards the batched-gRPC design, HLD R6/U4). U5 asserts a route applied to one
+neighbor's client never touches another neighbor's stub.
+"""
+import pytest
+
+pytest.importorskip("gobgp.shim._gbapi",
+                    reason="gobgp gRPC stubs are generated into the PTF image")
+
+from gobgp.shim import parser  # noqa: E402
+from gobgp.shim.translator import (  # noqa: E402
+    NeighborClient, build_path, stream_requests, _STREAM_CHUNK)
+from gobgp.shim._gbapi import gb, common  # noqa: E402
+from gobgp.tests.fakes import FakeStub  # noqa: E402
+
+
+def _client(family="v4", stub=None, self_nh="10.10.246.254"):
+    return NeighborClient("127.0.0.1:50052", family, "ARISTA01T1",
+                          self_nexthop=self_nh, stub=stub or FakeStub())
+
+
+def _attrs(path, field):
+    """Return the sub-messages of the given oneof kind carried in path.pattrs.
+
+    Path attributes are a typed ``oneof`` on ``Attribute``, so selecting e.g.
+    every NEXT_HOP is ``HasField('next_hop')``.
+    """
+    return [getattr(a, field) for a in path.pattrs if a.HasField(field)]
+
+
+# --------------------------------------------------------------------------- #
+# U2 -- translation correctness
+# --------------------------------------------------------------------------- #
+def test_u2_v4_path_family_and_nexthop():
+    p = build_path("10.0.0.0/24", "v4", nexthop="1.1.1.1")
+    assert p.family.afi == common.Family.AFI_IP
+    assert p.family.safi == common.Family.SAFI_UNICAST
+    ipp = p.nlri.prefix  # typed NLRI oneof -> IPAddressPrefix
+    assert ipp.prefix == "10.0.0.0" and ipp.prefix_len == 24
+    nhs = [nh.next_hop for nh in _attrs(p, "next_hop")]
+    assert nhs == ["1.1.1.1"]
+
+
+def test_u2_v6_nexthop_in_mpreach():
+    p = build_path("2001:db8::/48", "v6", nexthop="fe80::1")
+    assert p.family.afi == common.Family.AFI_IP6
+    # v6 next hop rides in MpReachNLRI, not a bare NextHopAttribute
+    assert not _attrs(p, "next_hop")
+    mpr = _attrs(p, "mp_reach")
+    assert mpr and list(mpr[0].next_hops) == ["fe80::1"]
+
+
+def test_u2_build_paths_count_matches_prefixes():
+    cmds = [parser.parse_command(
+        "announce route 10.0.%d.0/24 next-hop self" % i) for i in range(50)]
+    add, dele, errors = _client().build_paths(cmds)
+    assert len(add) == 50 and dele == [] and errors == []
+
+
+def test_u2_nexthop_self_resolves_to_local_ip():
+    c = _client(self_nh="10.10.246.254")
+    add, _, _ = c.build_paths([parser.parse_command(
+        "announce route 10.0.0.0/24 next-hop self")])
+    nh = [x.next_hop for x in _attrs(add[0], "next_hop")]
+    assert nh == ["10.10.246.254"]
+
+
+def test_u2_withdraw_flag_set():
+    add, dele, _ = _client().build_paths([parser.parse_command(
+        "withdraw route 10.0.0.0/24 next-hop self")])
+    assert add == [] and len(dele) == 1 and dele[0].is_withdraw is True
+
+
+def test_u2_v6_withdraw_flag_set():
+    add, dele, _ = _client(family="v6").build_paths([parser.parse_command(
+        "withdraw route 2001:db8::/48 next-hop self")])
+    assert add == [] and len(dele) == 1 and dele[0].is_withdraw is True
+
+
+# --------------------------------------------------------------------------- #
+# U3 -- as-path guard (translate half)
+# --------------------------------------------------------------------------- #
+def test_u3_aspath_over_255_rejected():
+    with pytest.raises(ValueError):
+        build_path("10.0.0.0/24", "v4", nexthop="1.1.1.1",
+                   aspath=[65000] * 256)
+
+
+def test_u3_aspath_255_ok():
+    p = build_path("10.0.0.0/24", "v4", nexthop="1.1.1.1", aspath=[65000] * 255)
+    assert _attrs(p, "as_path")
+
+
+def test_u3_prefix_len_out_of_range_rejected():
+    # An out-of-range length passes isdigit() but would build a Path that
+    # poisons the batched AddPathStream -- reject it before it is built.
+    for prefix, family in (("10.0.0.0/33", "v4"), ("2001:db8::/129", "v6")):
+        with pytest.raises(ValueError):
+            build_path(prefix, family, nexthop="1.1.1.1")
+
+
+def test_u3_announce_without_nexthop_rejected():
+    # 'next-hop self' with no self_nexthop resolves to None -> an announce with
+    # no NEXT_HOP; fail fast rather than stream an invalid UPDATE.
+    with pytest.raises(ValueError):
+        build_path("10.0.0.0/24", "v4", nexthop=None)
+    with pytest.raises(ValueError):
+        build_path("2001:db8::/48", "v6", nexthop=None)
+    # withdraw carries no next-hop -> must NOT raise
+    build_path("10.0.0.0/24", "v4", nexthop=None, is_withdraw=True)
+
+
+def test_u3_nexthop_self_unset_is_per_route_error():
+    # self_nexthop=None + 'next-hop self' announce -> isolated per-route error;
+    # a sibling route with an explicit next-hop still applies.
+    c = _client(self_nh=None)
+    add, dele, errors = c.build_paths([
+        parser.parse_command("announce route 10.0.0.0/24 next-hop self"),
+        parser.parse_command("announce route 10.0.1.0/24 next-hop 1.1.1.1"),
+    ])
+    assert len(add) == 1 and len(errors) == 1
+
+
+def test_u3_bare_announce_no_nexthop_is_per_route_error():
+    # A bare 'announce route X' (no next-hop clause) must NOT be silently
+    # coalesced to self_nexthop; build_path rejects it as a per-route error.
+    c = _client(self_nh="10.10.246.254")
+    add, dele, errors = c.build_paths(
+        [parser.parse_command("announce route 10.0.0.0/24")])
+    assert add == [] and len(errors) == 1
+
+
+def test_u3_bare_withdraw_carries_no_nexthop():
+    # A bare 'withdraw route X' (no next-hop clause) is applied and its Path
+    # carries no NEXT_HOP attribute.
+    c = _client(self_nh="10.10.246.254")
+    add, dele, errors = c.build_paths(
+        [parser.parse_command("withdraw route 10.0.0.0/24")])
+    assert errors == [] and len(dele) == 1
+    assert not _attrs(dele[0], "next_hop")
+
+
+# --------------------------------------------------------------------------- #
+# U4 -- batching: N routes -> ONE stream, ceil(N/chunk) messages
+# --------------------------------------------------------------------------- #
+def test_u4_stream_requests_chunking():
+    paths = [build_path("10.%d.%d.0/24" % (i // 256, i % 256), "v4",
+                        nexthop="1.1.1.1") for i in range(2500)]
+    reqs = list(stream_requests(paths))
+    assert len(reqs) == 3  # ceil(2500/1000)
+    assert sum(len(r.paths) for r in reqs) == 2500
+    assert all(r.table_type == gb.TABLE_TYPE_GLOBAL for r in reqs)
+
+
+def test_u4_apply_many_single_stream_call_not_per_route():
+    stub = FakeStub()
+    c = _client(stub=stub)
+    cmds = [parser.parse_command(
+        "announce route 10.%d.%d.0/24 next-hop self" % (i // 256, i % 256))
+        for i in range(2500)]
+    c.apply_many(cmds)
+    assert stub.call_count == 1          # ONE AddPathStream, not 2500 unary
+    assert stub.request_messages == 3    # chunked at _STREAM_CHUNK
+    assert stub.total_paths == 2500
+    assert _STREAM_CHUNK == 1000
+
+
+def test_u4_withdraw_uses_same_stream_api():
+    stub = FakeStub()
+    c = _client(stub=stub)
+    cmds = [parser.parse_command(
+        "withdraw route 10.0.%d.0/24 next-hop self" % i) for i in range(10)]
+    c.apply_many(cmds)
+    assert stub.call_count == 1
+    assert stub.withdraw_flags() == [True] * 10
+
+
+def test_u4_empty_batch_no_call():
+    stub = FakeStub()
+    _client(stub=stub).apply_many([parser.parse_command("")])
+    assert stub.call_count == 0
+
+
+# --------------------------------------------------------------------------- #
+# W1 -- one bad route never drops the whole batch (best-effort apply)
+# --------------------------------------------------------------------------- #
+def test_w1_bad_route_isolated_good_routes_still_applied():
+    stub = FakeStub()
+    c = _client(stub=stub)
+    cmds = [
+        parser.parse_command("announce route 10.0.0.0/24 next-hop self"),
+        parser.parse_command("announce route NOTAPREFIX next-hop self"),
+        parser.parse_command("announce route 10.0.1.0/24 next-hop self"),
+    ]
+    errors = c.apply_many(cmds)
+    assert stub.total_paths == 2          # both good routes applied
+    assert len(errors) == 1 and "NOTAPREFIX" in errors[0]
+
+
+def test_w1_long_aspath_isolated_not_batch_fatal():
+    stub = FakeStub()
+    c = _client(stub=stub)
+    good = parser.parse_command("announce route 10.0.0.0/24 next-hop self")
+    bad = dict(op="announce", is_withdraw=False, prefixes=["10.0.9.0/24"],
+               nexthop="self", aspath=[65000] * 300)
+    errors = c.apply_many([good, bad])
+    assert stub.total_paths == 1
+    assert len(errors) == 1 and "as-path too long" in errors[0]
+
+
+def test_w1_clean_batch_returns_no_errors():
+    stub = FakeStub()
+    assert _client(stub=stub).apply_many(
+        [parser.parse_command("announce route 10.0.0.0/24 next-hop self")]) == []
+
+
+# --------------------------------------------------------------------------- #
+# U5 -- per-neighbor targeting
+# --------------------------------------------------------------------------- #
+def test_u5_route_on_one_client_never_touches_another():
+    stub_a, stub_b = FakeStub(), FakeStub()
+    ca = _client(stub=stub_a)
+    _client(stub=stub_b)  # neighbor B's client exists but is never driven
+    ca.apply_many([parser.parse_command(
+        "announce route 10.0.0.0/24 next-hop self")])
+    assert stub_a.total_paths == 1
+    assert stub_b.call_count == 0 and stub_b.total_paths == 0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,6 +78,43 @@ stages:
       name: DetectChanges
       displayName: "Check changed files under tools/skip_expiry"
 
+  - job: detect_gobgp_shim_changes
+    displayName: "Detect GoBGP shim changes"
+    timeoutInMinutes: 10
+    continueOnError: false
+    pool: sonic-ubuntu-1c
+    steps:
+    - checkout: self
+      clean: true
+
+    - script: |
+        set -euo pipefail
+
+        TARGET_BRANCH="${SYSTEM_PULLREQUEST_TARGETBRANCH:-refs/heads/master}"
+        TARGET_BRANCH="${TARGET_BRANCH#refs/heads/}"
+        SHIM_PATH="ansible/roles/vm_set/files/gobgp"
+
+        # Default to running the tests. A gate that cannot work out its own
+        # base must not drop coverage, and must not fail the pipeline either.
+        CHANGED="true"
+
+        if git fetch origin "${TARGET_BRANCH}" --depth=1 &&
+           BASE_COMMIT=$(git merge-base "origin/${TARGET_BRANCH}" HEAD 2>/dev/null) &&
+           CHANGED_FILES=$(git diff --name-only "${BASE_COMMIT}" HEAD -- "${SHIM_PATH}" | tr '\n' ' '); then
+          if [[ -n "${CHANGED_FILES}" ]]; then
+            echo "Detected changes under ${SHIM_PATH}: ${CHANGED_FILES}"
+          else
+            CHANGED="false"
+            echo "No changes detected under ${SHIM_PATH}"
+          fi
+        else
+          echo "Cannot diff against origin/${TARGET_BRANCH}; running the tests"
+        fi
+
+        echo "##vso[task.setvariable variable=GOBGP_SHIM_CHANGED;isOutput=true]${CHANGED}"
+      name: DetectChanges
+      displayName: "Check changed files under ansible/roles/vm_set/files/gobgp"
+
   - job: static_analysis
     displayName: "Static Analysis"
     timeoutInMinutes: 10
@@ -151,6 +188,36 @@ stages:
         set -euo pipefail
         python -m pytest tools/skip_expiry/tests/unit_test_*.py -q
       displayName: "Run skip_expiry unit tests"
+
+
+- stage: GoBGP_Shim_Unit_Tests
+  displayName: "GoBGP Shim Unit Tests"
+  dependsOn: Pre_test
+  condition: >-
+    and(
+      succeeded(),
+      not(canceled()),
+      eq(dependencies.Pre_test.outputs['detect_gobgp_shim_changes.DetectChanges.GOBGP_SHIM_CHANGED'], 'true')
+    )
+  jobs:
+  - job: run_gobgp_shim_unit_tests
+    displayName: "Run GoBGP shim unit tests"
+    timeoutInMinutes: 15
+    continueOnError: false
+    pool: sonic-ubuntu-1c
+    steps:
+    - checkout: self
+      clean: true
+
+    - script: |
+        set -euo pipefail
+        sudo uv pip install --system pytest
+      displayName: "Install unit test dependencies"
+
+    - script: |
+        set -euo pipefail
+        python -m pytest ansible/roles/vm_set/files/gobgp/tests -q -rs
+      displayName: "Run GoBGP shim unit tests"
 
 
 - stage: Test


### PR DESCRIPTION
### Description of PR

Summary:
Adds the GoBGP-based PTF route-speaker engine as a self-contained, **dormant** (unwired) Python package under `ansible/roles/vm_set/files/gobgp/`. This is the first increment of the GoBGP PTF speaker feature: a scalable, opt-in replacement for the ExaBGP speaker that streams 100k+ prefixes/neighbor to per-neighbor `gobgpd` over the gobgp gRPC API, addressing ExaBGP's route-injection throughput ceiling at high scale.

Nothing in the existing test/ansible paths imports this package, so it cannot change current behavior. The runtime wiring (`announce_routes`, `ptf_control`, and the `bgp_speaker` selector) lands in follow-up PRs and keeps **ExaBGP the default**.

The gobgp gRPC stubs this package imports are generated into the docker-ptf image by [sonic-net/sonic-buildimage#28732](https://github.com/sonic-net/sonic-buildimage/pull/28732) from the same pinned gobgp checkout that builds `gobgpd`, so the stubs and the daemon always describe the same gobgp version and no generated code is carried in this repo. That PR should merge first; because this package is dormant, merging out of order breaks nothing — the three test modules that need the stubs skip with a clear reason, and the other 20 tests still run.

Governed by HLD [sonic-net/sonic-mgmt#26382](https://github.com/sonic-net/sonic-mgmt/pull/26382).

Fixes # (N/A — feature increment; tracked by HLD PR above)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Tested branch

- [x] master
- [ ] N/A

### Test result

- master: 57 package unit tests pass with no live `gobgpd`, via a fake gRPC stub — grammar, batching call-count, per-neighbor targeting, ADJ_IN, sharding invariants, per-route error isolation, and the HTTP contract (body cap, plain-text errors, bind-clash exit). 20 of them need nothing but `pytest` and are what the new CI stage runs; the remaining 37 need the generated stubs and run inside the PTF image, skipping visibly elsewhere (`20 passed, 3 skipped` on a bare agent). `flake8 --max-line-length=120` and repo pre-commit clean.
- The translator/receive gRPC surface was additionally validated against a live `gobgpd` v4.7.0: every path-attribute branch (origin, AS-path, MED, local-pref, communities/large/extended, next-hop) and both IPv4 and IPv6 announce/withdraw round-trip through `AddPathStream`/`ListPath`.
- Entrypoint smoke-tested: a shard binds only its own port subset, an empty POST returns 200, a backend-down POST returns 500 gracefully, and a second shim on an occupied port exits non-zero.
- Full wire-on end-to-end on a testbed lands in the later PRs.

### Approach

#### What is the motivation for this PR?

ExaBGP does not sustain the route-injection rates needed for large-scale route scaling tests (100k+ prefixes/neighbor). This introduces a GoBGP-backed speaker engine that batches route programming into chunked gRPC streams and shards work across per-neighbor `gobgpd` processes.

#### How did you do it?

Added a dormant package with a clean separation of concerns:
- `shim/parser.py` — ExaBGP command grammar → route dicts (bounds-checked; truncated input degrades to a no-op instead of raising).
- `shim/translator.py` — route dict → gobgp `Path`; `NeighborClient` batches a request's routes into one chunked `AddPathStream` per direction (announce and withdraw), never a unary call per route; a bad prefix or over-long AS-path is isolated so it never drops the rest of the batch.
- `shim/receive.py` — structured ADJ_IN (received-routes) query.
- `shim/server.py` — Flask HTTP front end; returns 200 iff every route applied, 500 listing the failed routes (idempotent `AddPath` → retry-safe), and 413 above the body cap. Error bodies carry the failing command and exception type, never an interpreter traceback.
- `shim/__main__.py` — shard-aware entrypoint (`--portmap --shard i/k`); pre-binds every owned port and exits non-zero on bind failure so supervisord restarts it.
- `shardmap.py` — POOL/sharded port partitioning.
- `shim/_gbapi.py` — the single import surface for the gobgp gRPC stubs, which the PTF image generates into `/usr/local/lib/gobgp-api`. `GOBGP_API_PATH` overrides the location. Keeping the stubs out of this repo means a gobgp or protobuf-toolchain bump never needs a regeneration PR here.
- `azure-pipelines.yml` — a path-gated `GoBGP_Shim_Unit_Tests` stage that runs the protobuf-free tests on a plain agent with `pytest` alone. The gate runs the tests whenever it cannot compute a merge base, so a shallow or unusual checkout neither drops coverage nor fails the pipeline.

#### How did you verify/test it?

See Test result above: unit tests in both lanes, a live `gobgpd` v4.7.0 gRPC round-trip, and entrypoint smoke tests.

#### Any platform specific information?

None — PTF/testbed infrastructure only; no DUT/on-device code.

#### Supported testbed topology if it's a new test case?

N/A — engine package, not a test case. Applies to any topology that uses the PTF BGP speaker once the opt-in flag is wired in.

### Documentation

Design is documented in the HLD PR [sonic-net/sonic-mgmt#26382](https://github.com/sonic-net/sonic-mgmt/pull/26382).
