### PR TITLE
[cisco] Correct test assumptions for VoQ CGM drop-probability for various NPUs

### DIFF
--- a/tests/qos/test_ecn_config.py
+++ b/tests/qos/test_ecn_config.py
@@ -100,6 +100,14 @@ def verify_command_result(result, cmd):
     assert not traceback_found, "Traceback found in {}".format(cmd)
 
 
+def is_availability_based_hwsku(duthost):
+    # G200X (Cisco-8122) reports the drop table by pool AVAILABILITY rather than
+    # OCCUPANCY. On availability-based hwskus, global region 0 (lowest
+    # availability) drops every VoQ. Occupancy-based hwskus (Q200 default, etc.)
+    # drop only at the last VoQ quant.
+    return "Cisco-8122" in duthost.facts["hwsku"]
+
+
 @pytest.mark.disable_loganalyzer
 def test_verify_ecn_marking_config(duthosts, rand_one_dut_hostname, request):
     """
@@ -259,13 +267,20 @@ def test_verify_ecn_marking_config(duthosts, rand_one_dut_hostname, request):
                                          '''.format(port, pg_to_test, g_idx, voq_idx,
                                                     age_idx, raw_value, mark_list)
 
-                ''' Verify drop is 7 for last quant only'''
+                ''' Verify drop is 7 at the last VoQ quant. On availability-based
+                    hwskus, global region 0 (lowest availability) also drops
+                    every VoQ; occupancy-based hwskus drop only at the last
+                    VoQ quant. '''
                 if voq_drop_data:
+                    availability_based = is_availability_based_hwsku(duthost)
                     for g_idx in range(sms_quant_len):
                         for voq_idx in range(voq_quant_len):
                             for age_idx in range(age_quant_len):
                                 actual_value = voq_drop_data[g_idx][voq_idx][age_idx]
-                                expected_value = 7 if voq_idx == (voq_quant_len - 1) else 0
+                                if (availability_based and g_idx == 0) or voq_idx == (voq_quant_len - 1):
+                                    expected_value = 7
+                                else:
+                                    expected_value = 0
                                 assert (
                                         actual_value == expected_value
                                 ), '''

--- a/tests/qos/test_ecn_config.py
+++ b/tests/qos/test_ecn_config.py
@@ -101,11 +101,7 @@ def verify_command_result(result, cmd):
 
 
 def is_availability_based_hwsku(duthost):
-    # G200X (Cisco-8122) reports the drop table by pool AVAILABILITY rather than
-    # OCCUPANCY. On availability-based hwskus, global region 0 (lowest
-    # availability) drops every VoQ. Occupancy-based hwskus (Q200 default, etc.)
-    # drop only at the last VoQ quant.
-    return "Cisco-8122" in duthost.facts["hwsku"]
+    return any(npu in duthost.facts["hwsku"] for npu in ["Cisco-8122", "Cisco-8223"])
 
 
 @pytest.mark.disable_loganalyzer


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (internal to Cisco)

`test_verify_ecn_marking_config` (in `tests/qos/test_ecn_config.py`) validates the per-cell VoQ CGM drop-probability table returned by `show platform npu voq cgm_profile -d`. The drop check assumed a single, occupancy-based CGM layout where drop level 7 appears only at the last VoQ quant.

This PR makes the drop check ASIC-aware while preserving the existing behavior other ASICs.


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511
- [X] 202512
- [X] 202605


Failure type: day-one issue (test never accounted for the availability-based CGM layout)

### Approach
#### What is the motivation for this PR?

On `Cisco-8122*`, `test_verify_ecn_marking_config` fails the drop-probability assertion even though the ASIC is configured correctly, due to hard-coded expectations. 

#### How did you do it?

- Added a small helper to identify availability-based hwskus.
- In the drop check, on availability-based hwskus the expected value is drop level 7 for global region 0 (every VoQ) in addition to the last VoQ quant. Occupancy-based hwskus keep the original expectation.


#### How did you verify/test it?

- Ran `qos/test_ecn_config.py::test_verify_ecn_marking_config` on a `Cisco-8122X` testbed: the test passes with the fix.
- Cross-checked the raw `show platform npu voq cgm_profile -d` output for various ASICs to confirm the drop patterns.
- flake8 clean (`--max-line-length=120`).

#### Any platform specific information?

- Applies to Cisco 8000 (Silicon One) platforms only. The test already skips Broadcom devices and HBM-based devices.

#### Supported testbed topology if it's a new test case?

- Not a new test case. Existing test, marked `topology('any')`.

### Documentation

Tested against fork of master, SHA 59d8254de - Pass on Cisco-8101, Cisco-8122, Cisco-8223
