### PR TITLE
Backport of #25494 to the 202605 branch.

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -24,8 +24,12 @@ DOCKER_LOG_GENERATOR_FILE = '/log_generator.py'
 STP_LOG_FILE = '/var/log/stpd.log'
 # Log pattern for tests/syslog/log_generator.py
 LOG_EXPECT_LAST_MESSAGE = '.*{}rate-limit-test: This is a test log:.*'
-# rsyslogd emits this when container rate-limit starts dropping messages.
-LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = '.*begin to drop messages due to rate-limiting.*'
+# rsyslogd emits one of two messages depending on version when rate-limiting kicks in:
+#   - "begin to drop messages due to rate-limiting"  (logged when drops start)
+#   - "N messages lost due to rate-limiting (M allowed within K seconds)"  (logged as summary)
+# Both indicate that rate limiting is working. The exact form and frequency are
+# rsyslogd-version-dependent, so only a presence check is performed (not an exact count).
+LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = r'.*(?:begin to drop messages|messages lost) due to rate-limiting.*'
 
 pytestmark = [
     pytest.mark.topology("any")
@@ -161,24 +165,25 @@ def verify_container_rate_limit(rand_selected_dut, ignore_containers=[]):
             'docker cp {} {}:{}'.format(REMOTE_LOG_GENERATOR_FILE, container_name, DOCKER_LOG_GENERATOR_FILE))
         additional_files = get_loganalyzer_additional_files(service_name)
 
-        # When logs are routed to an additional file (e.g. stpd.log for STP):
-        # 1. The rsyslog transition message "begin to drop messages due to rate-limiting"
-        #    may land outside the LogAnalyzer marker window, so it cannot be asserted.
-        # 2. rsyslog rate-limiting uses a sliding time window (RATE_LIMIT_INTERVAL seconds).
-        #    After config_reload the window may not be fully reset, so the number of messages
-        #    dropped (and thus the count reaching the log) is non-deterministic — it can be
-        #    anywhere from RATE_LIMIT_BURST to LOG_MESSAGE_GENERATE_COUNT.
-        # For both reasons, set expected_matches_target=0 which tells LogAnalyzer to skip
-        # the exact count check and only verify the pattern appeared at least once.
-        # For containers that log directly to syslog, the window is fresh and the exact
-        # drop count is deterministic, so assert RATE_LIMIT_BURST + 1 matches.
+        # When logs are routed to an additional file (e.g. stpd.log for STP),
+        # rsyslog rate-limiting uses a sliding time window (RATE_LIMIT_INTERVAL seconds).
+        # After config_reload the window may not be fully reset, so the number of messages
+        # that reach the log is non-deterministic — anywhere from RATE_LIMIT_BURST to
+        # LOG_MESSAGE_GENERATE_COUNT.  In that case skip the exact count check.
+        # For containers that log directly to syslog, assert exactly RATE_LIMIT_BURST test
+        # messages reached the log — one fewer than LOG_MESSAGE_GENERATE_COUNT — which
+        # proves the burst limit is enforced.
+        # The rate-limit notification is checked separately via presence_log_regex: its
+        # exact count is non-deterministic across rsyslogd versions, so it is excluded from
+        # the per-message tally and only verified to appear at least once.
         if additional_files:
             expect_log_regex = [LOG_EXPECT_LAST_MESSAGE.format(container_name + '#')]
             expect_log_matches = 0
+            presence_log_regex = None
         else:
-            expect_log_regex = [LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED,
-                                LOG_EXPECT_LAST_MESSAGE.format(container_name + '#')]
-            expect_log_matches = RATE_LIMIT_BURST + 1
+            expect_log_regex = [LOG_EXPECT_LAST_MESSAGE.format(container_name + '#')]
+            expect_log_matches = RATE_LIMIT_BURST
+            presence_log_regex = [LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED]
 
         verify_rate_limit_with_log_generator(rand_selected_dut,
                                              container_name,
@@ -187,6 +192,7 @@ def verify_container_rate_limit(rand_selected_dut, ignore_containers=[]):
                                                                                                 RATE_LIMIT_BURST),
                                              expect_log_regex,
                                              expect_log_matches,
+                                             presence_log_regex=presence_log_regex,
                                              additional_files=additional_files)
 
         rsyslog_pid = get_rsyslogd_pid(rand_selected_dut, container_name)
@@ -240,6 +246,7 @@ def verify_host_rate_limit(rand_selected_dut):
                                                                                               RATE_LIMIT_BURST),
                                          [LOG_EXPECT_LAST_MESSAGE.format('')],
                                          RATE_LIMIT_BURST,
+                                         presence_log_regex=[LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED],
                                          is_host=True)
 
     with expect_host_rsyslog_restart(rand_selected_dut):
@@ -272,15 +279,20 @@ def verify_config_rate_limit_fail(duthost, service_name):
 
 
 def verify_rate_limit_with_log_generator(duthost, service_name, log_marker, expect_log_regex, expect_log_matches,
-                                         is_host=False, additional_files=None):
+                                         presence_log_regex=None, is_host=False, additional_files=None):
     """Generator syslog with a script and verify that syslog rate limit reached
 
     Args:
         duthost (object): DUT host object
         service_name (str): Service name
         log_marker (str): Log start marker
-        expect_log_regex (list): A list of expected log message regular expression
-        expect_log_matches (int): Number of log lines matches the expect_log_regex
+        expect_log_regex (list): A list of expected log message regular expressions; the total
+            number of matching lines must equal expect_log_matches.
+        expect_log_matches (int): Exact number of log lines expected to match expect_log_regex.
+            Set to 0 to skip the exact count check (only verifies at least one match).
+        presence_log_regex (list, optional): Patterns that must appear at least once in the
+            log window.  Verified via a separate LogAnalyzer pass so their (variable) count
+            does not skew the expect_log_matches tally.  Defaults to None.
         is_host (bool, optional): Verify on host side or container side. Defaults to False.
         additional_files (dict, optional): Additional log files for log analyzer. Defaults to None.
     """
@@ -288,6 +300,15 @@ def verify_rate_limit_with_log_generator(duthost, service_name, log_marker, expe
                               additional_files=additional_files or {})
     loganalyzer.expect_regex = expect_log_regex
     loganalyzer.expected_matches_target = expect_log_matches
+
+    # Initialise the presence-check analyzer before entering the window so both
+    # analyzers capture the same log section.
+    if presence_log_regex:
+        presence_analyzer = LogAnalyzer(ansible_host=duthost,
+                                        marker_prefix=log_marker + '_presence',
+                                        additional_files=additional_files or {})
+        presence_analyzer.expect_regex = presence_log_regex
+        presence_marker = presence_analyzer.init()
 
     if is_host:
         run_generator_cmd = "python3 {}".format(REMOTE_LOG_GENERATOR_FILE)
@@ -300,6 +321,9 @@ def verify_rate_limit_with_log_generator(duthost, service_name, log_marker, expe
         # to the host syslog. Without this, the notification may arrive after the
         # LogAnalyzer end marker, causing intermittent test failures.
         time.sleep(5)
+
+    if presence_log_regex:
+        presence_analyzer.analyze(presence_marker)
 
 
 def get_loganalyzer_additional_files(service_name):


### PR DESCRIPTION
### Description of PR
`tests/syslog/test_syslog_rate_limit.py` only matched the older rsyslogd
rate-limit notification (`"begin to drop messages due to rate-limiting"`)
and asserted `RATE_LIMIT_BURST + 1` matches. On images whose rsyslogd
emits only the newer summary form (`"N messages lost due to rate-limiting
(M allowed within K seconds)"`), the pattern never matches and the count
assertion fails.

This PR:
- Widens `LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED` to accept either form via
  alternation.
- Splits the rate-limit-reached check into a separate presence-only
  LogAnalyzer pass (`presence_log_regex`), so its non-deterministic count
  across rsyslogd versions no longer skews the per-message tally.
- Adjusts the exact-match assertion to `RATE_LIMIT_BURST` (the test
  messages only), leaving the notification to the presence check.

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/26712

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605


### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605
- [ ] N/A


### Approach
#### What is the motivation for this PR?
`test_syslog_rate_limit` fails on 202605 DUTs whose rsyslogd emits only
the "messages lost" summary form of the rate-limit notification. The
test's expectation is tied to one specific rsyslogd version's phrasing
and to a combined match count that includes that notification, so any
version drift breaks the test.

#### How did you do it?
Cherry-picked #25494 from master. The change:
1. Broadens the notification regex to
   `r'.*(?:begin to drop messages|messages lost) due to rate-limiting.*'`.
2. Introduces a `presence_log_regex` parameter on
   `verify_rate_limit_with_log_generator` that runs a second LogAnalyzer
   pass over the same window purely as a presence check.
3. Removes the notification pattern from `expect_log_regex` on the
   syslog-direct branch and drops `expect_log_matches` from
   `RATE_LIMIT_BURST + 1` to `RATE_LIMIT_BURST` so the exact-count
   assertion only covers the deterministic test messages.
4. Wires the presence check into `verify_host_rate_limit` and the
   syslog-direct branch of `verify_container_rate_limit`.

#### How did you verify/test it?
1. Reproduced the failure on a 202605 DUT running an rsyslogd that emits
   only the "messages lost" summary form.
2. Applied the fix and reran `tests/syslog/test_syslog_rate_limit.py`;
   test now passes.
3. Verified on a DUT that emits the "begin to drop messages" form to
   confirm no regression on the older-message path

#### Any platform specific information?
No. The fix is rsyslogd-version-driven and applies to all platforms.

#### Supported testbed topology if it's a new test case?
N/A — bug fix for existing test (`topology("any")`).

### Documentation
N/A
