### PR TITLE
[pc/test_lag_2.py] Prevent test failures from setting EOS lacp rate and prevent teardown setting neighbors lacp rate to normal by default

### DIFF
--- a/tests/common/devices/cisco.py
+++ b/tests/common/devices/cisco.py
@@ -164,6 +164,15 @@ class CiscoHost(AnsibleHostBase):
         return 'line protocol is up' in show_int_result['stdout_lines'][0]
 
     @adapt_interface_name
+    def get_interface_lacp_rate_mode(self, interface_name):
+        """Returns the current LACP period mode ('fast' or 'normal') from running config."""
+        out = self.commands(commands=['show running-config interface %s' % interface_name])
+        if out.get('failed', False):
+            raise Exception("Failed to get LACP rate mode for interface [%s]" % interface_name)
+        config = (out.get("stdout") or [""])[0]
+        return "fast" if "lacp period short" in config else "normal"
+
+    @adapt_interface_name
     def set_interface_lacp_rate_mode(self, interface_name, mode):
         if mode == 'fast':
             command = 'lacp period short'

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -480,7 +480,9 @@ class EosHost(AnsibleHostBase):
     def get_interface_lacp_rate_mode(self, interface_name):
         """Returns the current LACP timer mode ('fast' or 'normal') from running config."""
         out = self.eos_command(commands=["show running-config interfaces %s" % interface_name])
-        config = out.get("stdout", [""])[0]
+        if out.get("failed", False):
+            raise Exception("Failed to get LACP rate mode for interface [%s]" % interface_name)
+        config = (out.get("stdout") or [""])[0]
         return "fast" if ("lacp timer fast" in config or "lacp rate fast" in config) else "normal"
 
     def set_interface_lacp_rate_mode(self, interface_name, mode):

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -477,14 +477,23 @@ class EosHost(AnsibleHostBase):
                     return False
         return True
 
+    def get_interface_lacp_rate_mode(self, interface_name):
+        """Returns the current LACP timer mode ('fast' or 'normal') from running config."""
+        out = self.eos_command(commands=["show running-config interfaces %s" % interface_name])
+        config = out.get("stdout", [""])[0]
+        return "fast" if ("lacp timer fast" in config or "lacp rate fast" in config) else "normal"
+
     def set_interface_lacp_rate_mode(self, interface_name, mode):
+        # Pre-check: no-op/skip if already in the desired mode
+        if self.get_interface_lacp_rate_mode(interface_name) == mode:
+            logging.info("Interface [%s] lacp timer already set to [%s], skipping" % (interface_name, mode))
+            return None
+
         out = self.eos_config(
             lines=['lacp rate %s' % mode],
             parents='interface %s' % interface_name)
 
-        # FIXME: out['failed'] will be False even when a command is deprecated, so we have to check out['changed']
-        # However, if the lacp rate is already in expected state, out['changed'] will be False and treated as
-        # error.
+        # out['failed'] will be False even when a command is deprecated, so we have to check out['changed']
         if out.get('failed', False) is True or out['changed'] is False:
             # new eos deprecate lacp rate and use lacp timer command
             out = self.eos_config(

--- a/tests/common/devices/onyx.py
+++ b/tests/common/devices/onyx.py
@@ -75,7 +75,7 @@ class OnyxHost(AnsibleHostBase):
     def get_interface_lacp_rate_mode(self, interface_name):
         """Returns the current LACP rate mode ('fast' or 'normal') from running config."""
         out = self.host.onyx_command(
-            commands=['show running-config interfaces %s' % interface_name])
+            commands=['show running-config interfaces %s' % interface_name])[self.hostname]
         if out.get("failed", False):
             raise Exception("Failed to get LACP rate mode for interface [%s]" % interface_name)
         config = (out.get("stdout") or [""])[0]

--- a/tests/common/devices/onyx.py
+++ b/tests/common/devices/onyx.py
@@ -72,6 +72,15 @@ class OnyxHost(AnsibleHostBase):
         out = self.host.onyx_config(commands=[cmd])
         return out
 
+    def get_interface_lacp_rate_mode(self, interface_name):
+        """Returns the current LACP rate mode ('fast' or 'normal') from running config."""
+        out = self.host.onyx_command(
+            commands=['show running-config interfaces %s' % interface_name])
+        if out.get("failed", False):
+            raise Exception("Failed to get LACP rate mode for interface [%s]" % interface_name)
+        config = (out.get("stdout") or [""])[0]
+        return "fast" if "lacp rate fast" in config else "normal"
+
     def set_interface_lacp_rate_mode(self, interface_name, mode):
         out = self.host.onyx_config(
             lines=['lacp rate %s' % mode],

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -327,35 +327,38 @@ class LagTest:
             port = self.vm_neighbors[po_intf]['port']
             neighbor_lag_intfs.append(self.__resolve_vm_neighbor_intf(peer_device, port))
 
+        # Get the vm host(veos) by its host name
+        vm_host = self.nbrhosts[peer_device]['host']
+
+        # Save the initial LACP rate for each interface so it can be restored afterwards,
+        # regardless of whether the testbed was pre-configured to fast or slow.
+        initial_lacp_rates = {}
+        for neighbor_lag_member in neighbor_lag_intfs:
+            initial_lacp_rates[neighbor_lag_member] = vm_host.get_interface_lacp_rate_mode(neighbor_lag_member)
+            logger.info("Initial lacp rate for %s in %s: %s"
+                        % (neighbor_lag_member, peer_device, initial_lacp_rates[neighbor_lag_member]))
+
         try:
-            lag_rate_current_setting = None
-
-            # Get the vm host(veos) by it host name
-            vm_host = self.nbrhosts[peer_device]['host']
-
             # Make sure all lag members on VM are set to fast
             for neighbor_lag_member in neighbor_lag_intfs:
                 logger.info("Changing lacp rate to fast for %s in %s" % (neighbor_lag_member, peer_device))
                 vm_host.set_interface_lacp_rate_mode(neighbor_lag_member, 'fast')
-            lag_rate_current_setting = 'fast'
             time.sleep(5)
             for iface_behind_lag in iface_behind_lag_member:
                 self.__verify_lag_lacp_timing(1, iface_behind_lag)
-
-            # Make sure all lag members on VM are set to slow
             for neighbor_lag_member in neighbor_lag_intfs:
                 logger.info("Changing lacp rate to slow for %s in %s" % (neighbor_lag_member, peer_device))
                 vm_host.set_interface_lacp_rate_mode(neighbor_lag_member, 'normal')
-            lag_rate_current_setting = 'slow'
             time.sleep(5)
             for iface_behind_lag in iface_behind_lag_member:
                 self.__verify_lag_lacp_timing(30, iface_behind_lag)
         finally:
-            # Restore lag rate setting on VM in case of failure
-            if lag_rate_current_setting == 'fast':
-                for neighbor_lag_member in neighbor_lag_intfs:
-                    logger.info("Changing lacp rate to slow for %s in %s" % (neighbor_lag_member, peer_device))
-                    vm_host.set_interface_lacp_rate_mode(neighbor_lag_member, 'normal')
+            # Restore each interface to its original LACP rate
+            for neighbor_lag_member in neighbor_lag_intfs:
+                original_rate = initial_lacp_rates.get(neighbor_lag_member, 'normal')
+                logger.info("Restoring lacp rate to %s for %s in %s"
+                            % (original_rate, neighbor_lag_member, peer_device))
+                vm_host.set_interface_lacp_rate_mode(neighbor_lag_member, original_rate)
 
     def run_single_lag_test(self, lag_name, lag_facts):
         logger.info("Start checking single lag for: %s" % lag_name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #26710 and Fixes #26711
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38960178
Failure type: day-one issue

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
- 202511: 20251110.41 - tested locally (previously failing / bad state after test -> pass and good state after test)
### Approach
#### What is the motivation for this PR?
Prevent failures in `pc/test_lag_2.py` when LACP rate is set to fast on neighbors before the test. Also prevent `pc/test_lag_2.py` from setting the neighbor LACP rate to `normal` after the test, despite it being fast in pretest.
#### How did you do it?
- Prevent EOS from erroring if desired set lacp rate matches current lacp rate, by adding pre-check to check if this is the case and no-op (#26710)
- Prevent test from tearing down and setting neighbor lacp rate to normal by default, by saving pretest state and restoring pretest state at teardown (rather than default to normal) (#26711)
#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Tested locally and confirmed these 2 scenarios are fixed
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A