### PR TITLE
[process_monitoring]: Wait for services after DB recovery

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -504,12 +504,6 @@ class SonicHost(AnsibleHostBase):
                 && cat /etc/supervisor/critical_processes'".format(container_name)
         file_content = self.shell(cmd, module_ignore_errors=True)
         file_content = self._retry_if_oci_exec_race(cmd, file_content)
-        if file_content.get("rc", 1) != 0:
-            logging.warning(
-                "Reading critical_processes from container '%s' failed: rc=%s, stderr=%s",
-                container_name, file_content.get("rc"), file_content.get("stderr"))
-            return critical_group_list, critical_process_list, False
-
         for line in file_content["stdout_lines"]:
             line_info = line.strip().split(':')
             if len(line_info) != 2:

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -504,6 +504,12 @@ class SonicHost(AnsibleHostBase):
                 && cat /etc/supervisor/critical_processes'".format(container_name)
         file_content = self.shell(cmd, module_ignore_errors=True)
         file_content = self._retry_if_oci_exec_race(cmd, file_content)
+        if file_content.get("rc", 1) != 0:
+            logging.warning(
+                "Reading critical_processes from container '%s' failed: rc=%s, stderr=%s",
+                container_name, file_content.get("rc"), file_content.get("stderr"))
+            return critical_group_list, critical_process_list, False
+
         for line in file_content["stdout_lines"]:
             line_info = line.strip().split(':')
             if len(line_info) != 2:

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -15,6 +15,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common.reboot import wait_for_startup
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
+from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import pdu_reboot, wait_until, kill_process_by_pid
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, NAMESPACE_PREFIX
 from tests.common.helpers.dut_utils import get_program_info
@@ -651,7 +652,10 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
         wait_for_startup(duthost, localhost, delay=10, timeout=timeout)
         logger.info("SSH is up, waiting for critical processes...")
 
-        # Wait for all critical processes to be healthy
+        # SSH can become available before the SONiC containers are ready.
+        wait_critical_processes(duthost)
+
+        # Restore any process intentionally stopped by the test.
         ensure_all_critical_processes_running(duthost, containers_in_namespaces)
         logger.info("All critical processes are running")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Summary:
Wait for SONiC services to recover after the database-container power cycle before restoring processes and running module teardown.

Fixes # (no issue filed; related to #25032)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->



### Approach
#### What is the motivation for this PR?

On 202605, `test_monitoring_critical_processes` power-cycles the DUT after testing the database container. Recovery waits only for SSH before calling `ensure_all_critical_processes_running()`, which is a one-shot process restoration function rather than a readiness poll.

SSH can become available before the database and other SONiC containers are ready. A failed `docker exec` can also return empty process lists that are interpreted as healthy. Recovery may then proceed to interface checks and the module-scoped `config_reload`, causing teardown errors reported against `test_orchagent_heartbeat`.

#### How did you do it?

After SSH returns, call the existing `wait_critical_processes()` helper before restoring processes intentionally stopped by the test.

Also check the result of reading `/etc/supervisor/critical_processes` after the existing OCI runtime retry. A remaining nonzero return code is reported as a failed process-list read instead of being treated as an empty healthy list.

#### How did you verify/test it?

- `python3 -m py_compile tests/process_monitoring/test_critical_process_monitoring.py tests/common/devices/sonic.py`
- `git diff --check`

#### Any platform specific information?
The affected path is used when the database container is included in critical-process monitoring and recovery requires a DUT power cycle. 
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A