### PR TITLE
[bgp update timer] Add neighbor type handling for LowerMgmtAggregator

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -203,6 +203,14 @@ def common_setup_teardown(
         neigh_type = "LowerRegionalHub"
         if confed_asn is not None:
             use_vtysh = True
+    elif dut_type in ["LowerMgmtAggregator"]:
+        neigh_type = "MgmtSpineRouter"
+        if confed_asn is not None:
+            use_vtysh = True
+    elif dut_type in ["UpperMgmtAggregator"]:
+        neigh_type = "LowerMgmtAggregator"
+        if confed_asn is not None:
+            use_vtysh = True
     else:
         neigh_type = "ToRRouter"
 


### PR DESCRIPTION
### Description of PR

Summary:
`test_bgp_update_timer.py` is marked `topology("any")`, so it also runs on mgmt-aggregator
(LMA/UMA) testbeds. `common_setup_teardown` maps the DUT's minigraph `dut_type` to the
pseudo-neighbor type, but had no branch for `LowerMgmtAggregator` / `UpperMgmtAggregator` —
both fell through to the `else` and got `neigh_type = "ToRRouter"` with `use_vtysh = False`.
That is not the aggregator's real peer type, and these topologies run BGP confederation, so
the neighbor must be programmed via vtysh (same as FT2 / LRH / URH).

Fixes # (issue)

### Type of change

- [x] Test case improvement

### Tested branch

- [x] master

### Test result

<!-- fill in: image version + result on an LMA and a UMA testbed -->

### Approach

#### What is the motivation for this PR?

Make the update-timer measurement valid on mgmt-aggregator testbeds instead of silently
falling back to the `ToRRouter` path.

#### How did you do it?

Added two `elif` branches following the existing `UpperRegionalHub -> LowerRegionalHub`
pattern — map each DUT to its real *downstream* peer type, and use vtysh when a confederation
ASN is present:

| DUT `dut_type`        | `neigh_type`          |
| --------------------- | --------------------- |
| `LowerMgmtAggregator` | `MgmtSpineRouter`     |
| `UpperMgmtAggregator` | `LowerMgmtAggregator` |

No behavior change for existing topologies — the new branches are only reachable for the two
aggregator types that previously hit the `else` fallback.

#### How did you verify/test it?

<!-- fill in -->

#### Any platform specific information?

No — keys off topology-derived `dut_type` only.

### Dependency

Depends on #26723 (must merge first): `common_setup_teardown` uses the `setup_interfaces`
fixture, which raises `TypeError: Unsupported topology: lma` until #26723 adds lma/uma.
Related: #26639.