### PR TITLE
Detect flat memory transceivers on all platforms, not just Mellanox

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -466,7 +466,10 @@ print(port_indexes_with_flat_memory)
 EOF
 """
     dut.shell(cmd)
-    port_indexes_with_flat_memory = dut.shell("python3 get_port_indexes_with_flat_memory.py")["stdout"]
-    port_indexes_with_flat_memory = ast.literal_eval(port_indexes_with_flat_memory)
+    output = dut.shell("python3 get_port_indexes_with_flat_memory.py", module_ignore_errors=True)
+    if output["rc"] != 0:
+        logging.warning(f"Failed to get port indexes with flat memory on {dut.hostname}: {output['stderr']}")
+        return []
+    port_indexes_with_flat_memory = ast.literal_eval(output["stdout"])
     logging.info(f"Port indexes with flat memory: {port_indexes_with_flat_memory}")
     return port_indexes_with_flat_memory

--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -13,7 +13,6 @@ from collections import defaultdict
 from natsort import natsorted
 from .transceiver_utils import all_transceivers_detected
 import ast
-from tests.common.mellanox_data import is_mellanox_device
 
 
 def parse_intf_status(lines):
@@ -431,9 +430,7 @@ def get_ports_with_flat_memory(dut, conn_graph_facts):
     """
     This method is to get ports with flat memory
     """
-    port_indexes_with_flat_memory = []
-    if is_mellanox_device(dut):
-        port_indexes_with_flat_memory = get_port_indexes_with_flat_memory(dut)
+    port_indexes_with_flat_memory = get_port_indexes_with_flat_memory(dut)
 
     physical_intfs = conn_graph_facts["device_conn"][dut.hostname]
     physical_port_index_map = get_physical_port_indices(dut, physical_intfs)

--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -13,7 +13,6 @@ from collections import defaultdict
 from natsort import natsorted
 from .transceiver_utils import all_transceivers_detected
 import ast
-from tests.common.mellanox_data import is_mellanox_device
 
 
 def parse_intf_status(lines):
@@ -428,9 +427,7 @@ def get_ports_with_flat_memory(dut, conn_graph_facts):
     """
     This method is to get ports with flat memory
     """
-    port_indexes_with_flat_memory = []
-    if is_mellanox_device(dut):
-        port_indexes_with_flat_memory = get_port_indexes_with_flat_memory(dut)
+    port_indexes_with_flat_memory = get_port_indexes_with_flat_memory(dut)
 
     physical_intfs = conn_graph_facts["device_conn"][dut.hostname]
     physical_port_index_map = get_physical_port_indices(dut, physical_intfs)


### PR DESCRIPTION
## Description of PR

Summary:
Fixes # (issue)

`get_ports_with_flat_memory()` in `tests/common/platform/interface_utils.py` only checked for flat-memory transceivers on Mellanox devices, returning an empty list on every other platform. The underlying detection in `get_port_indexes_with_flat_memory()` (reading the transceiver EEPROM memory type) is vendor-agnostic, so the gate causes ports with flat memory transceivers to be misclassified on non-Mellanox platforms.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202411
- [ ] 202505
- [ ] 202510

### Approach

#### What is the motivation for this PR?

On non-Mellanox platforms, ports with flat memory transceivers were never identified, so tests relying on this helper treated flat-memory modules as paged-memory transceivers and applied the wrong expectations.

#### How did you do it?

Call `get_port_indexes_with_flat_memory(dut)` unconditionally in `get_ports_with_flat_memory()` and drop the now-unused `is_mellanox_device` import.

#### How did you verify/test it?

Ran the affected platform tests against a DUT with flat memory transceivers (OSFP 800G DAC cables) and verified the ports are now correctly detected.