### PR TITLE
[snappi][dataplane] Add baseline regression gate for min-frame-size no-loss test

### DIFF
--- a/tests/snappi_tests/dataplane/test_min_frame_size.py
+++ b/tests/snappi_tests/dataplane/test_min_frame_size.py
@@ -17,8 +17,21 @@ FRAME_SIZE_STEP = 64
 START_FRAME = 64
 END_FRAME = 9100
 
+# Known-good no-loss minimum frame size (bytes). The binary search returns the
+# SMALLEST frame that passes with zero loss:
+#   - result >  baseline  -> regression (e.g. baseline 192B, now needs 256B) -> FAIL
+#   - result <= baseline  -> healthy; result < baseline is a HW improvement (logged)
+#
+# DEFAULT_NO_LOSS_MIN_FRAME applies to every hwsku, so new hardware is regression-
+# checked without any test change. Add an entry to EXPECTED_NO_LOSS_MIN_FRAME only
+# when a specific hwsku/ip_version legitimately differs from the default.
+DEFAULT_NO_LOSS_MIN_FRAME = 192
+EXPECTED_NO_LOSS_MIN_FRAME = {
+    # "Force10-S6100": {"IPv4": 512, "IPv6": 512},
+}
 
-@pytest.mark.parametrize("ip_version", ["IPv4", "IPv6"])
+
+@pytest.mark.parametrize("ip_version", ["IPv6", "IPv4"])
 @pytest.mark.parametrize("rfc2889_enabled", [True, False])
 def test_min_frame_size_no_loss(
     request,
@@ -87,7 +100,6 @@ def test_min_frame_size_no_loss(
 
     snappi_config, snappi_obj_handles = create_snappi_config(snappi_extra_params)
     frame_sizes = list(range(START_FRAME, END_FRAME + 1, FRAME_SIZE_STEP))
-
     snappi_extra_params.traffic_flow_config = [
         {
             "line_rate": LINE_RATE_PERCENT,
@@ -194,6 +206,26 @@ def test_min_frame_size_no_loss(
             {"=" * 100}
             """
             logger.info(summary.strip())
+
+        # Regression gate: a larger min frame at zero loss is a regression; a smaller
+        # one is a HW improvement. Uses the per-hwsku override if defined, else the
+        # global default, so even a brand-new hwsku is still checked.
+        hwskus = {port["duthost"].facts["hwsku"] for port in snappi_ports}
+        hwsku = next(iter(hwskus)) if len(hwskus) == 1 else None
+        baseline = EXPECTED_NO_LOSS_MIN_FRAME.get(hwsku, {}).get(ip_version, DEFAULT_NO_LOSS_MIN_FRAME)
+
+        if best_frame_size < baseline:
+            logger.info(
+                "No-loss minimum frame size improved for hwsku=%s ip_version=%s: %d bytes "
+                "(baseline %d bytes). Consider tightening the baseline.",
+                hwsku, ip_version, best_frame_size, baseline,
+            )
+        pytest_assert(
+            best_frame_size <= baseline,
+            f"No-loss minimum frame size {best_frame_size} bytes for hwsku={hwsku} "
+            f"ip_version={ip_version} (FrameOrderingMode={frame_ordering_mode}) exceeds the "
+            f"known-good baseline of {baseline} bytes - regression.",
+        )
 
     finally:
         start_stop(snappi_api, operation="stop", op_type="traffic")


### PR DESCRIPTION
### Description of PR

Summary:
Adds a regression gate to `test_min_frame_size_no_loss` so the discovered
no-loss minimum frame size is validated against a known-good baseline instead
of only being logged/recorded.

Previously the test only asserted that the *maximum* frame size passed at 100%
line rate; the binary-search result (`best_frame_size`) was recorded as a metric
and logged but never asserted. As a result, a regression that increased the
no-loss minimum (e.g. 192B -> 256B) would still report zero loss and pass green.
The test was effectively a logging/telemetry tool with no baseline enforcement.

### Type of change


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
Adds a regression gate to `test_min_frame_size_no_loss` so the discovered
no-loss minimum frame size is validated against a known-good baseline instead
of only being logged/recorded.
#### How did you do it?
- Added `DEFAULT_NO_LOSS_MIN_FRAME` (192B), a global baseline applied to every
  hwsku so new hardware is regression-checked with no test change required.
- Added an optional `EXPECTED_NO_LOSS_MIN_FRAME` override map for per-hwsku /
  per-ip_version exceptions (ships empty).
- Added a regression gate after telemetry is recorded:
  - `best_frame_size > baseline` -> **FAIL** (regression)
  - `best_frame_size <= baseline` -> pass; a value below baseline is logged as a
    HW improvement with a hint to tighten the baseline.
#### How did you verify/test it?
- Ran against Ixia/IxNetwork backend; test fails when the reported no-loss
  minimum exceeds the baseline and passes (with an improvement log) when below.
```
------------------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------------------
WARNING  ixnetwork_restpy.connection:connection.py:351 Verification of certificates is disabled
INFO     ixnetwork_restpy.connection:connection.py:348 Determining the platform and rest_port using the 10.36.77.53 address...
WARNING  ixnetwork_restpy.connection:connection.py:351 Unable to connect to http://10.36.77.53:11010.
INFO     ixnetwork_restpy.connection:connection.py:348 Connection established to `https://10.36.77.53:11010 on windows`
INFO     ixnetwork_restpy.connection:connection.py:348 Using IxNetwork api server version 10.80.2413.2
INFO     ixnetwork_restpy.connection:connection.py:348 User info IxNetwork/WIN-11RK5TNKNAN/8010
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 snappi-1.59.1
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 snappi_ixnetwork-1.59.0
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 ixnetwork_restpy-1.9.0
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Config validation 0.004s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Ports configuration 0.056s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Captures configuration 0.031s
INFO     ixnetwork_restpy.connection:connection.py:348 [0.054s] Timer @ batchadd.py:387 -> Batch Add Completed
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Add location hosts [10.36.78.53, 10.36.84.32] 0.081s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Location hosts ready [10.36.78.53, 10.36.84.32] 0.019s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Speed conversion is not require for (port.name, speed) : [('Port_1', 'novusHundredGigNonFanOut'), ('Port_2', 'novusHundredGigNonFanOut'), ('Port_3', 'novusHundredGigNonFanOut')]
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Aggregation mode speed change 0.834s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Location configuration 3.449s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Layer1 configuration 0.055s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Lag Configuration 0.007s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Convert device config : 0.159s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Create IxNetwork device config : 0.000s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Push IxNetwork device config : 1.055s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Devices configuration 1.223s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Flows configuration 0.889s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Start interfaces 0.482s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
INFO     snappi_tests.dataplane.files.helper:helper.py:764 Start protocols
INFO     tests.common.utilities:utilities.py:121 Pause 20 seconds, reason: For protocols To start
INFO     snappi_tests.dataplane.files.helper:helper.py:764 Start traffic
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Flows generate/apply 4.771s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Flows clear statistics 12.704s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Captures start 0.000s
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Flows start 4.247s
INFO     snappi_tests.dataplane.files.helper:helper.py:676 Waiting for Traffic to Start ...
INFO     snappi_tests.dataplane.files.helper:helper.py:680 Done waiting for Traffic to Start
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:135 
Sanity check IPv4: max frame size 9088 bytes at 100% line rate

INFO     snappi_tests.dataplane.files.helper:helper.py:800 Framesize: 9088 and percentLineRate: 100
INFO     snappi_tests.dataplane.files.helper:helper.py:504 Running traffic for 30 seconds.
INFO     snappi_tests.dataplane.files.helper:helper.py:507 
INFO     snappi_tests.dataplane.files.helper:helper.py:816 Dumping Frame Size/Rate: 9088/100 RFC2889 Enabled: True Traffic Item Stats: 
+------------------------+-------------+-------------+--------+----------+
| name                   |   frames_tx |   frames_rx |   loss | Status   |
|------------------------+-------------+-------------+--------+----------|
| min_frame_size_no_loss |   172838583 |   172838571 |      0 | PASS     |
+------------------------+-------------+-------------+--------+----------+
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:178 ==================================================
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:179 Testing IPv4 Frame Size: 4544 bytes at 100% Line Rate
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:180 ==================================================
INFO     snappi_tests.dataplane.files.helper:helper.py:800 Framesize: 4544 and percentLineRate: 100
INFO     snappi_tests.dataplane.files.helper:helper.py:504 Running traffic for 30 seconds.
INFO     snappi_tests.dataplane.files.helper:helper.py:507 
INFO     snappi_tests.dataplane.files.helper:helper.py:816 Dumping Frame Size/Rate: 4544/100 RFC2889 Enabled: True Traffic Item Stats: 
+------------------------+-------------+-------------+--------+----------+
| name                   |   frames_tx |   frames_rx |   loss | Status   |
|------------------------+-------------+-------------+--------+----------|
| min_frame_size_no_loss |   247896735 |   247896717 |      0 | PASS     |
+------------------------+-------------+-------------+--------+----------+
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:178 ==================================================
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:179 Testing IPv4 Frame Size: 2240 bytes at 100% Line Rate
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:180 ==================================================
INFO     snappi_tests.dataplane.files.helper:helper.py:800 Framesize: 2240 and percentLineRate: 100
INFO     snappi_tests.dataplane.files.helper:helper.py:504 Running traffic for 30 seconds.
INFO     snappi_tests.dataplane.files.helper:helper.py:507 
INFO     snappi_tests.dataplane.files.helper:helper.py:816 Dumping Frame Size/Rate: 2240/100 RFC2889 Enabled: True Traffic Item Stats: 
+------------------------+-------------+-------------+--------+----------+
| name                   |   frames_tx |   frames_rx |   loss | Status   |
|------------------------+-------------+-------------+--------+----------|
| min_frame_size_no_loss |   483298890 |   483298851 |      0 | PASS     |
+------------------------+-------------+-------------+--------+----------+
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:178 ==================================================
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:179 Testing IPv4 Frame Size: 1088 bytes at 100% Line Rate
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:180 ==================================================
INFO     snappi_tests.dataplane.files.helper:helper.py:800 Framesize: 1088 and percentLineRate: 100
INFO     snappi_tests.dataplane.files.helper:helper.py:504 Running traffic for 30 seconds.
INFO     snappi_tests.dataplane.files.helper:helper.py:507 
INFO     snappi_tests.dataplane.files.helper:helper.py:816 Dumping Frame Size/Rate: 1088/100 RFC2889 Enabled: True Traffic Item Stats: 
+------------------------+-------------+-------------+--------+----------+
| name                   |   frames_tx |   frames_rx |   loss | Status   |
|------------------------+-------------+-------------+--------+----------|
| min_frame_size_no_loss |  1051041690 |  1051041612 |      0 | PASS     |
+------------------------+-------------+-------------+--------+----------+
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:178 ==================================================
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:179 Testing IPv4 Frame Size: 512 bytes at 100% Line Rate
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:180 ==================================================
INFO     snappi_tests.dataplane.files.helper:helper.py:800 Framesize: 512 and percentLineRate: 100
INFO     snappi_tests.dataplane.files.helper:helper.py:504 Running traffic for 30 seconds.
INFO     snappi_tests.dataplane.files.helper:helper.py:507 
INFO     snappi_tests.dataplane.files.helper:helper.py:816 Dumping Frame Size/Rate: 512/100 RFC2889 Enabled: True Traffic Item Stats: 
+------------------------+-------------+-------------+--------+----------+
| name                   |   frames_tx |   frames_rx |   loss | Status   |
|------------------------+-------------+-------------+--------+----------|
| min_frame_size_no_loss |  2108371800 |  2108371635 |      0 | PASS     |
+------------------------+-------------+-------------+--------+----------+
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:178 ==================================================
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:179 Testing IPv4 Frame Size: 256 bytes at 100% Line Rate
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:180 ==================================================
INFO     snappi_tests.dataplane.files.helper:helper.py:800 Framesize: 256 and percentLineRate: 100
INFO     snappi_tests.dataplane.files.helper:helper.py:504 Running traffic for 30 seconds.
INFO     snappi_tests.dataplane.files.helper:helper.py:507 
INFO     snappi_tests.dataplane.files.helper:helper.py:816 Dumping Frame Size/Rate: 256/100 RFC2889 Enabled: True Traffic Item Stats: 
+------------------------+-------------+-------------+--------+----------+
| name                   |   frames_tx |   frames_rx |   loss | Status   |
|------------------------+-------------+-------------+--------+----------|
| min_frame_size_no_loss |  3915195984 |  3915195664 |      0 | PASS     |
+------------------------+-------------+-------------+--------+----------+
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:178 ==================================================
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:179 Testing IPv4 Frame Size: 128 bytes at 100% Line Rate
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:180 ==================================================
INFO     snappi_tests.dataplane.files.helper:helper.py:800 Framesize: 128 and percentLineRate: 100
INFO     snappi_tests.dataplane.files.helper:helper.py:504 Running traffic for 30 seconds.
INFO     snappi_tests.dataplane.files.helper:helper.py:507 
INFO     snappi_tests.dataplane.files.helper:helper.py:816 Dumping Frame Size/Rate: 128/100 RFC2889 Enabled: True Traffic Item Stats: 
+------------------------+-------------+-------------+--------+----------+
| name                   |   frames_tx |   frames_rx |   loss | Status   |
|------------------------+-------------+-------------+--------+----------|
| min_frame_size_no_loss |  7734353201 |  7734352611 |      0 | PASS     |
+------------------------+-------------+-------------+--------+----------+
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:178 ==================================================
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:179 Testing IPv4 Frame Size: 64 bytes at 100% Line Rate
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:180 ==================================================
INFO     snappi_tests.dataplane.files.helper:helper.py:800 Framesize: 64 and percentLineRate: 100
INFO     snappi_tests.dataplane.files.helper:helper.py:504 Running traffic for 30 seconds.
INFO     snappi_tests.dataplane.files.helper:helper.py:507 
INFO     snappi_tests.dataplane.files.helper:helper.py:816 Dumping Frame Size/Rate: 64/100 RFC2889 Enabled: True Traffic Item Stats: 
+------------------------+-------------+-------------+--------+----------+
| name                   |   frames_tx |   frames_rx |   loss | Status   |
|------------------------+-------------+-------------+--------+----------|
| min_frame_size_no_loss | 12828471054 | 12828470040 |      0 | PASS     |
+------------------------+-------------+-------------+--------+----------+
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:188 Final Smallest Frame Size Without Loss for FrameOrderingMode IPv4: 'RFC2889' is: 64 bytes
INFO     root:db_reporter.py:49 DBReporter: Writing 1 metric records to file
INFO     root:db_reporter.py:97 DBReporter: Successfully wrote 1 metric records to /tmp/telemetry_test_fhj1hqeo/test_min_frame_size.metrics.json
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:209 Summary for IPv4 Frame Ordering Mode: True
            ====================================================================================================
            +--------------+------------------+--------------+-----------------+-------------+-------------+----------+----------+----------------+
| IP Version   | Frame Ordering   |   Frame Size |   Line Rate (%) |   Tx Frames |   Rx Frames |   Loss % | Status   |   Duration (s) |
|--------------+------------------+--------------+-----------------+-------------+-------------+----------+----------+----------------|
| IPv4         | True             |         9088 |             100 |   172838583 |   172838571 |        0 | PASS     |             30 |
| IPv4         | True             |         4544 |             100 |   247896735 |   247896717 |        0 | PASS     |             30 |
| IPv4         | True             |         2240 |             100 |   483298890 |   483298851 |        0 | PASS     |             30 |
| IPv4         | True             |         1088 |             100 |  1051041690 |  1051041612 |        0 | PASS     |             30 |
| IPv4         | True             |          512 |             100 |  2108371800 |  2108371635 |        0 | PASS     |             30 |
| IPv4         | True             |          256 |             100 |  3915195984 |  3915195664 |        0 | PASS     |             30 |
| IPv4         | True             |          128 |             100 |  7734353201 |  7734352611 |        0 | PASS     |             30 |
| IPv4         | True             |           64 |             100 | 12828471054 | 12828470040 |        0 | PASS     |             30 |
+--------------+------------------+--------------+-----------------+-------------+-------------+----------+----------+----------------+
            ====================================================================================================
INFO     tests.snappi_tests.dataplane.test_min_frame_size:test_min_frame_size.py:219 No-loss minimum frame size improved for hwsku=Accton-AS7726-32X ip_version=IPv4: 64 bytes (baseline 192 bytes). Consider tightening the baseline.
INFO     snappi_tests.dataplane.files.helper:helper.py:764 Stop traffic
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1522 Flows stop 6.581s
INFO     snappi_tests.dataplane.files.helper:helper.py:676 Waiting for Traffic to Stop ...
INFO     snappi_tests.dataplane.files.helper:helper.py:680 Done waiting for Traffic to Stop
INFO     snappi_tests.dataplane.files.helper:helper.py:764 Stop protocols
INFO     tests.common.utilities:utilities.py:121 Pause 20 seconds, reason: For protocols To stop

 tests/snappi_tests/dataplane/test_min_frame_size.py::test_min_frame_size_no_loss[True-IPv4] ✓                                                                                                                            100% █████     

---------------------------------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------------------------------
INFO     root:__init__.py:93 -------------------- fixture snappi_api teardown starts --------------------
INFO     root:__init__.py:102 -------------------- fixture snappi_api teardown ends --------------------
INFO     tests.conftest:conftest.py:3250 Skipping temporarily_disable_route_check fixture
INFO     tests.conftest:conftest.py:3031 Dumping Disk and Memory Space information after test on sonic-s6100-dut1
INFO     tests.conftest:conftest.py:3035 Collecting core dumps after test on sonic-s6100-dut1
INFO     tests.conftest:conftest.py:3046 Collecting running config after test on sonic-s6100-dut1
WARNING  tests.conftest:conftest.py:3187 Core dump or config check failed for test_min_frame_size.py, results: {"core_dump_check": {"failed": false, "new_core_dumps": {"sonic-s6100-dut1": []}}, "config_db_check": {"failed": true, "pre_only_config": {"sonic-s6100-dut1": {"null": {"FDB": {"Vlan2|00:1A:2B:3C:4D:5E": {"port": "Ethernet4", "type": "static"}}, "PORT_QOS_MAP": {"Ethernet64": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}, "Ethernet68": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}, "Ethernet72": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}, "Ethernet76": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}, "global": {"dscp_to_tc_map": "AZURE"}}, "TC_TO_QUEUE_MAP": {"AZURE": {"0": "0", "1": "1", "2": "2", "3": "3", "4": "4", "5": "5", "6": "6", "7": "7"}}, "PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "200"}}, "SCHEDULER": {"scheduler.0": {"type": "DWRR", "weight": "95"}, "scheduler.1": {"type": "DWRR", "weight": "5"}}, "BUFFER_POOL": {"egress_lossless_pool": {"mode": "static", "size": "15982720", "type": "egress"}, "egress_lossy_pool": {"mode": "dynamic", "size": "9243812", "type": "egress"}, "ingress_lossless_pool": {"mode": "dynamic", "size": "10875072", "type": "ingress", "xoff": "4194112"}}, "BUFFER_QUEUE": {"Ethernet64|0-2": {"profile": "egress_lossy_profile"}, "Ethernet64|3-4": {"profile": "egress_lossless_profile"}, "Ethernet64|5-6": {"profile": "egress_lossy_profile"}, "Ethernet68|0-2": {"profile": "egress_lossy_profile"}, "Ethernet68|3-4": {"profile": "egress_lossless_profile"}, "Ethernet68|5-6": {"profile": "egress_lossy_profile"}, "Ethernet72|0-2": {"profile": "egress_lossy_profile"}, "Ethernet72|3-4": {"profile": "egress_lossless_profile"}, "Ethernet72|5-6": {"profile": "egress_lossy_profile"}, "Ethernet76|0-2": {"profile": "egress_lossy_profile"}, "Ethernet76|3-4": {"profile": "egress_lossless_profile"}, "Ethernet76|5-6": {"profile": "egress_lossy_profile"}}, "WRED_PROFILE": {"AZURE_LOSSLESS": {"ecn": "ecn_all", "green_drop_probability": "100", "green_max_threshold": "2000000", "green_min_threshold": "500000", "red_drop_probability": "100", "red_max_threshold": "2097152", "red_min_threshold": "1048576", "wred_green_enable": "true", "wred_red_enable": "true", "wred_yellow_enable": "true", "yellow_drop_probability": "100", "yellow_max_threshold": "2097152", "yellow_min_threshold": "1048576"}}, "BUFFER_PG": {"Ethernet64|0-2": {"profile": "ingress_lossy_profile"}, "Ethernet64|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet64|5-6": {"profile": "ingress_lossy_profile"}, "Ethernet68|0-2": {"profile": "ingress_lossy_profile"}, "Ethernet68|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet68|5-6": {"profile": "ingress_lossy_profile"}, "Ethernet72|0-2": {"profile": "ingress_lossy_profile"}, "Ethernet72|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet72|5-6": {"profile": "ingress_lossy_profile"}, "Ethernet76|0-2": {"profile": "ingress_lossy_profile"}, "Ethernet76|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet76|5-6": {"profile": "ingress_lossy_profile"}}, "TC_TO_PRIORITY_GROUP_MAP": {"AZURE": {"0": "0", "1": "0", "2": "0", "3": "3", "4": "4", "5": "0", "6": "0", "7": "7"}}, "DSCP_TO_TC_MAP": {"AZURE": {"0": "1", "1": "1", "10": "1", "11": "1", "12": "1", "13": "1", "14": "1", "15": "1", "16": "1", "17": "1", "18": "1", "19": "1", "2": "1", "20": "1", "21": "1", "22": "1", "23": "1", "24": "1", "25": "1", "26": "1", "27": "1", "28": "1", "29": "1", "3": "3", "30": "1", "31": "1", "32": "1", "33": "1", "34": "1", "35": "1", "36": "1", "37": "1", "38": "1", "39": "1", "4": "4", "40": "1", "41": "1", "42": "1", "43": "1", "44": "1", "45": "1", "46": "5", "47": "1", "48": "6", "49": "1", "5": "2", "50": "1", "51": "1", "52": "1", "53": "1", "54": "1", "55": "1", "56": "1", "57": "1", "58": "1", "59": "1", "6": "1", "60": "1", "61": "1", "62": "1", "63": "1", "7": "1", "8": "0", "9": "1"}}, "MAP_PFC_PRIORITY_TO_QUEUE": {"AZURE": {"0": "0", "1": "1", "2": "2", "3": "3", "4": "4", "5": "5", "6": "6", "7": "7"}}, "QUEUE": {"Ethernet64|0": {"scheduler": "scheduler.0", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet64|1": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet64|2": {"scheduler": "scheduler.0"}, "Ethernet64|3": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet64|4": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet64|5": {"scheduler": "scheduler.0"}, "Ethernet64|6": {"scheduler": "scheduler.0"}, "Ethernet68|0": {"scheduler": "scheduler.0", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet68|1": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet68|2": {"scheduler": "scheduler.0"}, "Ethernet68|3": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet68|4": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet68|5": {"scheduler": "scheduler.0"}, "Ethernet68|6": {"scheduler": "scheduler.0"}, "Ethernet72|0": {"scheduler": "scheduler.0", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet72|1": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet72|2": {"scheduler": "scheduler.0"}, "Ethernet72|3": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet72|4": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet72|5": {"scheduler": "scheduler.0"}, "Ethernet72|6": {"scheduler": "scheduler.0"}, "Ethernet76|0": {"scheduler": "scheduler.0", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet76|1": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet76|2": {"scheduler": "scheduler.0"}, "Ethernet76|3": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet76|4": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet76|5": {"scheduler": "scheduler.0"}, "Ethernet76|6": {"scheduler": "scheduler.0"}}, "PORTCHANNEL": {"PortChannel2": {"admin_status": "up", "fast_rate": "false", "lacp_key": "auto", "min_links": "1", "mix_speed": "false", "mtu": "9100"}}, "PORTCHANNEL_INTERFACE": {"PortChannel1": {}, "PortChannel1|2000:1::1/126": {}}, "BUFFER_PROFILE": {"egress_lossless_profile": {"pool": "egress_lossless_pool", "size": "1518", "static_th": "15982720"}, "egress_lossy_profile": {"dynamic_th": "3", "pool": "egress_lossy_pool", "size": "1518"}, "ingress_lossy_profile": {"dynamic_th": "3", "pool": "ingress_lossless_pool", "size": "0"}, "pg_lossless_100000_5m_profile": {"dynamic_th": "3", "pool": "ingress_lossless_pool", "size": "1248", "xoff": "165568", "xon": "2288", "xon_offset": "2288"}}}}}, "cur_only_config": {"sonic-s6100-dut1": {"null": {"DEVICE_NEIGHBOR": {"Ethernet0": {"name": "snappi-sonic", "port": "Ethernet1"}}, "BGP_NEIGHBOR": {"20.1.1.2": {"asn": "65200", "holdtime": "180", "keepalive": "60", "local_addr": "20.1.1.1", "name": "snappi-sonic", "nhopself": "0", "rrclient": "0"}, "2000:1::2": {"asn": "65200", "holdtime": "180", "keepalive": "60", "local_addr": "2000:1::1", "name": "snappi-sonic", "nhopself": "0", "rrclient": "0"}, "2001:1::2": {"asn": "65200", "holdtime": "180", "keepalive": "60", "local_addr": "2001:1::1", "name": "snappi-sonic", "nhopself": "0", "rrclient": "0"}, "2002:1::2": {"asn": "65200", "holdtime": "180", "keepalive": "60", "local_addr": "2002:1::1", "name": "snappi-sonic", "nhopself": "0", "rrclient": "0"}, "2003:1::2": {"asn": "65200", "holdtime": "180", "keepalive": "60", "local_addr": "2003:1::1", "name": "snappi-sonic", "nhopself": "0", "rrclient": "0"}, "21.1.1.2": {"asn": "65200", "holdtime": "180", "keepalive": "60", "local_addr": "21.1.1.1", "name": "snappi-sonic", "nhopself": "0", "rrclient": "0"}, "22.1.1.2": {"asn": "65200", "holdtime": "180", "keepalive": "60", "local_addr": "22.1.1.1", "name": "snappi-sonic", "nhopself": "0", "rrclient": "0"}, "23.1.1.2": {"asn": "65200", "holdtime": "180", "keepalive": "60", "local_addr": "23.1.1.1", "name": "snappi-sonic", "nhopself": "0", "rrclient": "0"}}, "DEVICE_NEIGHBOR_METADATA": {"snappi-sonic": {"hwsku": "Snappi", "mgmt_addr": "172.16.149.206", "type": "ToRRouter"}}}}}, "inconsistent_config": {"sonic-s6100-dut1": {"null": {"LOOPBACK_INTERFACE": {"pre_value": {"Loopback0": {}, "Loopback0|2.2.2.2/32": {}}, "cur_value": {"Loopback0": {}, "Loopback0|1.1.1.1/32": {}, "Loopback0|1::1/128": {}}}, "PORT": {"pre_value": {"Ethernet0": {"admin_status": "up", "alias": "hundredGigE1", "description": "ARISTA01T2:Ethernet1", "fec": "rs", "index": "1", "lanes": "1,2,3,4", "mtu": "9100", "parent_port": "Ethernet0", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet100": {"admin_status": "up", "alias": "hundredGigE26", "description": "ARISTA10T0:Ethernet1", "fec": "rs", "index": "26", "lanes": "101,102,103,104", "mtu": "9100", "parent_port": "Ethernet100", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet104": {"admin_status": "up", "alias": "hundredGigE27", "description": "ARISTA11T0:Ethernet1", "fec": "rs", "index": "27", "lanes": "105,106,107,108", "mtu": "9100", "parent_port": "Ethernet104", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet108": {"admin_status": "up", "alias": "hundredGigE28", "description": "ARISTA12T0:Ethernet1", "fec": "rs", "index": "28", "lanes": "109,110,111,112", "mtu": "9100", "parent_port": "Ethernet108", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet112": {"admin_status": "up", "alias": "hundredGigE29", "description": "ARISTA13T0:Ethernet1", "fec": "rs", "index": "29", "lanes": "113,114,115,116", "mtu": "9100", "parent_port": "Ethernet112", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet116": {"admin_status": "up", "alias": "hundredGigE30", "description": "ARISTA14T0:Ethernet1", "fec": "rs", "index": "30", "lanes": "117,118,119,120", "mtu": "9100", "parent_port": "Ethernet116", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet12": {"admin_status": "up", "alias": "hundredGigE4", "description": "ARISTA04T2:Ethernet1", "fec": "rs", "index": "4", "lanes": "13,14,15,16", "mtu": "9100", "parent_port": "Ethernet12", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet120": {"admin_status": "up", "alias": "hundredGigE31", "description": "ARISTA15T0:Ethernet1", "fec": "rs", "index": "31", "lanes": "121,122,123,124", "mtu": "9100", "parent_port": "Ethernet120", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet124": {"admin_status": "up", "alias": "hundredGigE32", "description": "ARISTA16T0:Ethernet1", "fec": "rs", "index": "32", "lanes": "125,126,127,128", "mtu": "9100", "parent_port": "Ethernet124", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet16": {"admin_status": "up", "alias": "hundredGigE5", "description": "ARISTA05T2:Ethernet1", "fec": "rs", "index": "5", "lanes": "17,18,19,20", "mtu": "9100", "parent_port": "Ethernet16", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet20": {"admin_status": "up", "alias": "hundredGigE6", "description": "ARISTA06T2:Ethernet1", "fec": "rs", "index": "6", "lanes": "21,22,23,24", "mtu": "9100", "parent_port": "Ethernet20", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet24": {"admin_status": "up", "alias": "hundredGigE7", "description": "ARISTA07T2:Ethernet1", "fec": "rs", "index": "7", "lanes": "25,26,27,28", "mtu": "9100", "parent_port": "Ethernet24", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet28": {"admin_status": "up", "alias": "hundredGigE8", "description": "ARISTA08T2:Ethernet1", "fec": "rs", "index": "8", "lanes": "29,30,31,32", "mtu": "9100", "parent_port": "Ethernet28", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet32": {"admin_status": "up", "alias": "hundredGigE9", "description": "ARISTA09T2:Ethernet1", "fec": "rs", "index": "9", "lanes": "33,34,35,36", "mtu": "9100", "parent_port": "Ethernet32", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet36": {"admin_status": "up", "alias": "hundredGigE10", "description": "ARISTA10T2:Ethernet1", "fec": "rs", "index": "10", "lanes": "37,38,39,40", "mtu": "9100", "parent_port": "Ethernet36", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet4": {"admin_status": "up", "alias": "hundredGigE2", "description": "ARISTA02T2:Ethernet1", "fec": "rs", "index": "2", "lanes": "5,6,7,8", "mtu": "9100", "parent_port": "Ethernet4", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet40": {"admin_status": "up", "alias": "hundredGigE11", "description": "ARISTA11T2:Ethernet1", "fec": "rs", "index": "11", "lanes": "41,42,43,44", "mtu": "9100", "parent_port": "Ethernet40", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet44": {"admin_status": "up", "alias": "hundredGigE12", "description": "ARISTA12T2:Ethernet1", "fec": "rs", "index": "12", "lanes": "45,46,47,48", "mtu": "9100", "parent_port": "Ethernet44", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet48": {"admin_status": "up", "alias": "hundredGigE13", "description": "ARISTA13T2:Ethernet1", "fec": "rs", "index": "13", "lanes": "49,50,51,52", "mtu": "9100", "parent_port": "Ethernet48", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet52": {"admin_status": "up", "alias": "hundredGigE14", "description": "ARISTA14T2:Ethernet1", "fec": "rs", "index": "14", "lanes": "53,54,55,56", "mtu": "9100", "parent_port": "Ethernet52", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet56": {"admin_status": "up", "alias": "hundredGigE15", "description": "ARISTA15T2:Ethernet1", "fec": "rs", "index": "15", "lanes": "57,58,59,60", "mtu": "9100", "parent_port": "Ethernet56", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet60": {"admin_status": "up", "alias": "hundredGigE16", "description": "ARISTA16T2:Ethernet1", "fec": "rs", "index": "16", "lanes": "61,62,63,64", "mtu": "9100", "parent_port": "Ethernet60", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet64": {"admin_status": "up", "alias": "hundredGigE17", "description": "ARISTA01T0:Ethernet1", "fec": "rs", "index": "17", "lanes": "65,66,67,68", "mtu": "9100", "parent_port": "Ethernet64", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet68": {"admin_status": "up", "alias": "hundredGigE18", "description": "ARISTA02T0:Ethernet1", "fec": "rs", "index": "18", "lanes": "69,70,71,72", "mtu": "9100", "parent_port": "Ethernet68", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet72": {"admin_status": "up", "alias": "hundredGigE19", "description": "ARISTA03T0:Ethernet1", "fec": "rs", "index": "19", "lanes": "73,74,75,76", "mtu": "9100", "parent_port": "Ethernet72", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet76": {"admin_status": "up", "alias": "hundredGigE20", "description": "ARISTA04T0:Ethernet1", "fec": "rs", "index": "20", "lanes": "77,78,79,80", "mtu": "9100", "parent_port": "Ethernet76", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet8": {"admin_status": "up", "alias": "hundredGigE3", "description": "ARISTA03T2:Ethernet1", "fec": "rs", "index": "3", "lanes": "9,10,11,12", "mtu": "9100", "parent_port": "Ethernet8", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet80": {"admin_status": "up", "alias": "hundredGigE21", "description": "ARISTA05T0:Ethernet1", "fec": "rs", "index": "21", "lanes": "81,82,83,84", "mtu": "9100", "parent_port": "Ethernet80", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet84": {"admin_status": "up", "alias": "hundredGigE22", "description": "ARISTA06T0:Ethernet1", "fec": "rs", "index": "22", "lanes": "85,86,87,88", "mtu": "9100", "parent_port": "Ethernet84", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet88": {"admin_status": "up", "alias": "hundredGigE23", "description": "ARISTA07T0:Ethernet1", "fec": "rs", "index": "23", "lanes": "89,90,91,92", "mtu": "9100", "parent_port": "Ethernet88", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet92": {"admin_status": "up", "alias": "hundredGigE24", "description": "ARISTA08T0:Ethernet1", "fec": "rs", "index": "24", "lanes": "93,94,95,96", "mtu": "9100", "parent_port": "Ethernet92", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}, "Ethernet96": {"admin_status": "up", "alias": "hundredGigE25", "description": "ARISTA09T0:Ethernet1", "fec": "rs", "index": "25", "lanes": "97,98,99,100", "mtu": "9100", "parent_port": "Ethernet96", "pfc_asym": "off", "speed": "100000", "subport": "1", "tpid": "0x8100"}}, "cur_value": {"Ethernet0": {"admin_status": "up", "alias": "Eth1(Port1)", "autoneg": "off", "index": "1", "lanes": "1,2,3,4", "mtu": "9100", "parent_port": "Ethernet0", "speed": "100000", "subport": "1"}, "Ethernet100": {"admin_status": "up", "alias": "Eth26(Port26)", "autoneg": "off", "index": "26", "lanes": "101,102,103,104", "mtu": "9100", "parent_port": "Ethernet100", "speed": "100000", "subport": "1"}, "Ethernet104": {"admin_status": "up", "alias": "Eth27(Port27)", "autoneg": "off", "index": "27", "lanes": "105,106,107,108", "mtu": "9100", "parent_port": "Ethernet104", "speed": "100000", "subport": "1"}, "Ethernet108": {"admin_status": "up", "alias": "Eth28(Port28)", "autoneg": "off", "index": "28", "lanes": "109,110,111,112", "mtu": "9100", "parent_port": "Ethernet108", "speed": "100000", "subport": "1"}, "Ethernet112": {"admin_status": "up", "alias": "Eth29(Port29)", "autoneg": "off", "index": "29", "lanes": "113,114,115,116", "mtu": "9100", "parent_port": "Ethernet112", "speed": "100000", "subport": "1"}, "Ethernet116": {"admin_status": "up", "alias": "Eth30(Port30)", "autoneg": "off", "index": "30", "lanes": "117,118,119,120", "mtu": "9100", "parent_port": "Ethernet116", "speed": "100000", "subport": "1"}, "Ethernet12": {"admin_status": "up", "alias": "Eth4(Port4)", "autoneg": "off", "index": "4", "lanes": "13,14,15,16", "mtu": "9100", "parent_port": "Ethernet12", "speed": "100000", "subport": "1"}, "Ethernet120": {"admin_status": "up", "alias": "Eth31(Port31)", "autoneg": "off", "index": "31", "lanes": "121,122,123,124", "mtu": "9100", "parent_port": "Ethernet120", "speed": "100000", "subport": "1"}, "Ethernet124": {"admin_status": "up", "alias": "Eth32(Port32)", "autoneg": "off", "index": "32", "lanes": "125,126,127,128", "mtu": "9100", "parent_port": "Ethernet124", "speed": "100000", "subport": "1"}, "Ethernet16": {"admin_status": "up", "alias": "Eth5(Port5)", "autoneg": "off", "index": "5", "lanes": "17,18,19,20", "mtu": "9100", "parent_port": "Ethernet16", "speed": "100000", "subport": "1"}, "Ethernet20": {"admin_status": "up", "alias": "Eth6(Port6)", "autoneg": "off", "index": "6", "lanes": "21,22,23,24", "mtu": "9100", "parent_port": "Ethernet20", "speed": "100000", "subport": "1"}, "Ethernet24": {"admin_status": "up", "alias": "Eth7(Port7)", "autoneg": "off", "index": "7", "lanes": "25,26,27,28", "mtu": "9100", "parent_port": "Ethernet24", "speed": "100000", "subport": "1"}, "Ethernet28": {"admin_status": "up", "alias": "Eth8(Port8)", "autoneg": "off", "index": "8", "lanes": "29,30,31,32", "mtu": "9100", "parent_port": "Ethernet28", "speed": "100000", "subport": "1"}, "Ethernet32": {"admin_status": "up", "alias": "Eth9(Port9)", "autoneg": "off", "index": "9", "lanes": "33,34,35,36", "mtu": "9100", "parent_port": "Ethernet32", "speed": "100000", "subport": "1"}, "Ethernet36": {"admin_status": "up", "alias": "Eth10(Port10)", "autoneg": "off", "index": "10", "lanes": "37,38,39,40", "mtu": "9100", "parent_port": "Ethernet36", "speed": "100000", "subport": "1"}, "Ethernet4": {"admin_status": "up", "alias": "Eth2(Port2)", "autoneg": "off", "index": "2", "lanes": "5,6,7,8", "mtu": "9100", "parent_port": "Ethernet4", "speed": "100000", "subport": "1"}, "Ethernet40": {"admin_status": "up", "alias": "Eth11(Port11)", "autoneg": "off", "index": "11", "lanes": "41,42,43,44", "mtu": "9100", "parent_port": "Ethernet40", "speed": "100000", "subport": "1"}, "Ethernet44": {"admin_status": "up", "alias": "Eth12(Port12)", "autoneg": "off", "index": "12", "lanes": "45,46,47,48", "mtu": "9100", "parent_port": "Ethernet44", "speed": "100000", "subport": "1"}, "Ethernet48": {"admin_status": "up", "alias": "Eth13(Port13)", "autoneg": "off", "index": "13", "lanes": "49,50,51,52", "mtu": "9100", "parent_port": "Ethernet48", "speed": "100000", "subport": "1"}, "Ethernet52": {"admin_status": "up", "alias": "Eth14(Port14)", "autoneg": "off", "index": "14", "lanes": "53,54,55,56", "mtu": "9100", "parent_port": "Ethernet52", "speed": "100000", "subport": "1"}, "Ethernet56": {"admin_status": "up", "alias": "Eth15(Port15)", "autoneg": "off", "index": "15", "lanes": "57,58,59,60", "mtu": "9100", "parent_port": "Ethernet56", "speed": "100000", "subport": "1"}, "Ethernet60": {"admin_status": "up", "alias": "Eth16(Port16)", "autoneg": "off", "index": "16", "lanes": "61,62,63,64", "mtu": "9100", "parent_port": "Ethernet60", "speed": "100000", "subport": "1"}, "Ethernet64": {"admin_status": "up", "alias": "Eth17(Port17)", "autoneg": "off", "index": "17", "lanes": "65,66,67,68", "mtu": "9100", "parent_port": "Ethernet64", "speed": "100000", "subport": "1"}, "Ethernet68": {"admin_status": "up", "alias": "Eth18(Port18)", "autoneg": "off", "index": "18", "lanes": "69,70,71,72", "mtu": "9100", "parent_port": "Ethernet68", "speed": "100000", "subport": "1"}, "Ethernet72": {"admin_status": "up", "alias": "Eth19(Port19)", "autoneg": "off", "index": "19", "lanes": "73,74,75,76", "mtu": "9100", "parent_port": "Ethernet72", "speed": "100000", "subport": "1"}, "Ethernet76": {"admin_status": "up", "alias": "Eth20(Port20)", "autoneg": "off", "index": "20", "lanes": "77,78,79,80", "mtu": "9100", "parent_port": "Ethernet76", "speed": "100000", "subport": "1"}, "Ethernet8": {"admin_status": "up", "alias": "Eth3(Port3)", "autoneg": "off", "index": "3", "lanes": "9,10,11,12", "mtu": "9100", "parent_port": "Ethernet8", "speed": "100000", "subport": "1"}, "Ethernet80": {"admin_status": "up", "alias": "Eth21(Port21)", "autoneg": "off", "index": "21", "lanes": "81,82,83,84", "mtu": "9100", "parent_port": "Ethernet80", "speed": "100000", "subport": "1"}, "Ethernet84": {"admin_status": "up", "alias": "Eth22(Port22)", "autoneg": "off", "index": "22", "lanes": "85,86,87,88", "mtu": "9100", "parent_port": "Ethernet84", "speed": "100000", "subport": "1"}, "Ethernet88": {"admin_status": "up", "alias": "Eth23(Port23)", "autoneg": "off", "index": "23", "lanes": "89,90,91,92", "mtu": "9100", "parent_port": "Ethernet88", "speed": "100000", "subport": "1"}, "Ethernet92": {"admin_status": "up", "alias": "Eth24(Port24)", "autoneg": "off", "index": "24", "lanes": "93,94,95,96", "mtu": "9100", "parent_port": "Ethernet92", "speed": "100000", "subport": "1"}, "Ethernet96": {"admin_status": "up", "alias": "Eth25(Port25)", "autoneg": "off", "index": "25", "lanes": "97,98,99,100", "mtu": "9100", "parent_port": "Ethernet96", "speed": "100000", "subport": "1"}}}, "VLAN": {"pre_value": {"Vlan100": {"vlanid": "100"}}, "cur_value": {"Vlan100": {"vlanid": "100"}, "Vlan1000": {"vlanid": "1000"}}}, "DEVICE_METADATA": {"pre_value": {"localhost": {"buffer_model": "traditional", "default_bgp_status": "up", "default_pfcwd_status": "disable", "docker_routing_config_mode": "split", "frr_mgmt_framework_config": "true", "hostname": "sonic", "hwsku": "Accton-AS7726-32X", "mac": "90:3c:b3:94:ad:7e", "platform": "x86_64-accton_as7726_32x-r0", "synchronous_mode": "enable", "type": "LeafRouter"}}, "cur_value": {"localhost": {"bgp_asn": "65100", "buffer_model": "traditional", "default_bgp_status": "up", "default_pfcwd_status": "disable", "docker_routing_config_mode": "split", "frr_mgmt_framework_config": "true", "hostname": "sonic", "hwsku": "Accton-AS7726-32X", "mac": "90:3c:b3:94:ad:7e", "platform": "x86_64-accton_as7726_32x-r0", "synchronous_mode": "enable", "type": "ToRRouter"}}}, "CRM": {"pre_value": {"Config": {"acl_counter_high_threshold": "85", "acl_counter_low_threshold": "70", "acl_counter_threshold_type": "percentage", "acl_entry_high_threshold": "85", "acl_entry_low_threshold": "70", "acl_entry_threshold_type": "percentage", "acl_group_high_threshold": "85", "acl_group_low_threshold": "70", "acl_group_threshold_type": "percentage", "acl_table_high_threshold": "85", "acl_table_low_threshold": "70", "acl_table_threshold_type": "percentage", "dnat_entry_high_threshold": "85", "dnat_entry_low_threshold": "70", "dnat_entry_threshold_type": "percentage", "fdb_entry_high_threshold": "85", "fdb_entry_low_threshold": "70", "fdb_entry_threshold_type": "percentage", "ipmc_entry_high_threshold": "85", "ipmc_entry_low_threshold": "70", "ipmc_entry_threshold_type": "percentage", "ipv4_neighbor_high_threshold": "85", "ipv4_neighbor_low_threshold": "70", "ipv4_neighbor_threshold_type": "percentage", "ipv4_nexthop_high_threshold": "85", "ipv4_nexthop_low_threshold": "70", "ipv4_nexthop_threshold_type": "percentage", "ipv4_route_high_threshold": "85", "ipv4_route_low_threshold": "70", "ipv4_route_threshold_type": "percentage", "ipv6_neighbor_high_threshold": "85", "ipv6_neighbor_low_threshold": "70", "ipv6_neighbor_threshold_type": "percentage", "ipv6_nexthop_high_threshold": "85", "ipv6_nexthop_low_threshold": "70", "ipv6_nexthop_threshold_type": "percentage", "ipv6_route_high_threshold": "85", "ipv6_route_low_threshold": "70", "ipv6_route_threshold_type": "percentage", "mpls_inseg_high_threshold": "85", "mpls_inseg_low_threshold": "70", "mpls_inseg_threshold_type": "percentage", "mpls_nexthop_high_threshold": "85", "mpls_nexthop_low_threshold": "70", "mpls_nexthop_threshold_type": "percentage", "nexthop_group_high_threshold": "85", "nexthop_group_low_threshold": "70", "nexthop_group_member_high_threshold": "85", "nexthop_group_member_low_threshold": "70", "nexthop_group_member_threshold_type": "percentage", "nexthop_group_threshold_type": "percentage", "polling_interval": "30", "snat_entry_high_threshold": "85", "snat_entry_low_threshold": "70", "snat_entry_threshold_type": "percentage"}}, "cur_value": {"Config": {"acl_counter_high_threshold": "85", "acl_counter_low_threshold": "70", "acl_counter_threshold_type": "percentage", "acl_entry_high_threshold": "85", "acl_entry_low_threshold": "70", "acl_entry_threshold_type": "percentage", "acl_group_high_threshold": "85", "acl_group_low_threshold": "70", "acl_group_threshold_type": "percentage", "acl_table_high_threshold": "85", "acl_table_low_threshold": "70", "acl_table_threshold_type": "percentage", "dnat_entry_high_threshold": "85", "dnat_entry_low_threshold": "70", "dnat_entry_threshold_type": "percentage", "fdb_entry_high_threshold": "85", "fdb_entry_low_threshold": "70", "fdb_entry_threshold_type": "percentage", "ipmc_entry_high_threshold": "85", "ipmc_entry_low_threshold": "70", "ipmc_entry_threshold_type": "percentage", "ipv4_neighbor_high_threshold": "85", "ipv4_neighbor_low_threshold": "70", "ipv4_neighbor_threshold_type": "percentage", "ipv4_nexthop_high_threshold": "85", "ipv4_nexthop_low_threshold": "70", "ipv4_nexthop_threshold_type": "percentage", "ipv4_route_high_threshold": "85", "ipv4_route_low_threshold": "70", "ipv4_route_threshold_type": "percentage", "ipv6_neighbor_high_threshold": "85", "ipv6_neighbor_low_threshold": "70", "ipv6_neighbor_threshold_type": "percentage", "ipv6_nexthop_high_threshold": "85", "ipv6_nexthop_low_threshold": "70", "ipv6_nexthop_threshold_type": "percentage", "ipv6_route_high_threshold": "85", "ipv6_route_low_threshold": "70", "ipv6_route_threshold_type": "percentage", "mpls_inseg_high_threshold": "85", "mpls_inseg_low_threshold": "70", "mpls_inseg_threshold_type": "percentage", "mpls_nexthop_high_threshold": "85", "mpls_nexthop_low_threshold": "70", "mpls_nexthop_threshold_type": "percentage", "nexthop_group_high_threshold": "85", "nexthop_group_low_threshold": "70", "nexthop_group_member_high_threshold": "85", "nexthop_group_member_low_threshold": "70", "nexthop_group_member_threshold_type": "percentage", "nexthop_group_threshold_type": "percentage", "polling_interval": "300", "snat_entry_high_threshold": "85", "snat_entry_low_threshold": "70", "snat_entry_threshold_type": "percentage"}}}, "INTERFACE": {"pre_value": {"Ethernet0": {}, "Ethernet104": {}, "Ethernet108": {}, "Ethernet4": {}, "Ethernet64": {}, "Ethernet68": {}, "Ethernet72": {}, "Ethernet76": {}, "Ethernet0|10.1.1.1/24": {}, "Ethernet104|104.1.1.1/24": {}, "Ethernet108|108.1.1.1/24": {}, "Ethernet4|10.2.1.1/24": {}, "Ethernet64|2001::1/64": {}, "Ethernet64|21.1.1.1/24": {}, "Ethernet68|2002::1/64": {}, "Ethernet68|22.1.1.1/24": {}, "Ethernet72|2003::1/64": {}, "Ethernet72|23.1.1.1/24": {}, "Ethernet76|2004::1/64": {}, "Ethernet76|24.1.1.1/24": {}}, "cur_value": {"Ethernet0": {}, "Ethernet64": {}, "Ethernet68": {}, "Ethernet72": {}, "Ethernet76": {}, "Ethernet0|100.1.1.2/24": {}, "Ethernet64|20.1.1.1/24": {}, "Ethernet64|2000:1::1/124": {}, "Ethernet68|2001:1::1/124": {}, "Ethernet68|21.1.1.1/24": {}, "Ethernet72|2002:1::1/124": {}, "Ethernet72|22.1.1.1/24": {}, "Ethernet76|2003:1::1/124": {}, "Ethernet76|23.1.1.1/24": {}}}, "VLAN_INTERFACE": {"pre_value": {"Vlan100": {}, "Vlan100|192.168.1.253/24": {}}, "cur_value": {"Vlan1000": {}, "Vlan1000|192.168.1.1/16": {}, "Vlan1000|5001::1/64": {}}}}}}}}
 tests/snappi_tests/dataplane/test_min_frame_size.py::test_min_frame_size_no_loss[False-IPv4] ✓                                                                                                                          100% ██████████
=========================================================================================================== warnings summary ===========================================================================================================
../../../opt/venv/lib/python3.12/site-packages/_pytest/config/__init__.py:852
  /opt/venv/lib/python3.12/site-packages/_pytest/config/__init__.py:852: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; tests.common.plugins.ptfadapter
    self.import_plugin(import_spec)


tests/snappi_tests/dataplane/test_min_frame_size.py::test_min_frame_size_no_loss[True-IPv4]
tests/snappi_tests/dataplane/test_min_frame_size.py::test_min_frame_size_no_loss[False-IPv4]
  /opt/venv/lib/python3.12/site-packages/ansible/plugins/loader.py:1485: UserWarning: AnsibleCollectionFinder has already been configured
    warnings.warn('AnsibleCollectionFinder has already been configured')

  /opt/venv/lib/python3.12/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host '10.36.77.53'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs

Results (737.80s (0:12:17)):
       2 passed
INFO:root:Can not get Allure report URL. Please check logs
root@4662fed26f9a:~/sonic-mgmt/tests# 
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
