### PR TITLE
[platform_api] add supervisor readiness check before waiting for port

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -1193,7 +1193,20 @@ def start_platform_api_service(duthosts, enum_rand_one_per_hwsku_hostname,
         duthost.command('docker exec -i pmon supervisorctl reread')
         duthost.command('docker exec -i pmon supervisorctl update')
 
-        res = localhost.wait_for(host=dut_ip, port=SERVER_PORT, state='started', delay=1, timeout=10)
+        # Wait for supervisor to report the service as RUNNING before checking the port
+        def _platform_api_server_running():
+            res = duthost.command(
+                'docker exec -i pmon supervisorctl status platform_api_server',
+                module_ignore_errors=True
+            )
+            return 'RUNNING' in res.get('stdout', '')
+
+        pytest_assert(
+            wait_until(30, 1, 0, _platform_api_server_running),
+            "platform_api_server did not reach RUNNING state in supervisor after 30s"
+        )
+
+        res = localhost.wait_for(host=dut_ip, port=SERVER_PORT, state='started', delay=1, timeout=30)
         assert res['failed'] is False
 
 


### PR DESCRIPTION
### Description of PR

Summary:
After `supervisorctl update`, `platform_api_server` can take longer than 10s to reach RUNNING (especially on first `sonic_platform` import), which caused spurious timeouts when waiting for the port. Poll `supervisorctl status` until the process is RUNNING before checking the port, and increase the port `wait_for` timeout from 10s to 30s.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Approach
#### What is the motivation for this PR?
`start_platform_api_service` waited on the HTTP port immediately after `supervisorctl update`. On slow starts (first import of `sonic_platform`), the process was not RUNNING yet within 10s, so tests failed with false timeouts.

#### How did you do it?
In `tests/common/platform/device_utils.py`, after starting the service via supervisor:
1. Poll `supervisorctl status platform_api_server` with `wait_until` until status is RUNNING (up to 30s)
2. Increase the subsequent localhost `wait_for` port timeout from 10s to 30s


#### Supported testbed topology if it's a new test case?
N/A (framework fix for existing platform API fixture)

### Documentation
N/A