### PR TITLE
[dualtor][active-active] Support config mux mode all

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1886,8 +1886,10 @@ def config_active_active_dualtor_active_standby(duthosts, active_active_ports, t
 
 
 @pytest.fixture
-def toggle_all_aa_ports_to_lower_tor(config_active_active_dualtor_active_standby,
-                                     lower_tor_host, upper_tor_host, active_active_ports, active_standby_ports):  # noqa: F811
+def toggle_all_aa_ports_to_lower_tor(
+    config_active_active_dualtor_active_standby,
+    lower_tor_host, upper_tor_host, active_active_ports, active_standby_ports  # noqa: F811
+):
     if active_active_ports:
         ports_to_config = active_active_ports if active_standby_ports else "all"
         config_active_active_dualtor_active_standby(lower_tor_host, upper_tor_host, ports_to_config)
@@ -1895,8 +1897,10 @@ def toggle_all_aa_ports_to_lower_tor(config_active_active_dualtor_active_standby
 
 
 @pytest.fixture
-def toggle_all_aa_ports_to_rand_selected_tor(config_active_active_dualtor_active_standby, rand_selected_dut,
-                                             rand_unselected_dut, active_active_ports, active_standby_ports):  # noqa: F811
+def toggle_all_aa_ports_to_rand_selected_tor(
+    config_active_active_dualtor_active_standby, rand_selected_dut,
+    rand_unselected_dut, active_active_ports, active_standby_ports  # noqa: F811
+):
     if active_active_ports:
         ports_to_config = active_active_ports if active_standby_ports else "all"
         config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, ports_to_config)
@@ -1904,8 +1908,10 @@ def toggle_all_aa_ports_to_rand_selected_tor(config_active_active_dualtor_active
 
 
 @pytest.fixture
-def toggle_all_aa_ports_to_rand_unselected_tor(config_active_active_dualtor_active_standby, rand_selected_dut,
-                                               rand_unselected_dut, active_active_ports, active_standby_ports):  # noqa: F811
+def toggle_all_aa_ports_to_rand_unselected_tor(
+    config_active_active_dualtor_active_standby, rand_selected_dut,
+    rand_unselected_dut, active_active_ports, active_standby_ports  # noqa: F811
+):
     if active_active_ports:
         ports_to_config = active_active_ports if active_standby_ports else "all"
         config_active_active_dualtor_active_standby(rand_unselected_dut, rand_selected_dut, ports_to_config)

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1702,6 +1702,8 @@ def check_active_active_port_status(duthost, ports, status):
     logging.debug("Check mux status for ports {} is {}".format(ports, status))
     show_mux_status_ret = show_muxcable_status(duthost)
     logging.debug("show_mux_status_ret: {}".format(json.dumps(show_mux_status_ret, indent=4)))
+    if ports == "all":
+        ports = list(show_mux_status_ret.keys())
     for port in ports:
         if port not in show_mux_status_ret:
             return False
@@ -1712,7 +1714,7 @@ def check_active_active_port_status(duthost, ports, status):
 
 @pytest.fixture
 def validate_active_active_dualtor_setup(
-        duthosts, active_active_ports, ptfhost, tbinfo, restart_nic_simulator):  # noqa: F811
+        duthosts, active_active_ports, active_standby_ports, ptfhost, tbinfo, restart_nic_simulator):  # noqa: F811
     """Validate that both ToRs are active for active-active mux ports."""
     if not ('dualtor' in tbinfo['topo']['name'] and active_active_ports):
         return
@@ -1727,17 +1729,30 @@ def validate_active_active_dualtor_setup(
     icmp_responder_status = ptfhost.shell("supervisorctl status icmp_responder", module_ignore_errors=True)["stdout"]
     pt_assert("RUNNING" in icmp_responder_status, "icmp_responder not running in ptf")
 
-    for port in active_active_ports:
+    if active_standby_ports:
+        # The topology is a dualtor-mixed and has active-standby ports, let's
+        # config the mux mode one by one
+        for port in active_active_ports:
+            for duthost in duthosts:
+                cmd = "config mux mode active {}".format(port)
+                pt_assert(
+                    wait_until(
+                        90, 10, 0, run_mux_config_command, duthost, cmd,
+                        expected_output=["OK"],
+                        forbidden_output=["this is not a valid port present on mux_cable"]
+                    ),
+                    "Port was not present on mux cable after 90 seconds - '{}' failed".format(cmd)
+                )
+    else:
+        # All mux ports are active-active, let's config the
+        # mux mode all at once
+        cmd = "config mux mode active all"
         for duthost in duthosts:
-            cmd = "config mux mode active {}".format(port)
             pt_assert(
-                wait_until(
-                    90, 10, 0, run_mux_config_command, duthost, cmd,
-                    expected_output=["OK"],
-                    forbidden_output=["this is not a valid port present on mux_cable"]
-                ),
-                "Port was not present on mux cable after 90 seconds - '{}' failed".format(cmd)
+                wait_until(90, 10, 0, run_mux_config_command, duthost, cmd, expected_output=["OK"]),
+                "config mux mode active all failed on device {}".format(duthost.hostname)
             )
+
     duthosts.shell("systemctl restart mux.service")
     # verify both ToRs are active
     for duthost in duthosts:
@@ -1755,9 +1770,14 @@ def config_active_active_dualtor(active_tor, standby_tor, ports, unconditionally
     logging.info("Configuring {} as active".format(active_tor.hostname))
     logging.info("Configuring {} as standby".format(standby_tor.hostname))
 
-    for port in ports:
-        active_side_commands.append("config mux mode active {}".format(port))
-        standby_side_commands.append("config mux mode standby {}".format(port))
+    # ports can be either string "all" or a list of mux ports
+    if ports == "all":
+        active_side_commands.append("config mux mode active all")
+        standby_side_commands.append("config mux mode standby all")
+    else:
+        for port in ports:
+            active_side_commands.append("config mux mode active {}".format(port))
+            standby_side_commands.append("config mux mode standby {}".format(port))
 
     if not check_active_active_port_status(active_tor, ports, 'active') or unconditionally:
         for cmd in active_side_commands:
@@ -1777,11 +1797,10 @@ def config_active_active_dualtor(active_tor, standby_tor, ports, unconditionally
             "Port was not present on mux cable after 90 seconds - '{}' failed".format(cmd)
         )
 
-    pt_assert(wait_until(30, 5, 0, check_active_active_port_status, active_tor, ports, 'active'),
+    pt_assert(wait_until(60, 5, 0, check_active_active_port_status, active_tor, ports, 'active'),
               "Could not config ports {} to active on {}".format(ports, active_tor.hostname))
-    pt_assert(wait_until(30, 5, 0, check_active_active_port_status, standby_tor, ports, 'standby'),
+    pt_assert(wait_until(60, 5, 0, check_active_active_port_status, standby_tor, ports, 'standby'),
               "Could not config ports {} to standby on {}".format(ports, standby_tor.hostname))
-    time.sleep(90)
 
 
 def _check_docker_status(duthost):
@@ -1810,13 +1829,17 @@ def _create_config_active_active_dualtor_handler(active_active_ports, ports_to_r
     """Create a handler function for configuring active-active dualtor."""
     def _config_active_active_dualtor_active_standby(active_tor, standby_tor, ports, unconditionally=False):
         wait_until(300, 10, 0, _check_docker_status, standby_tor)
-        for port in ports:
-            if port not in active_active_ports:
-                raise ValueError("Port {} is not in the active-active ports".format(port))
+        if isinstance(ports, str):
+            if ports != "all":
+                raise ValueError("Invalid port string: {}".format(ports))
+        else:
+            for port in ports:
+                if port not in active_active_ports:
+                    raise ValueError("Port {} is not in the active-active ports".format(port))
 
         config_active_active_dualtor(active_tor, standby_tor, ports, unconditionally)
 
-        ports_to_restore.extend(ports)
+        ports_to_restore.extend(active_active_ports if ports == "all" else ports)
 
     return _config_active_active_dualtor_active_standby
 
@@ -1864,25 +1887,28 @@ def config_active_active_dualtor_active_standby(duthosts, active_active_ports, t
 
 @pytest.fixture
 def toggle_all_aa_ports_to_lower_tor(config_active_active_dualtor_active_standby,
-                                     lower_tor_host, upper_tor_host, active_active_ports):  # noqa: F811
+                                     lower_tor_host, upper_tor_host, active_active_ports, active_standby_ports):  # noqa: F811
     if active_active_ports:
-        config_active_active_dualtor_active_standby(lower_tor_host, upper_tor_host, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(lower_tor_host, upper_tor_host, ports_to_config)
     return
 
 
 @pytest.fixture
 def toggle_all_aa_ports_to_rand_selected_tor(config_active_active_dualtor_active_standby, rand_selected_dut,
-                                             rand_unselected_dut, active_active_ports):  # noqa: F811
+                                             rand_unselected_dut, active_active_ports, active_standby_ports):  # noqa: F811
     if active_active_ports:
-        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, ports_to_config)
     return
 
 
 @pytest.fixture
 def toggle_all_aa_ports_to_rand_unselected_tor(config_active_active_dualtor_active_standby, rand_selected_dut,
-                                               rand_unselected_dut, active_active_ports):  # noqa: F811
+                                               rand_unselected_dut, active_active_ports, active_standby_ports):  # noqa: F811
     if active_active_ports:
-        config_active_active_dualtor_active_standby(rand_unselected_dut, rand_selected_dut, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(rand_unselected_dut, rand_selected_dut, ports_to_config)
     return
 
 
@@ -1983,9 +2009,11 @@ def check_simulator_flap_counter(
 @pytest.fixture
 def setup_standby_ports_on_rand_selected_tor(active_active_ports, rand_selected_dut, rand_unselected_dut,  # noqa: F811
                                              config_active_active_dualtor_active_standby,                  # noqa: F811
-                                             validate_active_active_dualtor_setup):                        # noqa: F811
+                                             validate_active_active_dualtor_setup,                         # noqa: F811
+                                             active_standby_ports):                                        # noqa: F811
     if active_active_ports:
-        config_active_active_dualtor_active_standby(rand_unselected_dut, rand_selected_dut, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(rand_unselected_dut, rand_selected_dut, ports_to_config)
     return
 
 
@@ -1993,9 +2021,11 @@ def setup_standby_ports_on_rand_selected_tor(active_active_ports, rand_selected_
 def setup_standby_ports_on_rand_unselected_tor(active_active_ports, rand_selected_dut,      # noqa: F811
                                                rand_unselected_dut,
                                                config_active_active_dualtor_active_standby,
-                                               validate_active_active_dualtor_setup):
+                                               validate_active_active_dualtor_setup,
+                                               active_standby_ports):                       # noqa: F811
     if active_active_ports:
-        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, ports_to_config)
     return
 
 
@@ -2007,12 +2037,14 @@ def setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m(
     validate_active_active_dualtor_setup,
     upper_tor_host,
     lower_tor_host,
-    duthosts
+    duthosts,
+    active_standby_ports                                                   # noqa: F811
 ):
     if active_active_ports:
         active_tor = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         standby_tor = upper_tor_host if active_tor == lower_tor_host else lower_tor_host
-        config_active_active_dualtor_active_standby(active_tor, standby_tor, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(active_tor, standby_tor, ports_to_config)
     return
 
 
@@ -2024,12 +2056,14 @@ def setup_standby_ports_on_non_enum_rand_one_per_hwsku_host_m(
     validate_active_active_dualtor_setup,
     upper_tor_host,
     lower_tor_host,
-    duthosts
+    duthosts,
+    active_standby_ports                                                   # noqa F811
 ):
     if active_active_ports:
         active_tor = duthosts[enum_rand_one_per_hwsku_hostname]
         standby_tor = upper_tor_host if active_tor == lower_tor_host else lower_tor_host
-        config_active_active_dualtor_active_standby(active_tor, standby_tor, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(active_tor, standby_tor, ports_to_config)
     return
 
 
@@ -2038,10 +2072,12 @@ def setup_standby_ports_on_rand_unselected_tor_unconditionally(
     active_active_ports,                                                   # noqa: F811
     rand_selected_dut,
     rand_unselected_dut,
-    config_active_active_dualtor_active_standby
+    config_active_active_dualtor_active_standby,
+    active_standby_ports                                                   # noqa: F811
 ):
     if active_active_ports:
-        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, active_active_ports, True)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, ports_to_config, True)
     return
 
 
@@ -2050,11 +2086,13 @@ def setup_standby_ports_on_rand_unselected_tor_unconditionally_module(
     active_active_ports,                                                   # noqa: F811
     rand_selected_dut,
     rand_unselected_dut,
-    config_active_active_dualtor_active_standby_module
+    config_active_active_dualtor_active_standby_module,
+    active_standby_ports                                                   # noqa: F811
 ):
     if active_active_ports:
+        ports_to_config = active_active_ports if active_standby_ports else "all"
         config_active_active_dualtor_active_standby_module(rand_selected_dut, rand_unselected_dut,
-                                                           active_active_ports, True)
+                                                           ports_to_config, True)
     return
 
 
@@ -2065,12 +2103,14 @@ def setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditi
     config_active_active_dualtor_active_standby,
     upper_tor_host,
     lower_tor_host,
-    duthosts
+    duthosts,
+    active_standby_ports                                                   # noqa: F811
 ):
     if active_active_ports:
         active_tor = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         standby_tor = upper_tor_host if active_tor == lower_tor_host else lower_tor_host
-        config_active_active_dualtor_active_standby(active_tor, standby_tor, active_active_ports, True)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(active_tor, standby_tor, ports_to_config, True)
     return
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,6 @@ from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active 
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder_session                  # noqa: F401
 from tests.common.dualtor.dual_tor_utils import disable_timed_oscillation_active_standby    # noqa: F401
 from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor
-from tests.common.dualtor.dual_tor_common import active_active_ports                        # noqa: F401
 from tests.common.dualtor import mux_simulator_control                                      # noqa: F401
 
 from tests.common.helpers.constants import (
@@ -4037,7 +4036,7 @@ class DualtorMuxPortSetupConfig(enum.Flag):
 
 
 @pytest.fixture(autouse=True)
-def setup_dualtor_mux_ports(active_active_ports, duthost, duthosts, tbinfo, request, mux_server_url):       # noqa:F811
+def setup_dualtor_mux_ports(duthost, duthosts, tbinfo, request, mux_server_url):       # noqa:F811
     """Setup dualtor mux ports."""
     def _get_enumerated_dut_hostname(request):
         for k, v in request.node.callspec.params.items():
@@ -4132,7 +4131,7 @@ def setup_dualtor_mux_ports(active_active_ports, duthost, duthosts, tbinfo, requ
             config_active_active_dualtor(
                 duthosts[active_dut_hostname],
                 duthosts[standby_dut_hostname],
-                active_active_ports,
+                "all",
                 dualtor_setup_config & DualtorMuxPortSetupConfig.DUALTOR_SETUP_MUX_PORT_MANUAL_MODE
             )
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- 202605: 20260531.08

```
route/test_static_route.py::test_static_route[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                                                       [  7%]
route/test_static_route.py::test_static_route_ecmp[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                                                  [ 15%]
route/test_static_route.py::test_static_route_ipv6[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                                                  [ 23%]
route/test_static_route.py::test_static_route_ecmp_ipv6[bjw3-can-7260-16] SKIPPED (Test case may fail due to a known issue / Test not supported for 201911 images or older. Does not apply to standalone topos.)                                                                                                                             [ 30%]
route/test_static_route.py::test_static_route_warmboot[bjw3-can-7260-16] SKIPPED (Warm reboot is not supported on dualtor, m0, m1, or mx topologies)                                                                                                                                                                                         [ 38%]
route/test_static_route.py::test_static_route_ecmp_warmboot[bjw3-can-7260-16] SKIPPED (Warm reboot is not supported on dualtor, m0, m1, or mx topologies)                                                                                                                                                                                    [ 46%]
route/test_static_route.py::test_static_route_ipv6_warmboot[bjw3-can-7260-16] SKIPPED (Warm reboot is not supported on dualtor, m0, m1, or mx topologies)                                                                                                                                                                                    [ 53%]
route/test_static_route.py::test_static_route_config_reload_with_traffic[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                            [ 61%]
route/test_static_route.py::test_static_route_removal_after_config_reload[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                           [ 69%]
route/test_static_route.py::test_static_route_removal_after_config_reload_ipv6[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                      [ 76%]
route/test_static_route.py::test_static_route_blackhole_removal_after_config_reload PASSED                                                                                                                                                                                                                                                   [ 84%]
route/test_static_route.py::test_static_route_no_bgp_churn[ipv4] PASSED                                                                                                                                                                                                                                                                      [ 92%]
route/test_static_route.py::test_static_route_no_bgp_churn[ipv6] PASSED  
```

### Approach
#### What is the motivation for this PR?

Support using `config mux mode <active|standby|all> all` to config mux ports instead of firing the config one port by one port.

Signed-off-by: Longxiang <lolv@microsoft.com>


#### How did you do it?
As the motivation.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
verified in 202605 branch:
```
route/test_static_route.py::test_static_route[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                                                       [  7%]
route/test_static_route.py::test_static_route_ecmp[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                                                  [ 15%]
route/test_static_route.py::test_static_route_ipv6[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                                                  [ 23%]
route/test_static_route.py::test_static_route_ecmp_ipv6[bjw3-can-7260-16] SKIPPED (Test case may fail due to a known issue / Test not supported for 201911 images or older. Does not apply to standalone topos.)                                                                                                                             [ 30%]
route/test_static_route.py::test_static_route_warmboot[bjw3-can-7260-16] SKIPPED (Warm reboot is not supported on dualtor, m0, m1, or mx topologies)                                                                                                                                                                                         [ 38%]
route/test_static_route.py::test_static_route_ecmp_warmboot[bjw3-can-7260-16] SKIPPED (Warm reboot is not supported on dualtor, m0, m1, or mx topologies)                                                                                                                                                                                    [ 46%]
route/test_static_route.py::test_static_route_ipv6_warmboot[bjw3-can-7260-16] SKIPPED (Warm reboot is not supported on dualtor, m0, m1, or mx topologies)                                                                                                                                                                                    [ 53%]
route/test_static_route.py::test_static_route_config_reload_with_traffic[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                            [ 61%]
route/test_static_route.py::test_static_route_removal_after_config_reload[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                           [ 69%]
route/test_static_route.py::test_static_route_removal_after_config_reload_ipv6[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                      [ 76%]
route/test_static_route.py::test_static_route_blackhole_removal_after_config_reload PASSED                                                                                                                                                                                                                                                   [ 84%]
route/test_static_route.py::test_static_route_no_bgp_churn[ipv4] PASSED                                                                                                                                                                                                                                                                      [ 92%]
route/test_static_route.py::test_static_route_no_bgp_churn[ipv6] PASSED  
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
