### PR TITLE
bgp: enable lma/uma topologies for bgp tests

### DIFF
--- a/tests/bgp/test_bgp_command.py
+++ b/tests/bgp/test_bgp_command.py
@@ -7,7 +7,7 @@ from tests.common.utilities import is_ipv6_only_topology
 
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", "m0", "mx", "m1", "c0"),
+    pytest.mark.topology("t0", "t1", "m0", "mx", "m1", "c0", "lma", "uma"),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -17,7 +17,7 @@ from tests.common.utilities import wait_until
 from tests.common.utilities import is_ipv6_only_topology
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'm1', 'lt2', 'ft2', 'c0'),
+    pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'm1', 'lt2', 'ft2', 'c0', 'lma', 'uma'),
 ]
 
 TEST_ITERATIONS = 5
@@ -75,6 +75,13 @@ def common_setup_teardown(
             use_vtysh = True
     elif dut_type in ["UpperRegionalHub"]:
         neigh_type = "LowerRegionalHub"
+        if confed_asn is not None:
+            use_vtysh = True
+    elif dut_type in ["LowerMgmtAggregator", "UpperMgmtAggregator"]:
+        # Mgmt aggregators run BGP confederation. The test neighbor is an
+        # external eBGP peer, so it must be added directly to FRR via vtysh
+        # (the config_db path is not rendered for these peers).
+        neigh_type = "MgmtSpineRouter"
         if confed_asn is not None:
             use_vtysh = True
     else:

--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -77,11 +77,12 @@ def common_setup_teardown(
         neigh_type = "LowerRegionalHub"
         if confed_asn is not None:
             use_vtysh = True
-    elif dut_type in ["LowerMgmtAggregator", "UpperMgmtAggregator"]:
-        # Mgmt aggregators run BGP confederation. The test neighbor is an
-        # external eBGP peer, so it must be added directly to FRR via vtysh
-        # (the config_db path is not rendered for these peers).
+    elif dut_type in ["LowerMgmtAggregator"]:
         neigh_type = "MgmtSpineRouter"
+        if confed_asn is not None:
+            use_vtysh = True
+    elif dut_type in ["UpperMgmtAggregator"]:
+        neigh_type = "LowerMgmtAggregator"
         if confed_asn is not None:
             use_vtysh = True
     else:

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 vrfname = 'default'
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", 'm1', 'lt2', 'ft2', 'c0'),
+    pytest.mark.topology("t0", "t1", 'm1', 'lt2', 'ft2', 'c0', 'lma', 'uma'),
 ]
 
 

--- a/tests/bgp/test_bgp_session_flap.py
+++ b/tests/bgp/test_bgp_session_flap.py
@@ -29,7 +29,7 @@ cpuSpike = 10
 memSpike = 1.3
 
 pytestmark = [
-    pytest.mark.topology('t1', 't2', 'lrh', 'urh', 'm1', 'lt2', 'ft2', 'c0')
+    pytest.mark.topology('t1', 't2', 'lrh', 'urh', 'm1', 'lt2', 'ft2', 'c0', 'lma', 'uma')
 ]
 
 

--- a/tests/bgp/test_bgp_stress_link_flap.py
+++ b/tests/bgp/test_bgp_stress_link_flap.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('t0', 't1', "m0", "mx", 'm1', 'lt2', 'ft2', 'c0')
+    pytest.mark.topology('t0', 't1', "m0", "mx", 'm1', 'lt2', 'ft2', 'c0', 'lma', 'uma')
 ]
 
 stop_tasks = False

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -23,7 +23,7 @@ STATS_COLLECT_TIMEOUT = 30
 STATS_COLLECT_INTERVAL = 5
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'lt2', 'ft2'),
+    pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'lt2', 'ft2', 'lma', 'uma'),
     pytest.mark.disable_loganalyzer
 ]
 

--- a/tests/bgp/test_frr_config_check.py
+++ b/tests/bgp/test_frr_config_check.py
@@ -10,7 +10,7 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1'),
+    pytest.mark.topology('t0', 't1', 'lma', 'uma'),
     pytest.mark.disable_loganalyzer,
 ]
 
@@ -454,7 +454,7 @@ def test_frr_config_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname, g
     logger.info("Completed {} iterations of config reload and verification".format(num_iterations))
 
 
-@pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh')
+@pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'lma', 'uma')
 def test_frr_large_config_load_stress(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                                       get_function_completeness_level):
     """Stress test FRR config file loading with large configuration.


### PR DESCRIPTION
- Add 'lma'/'uma' topology markers to Tier 2 BGP tests so they run on the single-node mgmt-aggregator testbeds.
- test_bgp_peer_shutdown: add Lower/UpperMgmtAggregator branch that adds the test neighbor to FRR via vtysh when running under BGP confederation.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
run on both lma and uma topology

<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
