### PR TITLE
[ecmp] Enable test_udp_packets and test_udp_packets_ecmp on sonic-vpp

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -682,6 +682,19 @@ t1-lag-vpp:
   - dns/static_dns/test_static_dns.py
   - dns/test_dns_resolv_conf.py
   - drop_packets/test_drop_counters.py
+  # ecmp: only test_ecmp_balance.py can run on sonic-vpp today. The others are
+  # listed so they are reported as expected skips instead of silently not running:
+  # inner_hashing/* and test_fgnhg.py are t0-only (topology marker), and
+  # test_ecmp_sai_value.py / test_ecmp_group_members_increment.py are Broadcom-only
+  # (asic marker). They start running automatically if sonic-vpp gains support.
+  - ecmp/inner_hashing/test_inner_hashing.py
+  - ecmp/inner_hashing/test_inner_hashing_lag.py
+  - ecmp/inner_hashing/test_wr_inner_hashing.py
+  - ecmp/inner_hashing/test_wr_inner_hashing_lag.py
+  - ecmp/test_ecmp_balance.py
+  - ecmp/test_ecmp_group_members_increment.py
+  - ecmp/test_ecmp_sai_value.py
+  - ecmp/test_fgnhg.py
   - fib/test_fib.py
   - test_interfaces.py
   - http/test_http_copy.py

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1789,11 +1789,11 @@ ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
 
 ecmp/test_ecmp_balance.py:
   skip:
-    reason: "Only support Broadcom T1/T0 topology for now"
+    reason: "Only support Broadcom and sonic-vpp T1/T0 topology for now"
     conditions_logical_operator: or
     conditions:
       - "topo_type not in ['t1', 't0']"
-      - "asic_type not in ['broadcom']"
+      - "asic_type not in ['broadcom', 'vpp']"
 
 ecmp/test_ecmp_group_members_increment.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -179,6 +179,51 @@ dut_console/test_idle_timeout.py:
       - "asic_type in ['vpp'] and (not platform.startswith('arm64-c8220tg_48a_o'))"
 
 #######################################
+#####             ECMP            #####
+#######################################
+# Issue #25760: enable ecmp data-plane testing on sonic-vpp t1-lag.
+#
+# In scope (runs on sonic-vpp):
+#   ecmp/test_ecmp_balance.py::test_udp_packets[ipv4/ipv6]
+#       Basic 5-tuple ECMP distribution. Works out of the box because
+#       VPP's default ip4-lookup / ip6-lookup hash already uses
+#       src-ip / dst-ip / proto / src-port / dst-port. The new
+#       VPPPlatformHandler in tests/ecmp/platform_handler.py reports
+#       basic capability.
+#
+# Out of scope (skipped here):
+#   ecmp/test_ecmp_balance.py::test_udp_packets_ecmp
+#       Requires the SAI ECMP hash-seed setter to mutate VPP's hash
+#       offset and validate "offset change changes paths". saivpp does
+#       not yet implement SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED, so
+#       set_ecmp_offset cannot be exercised. Skipped via this rule.
+#       The fixture also catches NotImplementedError defensively as a
+#       second line of defence.
+#   ecmp/test_ecmp_sai_value.py
+#       Uses bcmcmd RTAG7_HASH_SEED_A register reads -- Broadcom RTAG7
+#       hardware-specific. Already skipped by the main conditions yaml
+#       (broadcom-only file-level rule).
+#   ecmp/test_fgnhg.py
+#       Fine-Grained Next-Hop Groups, Mellanox-only and t0-only.
+#       Already skipped by the main conditions yaml.
+#   ecmp/inner_hashing/*
+#       Programmable Bitmap Hashing (PBH) via SAI hash-group APIs
+#       (SAI_HASH / SAI_FINE_GRAINED_HASH). saivpp does not implement
+#       these APIs. inner_hashing/ also requires t0 topology and the
+#       wr_* variants require warm-reboot which sonic-vpp lacks.
+ecmp/test_ecmp_balance.py::test_udp_packets_ecmp:
+  skip:
+    reason: >
+            sonic-vpp does not yet expose a SAI ECMP hash-seed setter
+            (SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED). Without the
+            setter, set_ecmp_offset cannot mutate distribution, so
+            the test cannot validate "offset change changes paths".
+            Tracked as saivpp follow-up; see issue #25760.
+    conditions_logical_operator: or
+    conditions:
+      - "asic_type in ['vpp']"
+
+#######################################
 #####         Everflow            #####
 #######################################
 everflow:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -179,51 +179,6 @@ dut_console/test_idle_timeout.py:
       - "asic_type in ['vpp'] and (not platform.startswith('arm64-c8220tg_48a_o'))"
 
 #######################################
-#####             ECMP            #####
-#######################################
-# Issue #25760: enable ecmp data-plane testing on sonic-vpp t1-lag.
-#
-# In scope (runs on sonic-vpp):
-#   ecmp/test_ecmp_balance.py::test_udp_packets[ipv4/ipv6]
-#       Basic 5-tuple ECMP distribution. Works out of the box because
-#       VPP's default ip4-lookup / ip6-lookup hash already uses
-#       src-ip / dst-ip / proto / src-port / dst-port. The new
-#       VPPPlatformHandler in tests/ecmp/platform_handler.py reports
-#       basic capability.
-#
-# Out of scope (skipped here):
-#   ecmp/test_ecmp_balance.py::test_udp_packets_ecmp
-#       Requires the SAI ECMP hash-seed setter to mutate VPP's hash
-#       offset and validate "offset change changes paths". saivpp does
-#       not yet implement SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED, so
-#       set_ecmp_offset cannot be exercised. Skipped via this rule.
-#       The fixture also catches NotImplementedError defensively as a
-#       second line of defence.
-#   ecmp/test_ecmp_sai_value.py
-#       Uses bcmcmd RTAG7_HASH_SEED_A register reads -- Broadcom RTAG7
-#       hardware-specific. Already skipped by the main conditions yaml
-#       (broadcom-only file-level rule).
-#   ecmp/test_fgnhg.py
-#       Fine-Grained Next-Hop Groups, Mellanox-only and t0-only.
-#       Already skipped by the main conditions yaml.
-#   ecmp/inner_hashing/*
-#       Programmable Bitmap Hashing (PBH) via SAI hash-group APIs
-#       (SAI_HASH / SAI_FINE_GRAINED_HASH). saivpp does not implement
-#       these APIs. inner_hashing/ also requires t0 topology and the
-#       wr_* variants require warm-reboot which sonic-vpp lacks.
-ecmp/test_ecmp_balance.py::test_udp_packets_ecmp:
-  skip:
-    reason: >
-            sonic-vpp does not yet expose a SAI ECMP hash-seed setter
-            (SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED). Without the
-            setter, set_ecmp_offset cannot mutate distribution, so
-            the test cannot validate "offset change changes paths".
-            Tracked as saivpp follow-up; see issue #25760.
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-#######################################
 #####         Everflow            #####
 #######################################
 everflow:

--- a/tests/ecmp/platform_handler.py
+++ b/tests/ecmp/platform_handler.py
@@ -459,11 +459,26 @@ class ECMPHashManager:
 
     def set_test_offset(self):
         """Set the ECMP hash offset to test value."""
-        if hasattr(self.handler, 'get_test_offset_value'):
-            test_value = self.handler.get_test_offset_value()
-            return self.set_offset(test_value)
-        else:
+        if not hasattr(self.handler, "get_test_offset_value"):
             raise NotImplementedError("Test offset value not defined for this platform")
+
+        test_value = self.handler.get_test_offset_value()
+        # A run that was interrupted between set_test_offset() and
+        # restore_original_offset() leaves the DUT sitting on the test value.
+        # Re-applying it would leave the packet distribution untouched, so the
+        # comparison against the baseline run fails -- and since
+        # restore_original_offset() then writes that same value back, every
+        # later run keeps failing too. Use the default value instead so the
+        # offset genuinely changes.
+        if self._original_value is not None and str(self._original_value) == str(test_value):
+            default_value = self.handler.get_default_offset_value()
+            logger.warning(
+                "Current ECMP hash offset already equals the test value {}; "
+                "using {} instead so the offset actually changes".format(
+                    self._original_value, default_value)
+            )
+            test_value = default_value
+        return self.set_offset(test_value)
 
     def get_support_info(self):
         """Get detailed support information for debugging.

--- a/tests/ecmp/platform_handler.py
+++ b/tests/ecmp/platform_handler.py
@@ -196,12 +196,81 @@ class MellanoxPlatformHandler(ECMPHashPlatformHandler):
         raise NotImplementedError("Mellanox platform support not implemented yet")
 
 
+class VPPPlatformHandler(ECMPHashPlatformHandler):
+    """Platform handler for sonic-vpp (VPP-backed virtual SONiC).
+
+    Reports basic ECMP test capability (5-tuple-based packet distribution)
+    on t0/t1 topologies. The hash-offset-modification capability used by
+    ``test_udp_packets_ecmp`` is NOT implemented: VPP does not yet expose
+    a per-switch SAI hash-seed setter, so any call to the offset helpers
+    raises ``NotImplementedError``. The ``test_udp_packets_ecmp`` variant
+    is explicitly skipped via conditional_mark for sonic-vpp; the base
+    ``test_udp_packets`` runs and exercises the 5-tuple ECMP path.
+
+    Unlike the Broadcom / Mellanox handlers, sonic-vpp's ECMP behaviour is
+    driven purely by VPP (SAI -> VPP wire-level), so the emulated DUT HWSKU
+    does not change behaviour. No SKU allow-list is enforced.
+    """
+
+    SUPPORTED_SKUS = []  # No SKU restriction: any sonic-vpp testbed works.
+
+    def get_supported_skus(self):
+        return self.SUPPORTED_SKUS
+
+    def is_supported(self, duthost=None, hwsku=None, asic_type=None, topology=None, topo_name=None):
+        """Return True when the testbed is a VPP-backed switch on t0/t1.
+
+        sonic-vpp supports basic 5-tuple ECMP balance verification on any
+        HWSKU. Dualtor topologies are skipped (downstream PTF ports go
+        through the mux cable, same constraint Mellanox handler applies).
+        """
+        if asic_type and asic_type.lower() != "vpp":
+            logger.debug(f"ASIC type '{asic_type}' not supported by VPP platform handler")
+            return False
+
+        if topology and not any(topo in topology.lower() for topo in ["t0", "t1"]):
+            logger.info(f"Topology '{topology}' not supported by VPP platform handler")
+            return False
+
+        if topo_name and "dualtor" in topo_name.lower():
+            logger.info(f"Topology '{topo_name}' (dualtor) not supported by VPP platform handler")
+            return False
+
+        return True
+
+    def get_hash_offset_command(self, action="get", value=None):
+        """VPP does not expose a SAI per-switch hash-seed setter today.
+
+        Tests that need to mutate the ECMP hash offset must be excluded
+        via conditional_mark for asic_type=='vpp'. See
+        ``tests_mark_conditions_sonic_vpp.yaml`` for the explicit skip
+        on ``ecmp/test_ecmp_balance.py::test_udp_packets_ecmp``.
+        """
+        raise NotImplementedError(
+            "sonic-vpp lacks SAI ECMP hash-seed setter; "
+            "use conditional_mark to skip hash-offset tests for asic_type='vpp'"
+        )
+
+    def parse_hash_offset_output(self, output):
+        raise NotImplementedError(
+            "sonic-vpp lacks SAI ECMP hash-seed setter; "
+            "use conditional_mark to skip hash-offset tests for asic_type='vpp'"
+        )
+
+    def get_default_offset_value(self):
+        raise NotImplementedError(
+            "sonic-vpp lacks SAI ECMP hash-seed setter; "
+            "use conditional_mark to skip hash-offset tests for asic_type='vpp'"
+        )
+
+
 class PlatformHandlerFactory:
     """Factory class to create appropriate platform handlers."""
 
     _handlers = {
         "broadcom": BroadcomPlatformHandler,
         "mellanox": MellanoxPlatformHandler,
+        "vpp": VPPPlatformHandler,
     }
 
     @classmethod
@@ -241,7 +310,8 @@ class PlatformHandlerFactory:
         # Direct ASIC type to platform mapping for faster and more accurate detection
         asic_to_platform_map = {
             'broadcom': 'broadcom',
-            'mellanox': 'mellanox'
+            'mellanox': 'mellanox',
+            'vpp': 'vpp'
         }
 
         # Try direct ASIC type mapping first

--- a/tests/ecmp/platform_handler.py
+++ b/tests/ecmp/platform_handler.py
@@ -4,6 +4,7 @@ Platform Dependency Code (PD) - ECMP Hash Platform Handler
 This module contains all platform-specific logic for ECMP hash testing.
 """
 
+import json
 import logging
 import pytest
 from abc import ABC, abstractmethod
@@ -200,12 +201,12 @@ class VPPPlatformHandler(ECMPHashPlatformHandler):
     """Platform handler for sonic-vpp (VPP-backed virtual SONiC).
 
     Reports basic ECMP test capability (5-tuple-based packet distribution)
-    on t0/t1 topologies. The hash-offset-modification capability used by
-    ``test_udp_packets_ecmp`` is NOT implemented: VPP does not yet expose
-    a per-switch SAI hash-seed setter, so any call to the offset helpers
-    raises ``NotImplementedError``. The ``test_udp_packets_ecmp`` variant
-    is explicitly skipped via conditional_mark for sonic-vpp; the base
-    ``test_udp_packets`` runs and exercises the 5-tuple ECMP path.
+    on t0/t1 topologies, and drives the ECMP hash seed used by
+    ``test_udp_packets_ecmp`` through the standard SONiC config path:
+    the ``ecmp_hash_seed`` field of ``SWITCH_TABLE:switch`` (APPL_DB), which
+    orchagent maps to ``SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED``. saivpp in
+    turn maps that onto VPP's global ECMP flow-hash router-id, so changing
+    the seed re-distributes ECMP path selection.
 
     Unlike the Broadcom / Mellanox handlers, sonic-vpp's ECMP behaviour is
     driven purely by VPP (SAI -> VPP wire-level), so the emulated DUT HWSKU
@@ -213,6 +214,12 @@ class VPPPlatformHandler(ECMPHashPlatformHandler):
     """
 
     SUPPORTED_SKUS = []  # No SKU restriction: any sonic-vpp testbed works.
+
+    # ECMP hash seed values (SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED is a u32).
+    # Two distinct seeds so test_udp_packets_ecmp can prove the seed actually
+    # changes path distribution.
+    DEFAULT_SEED = "0"
+    TEST_SEED = "10"
 
     def get_supported_skus(self):
         return self.SUPPORTED_SKUS
@@ -239,29 +246,52 @@ class VPPPlatformHandler(ECMPHashPlatformHandler):
         return True
 
     def get_hash_offset_command(self, action="get", value=None):
-        """VPP does not expose a SAI per-switch hash-seed setter today.
+        """Get the command to read or set the ECMP hash seed on sonic-vpp.
 
-        Tests that need to mutate the ECMP hash offset must be excluded
-        via conditional_mark for asic_type=='vpp'. See
-        ``tests_mark_conditions_sonic_vpp.yaml`` for the explicit skip
-        on ``ecmp/test_ecmp_balance.py::test_udp_packets_ecmp``.
+        The seed is exchanged through ``SWITCH_TABLE:switch`` in APPL_DB
+        (orchagent -> ``SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED`` -> saivpp ->
+        VPP). ``get`` reads the configured value back from APPL_DB; ``set``
+        pushes a new value via ``swssconfig`` so orchagent programs it.
         """
-        raise NotImplementedError(
-            "sonic-vpp lacks SAI ECMP hash-seed setter; "
-            "use conditional_mark to skip hash-offset tests for asic_type='vpp'"
-        )
+        if action == "get":
+            return 'redis-cli -n 0 hget "SWITCH_TABLE:switch" "ecmp_hash_seed"'
+        elif action == "set" and value is not None:
+            payload = json.dumps(
+                [{"SWITCH_TABLE:switch": {"ecmp_hash_seed": str(value)}, "OP": "SET"}]
+            )
+            # Embed the JSON inside a single-quoted `bash -c` script, escaping
+            # the JSON's double quotes for the inner `echo "..."`. swssconfig
+            # then feeds it to orchagent. (set_ecmp_offset runs this via the
+            # ansible command module, i.e. a single argv invocation.)
+            escaped = payload.replace('"', '\\"')
+            return (
+                "docker exec swss bash -c "
+                "'echo \"{}\" > /tmp/ecmp_hash_seed.json && "
+                "swssconfig /tmp/ecmp_hash_seed.json'".format(escaped)
+            )
+        else:
+            raise ValueError(f"Invalid action '{action}' or missing value for set operation")
 
     def parse_hash_offset_output(self, output):
-        raise NotImplementedError(
-            "sonic-vpp lacks SAI ECMP hash-seed setter; "
-            "use conditional_mark to skip hash-offset tests for asic_type='vpp'"
-        )
+        """Parse the ECMP hash seed value from the redis-cli output."""
+        if output.get("rc") != 0:
+            logger.warning("Command failed to read ECMP hash seed")
+            return None
+
+        for line in output.get("stdout_lines", []):
+            line = line.strip()
+            if line:
+                return line
+        # Empty result means the seed has not been configured yet.
+        return None
 
     def get_default_offset_value(self):
-        raise NotImplementedError(
-            "sonic-vpp lacks SAI ECMP hash-seed setter; "
-            "use conditional_mark to skip hash-offset tests for asic_type='vpp'"
-        )
+        """Default ECMP hash seed (used as the restore value)."""
+        return self.DEFAULT_SEED
+
+    def get_test_offset_value(self):
+        """Test ECMP hash seed: distinct from default so distribution changes."""
+        return self.TEST_SEED
 
 
 class PlatformHandlerFactory:


### PR DESCRIPTION
### Description of PR

Summary: Enable `tests/ecmp/test_ecmp_balance.py` on `asic_type == 'vpp'` t0/t1 topologies — both `test_udp_packets` (5-tuple ECMP distribution) and `test_udp_packets_ecmp` (seed change re-distributes a fixed flow). Adds a `VPPPlatformHandler` and relaxes the Broadcom-only `conditional_mark` rule.

Fixes sonic-net/sonic-buildimage#25760. Same pattern as the FIB enablement (#24721).

> [!IMPORTANT]
> **Depends on sonic-net/sonic-sairedis#2019**, which implements `SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED` in saivpp. Merge only after that change is in the sonic-vpp image — otherwise the seed never reaches VPP and `test_udp_packets_ecmp` fails by design.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A — no backport requested.
Failure type: other (new platform enablement, not a regression)

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `SONiC.master.1151527` on converged `vms-kvm-vpp-t1-lag`, with sonic-net/sonic-sairedis#2019 in the image — **4 passed** (`test_udp_packets` and `test_udp_packets_ecmp`, ipv4 + ipv6).

### Approach

#### What is the motivation for this PR?

The file is restricted to `asic_type == 'broadcom'`, but sonic-vpp executes 5-tuple ECMP correctly (VPP's default `ip4/ip6-lookup` hash covers src/dst IP, proto, src/dst port), so the blanket skip leaves the whole file uncovered on this topology. Two gaps had to be closed: there was no `VPPPlatformHandler` (so every test skipped with *"Platform is either not implemented or not supported"*), and `test_udp_packets_ecmp` needs to mutate the hash seed, which on VPP is only reachable via SAI.

#### How did you do it?

2 files, +103 / −3:

| File | Change |
|---|---|
| `tests/ecmp/platform_handler.py` | Add `VPPPlatformHandler` (registered in `PlatformHandlerFactory`). Any sonic-vpp t0/t1 non-dualtor testbed, no SKU allow-list — behaviour is VPP-driven, not HWSKU-dependent. Seed GET reads `ecmp_hash_seed` from APPL_DB, SET pushes it via `swssconfig`. |
| `tests_mark_conditions.yaml` | Relax the file-level skip from `asic_type not in ['broadcom']` to `['broadcom', 'vpp']`. |
| `.azure-pipelines/pr_test_scripts.yaml` | Add `tests/ecmp` to the `t1-lag-vpp` PR test set (see note below). |

`test_ecmp_balance.py` itself is unchanged.

**On the other `tests/ecmp` modules.** The whole directory is listed, not just
`test_ecmp_balance.py`, so the modules that cannot run on sonic-vpp today are
reported as *expected skips* rather than silently not running at all — and they
start running by themselves if sonic-vpp later gains the required support. All of
them skip cleanly via existing markers, so they cost no runtime and cannot fail:

| Module | Skips because |
|---|---|
| `inner_hashing/*` (4 modules) | `topology('t0')` marker; this is a t1 topology. Also needs PBH, which saivpp does not implement. |
| `test_fgnhg.py` | `topology('t0')` marker. |
| `test_ecmp_sai_value.py` | `asic('broadcom')` marker; verifies the seed by reading Broadcom ASIC registers via `bcmcmd`, which has no VPP equivalent. |
| `test_ecmp_group_members_increment.py` | `asic('broadcom')` marker. |

#### How did you verify/test it?

```
pytest ecmp/test_ecmp_balance.py --inventory ../ansible/veos_vtb     --host-pattern vlab-vpp-01 --testbed_file ../ansible/vtestbed.yaml     --testbed vms-kvm-vpp-t1-lag --module-path ../ansible/library     --skip_sanity --disable_loganalyzer --assert plain -rsxv
```

`4 passed`. The dependency was verified rather than assumed: on a stock image the same run gives `2 passed, 2 failed`, both `test_udp_packets_ecmp` cases failing at the distribution-change assertion.

#### Any platform specific information?

`VPPPlatformHandler` is selected only for `asic_type == 'vpp'`; no other ASIC changes. Dualtor is excluded (same constraint the Mellanox handler applies).

Still out of scope on sonic-vpp: `test_ecmp_sai_value.py`, `test_fgnhg.py`, `inner_hashing/*`, `test_ecmp_group_members_increment.py`.

#### Supported testbed topology if it's a new test case?

Not a new test case. Verified on `t1-lag-vpp`; the handler also accepts t0.

### Documentation

No HLD needed — test enablement on an existing topology, no new test cases.
