### PR TITLE
Fix TypeError in extract_log

### DIFF
--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -169,7 +169,7 @@ def convert_date(fct, s):
     locale.setlocale(locale.LC_ALL, loc)
 
     if dt is None:
-        dt = 0
+        dt = datetime.datetime.min
         logger.warning(f"Failed to convert date from string, skipping unparseable line: {s}")
     return dt
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In ansible/library/extract_log.py::convert_date, the returned datetime value defaults to int(0) if the datetime cannot be parsed from the passed logstring.  This may cause a TypeError on comparison as datetime objects are not directly comparable with integers.

For cases where the datetime cannot be parsed or converted, return datetime.datetime.min.  This preserves the functionality of the comparator operator and still provides a reasonable failure marker.

This was fixed in master as part of https://github.com/sonic-net/sonic-mgmt/pull/23725.  This PR only includes the one fix in the interests of target merges and overall release branch stability.

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
- master: Fix is already present.
- 202605: Verified that crm/test_crm.py no longer throws TypeError in internal testing.

### Approach
#### What is the motivation for this PR?
Remove potential for TypeError as a result of inability to convert a logging timestamp.  

#### How did you do it?
The minimum flag-value for the failure to convert a timestamp is now a timestamp.timestamp.min instance, which is comparable with other timestamp objects.

#### How did you verify/test it?
Verified that crm/test_crm.py no longer throws TypeError.
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
