### PR TITLE
[gnmi] Wait for functional gNMI readiness in apply_cert_config(), not just the listening port

### DIFF
--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -521,15 +521,27 @@ def verify_tcp_port(localhost, ip, port):
     logger.info("TCP: " + res['stdout'] + res['stderr'])
 
 
-def gnmi_capabilities(duthost, localhost):
+def gnmi_capabilities(duthost, localhost, vrf_name=None):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     duthost_mgmt_info = duthost.get_mgmt_ip()
     ip = duthost_mgmt_info['mgmt_ip']
     addr = f"[{ip}]" if duthost_mgmt_info['version'] == 'v6' else f"{ip}"
 
     port = env.gnmi_port
-    # Run gnmi_cli in gnmi container as workaround
-    cmd = "docker exec %s gnmi_cli -client_types=gnmi -a %s:%s " % (env.gnmi_container, addr, port)
+    if vrf_name and vrf_name != "default":
+        # For a non-default VRF the gnmi container does not have `ip vrf exec` privileges, so run
+        # gnmi_cli on the DUT host in the target VRF instead (same approach as
+        # gnmi_subscribe_polling()). Stage the binary on the DUT host filesystem if needed, so this
+        # check is self-contained regardless of what other fixtures the caller relies on.
+        duthost.shell(
+            "test -x /tmp/gnmi_cli || (docker cp %s:/usr/sbin/gnmi_cli /tmp/gnmi_cli && chmod +x /tmp/gnmi_cli)"
+            % env.gnmi_container,
+            module_ignore_errors=True,
+        )
+        cmd = "sudo ip vrf exec %s /tmp/gnmi_cli -client_types=gnmi -a %s:%s " % (vrf_name, addr, port)
+    else:
+        # Run gnmi_cli in gnmi container as workaround
+        cmd = "docker exec %s gnmi_cli -client_types=gnmi -a %s:%s " % (env.gnmi_container, addr, port)
     cmd += "-client_crt /etc/sonic/telemetry/gnmiclient.crt "
     cmd += "-client_key /etc/sonic/telemetry/gnmiclient.key "
     cmd += "-ca_crt /etc/sonic/telemetry/gnmiCA.pem "

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -75,7 +75,7 @@ def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost, ptfhost, vrf_c
     create_gnmi_certs(duthost, localhost, ptfhost, dut_ip=vrf_config.get("dut_ip"))
 
     create_checkpoint(duthost, SETUP_ENV_CP)
-    stopped_programs = apply_cert_config(duthost, vrf_config.get("vrf"))
+    stopped_programs = apply_cert_config(duthost, vrf_config.get("vrf"), localhost)
 
     yield
 

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -89,7 +89,7 @@ def apply_cert_config(duthost, vrf_name=None, localhost=None):
     # gnmi request rather than just the TCP handshake).
     if localhost is not None:
         def _gnmi_server_responsive():
-            ret, _ = gnmi_capabilities(duthost, localhost)
+            ret, _ = gnmi_capabilities(duthost, localhost, vrf_name)
             return ret == 0
 
         server_responsive = wait_until(30, 5, 0, _gnmi_server_responsive)

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -5,7 +5,7 @@ import json
 from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import get_dpu_ip, get_dpu_port
 from tests.common.helpers.gnmi_utils import GNMIEnvironment, add_gnmi_client_common_name, del_gnmi_client_common_name, \
-                                            dump_gnmi_log, dump_system_status
+                                            dump_gnmi_log, dump_system_status, gnmi_capabilities
 from tests.common.helpers.ntp_helper import NtpDaemon, get_ntp_daemon_in_use   # noqa: F401
 from tests.common.helpers.dut_utils import check_container_state
 
@@ -23,7 +23,7 @@ def is_mgmt_vrf_enabled(duthost):
     return res == "true"
 
 
-def apply_cert_config(duthost, vrf_name=None):
+def apply_cert_config(duthost, vrf_name=None, localhost=None):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     # Get subtype
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
@@ -78,6 +78,26 @@ def apply_cert_config(duthost, vrf_name=None):
         dump_gnmi_log(duthost)
         dump_system_status(duthost)
         pytest.fail("Failed to start gnmi server")
+
+    # The listening-port check above only proves the process has bound the socket; the gRPC
+    # service can still reject/hang new connections for a short window afterwards (e.g. while
+    # finishing cert/key hot-reload), which surfaced as intermittent "context deadline exceeded"
+    # dial errors from gnmi_cli immediately after apply_cert_config(). Confirm the server is
+    # actually able to complete a real gNMI RPC before handing control back to the caller,
+    # mirroring the post-rotation readiness pattern in
+    # tests/telemetry/test_telemetry_cert_rotation.py (wait_until(30, 5, 0, ...) around a live
+    # gnmi request rather than just the TCP handshake).
+    if localhost is not None:
+        def _gnmi_server_responsive():
+            ret, _ = gnmi_capabilities(duthost, localhost)
+            return ret == 0
+
+        server_responsive = wait_until(30, 5, 0, _gnmi_server_responsive)
+        if not server_responsive:
+            dump_gnmi_log(duthost)
+            dump_system_status(duthost)
+            pytest.fail("gnmi server is listening but not yet responsive to gNMI requests")
+
     if duthost.facts['platform'] != 'x86_64-kvm_x86_64-r0':
         is_time_synced = wait_until(80, 3, 0, check_system_time_sync, duthost)
         assert is_time_synced, "Failed to synchronize DUT system time with NTP Server"

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -16,6 +16,16 @@ GNMI_PROGRAM_NAME = ''
 GNMI_PORT = 0
 # Base wait unit (seconds) for GNMI server startup; the listening-port poll allows up to 2x this
 GNMI_SERVER_START_WAIT_TIME = 15
+# gnmi_cli's own client-side dial timeout (seen verbatim in its error message, e.g.
+# "Dialer(127.0.0.1:8080, 30s): context deadline exceeded" in sonic-mgmt#26737). A single failed
+# gnmi_capabilities() probe can therefore block for this entire duration.
+GNMI_DIAL_TIMEOUT_SECONDS = 30
+GNMI_READINESS_POLL_INTERVAL = 5
+# Must exceed one full failed probe (GNMI_DIAL_TIMEOUT_SECONDS) plus the poll interval, otherwise
+# a single slow/failed probe consumes the whole budget and wait_until() never attempts a second
+# probe -- which is exactly the "context deadline exceeded" failure this readiness poll is meant
+# to catch and retry past (sonic-mgmt#26737).
+GNMI_READINESS_POLL_TIMEOUT = 2 * GNMI_DIAL_TIMEOUT_SECONDS + GNMI_READINESS_POLL_INTERVAL
 
 
 def is_mgmt_vrf_enabled(duthost):
@@ -85,14 +95,18 @@ def apply_cert_config(duthost, vrf_name=None, localhost=None):
     # dial errors from gnmi_cli immediately after apply_cert_config(). Confirm the server is
     # actually able to complete a real gNMI RPC before handing control back to the caller,
     # mirroring the post-rotation readiness pattern in
-    # tests/telemetry/test_telemetry_cert_rotation.py (wait_until(30, 5, 0, ...) around a live
-    # gnmi request rather than just the TCP handshake).
+    # tests/telemetry/test_telemetry_cert_rotation.py (wait_until(...) around a live gnmi request
+    # rather than just the TCP handshake). The outer timeout is sized to survive one full failed
+    # probe (see GNMI_READINESS_POLL_TIMEOUT above) so a single dial-timeout failure -- the exact
+    # failure mode reported in #26737 -- doesn't consume the whole budget and prevent a second,
+    # potentially successful, probe.
     if localhost is not None:
         def _gnmi_server_responsive():
             ret, _ = gnmi_capabilities(duthost, localhost, vrf_name)
             return ret == 0
 
-        server_responsive = wait_until(30, 5, 0, _gnmi_server_responsive)
+        server_responsive = wait_until(
+            GNMI_READINESS_POLL_TIMEOUT, GNMI_READINESS_POLL_INTERVAL, 0, _gnmi_server_responsive)
         if not server_responsive:
             dump_gnmi_log(duthost)
             dump_system_status(duthost)

--- a/tests/gnmi/test_gnmi_2038.py
+++ b/tests/gnmi/test_gnmi_2038.py
@@ -35,7 +35,7 @@ def test_gnmi_capabilities_2038(duthosts, rand_one_dut_hostname, localhost, ptfh
     copy_certificate_to_dut(duthost)
     copy_certificate_to_ptf(ptfhost)
 
-    apply_cert_config(duthost)
+    apply_cert_config(duthost, localhost=localhost)
 
     # Verify certificate date on DUT
     check_cert_date_on_dut(duthost)


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
`apply_cert_config()` restarts the gNMI/telemetry process after copying fresh
certs, then polls `ss -ltnp` until the port is back in `LISTEN` state (#25809)
before returning. That confirms the socket is bound, but not that the gRPC
service behind it is actually ready to accept/complete a real gNMI RPC yet.
Tests that call `gnmi_capabilities()` (or other gNMI/gNOI RPCs) immediately
after `apply_cert_config()` returns can still intermittently hit a
client-side dial timeout (`context deadline exceeded`), even though the
listening-port check just passed moments earlier.

This PR adds a functional readiness poll after the existing listening-port
check in `apply_cert_config()`: it waits (up to 30s) until a real
`gnmi_capabilities()` call succeeds, mirroring the existing pattern already
used in `tests/telemetry/test_telemetry_cert_rotation.py`. The poll only
runs when the new optional `localhost` parameter is passed in, so existing
callers of `apply_cert_config()` are unaffected.

Fixes #26737

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
https://github.com/sonic-net/sonic-mgmt/issues/26737
Failure type: day-one issue — the listening-port check added in #25809 narrowed the flake window but did not close it; the underlying gap (listening ≠ ready to serve) predates this PR.

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: full `tests/gnmi/` suite run multiple times against a tor40 dualtor HW testbed with the initial fix (first commit) applied — all runs passed (e.g. 6 passed in 37m37s), with no recurrence of the `context deadline exceeded` dial-timeout flake that motivated this change.
- A subsequent staging run against `tests/gnmi/test_gnmi_configdb.py::test_gnmi_configdb_incremental_01[vrf_mgmt]` caught a real gap in the first commit: the readiness poll's `gnmi_capabilities()` call always dialed via `docker exec`, which cannot route into a non-default VRF, so the poll failed deterministically (not flaky) whenever `apply_cert_config()` is invoked with `vrf_name="mgmt"`. Fixed in the second commit by making `gnmi_capabilities()` VRF-aware (same `ip vrf exec` pattern already used by `gnmi_subscribe_polling()`). Pending: a fresh staging run to confirm `vrf_mgmt` now passes with the second commit.

### Approach
#### What is the motivation for this PR?

`gnmi/test_gnmi.py::test_gnmi_capabilities` and
`gnmi/test_gnmi_2038.py::test_gnmi_capabilities_2038` intermittently fail
with a `Dialer(<addr>:8080, 30s): context deadline exceeded` error shortly
after `apply_cert_config()` restarts the telemetry process, even though
`apply_cert_config()` already confirmed the port was in `LISTEN` state.

#### How did you do it?

- Added an optional `localhost` parameter to `apply_cert_config()`.
- After the existing `ss -ltnp` listening-port poll, if `localhost` is
  provided, poll `gnmi_capabilities(duthost, localhost)` with
  `wait_until(30, 5, 0, ...)` until it returns success, or fail the test
  with the same log dumps (`dump_gnmi_log`, `dump_system_status`) used
  elsewhere in this file.
- Updated `tests/gnmi/conftest.py` and `tests/gnmi/test_gnmi_2038.py` to
  pass `localhost` through to `apply_cert_config()`.
- Follow-up commit: made `gnmi_capabilities()` accept an optional
  `vrf_name` and use `sudo ip vrf exec <vrf> /tmp/gnmi_cli ...` (staging
  the binary on the DUT itself if needed) instead of `docker exec` when
  `vrf_name` is a non-default VRF, and threaded `vrf_name` through from
  `apply_cert_config()`'s readiness poll. Existing callers are unaffected
  since `vrf_name` defaults to `None`.

#### How did you verify/test it?

Reproduced the original failure on a tor40 dualtor HW testbed: captured
`gnmi_cli` stderr showing the 30s dial timeout, confirmed via `ss -ltnp` /
process listing that the telemetry process was already listening on the
port at the time of the failed dial, and confirmed the same command
succeeded later in the same run once the server had stabilized — pointing
at a functional-readiness gap rather than a networking/hairpin issue (also
reproduced with `127.0.0.1` as the dial target, ruling that out).

After applying this fix, ran the full `tests/gnmi/` suite multiple times on
the same testbed; all runs passed with no recurrence of the flake.

#### Any platform specific information?

None — the readiness poll only depends on the existing `gnmi_capabilities()`
helper and does not add any platform-conditional logic.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case. Applies to any topology that uses
`apply_cert_config()` (t0, dualtor, t1 multi-ASIC, etc.).

### Documentation

N/A — internal test-harness change only, no user-facing documentation impact.
