### PR TITLE
[drop_packets] Fix flaky _check_drops_on_dut when background traffic pre-empts counter

### DIFF
--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -123,7 +123,8 @@ def verify_drop_counters(duthosts, asic_index, dut_iface, get_cnt_cli_cmd, colum
         return drop_list
 
     def _check_drops_on_dut():
-        return packets_count in _get_drops_across_all_duthosts()
+        actual_drops = _get_drops_across_all_duthosts()
+        return max(actual_drops, default=0) >= packets_count
 
     if not wait_until(25, 1, 0, _check_drops_on_dut):
         # We were seeing a few more drop counters than expected, so we are allowing a small margin of error


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
During drop packets tests, unexpected drops are a known phenomenon([drop_counters.py:129](https://github.com/sonic-net/sonic-mgmt/blob/d99727d1cfe50bc86612ef2a3bc0f932f7e1f2d3/tests/common/helpers/drop_counters/drop_counters.py#L129)):
```
# We were seeing a few more drop counters than expected, so we are allowing a small margin of error
# The max number of unexpected drop we see equals to the number of vlan members in t0 topology
```
 
Exact equality check `packets_count in drops` fails when background traffic (e.g. NDP/ICMPv6 from VLAN members) causes the counter to skip over the expected value before the first poll.
Replace with `max(drops) >= packets_count` so the poll succeeds as soon as the counter reaches or exceeds the sent count. The existing DROP_MARGIN fallback still catches excessive over-drop.


<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
Stabilize the test

#### How did you do it?
Using >= operation instead of exact equality check for dropped packets.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Test executed several times on testbed when previously failed.

