### PR TITLE
Improve interlock in `check_appl_db` for `EosHost` nbrs

### DIFF
--- a/tests/common/macsec/macsec_helper.py
+++ b/tests/common/macsec/macsec_helper.py
@@ -16,7 +16,7 @@ import scapy.contrib.macsec as scapy_macsec
 
 from tests.common.macsec.macsec_platform_helper import sonic_db_cli
 from tests.common.devices.eos import EosHost
-from tests.common.utilities import convert_scapy_packet_to_bytes
+from tests.common.utilities import convert_scapy_packet_to_bytes, wait_until
 
 __all__ = [
     'check_wpa_supplicant_process',

--- a/tests/common/macsec/macsec_helper.py
+++ b/tests/common/macsec/macsec_helper.py
@@ -205,6 +205,9 @@ def check_appl_db(duthost, ctrl_links, policy, cipher_suite, send_sci):
     procs = []
     for port_name, nbr in list(ctrl_links.items()):
         if isinstance(nbr["host"], EosHost):
+            assert wait_until(300, 3, 0,
+                              lambda: duthost.iface_macsec_ok(port_name) and
+                              nbr["host"].iface_macsec_ok(nbr["port"]))
             continue
         proc = submit_async_task(
             __check_appl_db,

--- a/tests/macsec/test_deployment.py
+++ b/tests/macsec/test_deployment.py
@@ -24,11 +24,6 @@ class TestDeployment():
         duthost.shell("config save -y")
         config_reload(duthost)
         assert wait_until(300, 6, 12, check_appl_db, duthost, ctrl_links, policy, cipher_suite, send_sci)
-        # check_appl_db doesn't work with EosDut neighbors so check the macsec ports are up as well
-        for dut_port, nbr in list(ctrl_links.items()):
-            assert wait_until(300, 3, 0,
-                              lambda: duthost.iface_macsec_ok(dut_port) and
-                              nbr["host"].iface_macsec_ok(nbr["port"]))
         # Recover the original config file
         duthost.shell("sudo mv /tmp/config_db*.json /etc/sonic")
 

--- a/tests/macsec/test_deployment.py
+++ b/tests/macsec/test_deployment.py
@@ -24,6 +24,11 @@ class TestDeployment():
         duthost.shell("config save -y")
         config_reload(duthost)
         assert wait_until(300, 6, 12, check_appl_db, duthost, ctrl_links, policy, cipher_suite, send_sci)
+        # check_appl_db doesn't work with EosDut neighbors so check the macsec ports are up as well
+        for dut_port, nbr in list(ctrl_links.items()):
+            assert wait_until(300, 3, 0,
+                              lambda: duthost.iface_macsec_ok(dut_port) and
+                              nbr["host"].iface_macsec_ok(nbr["port"]))
         # Recover the original config file
         duthost.shell("sudo mv /tmp/config_db*.json /etc/sonic")
 


### PR DESCRIPTION
### Description of PR
Without this interlock test_config_reload ends up finishing the test before the ports come back up causing issues on subsequent tests

Summary:
Fixes #26706 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
202511 - `macsec/test_deployment.py` passes now

### Approach
#### What is the motivation for this PR?
`macsec/test_deployment.py::test_config_reload` completing early causes `macsec/test_deployment.py::test_scale_rekey` to fail due to ports still being down.

#### How did you do it?
Improve the interlock in `macsec/test_deployment.py::test_config_reload` to make sure the macsec ports are up even on `EosHost` nbrs.

#### How did you verify/test it?
Saw `macsec/test_deployment.py` passing all testlets on 202511.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
