### PR TITLE
conditional_mark: skip policer tests on Nexthop NH-4210

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1980,11 +1980,11 @@ everflow/test_everflow_per_interface.py::test_everflow_per_interface\[.*ipv4:
 
 everflow/test_everflow_testbed.py::EverflowIPv4Tests::test_everflow_dscp_with_policer:
   skip:
-    reason: "Test not supported on Mellanox platforms, Broadcom Th5 platform (x86_64-arista_7060x6_64pe_b), or Nokia IXR7220-H6-128 as policer is not supported. CS00012412189"
+    reason: "Test not supported on Mellanox platforms, Broadcom Th5 platform (x86_64-arista_7060x6_64pe_b), Nokia IXR7220-H6-128, or Nexthop NH-4210 as policer is not supported. CS00012412189"
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['mellanox']"
-      - "platform in ['x86_64-arista_7060x6_64pe_b', 'x86_64-nokia_ixr7220_h6_128-r0']"
+      - "platform in ['x86_64-arista_7060x6_64pe_b', 'x86_64-nokia_ixr7220_h6_128-r0', 'x86_64-nexthop_4210-r0021']"
 
 everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror:
   skip:
@@ -2033,12 +2033,12 @@ everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_eve
 
 everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_dscp_with_policer:
   skip:
-    reason: "Skipping test since mirror with policer is not supported on Cisco 8000 platforms, Broadcom DNX platforms, Broadcom Th5 platform (x86_64-arista_7060x6_64pe_b), and Nokia IXR7220-H6-128. CS00012412189"
+    reason: "Skipping test since mirror with policer is not supported on Cisco 8000 platforms, Broadcom DNX platforms, Broadcom Th5 platform (x86_64-arista_7060x6_64pe_b), Nokia IXR7220-H6-128, and Nexthop NH-4210. CS00012412189"
     conditions_logical_operator: "OR"
     conditions:
       - "asic_subtype in ['broadcom-dnx']"
       - "asic_type in ['cisco-8000']"
-      - "platform in ['x86_64-arista_7060x6_64pe_b', 'x86_64-nokia_ixr7220_h6_128-r0']"
+      - "platform in ['x86_64-arista_7060x6_64pe_b', 'x86_64-nokia_ixr7220_h6_128-r0', 'x86_64-nexthop_4210-r0021']"
 
 everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_dscp_with_policer[erspan_ipv4-cli-downstream-default]:
   skip:
@@ -2224,11 +2224,11 @@ everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_e
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer:
   skip:
-    reason: "Skipping test since mirror with policer is not supported on Cisco 8122 and 8223 platforms, Broadcom DNX platforms, Broadcom Th5 platform (x86_64-arista_7060x6_64pe_b), and Nokia IXR7220-H6-128. CS00012412189"
+    reason: "Skipping test since mirror with policer is not supported on Cisco 8122 and 8223 platforms, Broadcom DNX platforms, Broadcom Th5 platform (x86_64-arista_7060x6_64pe_b), Nokia IXR7220-H6-128, and Nexthop NH-4210. CS00012412189"
     conditions_logical_operator: "OR"
     conditions:
       - "asic_subtype in ['broadcom-dnx']"
-      - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0', 'x86_64-arista_7060x6_64pe_b', 'x86_64-8223_64e_mo-r0','x86_64-8223_64ef_mo-r0', 'x86_64-nokia_ixr7220_h6_128-r0']"
+      - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0', 'x86_64-arista_7060x6_64pe_b', 'x86_64-8223_64e_mo-r0','x86_64-8223_64ef_mo-r0', 'x86_64-nokia_ixr7220_h6_128-r0', 'x86_64-nexthop_4210-r0021']"
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[erspan_ipv4-cli-downstream-default]:
   skip:


### PR DESCRIPTION
### Description of PR

Summary:
Skip unsupported Everflow policer tests on the Nexthop NH-4210 platform.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: day-one issue

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

- Confirmed the failure in Elastictest plan `6a616030a045a4dff05cab9e` on `x86_64-nexthop_4210-r0021`.
- Both the original run and retry failed because SAI rejected `SAI_MIRROR_SESSION_ATTR_POLICER`.
- Validated that the conditional-mark logic skips the base, ingress, and egress Everflow policer test scopes for the NH-4210 platform.
- Conditional-mark unit tests passed.

### Approach
#### What is the motivation for this PR?

The Nexthop NH-4210 platform does not support attaching a policer to an ERSPAN mirror session. The affected Everflow test creates such a session, causing SAI to report:

```text
Platform does not support SAI_MIRROR_SESSION_ATTR_POLICER.
```

The mirror session cannot be programmed, and the test subsequently times out waiting for the CONFIG_DB and ASIC_DB ACL rule counts to match.

#### How did you do it?

Added `x86_64-nexthop_4210-r0021` to the existing platform skip conditions for all three `test_everflow_dscp_with_policer` test scopes. This follows the approach used for Nokia IXR7220-H6-128.

#### How did you verify/test it?

Parsed the conditional-mark YAML, ran its unit tests, and evaluated the three affected node IDs using NH-4210 platform facts to confirm that each receives the skip mark.

#### Any platform specific information?

Nexthop NH-4210 platform: `x86_64-nexthop_4210-r0021`.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
