### PR TITLE
[202511][vm_set/golden_config/port_utils]: Backport converged LT2 bring-up fixes (#26080)

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -487,11 +487,6 @@
       - name: Load variables from topology file for topo_{{ topo }}.yml
         include_vars: "vars/topo_{{ topo }}.yml"
 
-      - name: Set BGP confederation facts
-        set_fact:
-          bgp_confd_asn: "{{ hostvars[inventory_hostname]['configuration_properties']['common']['dut_confed_asn'] | default(None) }}"
-          bgp_confd_peers: "{{ hostvars[inventory_hostname]['configuration_properties']['common']['dut_confed_peers'] | default(None) }}"
-
       - name: saved original minigraph file in SONiC DUT(ignore errors when file does not exist)
         shell: mv /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.orig
         become: true
@@ -736,8 +731,6 @@
           vm_configuration: "{{ configuration if topo == 't1-filterleaf-lag' else omit }}"
           is_lit_mode: "{{ is_lit_mode | default(true) }}"
           npu_index: "{{ dut_index | default(0) | int }}"
-          bgp_confd_asn: "{{ bgp_confd_asn }}"
-          bgp_confd_peers: "{{ bgp_confd_peers }}"
           duts_list: "{{ testbed_facts['duts'] | default([]) }}"
           dut_loopbacks: "{{ topology.DUT.loopback | default({}) }}"
           console_ports: "{{ device_serial_link[inventory_hostname] | default(omit) if 'c0' in topo else omit }}"

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -487,6 +487,11 @@
       - name: Load variables from topology file for topo_{{ topo }}.yml
         include_vars: "vars/topo_{{ topo }}.yml"
 
+      - name: Set BGP confederation facts
+        set_fact:
+          bgp_confd_asn: "{{ hostvars[inventory_hostname]['configuration_properties']['common']['dut_confed_asn'] | default(None) }}"
+          bgp_confd_peers: "{{ hostvars[inventory_hostname]['configuration_properties']['common']['dut_confed_peers'] | default(None) }}"
+
       - name: saved original minigraph file in SONiC DUT(ignore errors when file does not exist)
         shell: mv /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.orig
         become: true
@@ -731,6 +736,8 @@
           vm_configuration: "{{ configuration if topo == 't1-filterleaf-lag' else omit }}"
           is_lit_mode: "{{ is_lit_mode | default(true) }}"
           npu_index: "{{ dut_index | default(0) | int }}"
+          bgp_confd_asn: "{{ bgp_confd_asn }}"
+          bgp_confd_peers: "{{ bgp_confd_peers }}"
           duts_list: "{{ testbed_facts['duts'] | default([]) }}"
           dut_loopbacks: "{{ topology.DUT.loopback | default({}) }}"
           console_ports: "{{ device_serial_link[inventory_hostname] | default(omit) if 'c0' in topo else omit }}"

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -776,7 +776,7 @@ class GenerateGoldenConfigDBModule(object):
         Generate golden_config for FT2 to enable FEC.
         **Only PORT table is updated**.
         """
-        SUPPORTED_TOPO = ["ft2-64", "lt2-p32o64", "lt2-o128", "ft2-o128"]
+        SUPPORTED_TOPO = ["ft2-64", "lt2-p32o64", "lt2-o128", "ft2-o128", "lt2-u32d128"]
         if self.topo_name not in SUPPORTED_TOPO:
             return "{}"
         SUPPORTED_PORT_SPEED = ["200000", "400000", "800000"]

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -63,7 +63,9 @@ class GenerateGoldenConfigDBModule(object):
                                     npu_index=dict(required=False, type='int', default=0),
                                     duts_list=dict(required=False, type='list', default=[]),
                                     dut_loopbacks=dict(required=False, type='dict', default={}),
-                                    console_ports=dict(required=False, type='dict', default=None)),
+                                    console_ports=dict(required=False, type='dict', default=None),
+                                    bgp_confd_asn=dict(required=False, type='str', default=None),
+                                    bgp_confd_peers=dict(required=False, type='str', default=None)),
                                     supports_check_mode=True)
         self.topo_name = self.module.params['topo_name']
         self.port_index_map = self.module.params['port_index_map']
@@ -77,6 +79,8 @@ class GenerateGoldenConfigDBModule(object):
         self.duts_list = self.module.params['duts_list']
         self.dut_loopbacks = self.module.params['dut_loopbacks']
         self.console_ports = self.module.params['console_ports']
+        self.bgp_confd_asn = self.module.params['bgp_confd_asn']
+        self.bgp_confd_peers = self.module.params['bgp_confd_peers']
 
     def generate_mgfx_golden_config_db(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
@@ -781,13 +785,21 @@ class GenerateGoldenConfigDBModule(object):
             return "{}"
         SUPPORTED_PORT_SPEED = ["200000", "400000", "800000"]
         ori_config = json.loads(self.get_config_from_minigraph())
-        port_config = ori_config.get("PORT", {})
+        golden_config = {"PORT": ori_config.get("PORT", {})}
+        port_config = golden_config["PORT"]
         for name, config in port_config.items():
             # Enable FEC for ports with supported speed
             if config["speed"] in SUPPORTED_PORT_SPEED and "fec" not in config:
                 config["fec"] = "rs"
 
-        return json.dumps({"PORT": port_config}, indent=4)
+        if self.bgp_confd_asn and self.bgp_confd_peers:
+            golden_config["BGP_DEVICE_GLOBAL"] = ori_config.get("BGP_DEVICE_GLOBAL", {})
+            golden_config["BGP_DEVICE_GLOBAL"]["CONFED"] = {
+                "asn": str(self.bgp_confd_asn),
+                "peers": str(self.bgp_confd_peers).replace(' ', ';')
+            }
+
+        return json.dumps(golden_config, indent=4)
 
     def generate_t0_f2_golden_config_db(self):
         """

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -63,9 +63,7 @@ class GenerateGoldenConfigDBModule(object):
                                     npu_index=dict(required=False, type='int', default=0),
                                     duts_list=dict(required=False, type='list', default=[]),
                                     dut_loopbacks=dict(required=False, type='dict', default={}),
-                                    console_ports=dict(required=False, type='dict', default=None),
-                                    bgp_confd_asn=dict(required=False, type='str', default=None),
-                                    bgp_confd_peers=dict(required=False, type='str', default=None)),
+                                    console_ports=dict(required=False, type='dict', default=None)),
                                     supports_check_mode=True)
         self.topo_name = self.module.params['topo_name']
         self.port_index_map = self.module.params['port_index_map']
@@ -79,8 +77,6 @@ class GenerateGoldenConfigDBModule(object):
         self.duts_list = self.module.params['duts_list']
         self.dut_loopbacks = self.module.params['dut_loopbacks']
         self.console_ports = self.module.params['console_ports']
-        self.bgp_confd_asn = self.module.params['bgp_confd_asn']
-        self.bgp_confd_peers = self.module.params['bgp_confd_peers']
 
     def generate_mgfx_golden_config_db(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
@@ -785,21 +781,13 @@ class GenerateGoldenConfigDBModule(object):
             return "{}"
         SUPPORTED_PORT_SPEED = ["200000", "400000", "800000"]
         ori_config = json.loads(self.get_config_from_minigraph())
-        golden_config = {"PORT": ori_config.get("PORT", {})}
-        port_config = golden_config["PORT"]
+        port_config = ori_config.get("PORT", {})
         for name, config in port_config.items():
             # Enable FEC for ports with supported speed
             if config["speed"] in SUPPORTED_PORT_SPEED and "fec" not in config:
                 config["fec"] = "rs"
 
-        if self.bgp_confd_asn and self.bgp_confd_peers:
-            golden_config["BGP_DEVICE_GLOBAL"] = ori_config.get("BGP_DEVICE_GLOBAL", {})
-            golden_config["BGP_DEVICE_GLOBAL"]["CONFED"] = {
-                "asn": str(self.bgp_confd_asn),
-                "peers": str(self.bgp_confd_peers).replace(' ', ';')
-            }
-
-        return json.dumps(golden_config, indent=4)
+        return json.dumps({"PORT": port_config}, indent=4)
 
     def generate_t0_f2_golden_config_db(self):
         """

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -140,6 +140,11 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             for i in range(33, 65):
                 for x, j in zip([1, 3, 5, 7], ["a", "b", "c", "d"]):
                     port_alias_to_name_map["etp%d%s" % (i, j)] = "Ethernet%d" % ((i - 1) * 8 + x - 1)
+        elif hwsku in ["NH-4210-F-O256"]:
+            for i in range(1, 129):
+                for x, j in zip([1, 5], ["a", "b"]):
+                    port_alias_to_name_map["etp%d%s" % (i, j)] = "Ethernet%d" % ((i - 1) * 8 + x - 1)
+            port_alias_to_name_map["etp129"] = "Ethernet1024"
         elif hwsku == "Arista-7060X6-64PE-256x200G":
             for i in range(1, 65):
                 for j in [1, 3, 5, 7]:

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -183,6 +183,8 @@
       fp_mtu: "{{ fp_mtu_size }}"
       max_fp_num: "{{ max_fp_num }}"
       netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
+      multi_vrf: "{{ topo_is_multi_vrf }}"
+      multi_vrf_data: "{{ convergence_data|default({}) }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
     become: yes
 


### PR DESCRIPTION
### Description of PR
Summary: Manual backport of #26080 to `202511`. The automatic cherry-pick could not create a PR because `ansible/library/generate_golden_config_db.py` conflicted with the older release-branch topology list.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Backport the converged `lt2-u32d128` testbed bring-up fixes from #26080 to the requested `202511` branch.

#### How did you do it?
Cherry-picked the three commits from #26080. Resolved the `SUPPORTED_TOPO` conflict by retaining the topology set present in `202511` and adding only `lt2-u32d128`, avoiding unrelated topology additions from newer branches.

The backport:
- Adds the `NH-4210-F-O256` port alias map.
- Passes `multi_vrf` and `multi_vrf_data` through the renumber topology path.
- Enables golden config generation for `lt2-u32d128`.

#### How did you verify/test it?
- Confirmed the `NH-4210-F-O256` alias map contains 257 ports and the expected boundary mappings (`etp1a`, `etp1b`, `etp128b`, and `etp129`).
- Ran Python syntax compilation for the modified Python modules.
- Ran `git diff --check` against `202511`.

#### Any platform specific information?
The port alias map is specific to Nexthop `NH-4210-F-O256`; the other changes apply to converged testbeds and `lt2-u32d128`.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
N/A.
