### PR TITLE
[sub_port_interfaces]: Resolve PTF neighbors before sending test traffic

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -288,6 +288,14 @@ def apply_route_config(request, tbinfo, duthost, ptfhost, port_type, define_sub_
 
             new_sub_ports[src_port].append((next_hop_sub_port, name_of_namespace))
 
+    # Make sure the DUT has resolved the PTF neighbors before any traffic is sent.
+    # Otherwise the first packet of a test may be lost while the neighbor is still
+    # being resolved, and the traffic helpers do not retry.
+    for src_port, next_hop_sub_ports in list(new_sub_ports.items()):
+        update_dut_arp_table(duthost, sub_ports[src_port]['neighbor_ip'].split('/')[0])
+        for next_hop_sub_port, _ in next_hop_sub_ports:
+            update_dut_arp_table(duthost, sub_ports[next_hop_sub_port]['neighbor_ip'].split('/')[0])
+
     yield {
         'new_sub_ports': new_sub_ports,
         'sub_ports': sub_ports
@@ -401,6 +409,14 @@ def apply_route_config_for_port(request, tbinfo, duthost, ptfhost, port_type, de
             add_static_route_to_ptf(ptfhost, dst_port_network, dut_port_ip)
 
             port_map[ptf_port]['dst_ports'].append((next_hop_sub_port, name_of_namespace))
+
+    # Make sure the DUT has resolved the PTF neighbors before any traffic is sent.
+    # Otherwise the first packet of a test may be lost while the neighbor is still
+    # being resolved, and the traffic helpers do not retry.
+    for port_data in list(port_map.values()):
+        update_dut_arp_table(duthost, port_data['ip'].split('/')[0])
+        for next_hop_sub_port, _ in port_data['dst_ports']:
+            update_dut_arp_table(duthost, sub_ports[next_hop_sub_port]['neighbor_ip'].split('/')[0])
 
     yield {
         'port_map': port_map,

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -36,6 +36,7 @@ TCP_PORT = 80
 UDP_PORT = 161
 BALANCING_TEST_TIMES = 625
 DEFAULT_BALANCING_RANGE = 0.25
+NEIGHBOR_RESOLUTION_TIMEOUT = 30
 
 
 def create_packet(eth_dst, eth_src, ip_dst, ip_src, vlan_vid, tr_type, ttl, dl_vlan_enable=False,
@@ -1070,7 +1071,11 @@ def update_dut_arp_table(duthost, ip):
         duthost: DUT host object
         ip: IP address of directly connected interface
     """
-    duthost.command("ping {} -c 3".format(ip), module_ignore_errors=True)
+    def _is_reachable():
+        return duthost.command("ping {} -c 1 -W 1".format(ip), module_ignore_errors=True)['rc'] == 0
+
+    if not wait_until(NEIGHBOR_RESOLUTION_TIMEOUT, 2, 0, _is_reachable):
+        logger.warning("Neighbor %s was not resolved within %s seconds", ip, NEIGHBOR_RESOLUTION_TIMEOUT)
 
 
 def check_balancing(port_hit_cnt):


### PR DESCRIPTION
### Description of PR

`tests/sub_port_interfaces/test_sub_port_interfaces.py` is intermittently flaky. A run fails with

```
Failed: Expected packet not available:
False
```

on the very first packet sent to the first destination sub-port, and the identical case passes on retry.

This is a test-side race, not a data plane bug. It is platform agnostic.

**Summary: Fixes # (issue)** — no issue filed; found while enabling this module on a new platform.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach

#### What is the motivation for this PR?

The traffic helpers give the DUT a fixed, very small budget and never retry:

```python
# sub_ports_helpers.py :: generate_and_verify_tcp_udp_traffic
ptfadapter.dataplane.flush()
time.sleep(1)
testutils.send_packet(...)          # exactly one packet

# common/pkt_filter/filter_pkt_in_buffer.py :: __find_pkt_in_buffer
time.sleep(3)                       # single shot, no polling
```

So a case has roughly 3 seconds for the DUT to receive, route and forward that one packet.

That budget is fine once the neighbor is resolved. But `apply_route_config` and `apply_route_config_for_port` rebuild the PTF namespaces and the ingress RIF/SVI and then `yield` immediately, with no convergence wait. The first packet of the test therefore races neighbor resolution — the DUT must punt it, ARP the PTF, learn the neighbor, and only then forward. When that slow path exceeds the 3 second budget the packet is lost and the case fails.

Both fixtures also select their sub-ports with `random.sample()`, so the set of already-resolved neighbors differs run to run. That is what makes the failure appear random.

Note that this module **already has the right pattern** — `apply_balancing_config` calls `update_dut_arp_table()` for every PTF `neighbor_ip` before its tests run. The other two route fixtures simply never got the same treatment.

#### How did you do it?

1. **`conftest.py`** — `apply_route_config` and `apply_route_config_for_port` now resolve the PTF neighbors they just configured before yielding, exactly as `apply_balancing_config` already does.

2. **`sub_ports_helpers.py`** — `update_dut_arp_table()` used a blind `ping -c 3` whose result was discarded, so it could return before the neighbor was actually resolved. It now polls until the address answers, up to `NEIGHBOR_RESOLUTION_TIMEOUT` (30s), and logs a warning rather than failing if it does not.

   Using *reachability* as the predicate keeps this safe for every caller: some existing call sites pass a DUT-local address rather than a PTF neighbor, and those answer instantly instead of blocking. When the neighbor is already resolved the first ping succeeds and the call returns immediately, so the normal path costs nothing.

#### How did you verify/test it?

Whole module on a KVM testbed, before and after:

| | result | duration |
|---|---|---|
| before | 29 passed, 3 skipped, 0 failed | 1764s |
| after | 29 passed, 3 skipped, 0 failed | 1721s |

164 warm-up pings were issued across the run and **every one succeeded on the first attempt**, so no case ever waited on the new timeout — hence the runtime is unchanged (in fact marginally faster, within run-to-run noise).

The case that had been failing intermittently, `test_routing_between_sub_ports_and_port[port-l3-TCP-UDP-ICMP]`, passed both standalone and in the full run.

#### Any platform specific information?

No. The change is platform agnostic and touches only the `sub_port_interfaces` fixtures.
