### PR TITLE
meta_validator: allow BMC and host to share PDU ports by naming convention

### DIFF
--- a/ansible/scripts/meta/validators/pdu_validator.py
+++ b/ansible/scripts/meta/validators/pdu_validator.py
@@ -375,9 +375,20 @@ class PDUValidator(GlobalValidator):
                 pairs.append({dut, bmc_host})
         return pairs
 
+    _BMC_SUFFIX = "-bmc"
+
+    def _is_bmc_host_pair_by_naming(self, device1, device2):
+        """Check if two devices are a BMC and its host based on the
+        naming convention where the BMC device name is
+        '<host>' + '-bmc'."""
+        return (device1 + self._BMC_SUFFIX == device2) or (device2 + self._BMC_SUFFIX == device1)
+
     def _is_bmc_host_pair(self, device1, device2):
         """Check if two devices are a BMC and its host sharing the
-        same chassis, based on testbed.yaml bmc_host mapping."""
+        same chassis, either via the '<host>-bmc' naming convention or
+        based on testbed.yaml bmc_host mapping."""
+        if self._is_bmc_host_pair_by_naming(device1, device2):
+            return True
         for pair in self._bmc_host_pairs:
             if device1 in pair and device2 in pair:
                 return True


### PR DESCRIPTION
### Description of PR
Summary:
The `pdu_validator` meta-check's `E4007 pdu_port_conflict` rule flags any PDU outlet shared by two devices as a conflict. However, a BMC device legitimately shares the same PSU/PDU outlets as its host (e.g. `<host>` and `<host>-bmc`). The existing `_is_bmc_host_pair()` exception only worked via a `bmc_host` field in `testbed.yaml`, which is not populated anywhere in the repo, making the exception effectively dead code and causing false-positive PDU-conflict errors when onboarding BMC devices.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
BMC devices sharing PDU outlets with their host were incorrectly flagged as `E4007 pdu_port_conflict` errors, since the pre-existing BMC/host exception logic depended on a `bmc_host` field in `testbed.yaml` that is never actually set.

#### How did you do it?
Added a naming-convention-based fallback (`<host>` / `<host>-bmc`) to `_is_bmc_host_pair()` in `pdu_validator.py`, checked first, while keeping the existing `bmc_host`-based check as a secondary path for backward compatibility.

#### How did you verify/test it?
Verified via standalone unit testing of `_is_bmc_host_pair()` with mocked base classes: confirmed `host`/`host-bmc` pairs (both orderings) are now recognized as non-conflicting, while unrelated device pairs are still correctly flagged as conflicts. Also verified with `flake8` and pre-commit hooks (trim whitespace, python ast check, flake8) all passing.

#### Any platform specific information?
N/A - this is a meta-check/testbed validation script, not a device-side change.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A