### PR TITLE
add retries due to eth0 appear delay

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -326,26 +326,36 @@ def verify_lldp_table(duthost, intf_status_output, test_name=""):
     context = " {}".format(test_name) if test_name else ""
     logger.info("Verifying LLDP table{}".format(context))
 
-    # Get LLDP table output using show_and_parse for robust parsing
-    lldp_table_parsed = duthost.show_and_parse("show lldp table")
-    lldp_table_interfaces = set()
-    for entry in lldp_table_parsed:
-        interface = entry.get('localport', '')
-        # Filter out separator/footer lines that show_and_parse may include
-        if interface and not interface.startswith('-') and not interface.startswith('Total'):
-            lldp_table_interfaces.add(interface)
+    def _parse_lldp_table():
+        # Get LLDP table output using show_and_parse for robust parsing
+        lldp_table_parsed = duthost.show_and_parse("show lldp table")
+        ifaces = set()
+        for entry in lldp_table_parsed:
+            interface = entry.get('localport', '')
+            # Filter out separator/footer lines that show_and_parse may include
+            if interface and not interface.startswith('-') and not interface.startswith('Total'):
+                ifaces.add(interface)
+        return ifaces
 
-    logger.info("LLDP table interfaces{}: {}".format(context, sorted(lldp_table_interfaces)))
-    logger.info("LLDP table interfaces in total: {}".format(len(lldp_table_interfaces)))
+    lldp_table_interfaces = set()
+
+    def _eth0_in_lldp_table():
+        nonlocal lldp_table_interfaces
+        lldp_table_interfaces = _parse_lldp_table()
+        return 'eth0' in lldp_table_interfaces
 
     # On virtual/KVM testbeds, eth0 has no LLDP neighbor so it won't appear in the LLDP table
     if is_virtual_platform(duthost):
+        lldp_table_interfaces = _parse_lldp_table()
         if 'eth0' not in lldp_table_interfaces:
             logger.info("eth0 not in LLDP table (expected on virtual/KVM testbed){}"
                         .format(context))
     else:
-        pytest_assert('eth0' in lldp_table_interfaces,
+        pytest_assert(wait_until(10, 1, 0, _eth0_in_lldp_table),
                       "eth0 is missing from LLDP table{}".format(context))
+
+    logger.info("LLDP table interfaces{}: {}".format(context, sorted(lldp_table_interfaces)))
+    logger.info("LLDP table interfaces in total: {}".format(len(lldp_table_interfaces)))
 
     # For LLDP table comparison: exclude eth0 from lldp_table, exclude PortChannels and admin down from intf_status
     lldp_table_interfaces_no_eth0 = lldp_table_interfaces - {'eth0'}


### PR DESCRIPTION
### Description of PR

After the config-reload, when doing test using `show lldp table`, eth0 does not occur due to the lldp-syncd delay, after several seconds it appears but the test fails. It fails with probability, add retries for some flexibilities. 

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
tested and passd on 202605

### Approach
#### What is the motivation for this PR?
Fix a flaky test
#### How did you do it?
Add retries to prevent single time verification
#### How did you verify/test it?
Run the test with fix 10+ times, none of them fails
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
