### PR TITLE
Fix FrozenInstanceError in perform_gnoi_upgrade when to_version is au…

### DIFF
--- a/tests/common/helpers/upgrade_helpers.py
+++ b/tests/common/helpers/upgrade_helpers.py
@@ -44,7 +44,7 @@ class GnoiUpgradeConfig:
     upgrade_type: str
     protocol: str = "HTTP"
     allow_fail: bool = False
-    to_version: Optional[str] = None  # Optional expected version string to validate after upgrade
+    to_version: Optional[str] = None  # Expected version to validate; empty/None => derive from image
     ss_target_type: Optional[str] = None   # e.g. "dpu"
     ss_target_index: Optional[int] = None  # e.g. 3
     metadata: Optional[GrpcMetadata] = None
@@ -376,7 +376,9 @@ def perform_gnoi_upgrade(
     pytest_assert(res.get("rc", 1) == 0, f"Downloaded file not found or empty on DUT: {cfg.dut_image_path}")
 
     # ---- 2b) Extract target version from the image binary if not provided ----
-    if not cfg.to_version:
+    # Empty/None to_version means "always use the version extracted from the image".
+    target_version = cfg.to_version
+    if not target_version:
         ver_result = duthost.shell(
             "sonic_installer binary_version {} 2>&1".format(cfg.dut_image_path)
             + " | grep 'SONiC-OS-' | awk -F'SONiC-OS-' '{print $2}'",
@@ -389,13 +391,13 @@ def perform_gnoi_upgrade(
                 cfg.dut_image_path, ver_result.get("stderr", "")
             ),
         )
-        cfg.to_version = "SONiC-OS-{}".format(extracted_version)
-        logger.info("Extracted target version from image: %s", cfg.to_version)
+        target_version = "SONiC-OS-{}".format(extracted_version)
+        logger.info("Extracted target version from image: %s", target_version)
 
     # ---- 3) SetPackage (via wrapper) ----
     setpkg_resp = ptf_gnoi.system_set_package(
         local_path=cfg.dut_image_path,
-        version=cfg.to_version,
+        version=target_version,
         activate=True,
     )
     logger.info("SetPackage response: %s", setpkg_resp)
@@ -439,8 +441,8 @@ def perform_gnoi_upgrade(
     images = _get_images_from_sonic_installer_list(duthost)
     logger.info("sonic-installer list parsed: %s", images)
     pytest_assert(
-        images.get("current") == cfg.to_version,
-        f"Current image mismatch after reboot. current={images.get('current')} expected={cfg.to_version}. full={images}"
+        images.get("current") == target_version,
+        f"Current image mismatch after reboot. current={images.get('current')} expected={target_version}. full={images}"
     )
 
     return {"transfer_resp": transfer_resp, "setpkg_resp": setpkg_resp}


### PR DESCRIPTION
This PR fixes a runtime FrozenInstanceError in the gNOI upgrade helper by avoiding mutation of GnoiUpgradeConfig, which is a frozen dataclass. When to_version is not provided, the helper derives it from the transferred image and now rebinds cfg using dataclasses.replace() so subsequent operations use the derived version.

Changes:

Import replace from dataclasses alongside dataclass.
Replace the invalid cfg.to_version = ... mutation with cfg = replace(cfg, to_version=...) when deriving the target version.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
Testcase fix
#### How did you do it?
Modify the way we assign cfg.to_version
#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/6a70f0d2c738d690ad9c2353?testcase=upgrade_path%2Ftest_upgrade_gnoi.py&type=log&leftSideViewMode=detail
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
