### PR TITLE
Fix packet_trimming teardown leaving dangling BUFFER_QUEUE leafref

### DIFF
--- a/tests/packet_trimming/conftest.py
+++ b/tests/packet_trimming/conftest.py
@@ -14,6 +14,7 @@ from tests.packet_trimming.packet_trimming_config import PacketTrimmingConfig
 from tests.packet_trimming.packet_trimming_helper import (
     delete_blocking_scheduler, check_trimming_capability, prepare_service_port, get_interface_peer_addresses,
     configure_tc_to_dscp_map, set_buffer_profile_for_block_queue, set_buffer_profile_for_trim_queue,
+    unset_buffer_profile_for_trim_queue,
     create_blocking_scheduler, configure_trimming_action, cleanup_trimming_acl, get_queue_id_by_dscp,
     get_test_ports, create_trim_queue_test_buffer_profile, delete_trim_queue_test_buffer_profile,
     is_queue_level_trim_sent_drop_supported)
@@ -214,6 +215,7 @@ def setup_trimming(duthost, test_params, trim_counter_params, request):
         set_buffer_profile_for_block_queue(duthost, counter_block_interface, trim_counter_params['block_queue'],
                                            trim_counter_params['trim_buffer_profiles']['uplink'])
         create_trim_queue_test_buffer_profile(duthost)
+        trim_queue_interfaces = list(block_interface) if isinstance(block_interface, list) else [block_interface]
         set_buffer_profile_for_trim_queue(duthost, block_interface)
 
         # The second interface is downlink interface. If the second interface exists, use downlink buffer profile
@@ -224,6 +226,8 @@ def setup_trimming(duthost, test_params, trim_counter_params, request):
             set_buffer_profile_for_block_queue(duthost, block_interface, test_params['block_queue'],
                                                test_params['trim_buffer_profiles']['downlink'])
             set_buffer_profile_for_trim_queue(duthost, block_interface)
+            trim_queue_interfaces += list(block_interface) if isinstance(block_interface, list) \
+                else [block_interface]
 
         # Also set the downlink buffer profile for the block queue used in counter tests, if applicable.
         if len(trim_counter_params['egress_ports']) > 1:
@@ -255,6 +259,9 @@ def setup_trimming(duthost, test_params, trim_counter_params, request):
             configure_trimming_action(duthost, test_params['trim_buffer_profiles'][buffer_profile], "off")
         for buffer_profile in trim_counter_params['trim_buffer_profiles']:
             configure_trimming_action(duthost, trim_counter_params['trim_buffer_profiles'][buffer_profile], "off")
+
+    with allure.step("Remove trim queue buffer profile reference from interfaces"):
+        unset_buffer_profile_for_trim_queue(duthost, trim_queue_interfaces)
 
     with allure.step("Delete trim queue test buffer profile"):
         delete_trim_queue_test_buffer_profile(duthost)

--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -1675,6 +1675,35 @@ def set_buffer_profile_for_trim_queue(duthost, interfaces, trim_queue_id=None, t
             raise
 
 
+def unset_buffer_profile_for_trim_queue(duthost, interfaces, trim_queue_id=None):
+    """
+    Remove the trim queue buffer profile reference from the BUFFER_QUEUE entries of interfaces.
+    Args:
+        duthost: DUT host object
+        interfaces (list or str): Port names to clean up, can be a list or single string
+        trim_queue_id (int): Queue index used for packet trimming (default: trim queue from packet_trimming_config)
+    """
+    # Convert the queue index to string for the Redis command
+    trim_queue_id = str(trim_queue_id) if trim_queue_id else str(PacketTrimmingConfig.get_trim_queue(duthost))
+
+    if isinstance(interfaces, str):
+        interfaces = [interfaces]
+
+    for interface in interfaces:
+        try:
+            trim_cmd = f"redis-cli -n 4 del 'BUFFER_QUEUE|{interface}|{trim_queue_id}'"
+            duthost.shell(trim_cmd)
+
+            logger.info(
+                f"Removed interface {interface} trimming queue {trim_queue_id} buffer profile reference")
+
+        except Exception as e:
+            if not isinstance(e, RuntimeError):
+                raise RuntimeError(
+                    f"Exception while cleaning up interface {interface} trimming queue: {str(e)}") from e
+            raise
+
+
 def prepare_service_port(duthost, service_port):
     """
     Prepare service port for packet trimming tests by checking existence,


### PR DESCRIPTION
### Description of PR
**Root-cause:**
setup_trimming writes BUFFER_PROFILE|trim_queue_test_profile and the BUFFER_QUEUE|<intf>|<trim_queue> entries that reference it directly, In teardown the BUFFER_PROFILE|trim_queue_test_profile is removed but left the referencing BUFFER_QUEUE entries in place. Deleting only the profile leaves a dangling leafref, so the module-scope yang_validation_check post-test run fails for every test in the module.

**Fixed**: delete the BUFFER_QUEUE entries in teardown before removing the profile.


Summary:
Fixes # (issue)

### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605


### Tested branch
- [X] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
master: Passed

### Approach
#### What is the motivation for this PR?
Fix yang_validation check issue in teardown when running trim case

#### How did you do it?
Delete the BUFFER_QUEUE entries in teardown before removing the profile.
#### How did you verify/test it?
Run test_packet_trimming_asymmetric.py 

#### Any platform specific information?
Platform supportting trim

#### Supported testbed topology if it's a new test case?


### Documentation
N/A
