### PR TITLE
Fixing `SSLV3_ALERT_CERTIFICATE_EXPIRED` error happening during restapi tests

### DIFF
--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import urllib3
 import ipaddress
+from datetime import datetime, timedelta, timezone
 from six.moves.urllib.parse import urlunparse
 
 from tests.common import config_reload
@@ -38,16 +39,43 @@ def setup_restapi_server(duthosts, rand_one_dut_hostname, localhost, setup_logan
     local_command = "openssl genrsa -out restapiCA.key 2048"
     localhost.shell(local_command)
 
-    # Create Root cert
+    # Set up validity windows. Backdate notBefore by 1 month so clock skew between
+    # the test runner and the DUT does not cause a premature/expired cert error.
+    # OpenSSL 3.0 lacks the x509 -not_before option, so use 'openssl ca' with
+    # -startdate/-enddate to set explicit validity windows.
+    now = datetime.now(timezone.utc)
+    cert_not_before = (now - timedelta(days=30)).strftime("%Y%m%d%H%M%SZ")
+    ca_not_after = (now + timedelta(days=1825)).strftime("%Y%m%d%H%M%SZ")
+    cert_not_after = (now + timedelta(days=825)).strftime("%Y%m%d%H%M%SZ")
+    localhost.shell("mkdir -p restapi_newcerts && touch restapi_index.txt && echo 01 > restapi_serial")
+    ca_config = ("[ca]\\ndefault_ca = CA_default\\n"
+                 "[CA_default]\\ndatabase = restapi_index.txt\\nserial = restapi_serial\\n"
+                 "new_certs_dir = restapi_newcerts\\ndefault_md = sha256\\n"
+                 "policy = policy_any\\ncopy_extensions = none\\n"
+                 "[policy_any]\\ncommonName = supplied\\n"
+                 "[v3_ca]\\nbasicConstraints = critical,CA:TRUE\\n"
+                 "keyUsage = critical,keyCertSign,cRLSign\\nsubjectKeyIdentifier = hash\\n")
+    localhost.shell(f"printf '{ca_config}' > restapi_ca.cnf")
+
+    # Create Root CSR and self-sign it as the CA cert with a backdated notBefore.
     local_command = "openssl req \
-                        -x509 \
                         -new \
-                        -nodes \
                         -key restapiCA.key \
-                        -sha256 \
-                        -days 1825 \
                         -subj '/CN=test.restapi.sonic' \
-                        -out restapiCA.pem"
+                        -out restapiCA.csr"
+    localhost.shell(local_command)
+    local_command = f"openssl ca \
+                        -batch \
+                        -config restapi_ca.cnf \
+                        -selfsign \
+                        -keyfile restapiCA.key \
+                        -in restapiCA.csr \
+                        -out restapiCA.pem \
+                        -extensions v3_ca \
+                        -startdate {cert_not_before} \
+                        -enddate {ca_not_after} \
+                        -notext \
+                        -md sha256"
     localhost.shell(local_command)
 
     # Create server key
@@ -62,16 +90,19 @@ def setup_restapi_server(duthosts, rand_one_dut_hostname, localhost, setup_logan
                         -out restapiserver.csr"
     localhost.shell(local_command)
 
-    # Sign server certificate
-    local_command = "openssl x509 \
-                        -req \
+    # Sign server certificate, reusing the backdated validity window and CA
+    # database set up for the CA certificate above.
+    local_command = f"openssl ca \
+                        -batch \
+                        -config restapi_ca.cnf \
+                        -cert restapiCA.pem \
+                        -keyfile restapiCA.key \
                         -in restapiserver.csr \
-                        -CA restapiCA.pem \
-                        -CAkey restapiCA.key \
-                        -CAcreateserial \
                         -out restapiserver.crt \
-                        -days 825 \
-                        -sha256"
+                        -startdate {cert_not_before} \
+                        -enddate {cert_not_after} \
+                        -notext \
+                        -md sha256"
     localhost.shell(local_command)
 
     # Create client key
@@ -86,16 +117,19 @@ def setup_restapi_server(duthosts, rand_one_dut_hostname, localhost, setup_logan
                         -out restapiclient.csr"
     localhost.shell(local_command)
 
-    # Sign client certificate
-    local_command = "openssl x509 \
-                        -req \
+    # Sign client certificate, reusing the same backdated validity window and CA
+    # database set up for the CA certificate above.
+    local_command = f"openssl ca \
+                        -batch \
+                        -config restapi_ca.cnf \
+                        -cert restapiCA.pem \
+                        -keyfile restapiCA.key \
                         -in restapiclient.csr \
-                        -CA restapiCA.pem \
-                        -CAkey restapiCA.key \
-                        -CAcreateserial \
                         -out restapiclient.crt \
-                        -days 825 \
-                        -sha256"
+                        -startdate {cert_not_before} \
+                        -enddate {cert_not_after} \
+                        -notext \
+                        -md sha256"
     localhost.shell(local_command)
 
     # Copy CA certificate and server certificate over to the DUT
@@ -116,10 +150,14 @@ def setup_restapi_server(duthosts, rand_one_dut_hostname, localhost, setup_logan
         # Perform a config load_minigraph to ensure config_db is not corrupted
         config_reload(duthost, config_source='minigraph')
         # Delete all created certs
-        local_command = "rm \
+        local_command = "rm -rf \
                             restapiCA.* \
                             restapiserver.* \
-                            restapiclient.*"
+                            restapiclient.* \
+                            restapi_ca.cnf \
+                            restapi_index.txt* \
+                            restapi_serial* \
+                            restapi_newcerts"
         localhost.shell(local_command)
 
 
@@ -144,7 +182,7 @@ def construct_url(duthosts, rand_one_dut_hostname):
             tup = ('https', netloc, path, '', '', '')
             endpoint = urlunparse(tup)
         except Exception:
-            logging.error("Invalid URL: "+endpoint)
+            logging.error("Invalid URL")
             return None
         return endpoint
     return get_endpoint


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR pushes the start date of restapi CA cert, server cert, and client cert one month back so that clock differences between the sonic-mgmt container and the restapi container do not cause the `SSLV3_ALERT_CERTIFICATE_EXPIRED` error when running restapi tests.

Summary:
Microsoft ADO ID: 38927870
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
Fixed the `SSLV3_ALERT_CERTIFICATE_EXPIRED` error happening during restapi tests

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 38927870
Failure type: day-one issue

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
20260510.06
```
restapi/test_restapi_client_cert_auth.py::test_client_cert_subject_name_matching PASSED                                    [100%]
```

### Approach
#### What is the motivation for this PR?
The following error was seen on some DUTs when running `test_restapi_client_cert_auth.py`:
```
ERROR  | urllib3.exceptions.SSLError: [SSL: SSLV3_ALERT_CERTIFICATE_EXPIRED] sslv3 alert certificate expired (_ssl.c:2559)
```
The root cause of this issue was that the DUT's clock was a few minutes behind the clock of the test runner (sonic-mgmt container). All restapi certs are created during the test inside sonic-mgmt and their validity starts from the time they are created (based on sonic-mgmt's clock), which is ahead of the DUT's time. As a result, the restapi container on the DUT rejects the client cert with the above error.

#### How did you do it?
Set the validity start date of all restapi certs to 30 days before their creation time. As long as the DUT's clock is not behind the sonic-mgmt's clock by more than 30 days, this solution fixes the `SSLV3_ALERT_CERTIFICATE_EXPIRED` error.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran `test_restapi_client_cert_auth.py` on a DUT.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A