### PR TITLE
[pfcwd] Use chip-side bcmcmd storm path for chip-capable SONiC fanouts on t2

### DIFF
--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -275,7 +275,7 @@ class PFCStorm(object):
         # already-populated peer_info['hwsku'] (avoids a second remote 'show version'
         # and a crash if a live HwSKU lookup returns None).
         sonic_pfc_chip = (get_chip_name_if_asic_pfc_storm_supported(self.peer_info.get('hwsku'))
-                          if self.peer_device.os == 'sonic' else None)
+                          if self.asic_type != 'vs' and self.peer_device.os == 'sonic' else None)
         if self.asic_type == 'vs':
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_eos.j2")
@@ -309,7 +309,7 @@ class PFCStorm(object):
         # already-populated peer_info['hwsku'] (avoids a second remote 'show version'
         # and a crash if a live HwSKU lookup returns None).
         sonic_pfc_chip = (get_chip_name_if_asic_pfc_storm_supported(self.peer_info.get('hwsku'))
-                          if self.peer_device.os == 'sonic' else None)
+                          if self.asic_type != 'vs' and self.peer_device.os == 'sonic' else None)
         if self.asic_type == 'vs':
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_eos.j2")

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 
 def get_chip_name_if_asic_pfc_storm_supported(fanout):
+    if not fanout:
+        return None
     hwSkuInfo = {
         "Arista DCS-7060DX5": "Tomahawk4",
         "Arista DCS-7060PX5": "Tomahawk4",
@@ -269,11 +271,16 @@ class PFCStorm(object):
         Populates the pfc storm start template
         """
         self._update_template_args()
+        # Resolve the SONiC fanout's chip-side PFC capability once per call from the
+        # already-populated peer_info['hwsku'] (avoids a second remote 'show version'
+        # and a crash if a live HwSKU lookup returns None).
+        sonic_pfc_chip = (get_chip_name_if_asic_pfc_storm_supported(self.peer_info.get('hwsku'))
+                          if self.peer_device.os == 'sonic' else None)
         if self.asic_type == 'vs':
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_eos.j2")
         elif (self.dut.topo_type == 't2' and self.peer_device.os == 'sonic'
-              and not get_chip_name_if_asic_pfc_storm_supported(self._get_sonic_fanout_hwsku())):
+              and not sonic_pfc_chip):
             # The t2 template drives pfc_gen via raw AF_PACKET, which the SONiC fanout's
             # SAI/syncd CPU-port trap drops on newer images, so the storm never reaches the
             # front panel. Only use it for fanouts whose ASIC does NOT support chip-side PFC
@@ -285,8 +292,7 @@ class PFCStorm(object):
                 TEMPLATES_DIR, "pfc_storm_mlnx_{}.j2".format(self.peer_device.os))
         elif ((self.peer_device.os == 'eos' and
                get_chip_name_if_asic_pfc_storm_supported(self._get_eos_fanout_version()[0])) or
-              (self.peer_device.os == 'sonic' and
-               get_chip_name_if_asic_pfc_storm_supported(self._get_sonic_fanout_hwsku()))):
+              (self.peer_device.os == 'sonic' and sonic_pfc_chip)):
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_arista_{}.j2".format(self.peer_device.os))
         else:
@@ -299,11 +305,16 @@ class PFCStorm(object):
         Populates the pfc storm stop template
         """
         self._update_template_args()
+        # Resolve the SONiC fanout's chip-side PFC capability once per call from the
+        # already-populated peer_info['hwsku'] (avoids a second remote 'show version'
+        # and a crash if a live HwSKU lookup returns None).
+        sonic_pfc_chip = (get_chip_name_if_asic_pfc_storm_supported(self.peer_info.get('hwsku'))
+                          if self.peer_device.os == 'sonic' else None)
         if self.asic_type == 'vs':
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_eos.j2")
         elif (self.dut.topo_type == 't2' and self.peer_device.os == 'sonic'
-              and not get_chip_name_if_asic_pfc_storm_supported(self._get_sonic_fanout_hwsku())):
+              and not sonic_pfc_chip):
             # Mirror _prepare_start_template: chip-capable SONiC fanouts use the bcmcmd path.
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_{}_t2.j2".format(self.peer_device.os))
@@ -312,8 +323,7 @@ class PFCStorm(object):
                 TEMPLATES_DIR, "pfc_storm_stop_mlnx_{}.j2".format(self.peer_device.os))
         elif ((self.peer_device.os == 'eos' and
                get_chip_name_if_asic_pfc_storm_supported(self._get_eos_fanout_version()[0])) or
-              (self.peer_device.os == 'sonic' and
-               get_chip_name_if_asic_pfc_storm_supported(self._get_sonic_fanout_hwsku()))):
+              (self.peer_device.os == 'sonic' and sonic_pfc_chip)):
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_arista_{}.j2".format(self.peer_device.os))
         else:

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -272,7 +272,12 @@ class PFCStorm(object):
         if self.asic_type == 'vs':
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_eos.j2")
-        elif self.dut.topo_type == 't2' and self.peer_device.os == 'sonic':
+        elif (self.dut.topo_type == 't2' and self.peer_device.os == 'sonic'
+              and not get_chip_name_if_asic_pfc_storm_supported(self._get_sonic_fanout_hwsku())):
+            # The t2 template drives pfc_gen via raw AF_PACKET, which the SONiC fanout's
+            # SAI/syncd CPU-port trap drops on newer images, so the storm never reaches the
+            # front panel. Only use it for fanouts whose ASIC does NOT support chip-side PFC
+            # generation; chip-capable SONiC fanouts fall through to the bcmcmd path below.
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_{}_t2.j2".format(self.peer_device.os))
         elif self.fanout_asic_type == 'mellanox' and self.peer_device.os == 'sonic':
@@ -297,7 +302,9 @@ class PFCStorm(object):
         if self.asic_type == 'vs':
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_eos.j2")
-        elif self.dut.topo_type == 't2' and self.peer_device.os == 'sonic':
+        elif (self.dut.topo_type == 't2' and self.peer_device.os == 'sonic'
+              and not get_chip_name_if_asic_pfc_storm_supported(self._get_sonic_fanout_hwsku())):
+            # Mirror _prepare_start_template: chip-capable SONiC fanouts use the bcmcmd path.
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_{}_t2.j2".format(self.peer_device.os))
         elif self.fanout_asic_type == 'mellanox' and self.peer_device.os == 'sonic':


### PR DESCRIPTION
### Description of PR
Fix `pfcwd/test_pfcwd_all_port_storm.py::test_all_port_storm_restore` failing on t2 topologies whose PFC-storm fanout is a chip-capable SONiC fanout (e.g. `Arista-7060X6-64PE` / Tomahawk5).

Summary: **0 ports reach storm state** and no `.* detected PFC storm .*` syslog appears — the storm never egresses the fanout front panel.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Approach
#### What is the motivation for this PR?
`_prepare_start_template` / `_prepare_stop_template` select the t2 SONiC template (`pfc_storm_sonic_t2.j2`) for **any** SONiC fanout on a t2 DUT. That template drives `pfc_gen` over raw **AF_PACKET**; on newer SONiC fanout images the SAI/syncd CPU-port trap **drops the host-injected 0x8808 PFC frames**, so the storm never reaches the wire.

`deploy_pfc_gen` already stages the chip-side generator (`pfc_gen_brcm_xgs.py`) for chip-capable fanouts, but the unconditional `t2` branch **shadows** the chip-side (`pfc_storm_arista_sonic.j2`) branch, so the `bcmcmd` path is never used.

#### How did you do it?
Gate the t2 AF_PACKET branch on the fanout **not** being chip-side-PFC capable (`get_chip_name_if_asic_pfc_storm_supported`). Chip-capable SONiC fanouts fall through to the existing `bcmcmd` chip-side path, bypassing the trap. Non chip-capable fanouts are unchanged.

#### How did you verify/test it?
On a single-node VoQ (t2) testbed with an `Arista-7060X6` SONiC fanout, `test_all_port_storm_restore` goes from **2 failed to 2 passed** (IPv4 + IPv6). Non chip-capable fanouts (e.g. `DellEMC-Z9332f-O32`, not in the chip table) are unaffected.

A related internal branch (`linjin/pfcwd-z9332f-th3-tx`) additionally extends the chip-side path to Z9332f/Tomahawk3 fanouts and can be folded in on top of this.

### Any platform specific information?
Affects t2 topologies using a chip-side-PFC-capable SONiC fanout (Broadcom XGS, e.g. Tomahawk5 7060X6).

### Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Internal tracking: also applied to the internal 202511 qualification branch — MSFT ADO PR 25951.