### PR TITLE
Test_BGP_Update_Timer - T2 Update

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -263,19 +263,19 @@ def restore_bgp_neighbors(duthost, asic_index, bgp_neighbors):
 
 
 def is_neighbor_sessions_established(duthost, neighbors):
-    is_established = True
-
-    # handle both multi-asic and single-asic
-    bgp_facts = duthost.bgp_facts(num_npus=duthost.sonichost.num_asics())[
-        "ansible_facts"
-    ]
     for neighbor in neighbors:
-        is_established &= (
-            neighbor.ip in bgp_facts["bgp_neighbors"]
-            and bgp_facts["bgp_neighbors"][neighbor.ip]["state"] == "established"
-        )
-
-    return is_established
+        namespace = getattr(neighbor, "namespace", None)
+        if duthost.is_multi_asic:
+            asic_index = duthost.asic_instance_from_namespace(namespace).asic_index
+            bgp_facts = duthost.bgp_facts(instance_id=asic_index)["ansible_facts"]
+        else:
+            bgp_facts = duthost.bgp_facts()["ansible_facts"]
+        if (
+            neighbor.ip not in bgp_facts["bgp_neighbors"]
+            or bgp_facts["bgp_neighbors"][neighbor.ip]["state"] != "established"
+        ):
+            return False
+    return True
 
 
 @pytest.fixture(scope='module')

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -18,6 +18,7 @@ from tests.bgp.bgp_helpers import (
         check_routes_presence
 )
 from tests.common.helpers.bgp import BGPNeighbor
+from tests.common.helpers.bgp import _shutdown_bgp_neighbor_with_vtysh
 from tests.common.utilities import wait_until, delete_running_config
 from tests.common.utilities import is_ipv6_only_topology
 
@@ -129,6 +130,14 @@ def _remove_outbound_route_filter(duthost, dut_asn, neighbor_ips, is_v6, namespa
 
     cmd = "vtysh {} {}".format(ns_option, " ".join("-c '{}'".format(c) for c in vtysh_cmds))
     duthost.shell(cmd, module_ignore_errors=True)
+
+
+def _flush_routes(duthost, routes, namespace):
+    for route in routes:
+        cmd = duthost.get_linux_ip_cmd_for_namespace(
+            "ip route flush {}".format(route["prefix"]), namespace
+        )
+        duthost.shell(cmd, module_ignore_errors=True)
 
 
 @pytest.fixture
@@ -536,8 +545,7 @@ def test_bgp_update_timer_single_route(
         _remove_outbound_route_filter(
             duthost, n0.peer_asn, [n0.ip, n1.ip], is_v6_topo, n0.namespace
         )
-        for route in constants.routes:
-            duthost.shell("ip route flush %s" % route["prefix"])
+        _flush_routes(duthost, constants.routes, n0.namespace)
 
 
 def test_bgp_update_timer_session_down(
@@ -588,17 +596,11 @@ def test_bgp_update_timer_session_down(
         def _shutdown_bgp_session():
             """Shutdown bgp session on dut."""
             if use_vtysh:
-                dut_asn = n0.peer_asn
-                neigh_ip = n0.ip
-                cmd = (
-                    "vtysh "
-                    "-c 'configure terminal' "
-                    f"-c 'router bgp {dut_asn}' "
-                    f"-c 'neighbor {neigh_ip} shutdown' ")
-            else:
-                cmd = "config bgp shutdown neighbor {}".format(n0.name)
-
-            return duthost.shell(cmd)
+                _shutdown_bgp_neighbor_with_vtysh(
+                    duthost, n0.ip, n0.peer_asn, namespace=n0.namespace
+                )
+                return duthost.shell("true")
+            return duthost.shell("config bgp shutdown neighbor {}".format(n0.name))
 
         with capture_bgp_packages_to_file(duthost, "any", bgp_pcap, n0.namespace):
             result = _shutdown_bgp_session()
@@ -646,5 +648,4 @@ def test_bgp_update_timer_session_down(
         _remove_outbound_route_filter(
             duthost, n0.peer_asn, [n0.ip, n1.ip], is_v6_topo, n0.namespace
         )
-        for route in constants.routes:
-            duthost.shell("ip route flush %s" % route["prefix"])
+        _flush_routes(duthost, constants.routes, n0.namespace)

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -32,7 +32,7 @@ from tests.common.helpers.constants import DEFAULT_NAMESPACE
 
 
 pytestmark = [
-    pytest.mark.topology("any", "t1-multi-asic"),
+    pytest.mark.topology("any", "t1-multi-asic", "t0", "t1", "t1-lag", "t1-8-lag", "t2"),
 ]
 
 PEER_COUNT = 2

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -116,7 +116,7 @@ def _config_bgp_neighbor_with_vtysh(duthost, peer_addr, peer_asn, dut_addr, dut_
         "-c 'router bgp {dut_asn}' "
         "-c 'neighbor {peer_addr} remote-as {peer_asn}' "
         "-c 'neighbor {peer_addr} activate' "
-    ).format(peer_addr=peer_addr, peer_asn=peer_asn, dut_addr=dut_addr, dut_asn=dut_asn)
+    ).format(peer_addr=peer_addr, peer_asn=peer_asn, dut_asn=dut_asn)
     duthost.shell(_vtysh_cmd(duthost, namespace, cmd))
 
 

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -103,7 +103,12 @@ def _write_variable_from_j2_to_configdb(duthost, template_file, **kwargs):
         duthost.file(path=save_dest_path, state="absent")
 
 
-def _config_bgp_neighbor_with_vtysh(duthost, peer_addr, peer_asn, dut_addr, dut_asn):
+def _vtysh_cmd(duthost, namespace, body):
+    """Build a namespace-scoped vtysh command string."""
+    return duthost.get_vtysh_cmd_for_namespace(body, namespace)
+
+
+def _config_bgp_neighbor_with_vtysh(duthost, peer_addr, peer_asn, dut_addr, dut_asn, namespace=None):
     """Configure BGP neighbor using vtysh command"""
     cmd = (
         "vtysh "
@@ -111,35 +116,30 @@ def _config_bgp_neighbor_with_vtysh(duthost, peer_addr, peer_asn, dut_addr, dut_
         "-c 'router bgp {dut_asn}' "
         "-c 'neighbor {peer_addr} remote-as {peer_asn}' "
         "-c 'neighbor {peer_addr} activate' "
-    )
-    duthost.shell(cmd.format(peer_addr=peer_addr,
-                             peer_asn=peer_asn,
-                             dut_addr=dut_addr,
-                             dut_asn=dut_asn))
+    ).format(peer_addr=peer_addr, peer_asn=peer_asn, dut_addr=dut_addr, dut_asn=dut_asn)
+    duthost.shell(_vtysh_cmd(duthost, namespace, cmd))
 
 
-def _remove_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn):
+def _remove_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn, namespace=None):
     """Remove BGP neighbor using vtysh command"""
     cmd = (
         "vtysh "
         "-c 'configure terminal' "
         "-c 'router bgp {dut_asn}' "
         "-c 'no neighbor {peer_addr}' "
-    )
-    duthost.shell(cmd.format(peer_addr=peer_addr,
-                             dut_asn=dut_asn))
+    ).format(peer_addr=peer_addr, dut_asn=dut_asn)
+    duthost.shell(_vtysh_cmd(duthost, namespace, cmd))
 
 
-def _shutdown_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn):
+def _shutdown_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn, namespace=None):
     """Shutdown BGP neighbor using vtysh command"""
     cmd = (
         "vtysh "
         "-c 'configure terminal' "
         "-c 'router bgp {dut_asn}' "
         "-c 'neighbor {peer_addr} shutdown' "
-    )
-    duthost.shell(cmd.format(peer_addr=peer_addr,
-                             dut_asn=dut_asn))
+    ).format(peer_addr=peer_addr, dut_asn=dut_asn)
+    duthost.shell(_vtysh_cmd(duthost, namespace, cmd))
 
 
 def run_bgp_facts(duthost, enum_asic_index):
@@ -252,7 +252,8 @@ class BGPNeighbor(object):
                 peer_addr=self.ip,
                 peer_asn=self.asn,
                 dut_addr=self.peer_ip,
-                dut_asn=self.peer_asn
+                dut_asn=self.peer_asn,
+                namespace=self.namespace,
             )
         elif not self.is_passive:
             _write_variable_from_j2_to_configdb(
@@ -301,7 +302,9 @@ class BGPNeighbor(object):
                 "-c 'neighbor %s ebgp-multihop'"
             )
             allow_ebgp_multihop_cmd %= (self.peer_asn, self.ip)
-            self.duthost.shell(allow_ebgp_multihop_cmd)
+            self.duthost.shell(
+                _vtysh_cmd(self.duthost, self.namespace, allow_ebgp_multihop_cmd)
+            )
 
     def stop_session(self):
         """Stop the BGP session."""
@@ -311,12 +314,13 @@ class BGPNeighbor(object):
             _remove_bgp_neighbor_with_vtysh(
                 self.duthost,
                 peer_addr=self.ip,
-                dut_asn=self.peer_asn
+                dut_asn=self.peer_asn,
+                namespace=self.namespace,
             )
         elif not self.is_passive:
-            for asichost in self.duthost.asics:
-                asichost.run_sonic_db_cli_cmd("CONFIG_DB del 'BGP_NEIGHBOR|{}'".format(self.ip))
-                asichost.run_sonic_db_cli_cmd("CONFIG_DB del 'DEVICE_NEIGHBOR_METADATA|{}'".format(self.name))
+            asichost = self.duthost.asic_instance_from_namespace(self.namespace)
+            asichost.run_sonic_db_cli_cmd("CONFIG_DB del 'BGP_NEIGHBOR|{}'".format(self.ip))
+            asichost.run_sonic_db_cli_cmd("CONFIG_DB del 'DEVICE_NEIGHBOR_METADATA|{}'".format(self.name))
 
         self.ptfhost.exabgp(name=self.name, state="absent")
 
@@ -340,7 +344,8 @@ class BGPNeighbor(object):
             _shutdown_bgp_neighbor_with_vtysh(
                 self.duthost,
                 peer_addr=self.ip,
-                dut_asn=self.peer_asn
+                dut_asn=self.peer_asn,
+                namespace=self.namespace,
             )
         elif not self.is_passive:
             for asichost in self.duthost.asics:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
@@ -68,11 +68,6 @@ bgp/test_bgp_suppress_fib.py:
     conditions:
     - asic_type in ['vs'] and 't2' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
-bgp/test_bgp_update_timer.py:
-  skip:
-    conditions:
-    - asic_type in ['vs'] and 't2' in topo_name
-    reason: This test case either cannot pass or should be skipped on virtual chassis
 bgp/test_bgpmon.py:
   skip:
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable `test_bgp_update_timer.py` on VS T2 virtual chassis by making BGP neighbor setup, session checks, shutdown, and cleanup use the correct ASIC namespace on multi-ASIC DUTs.

Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
N/A

### Approach
#### What is the motivation for this PR?

`test_bgp_update_timer.py` was skipped on VS T2 because parts of the test still assumed a single BGP instance. On T2, peers live in a specific ASIC namespace, so neighbor config, session checks, shutdown, and route cleanup need to target that namespace.

The test already worked on T0/T1; this change extends the same checks to T2.

#### How did you do it?
- Updated shared `BGPNeighbor` vtysh helpers to run in the peer’s namespace.
- Scoped CONFIG_DB cleanup in `BGPNeighbor.stop_session()` to the peer’s ASIC only.
- Updated `is_neighbor_sessions_established()` to check BGP state on the correct ASIC on multi-ASIC DUTs.
- In `test_bgp_update_timer.py`: use namespace-scoped neighbor shutdown (vtysh path), namespace-scoped route flush in cleanup
- Removed the VS T2 skip for this test.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
- Code verification  on the changed files.
- T0/T1 behavior unchanged when `namespace` is default (single-ASIC / existing CONFIG_DB path).
- Test runs on Github checkers / pipeline to validate.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A