### PR TITLE
[bgp_facts]: Avoid docker exec -i hang when pipelining is off

### DIFF
--- a/ansible/library/bgp_facts.py
+++ b/ansible/library/bgp_facts.py
@@ -107,7 +107,7 @@ class BgpModule(object):
             if remaining <= 0:
                 break
             per_call = min(20, max(5, int(remaining)))
-            docker_cmd = 'timeout -k 5 {t} docker exec -i {inst} vtysh -c "show ip bgp {cmd}" '.format(
+            docker_cmd = 'timeout -k 5 {t} docker exec {inst} vtysh -c "show ip bgp {cmd}" </dev/null'.format(
                 t=per_call, inst=instance, cmd=command_str)
             try:
                 rc, self.out, err = self.module.run_command(


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: 20260531.08

```
route/test_static_route.py::test_static_route[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                                                       [  7%]
route/test_static_route.py::test_static_route_ecmp[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                                                  [ 15%]
route/test_static_route.py::test_static_route_ipv6[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                                                  [ 23%]
route/test_static_route.py::test_static_route_ecmp_ipv6[bjw3-can-7260-16] SKIPPED (Test case may fail due to a known issue / Test not supported for 201911 images or older. Does not apply to standalone topos.)                                                                                                                             [ 30%]
route/test_static_route.py::test_static_route_warmboot[bjw3-can-7260-16] SKIPPED (Warm reboot is not supported on dualtor, m0, m1, or mx topologies)                                                                                                                                                                                         [ 38%]
route/test_static_route.py::test_static_route_ecmp_warmboot[bjw3-can-7260-16] SKIPPED (Warm reboot is not supported on dualtor, m0, m1, or mx topologies)                                                                                                                                                                                    [ 46%]
route/test_static_route.py::test_static_route_ipv6_warmboot[bjw3-can-7260-16] SKIPPED (Warm reboot is not supported on dualtor, m0, m1, or mx topologies)                                                                                                                                                                                    [ 53%]
route/test_static_route.py::test_static_route_config_reload_with_traffic[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                            [ 61%]
route/test_static_route.py::test_static_route_removal_after_config_reload[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                           [ 69%]
route/test_static_route.py::test_static_route_removal_after_config_reload_ipv6[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                      [ 76%]
route/test_static_route.py::test_static_route_blackhole_removal_after_config_reload PASSED                                                                                                                                                                                                                                                   [ 84%]
route/test_static_route.py::test_static_route_no_bgp_churn[ipv4] PASSED                                                                                                                                                                                                                                                                      [ 92%]
route/test_static_route.py::test_static_route_no_bgp_churn[ipv6] PASSED  
```

### Approach
#### What is the motivation for this PR?
the ansible library `bgp_facts` hangs after disabling the ansible pipeline (for debug purpose):
```
export ANSIBLE_KEEP_REMOTE_FILES=1
```

Signed-off-by: Longxiang <lolv@microsoft.com>

#### How did you do it?

`collect_data()` collected vtysh output by running `docker exec -i ...`
through `AnsibleModule.run_command()`. `run_command()` launches the child
with the module's **inherited stdin**, and the `-i` flag keeps
`docker exec` attached to that stdin until it reaches EOF.

- With pipelining **enabled**, the module is fed to the interpreter over
  stdin, so by the time `collect_data()` runs, stdin is already at EOF —
  `docker exec -i` returns immediately and the module works.
- With pipelining **disabled** (`ANSIBLE_KEEP_REMOTE_FILES=1`), the module
  is a file on the DUT and the interpreter's stdin is the **live,
  persistent SSH channel** (kept open by `ControlPersist`). It never
  reaches EOF, so `docker exec -i` stays attached and never exits.
  `run_command()`'s read loop then blocks forever (`cmd.poll()` stays
  `None`), and `bgp_facts` hangs.

Fix: drop the unnecessary `-i` (`vtysh -c` reads nothing from stdin) and
redirect the command's stdin from `/dev/null`, so `docker exec` always
sees an immediate EOF regardless of the pipelining mode.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

Run tests that call `bgp_facts` with pipelining disabled in 202605:

```
route/test_static_route.py::test_static_route[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                                                       [  7%]
route/test_static_route.py::test_static_route_ecmp[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                                                  [ 15%]
route/test_static_route.py::test_static_route_ipv6[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                                                  [ 23%]
route/test_static_route.py::test_static_route_ecmp_ipv6[bjw3-can-7260-16] SKIPPED (Test case may fail due to a known issue / Test not supported for 201911 images or older. Does not apply to standalone topos.)                                                                                                                             [ 30%]
route/test_static_route.py::test_static_route_warmboot[bjw3-can-7260-16] SKIPPED (Warm reboot is not supported on dualtor, m0, m1, or mx topologies)                                                                                                                                                                                         [ 38%]
route/test_static_route.py::test_static_route_ecmp_warmboot[bjw3-can-7260-16] SKIPPED (Warm reboot is not supported on dualtor, m0, m1, or mx topologies)                                                                                                                                                                                    [ 46%]
route/test_static_route.py::test_static_route_ipv6_warmboot[bjw3-can-7260-16] SKIPPED (Warm reboot is not supported on dualtor, m0, m1, or mx topologies)                                                                                                                                                                                    [ 53%]
route/test_static_route.py::test_static_route_config_reload_with_traffic[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                            [ 61%]
route/test_static_route.py::test_static_route_removal_after_config_reload[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                           [ 69%]
route/test_static_route.py::test_static_route_removal_after_config_reload_ipv6[bjw3-can-7260-16] PASSED                                                                                                                                                                                                                                      [ 76%]
route/test_static_route.py::test_static_route_blackhole_removal_after_config_reload PASSED                                                                                                                                                                                                                                                   [ 84%]
route/test_static_route.py::test_static_route_no_bgp_churn[ipv4] PASSED                                                                                                                                                                                                                                                                      [ 92%]
route/test_static_route.py::test_static_route_no_bgp_churn[ipv6] PASSED  
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
