### PR TITLE
[dhcp_server]: Restore relay after DHCP server cleanup

### DIFF
--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -90,8 +90,12 @@ def dhcp_server_setup_teardown(duthost):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def clean_dhcp_server_config_after_test(duthost):
+def clean_dhcp_server_config_after_test(duthost, request):
     clean_dhcp_server_config(duthost)
+
+    if "enable_sonic_dhcpv4_relay_agent" in request.fixturenames:
+        # Make relay restoration run after DHCP server configuration cleanup.
+        request.getfixturevalue("enable_sonic_dhcpv4_relay_agent")
 
     yield
 


### PR DESCRIPTION
### Description of PR

Summary:
Fix DHCP server test teardown ordering by making the existing cleanup fixture depend on the SONiC DHCPv4 relay fixture when requested. This removes local DHCP server ownership before ISC relay and dhcpmon restoration checks run.

ADO: https://dev.azure.com/msazure/One/_workitems/edit/39059919

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/39059919
Failure type: regression

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: isolated pytest fixture-order regression check passed (2 tests); repository pre-commit checks passed.
- 202605: affected failure observed in 720DT mx nightly `720dt.mx.202605_NightlyTest_20260801.1`; target-branch fix validation is pending.

### Approach
#### What is the motivation for this PR?

DHCP server tests pass their test bodies but fail in teardown because the relay fixture attempts to restore ISC relay and dhcpmon while `DHCP_SERVER_IPV4` still owns the VLAN. The services correctly remain stopped, and the stricter readiness check reports an error for each test.

#### How did you do it?

The existing autouse DHCP server cleanup fixture dynamically initializes `enable_sonic_dhcpv4_relay_agent` only for tests that already request it. This establishes a pytest dependency so DHCP server configuration cleanup runs first during teardown, followed by relay restoration and readiness validation.

#### How did you verify/test it?

Verified pytest dynamic fixture teardown ordering with an isolated regression check and ran the repository pre-commit checks for the modified file.

#### Any platform specific information?

The regression was observed on Arista 720DT-G48S4 mx nightlies, but the fixture ordering fix is platform independent.

#### Supported testbed topology if it is a new test case?

N/A

### Documentation

N/A