### PR TITLE
route: use l3_alpm_template check on Nexthop NH-4210

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -107,8 +107,10 @@ def check_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_
     asic_id = enum_rand_one_frontend_asic_index
 
     if (asic == "broadcom"):
-        if "x86_64-arista_7060x6" in platform or "x86_64-nokia_ixr7220_h6" in platform:
-            # For TH5 (Arista 7060x6) and TH6 (Nokia IXR7220 H6) family devices,
+        if ("x86_64-arista_7060x6" in platform or
+                "x86_64-nokia_ixr7220_h6" in platform or
+                "x86_64-nexthop_4210" in platform):
+            # For TH5 (Arista 7060x6) and TH6 (Nokia IXR7220 H6 and Nexthop 4210) family devices,
             # l3_alpm_template is set in config.bcm instead of l3_alpm_enable
             # * 1 - Combined (By default)
             # * 2 - Parallel


### PR DESCRIPTION
### Description of PR

Summary:
Use the `l3_alpm_template` route-scale configuration check on Nexthop NH-4210.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: day-one issue

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

- Confirmed the setup failure in Elastictest plan `6a616030a045a4dff05cab9e` on `x86_64-nexthop_4210-r0021`.
- Both IPv4 and IPv6 parameterizations failed because `bcmcmd "conf show l3_alpm_enable"` returned `Command not supported for this device`.
- Confirmed that the NH-4210 platform configuration sets `l3_alpm_template: 1`.
- Python compilation and platform-condition checks passed.

### Approach
#### What is the motivation for this PR?

`route/test_route_perf.py` validates the ALPM configuration before running route-scale tests. Nexthop NH-4210 is a TH6 platform that uses `l3_alpm_template` in `config.bcm`, but the test currently treats it as a legacy Broadcom platform and runs:

```text
bcmcmd "conf show l3_alpm_enable"
```

The command is unsupported on this device, so the test fails during setup before any routes are programmed.

#### How did you do it?

Extended the existing TH5/TH6 platform condition to include `x86_64-nexthop_4210`. This routes NH-4210 through `get_l3_alpm_template_from_config_bcm()`, following the Nokia TH6 handling introduced by PR #25061.

#### How did you verify/test it?

Confirmed the failure signature from the nightly logs, verified `l3_alpm_template: 1` in the NH-4210 platform configuration, compiled the modified module, and checked that the platform condition selects the template path for `x86_64-nexthop_4210-r0021`.

#### Any platform specific information?

Nexthop NH-4210 platform: `x86_64-nexthop_4210-r0021`.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
