### PR TITLE
Fix ARP entry not found issue in testARPCompleted on DualToR-AA

### DIFF
--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -9,6 +9,9 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa
 from tests.ptf_runner import ptf_runner
 from .utils import fdb_table_has_dummy_mac_for_interface
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa: F401
+from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby  # noqa: F401
+from tests.common.dualtor.dual_tor_utils import check_active_active_port_status, show_muxcable_status
+from tests.common.dualtor.dual_tor_common import active_active_ports  # noqa: F401
 
 
 pytestmark = [
@@ -51,6 +54,25 @@ class TestFdbMacLearning:
     PTF_HOST_NETMASK = "24"
     DUT_INTF_IP = "20.0.0.1"
     DUT_INTF_NETMASK = "24"
+
+    @staticmethod
+    def _wait_mux_port_forwarding_ready(duthost, port, timeout=90, interval=5):
+        def _check():
+            mux_status = show_muxcable_status(duthost).get(port, {})
+            return (mux_status.get('status') == 'active' and
+                    mux_status.get('hwstatus', '').lower() == 'consistent')
+        return wait_until(timeout, interval, 0, _check)
+
+    def _setup_dualtor_aa_test_port(self, duthosts, duthost, peer_dut, dut_interface,
+                                    active_active_ports_list, config_active_active_dualtor_active_standby):
+        if not active_active_ports_list or dut_interface not in active_active_ports_list:
+            return
+        for tor in duthosts:
+            tor.shell("config muxcable mode manual {}".format(dut_interface))
+        config_active_active_dualtor_active_standby(duthost, peer_dut, [dut_interface])
+        pytest_assert(self._wait_mux_port_forwarding_ready(duthost, dut_interface),
+                      "Mux port {} not active/consistent on {} before L3 test".format(
+                          dut_interface, duthost.hostname))
 
     def configureInterfaceIp(self, duthost, dut_intf, action=None):
         """
@@ -290,7 +312,9 @@ class TestFdbMacLearning:
                               "mac entry present when interface {} is down even after sonic-clear fdb all"
                               .format(target_ports_to_ptf_mapping[i][0]))
 
-    def testARPCompleted(self, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request, prepare_test):
+    @pytest.mark.dualtor_active_active_setup_standby_on_random_unselected_tor
+    def testARPCompleted(self, ptfadapter, duthosts, rand_one_dut_hostname, rand_unselected_dut, ptfhost,
+                         tbinfo, request, prepare_test, active_active_ports, config_active_active_dualtor_active_standby):
         """
             Select a DUT interface and corresponding PTF interface
             If DUT interface is in VLAN, remove it from the vlan
@@ -302,6 +326,9 @@ class TestFdbMacLearning:
         duthost = duthosts[rand_one_dut_hostname]
         dut_interface, ptf_port_index = target_ports_to_ptf_mapping[0]
         duthost.shell("sudo config interface startup {}".format(dut_interface))
+        self._setup_dualtor_aa_test_port(
+            duthosts, duthost, rand_unselected_dut, dut_interface,
+            active_active_ports, config_active_active_dualtor_active_standby)
         for vlan in conf_facts['VLAN_MEMBER']:
             for member_interface in conf_facts['VLAN_MEMBER'][vlan]:
                 if (member_interface == dut_interface):
@@ -309,7 +336,11 @@ class TestFdbMacLearning:
         try:
             self.configureInterfaceIp(duthost, dut_interface, action="add")
             self.configureNeighborIp(ptfhost, ptf_ports_available_in_topo[ptf_port_index], action="add")
-            time.sleep(2)
+            if active_active_ports and dut_interface in active_active_ports:
+                pytest_assert(self._wait_mux_port_forwarding_ready(duthost, dut_interface),
+                              "Mux port {} lost active/consistent hw state after L3 config on {}".format(
+                                  dut_interface, duthost.hostname))
+            time.sleep(5)
             ptfhost.shell("ping {} -c 3 -I {}".format(self.DUT_INTF_IP, self.PTF_HOST_IP), module_ignore_errors=True)
             int_ip_found = any((dut_interface in line and self.DUT_INTF_IP in line)
                                for line in duthost.command("show ip interface")["stdout_lines"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
testARPCompleted in fdb/test_fdb_mac_learning.py fails on dualtor-aa testbeds (e.g. tornado-dualtor / m6-31) with:
Failed: ARP entry not found for ip address 20.0.0.2

The test is written like a single-ToR (t0) test: it picks one ToR, configures L3 on one port, sends traffic from PTF, and checks show arp on that same ToR. On dualtor-aa, upstream traffic path is controlled by mux. If the selected ToR is not Active on the test port, PTF traffic does not reach it and ARP is missing on the DUT.

In the failing run, tor-dut-0 was selected, but mux on Ethernet8 was Standby/Unknown (after prepare_test shut all ports on the selected ToR). Traffic was handled by the peer ToR (tor-dut-1), while the test still checked ARP on tor-dut-0. Ping also showed 100% packet loss.

Root-Cause:
prepare_test (class autouse) shuts down all ports on the randomly selected ToR. On dualtor-aa, that disturbs mux (linkmgr moves toward Standby; hardware sync can fail → Unknown). The test only runs config interface startup later — that brings the port admin-up but does not restore mux to Active.
testARPCompleted had no dualtor-aa mux setup. It did not steer mux so PTF traffic hits the selected ToR before ping/ARP.

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
Before ping and ARP check, we tell mux which ToR should get PTF traffic:

On the test port only (e.g. Ethernet8), set selected ToR Active and the other ToR Standby.
Wait until mux is healthy (Active + hardware consistent).
Do the same check again after adding IPs, then run ping/ARP.
So traffic and the ARP check happen on the same ToR. After the test, mux goes back to auto automatically.



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
testARPCompleted in fdb/test_fdb_mac_learning.py is written as a single-ToR (t0) L3/ARP test but runs on dualtor-aa testbeds. It configures IP and checks show arp on the randomly selected ToR, but does not steer mux. On dualtor-aa, PTF upstream traffic can land on the peer ToR while the test asserts ARP on the selected ToR.

The failure is worsened by the class-scoped prepare_test fixture, which admin-shuts all ports on the selected ToR. That can leave mux in Standby/Unknown on the test port. Bringing the port admin-up alone does not restore mux Active with hw consistent forwarding.

#### How did you do it?
For dualtor-aa active-active mux ports only, testARPCompleted now:

1. Adds @pytest.mark.dualtor_active_active_setup_standby_on_random_unselected_tor and uses config_active_active_dualtor_active_standby / active_active_ports fixtures (same pattern as DHCP/FIB tests).
2. Adds _setup_dualtor_aa_test_port() to:
Set mux to manual on the test port on both ToRs
Configure selected ToR Active and peer Standby on that port via config_active_active_dualtor_active_standby
Wait until mux is active and hwstatus == consistent before L3 setup
3. Re-checks mux after L3 config (VLAN removal + IP on DUT/PTF) before ping/ARP.
4. Increases pre-ping sleep from 2s to 5s.
Mux is restored to auto after the test via the existing config_active_active_dualtor_active_standby fixture teardown (_restore_mux_ports in dual_tor_utils.py).

Non-dualtor-aa / non-AA-port paths are unchanged (_setup_dualtor_aa_test_port returns early).

Also adds # noqa: F811 on the testARPCompleted signature for pytest fixture parameter shadowing.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

Testbed: tornado-dualtor on sonic-ucs-m6-31 (dualtor-aa), container cicd_prod_202605

#### Any platform specific information?

Dualtor-AA 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
