### PR TITLE
test_monitor_config: skip policer for Nexthop NH-4210

### DIFF
--- a/tests/generic_config_updater/test_monitor_config.py
+++ b/tests/generic_config_updater/test_monitor_config.py
@@ -32,6 +32,8 @@ def is_policer_supported(duthost):
         return False
     if platform.startswith("x86_64-nokia_ixr7220"):
         return False
+    if platform.startswith("x86_64-nexthop_4210"):
+        return False
     return True
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Skip attaching a policer to ERSPAN mirror sessions on Nexthop NH-4210 platforms.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: day-one issue

### Test result

- Python compilation completed successfully.
- On Nexthop NH-4210 (`x86_64-nexthop_4210-r0021`), the existing test body passed but LogAnalyzer failed during teardown after the SDK rejected `SAI_MIRROR_SESSION_ATTR_POLICER`.
- Post-fix DUT validation is pending.

### Approach
#### What is the motivation for this PR?

`generic_config_updater/test_monitor_config.py::test_monitor_config_tc1_suite` attaches a policer to an ERSPAN mirror session by default. Nexthop NH-4210 SAI does not support this attribute and reports:

```text
Platform does not support SAI_MIRROR_SESSION_ATTR_POLICER.
```

The resulting mirror-session activation errors are detected by LogAnalyzer during teardown.

#### How did you do it?

Updated `is_policer_supported()` to return `False` for the `x86_64-nexthop_4210` platform family. This follows the existing handling for Arista 7060x6 and Nokia IXR7220 platforms with the same SAI limitation.

#### How did you verify/test it?

Ran Python compilation and `git diff --check` for the modified test module. The failure signature and DUT platform identifier were confirmed from the test log and DUT.

#### Any platform specific information?

Nexthop NH-4210 platform: `x86_64-nexthop_4210-r0021`.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
