### PR TITLE
[dut_console] Restore console stress read timeout

### DIFF
--- a/tests/common/connections/conserver_console_conn.py
+++ b/tests/common/connections/conserver_console_conn.py
@@ -44,9 +44,23 @@ class ConserverConsoleConn():
 
         self.console_cli = console_cli
 
-    def send_command(self, cmd, expect_string=CONSERVER_CLI_PROMPT, max_loops=None):
+    def send_command(
+        self,
+        cmd,
+        expect_string=CONSERVER_CLI_PROMPT,
+        max_loops=None,
+        read_timeout=None,
+        cmd_verify=True,
+    ):
+        """Send a command using Netmiko-compatible arguments.
+
+        Conserver does not perform command echo verification, so cmd_verify is
+        accepted for interface compatibility only.
+        """
         self.console_cli.sendline(cmd)
-        timeout = self.default_timeout
+        timeout = (
+            read_timeout if read_timeout is not None else self.default_timeout
+        )
         if max_loops:
             timeout = max(max_loops * self.delay_factor, timeout)
         self.console_cli.expect(expect_string, timeout=timeout)

--- a/tests/common/connections/conserver_console_conn.py
+++ b/tests/common/connections/conserver_console_conn.py
@@ -84,13 +84,13 @@ class ConserverConsoleConn():
         """Send command and read output until no data for 'last_read' seconds."""
         self.logger.debug("send_command_timing: cmd='%s'", cmd[:80])
 
-        start_time = time.time()
+        start_time = time.monotonic()
         self.console_cli.sendline(cmd)
 
         output = ""
         deadline = start_time + read_timeout
 
-        while time.time() < deadline:
+        while time.monotonic() < deadline:
             try:
                 self.console_cli.expect(r'.+', timeout=last_read)
                 output += self.console_cli.match.group().decode()
@@ -100,7 +100,7 @@ class ConserverConsoleConn():
                 self.logger.warning("send_command_timing: connection closed")
                 break
 
-        elapsed = time.time() - start_time
+        elapsed = time.monotonic() - start_time
         self.logger.debug("send_command_timing: finished in %.1fs, %d bytes collected",
                           elapsed, len(output))
         return output

--- a/tests/common/connections/linecard_console_conn.py
+++ b/tests/common/connections/linecard_console_conn.py
@@ -1,6 +1,7 @@
 import logging
 import pexpect
 import os
+import time
 
 LINECARD_CLI_PROMPT = r"admin@[a-zA-Z0-9\-]{1,20}:~\$"
 LINECARD_DEBUG_FILE = "/tmp/linecard_console_debug.log"
@@ -95,20 +96,31 @@ class LinecardConsoleConn():
 
         self.console_cli = console_cli
 
-    def send_command(self, cmd, expect_string=LINECARD_CLI_PROMPT, max_loops=None):
+    def send_command(
+        self,
+        cmd,
+        expect_string=LINECARD_CLI_PROMPT,
+        max_loops=None,
+        read_timeout=None,
+        cmd_verify=True,
+    ):
         """
-        Send a command to the linecard console and wait for response.
+        Send a command using Netmiko-compatible arguments.
 
         Args:
             cmd: Command to send
             expect_string: String to expect after command completion (default: shell prompt)
             max_loops: Maximum timeout multiplier
+            read_timeout: Maximum time to wait for the expected prompt
+            cmd_verify: Accepted for compatibility; picocom does not verify command echo
 
         Returns:
             Command output (without the command echo)
         """
         self.console_cli.sendline(cmd)
-        timeout = self.default_timeout
+        timeout = (
+            read_timeout if read_timeout is not None else self.default_timeout
+        )
         if max_loops:
             timeout = max(max_loops * self.delay_factor, timeout)
         self.console_cli.expect(expect_string, timeout=timeout)
@@ -116,6 +128,34 @@ class LinecardConsoleConn():
         linesep = self.console_cli.linesep.decode()
         # Remove the command echo (first line)
         return output.split(linesep, 1)[1].strip() if linesep in output else output.strip()
+
+    def send_command_timing(self, cmd, read_timeout=30, last_read=1.0):
+        """Send command and read output until no data arrives for last_read seconds."""
+        self.logger.debug("send_command_timing: cmd='%s'", cmd[:80])
+
+        start_time = time.time()
+        self.console_cli.sendline(cmd)
+
+        output = ""
+        deadline = start_time + read_timeout
+
+        while time.time() < deadline:
+            try:
+                self.console_cli.expect(r'.+', timeout=last_read)
+                output += self.console_cli.match.group().decode()
+            except pexpect.TIMEOUT:
+                break
+            except pexpect.EOF:
+                self.logger.warning("send_command_timing: connection closed")
+                break
+
+        elapsed = time.time() - start_time
+        self.logger.debug(
+            "send_command_timing: finished in %.1fs, %d bytes collected",
+            elapsed,
+            len(output),
+        )
+        return output
 
     def disconnect(self):
         """

--- a/tests/common/connections/linecard_console_conn.py
+++ b/tests/common/connections/linecard_console_conn.py
@@ -133,13 +133,13 @@ class LinecardConsoleConn():
         """Send command and read output until no data arrives for last_read seconds."""
         self.logger.debug("send_command_timing: cmd='%s'", cmd[:80])
 
-        start_time = time.time()
+        start_time = time.monotonic()
         self.console_cli.sendline(cmd)
 
         output = ""
         deadline = start_time + read_timeout
 
-        while time.time() < deadline:
+        while time.monotonic() < deadline:
             try:
                 self.console_cli.expect(r'.+', timeout=last_read)
                 output += self.console_cli.match.group().decode()
@@ -149,7 +149,7 @@ class LinecardConsoleConn():
                 self.logger.warning("send_command_timing: connection closed")
                 break
 
-        elapsed = time.time() - start_time
+        elapsed = time.monotonic() - start_time
         self.logger.debug(
             "send_command_timing: finished in %.1fs, %d bytes collected",
             elapsed,

--- a/tests/common/unit_tests/connections/unit_test_conserver_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_conserver_console_conn.py
@@ -1,6 +1,6 @@
 """Unit tests for the conserver console connection."""
 
-import importlib.util
+from importlib import import_module, util
 from pathlib import Path
 import sys
 import types
@@ -12,16 +12,16 @@ MODULE_PATH = (
     / "conserver_console_conn.py"
 )
 try:
-    import pexpect  # noqa: F401
+    import_module("pexpect")
 except ImportError:
     pexpect_stub = types.ModuleType("pexpect")
     pexpect_stub.TIMEOUT = type("TIMEOUT", (Exception,), {})
     pexpect_stub.EOF = type("EOF", (Exception,), {})
     sys.modules["pexpect"] = pexpect_stub
-SPEC = importlib.util.spec_from_file_location(
+SPEC = util.spec_from_file_location(
     "unit_target_conserver_console_conn", MODULE_PATH
 )
-MODULE = importlib.util.module_from_spec(SPEC)
+MODULE = util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 ConserverConsoleConn = MODULE.ConserverConsoleConn
 

--- a/tests/common/unit_tests/connections/unit_test_conserver_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_conserver_console_conn.py
@@ -1,0 +1,77 @@
+"""Unit tests for the conserver console connection."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "connections"
+    / "conserver_console_conn.py"
+)
+try:
+    import pexpect  # noqa: F401
+except ImportError:
+    sys.modules["pexpect"] = types.ModuleType("pexpect")
+SPEC = importlib.util.spec_from_file_location(
+    "unit_target_conserver_console_conn", MODULE_PATH
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+ConserverConsoleConn = MODULE.ConserverConsoleConn
+
+
+class FakeConsoleCli:
+    """Record pexpect calls without opening a console connection."""
+
+    linesep = b"\r\n"
+    before = b"show output\r\nLINE_0000: output\r\n"
+
+    def __init__(self):
+        self.command = None
+        self.expect_args = None
+
+    def sendline(self, command):
+        self.command = command
+
+    def expect(self, pattern, timeout):
+        self.expect_args = (pattern, timeout)
+
+
+def make_connection():
+    """Create a connection without invoking its I/O-heavy constructor."""
+    connection = ConserverConsoleConn.__new__(ConserverConsoleConn)
+    connection.console_cli = FakeConsoleCli()
+    connection.default_timeout = 30
+    connection.delay_factor = 1
+    return connection
+
+
+def test_send_command_supports_netmiko_timeout_and_echo_arguments():
+    """Use Netmiko-compatible arguments while preserving conserver output."""
+    connection = make_connection()
+
+    output = connection.send_command(
+        "show output",
+        expect_string=r"[#$]\s*$",
+        read_timeout=300,
+        cmd_verify=False,
+    )
+
+    assert connection.console_cli.command == "show output"
+    assert connection.console_cli.expect_args == (r"[#$]\s*$", 300)
+    assert output == "LINE_0000: output"
+
+
+def test_send_command_keeps_max_loops_compatibility():
+    """Retain the existing max_loops timeout behavior for current callers."""
+    connection = make_connection()
+
+    connection.send_command("show output", max_loops=60)
+
+    assert connection.console_cli.expect_args == (
+        "admin@[a-zA-Z0-9]{1,10}:~\\$",
+        60,
+    )

--- a/tests/common/unit_tests/connections/unit_test_linecard_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_linecard_console_conn.py
@@ -1,4 +1,4 @@
-"""Unit tests for the conserver console connection."""
+"""Unit tests for the linecard console connection."""
 
 import importlib.util
 from pathlib import Path
@@ -9,7 +9,7 @@ import types
 MODULE_PATH = (
     Path(__file__).resolve().parents[2]
     / "connections"
-    / "conserver_console_conn.py"
+    / "linecard_console_conn.py"
 )
 try:
     import pexpect  # noqa: F401
@@ -19,11 +19,21 @@ except ImportError:
     pexpect_stub.EOF = type("EOF", (Exception,), {})
     sys.modules["pexpect"] = pexpect_stub
 SPEC = importlib.util.spec_from_file_location(
-    "unit_target_conserver_console_conn", MODULE_PATH
+    "unit_target_linecard_console_conn", MODULE_PATH
 )
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
-ConserverConsoleConn = MODULE.ConserverConsoleConn
+LinecardConsoleConn = MODULE.LinecardConsoleConn
+
+
+class FakeMatch:
+    """Return one chunk from a pexpect match."""
+
+    def __init__(self, output):
+        self.output = output
+
+    def group(self):
+        return self.output
 
 
 class FakeConsoleCli:
@@ -32,28 +42,36 @@ class FakeConsoleCli:
     linesep = b"\r\n"
     before = b"show output\r\nLINE_0000: output\r\n"
 
-    def __init__(self):
+    def __init__(self, timing_output=None):
         self.command = None
         self.expect_args = None
+        self.timing_output = timing_output
+        self.match = None
 
     def sendline(self, command):
         self.command = command
 
     def expect(self, pattern, timeout):
         self.expect_args = (pattern, timeout)
+        if pattern == r'.+':
+            if self.timing_output is None:
+                raise MODULE.pexpect.TIMEOUT()
+            self.match = FakeMatch(self.timing_output)
+            self.timing_output = None
 
 
-def make_connection():
+def make_connection(timing_output=None):
     """Create a connection without invoking its I/O-heavy constructor."""
-    connection = ConserverConsoleConn.__new__(ConserverConsoleConn)
-    connection.console_cli = FakeConsoleCli()
+    connection = LinecardConsoleConn.__new__(LinecardConsoleConn)
+    connection.logger = MODULE.logging.getLogger(__name__)
+    connection.console_cli = FakeConsoleCli(timing_output)
     connection.default_timeout = 30
     connection.delay_factor = 1
     return connection
 
 
 def test_send_command_supports_netmiko_timeout_and_echo_arguments():
-    """Use Netmiko-compatible arguments while preserving conserver output."""
+    """Use Netmiko-compatible arguments while preserving linecard output."""
     connection = make_connection()
 
     output = connection.send_command(
@@ -68,13 +86,15 @@ def test_send_command_supports_netmiko_timeout_and_echo_arguments():
     assert output == "LINE_0000: output"
 
 
-def test_send_command_keeps_max_loops_compatibility():
-    """Retain the existing max_loops timeout behavior for current callers."""
-    connection = make_connection()
+def test_send_command_timing_supports_large_input_check():
+    """Provide the timing API used by the console stress input test."""
+    connection = make_connection(b"echo\r\nexpected-md5  -\r\n")
 
-    connection.send_command("show output", max_loops=60)
-
-    assert connection.console_cli.expect_args == (
-        "admin@[a-zA-Z0-9]{1,10}:~\\$",
-        60,
+    output = connection.send_command_timing(
+        "echo large-input | md5sum",
+        read_timeout=300,
+        last_read=2.0,
     )
+
+    assert connection.console_cli.command == "echo large-input | md5sum"
+    assert "expected-md5" in output

--- a/tests/common/unit_tests/connections/unit_test_linecard_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_linecard_console_conn.py
@@ -55,7 +55,7 @@ class FakeConsoleCli:
         self.expect_args = (pattern, timeout)
         if pattern == r'.+':
             if self.timing_output is None:
-                raise MODULE.pexpect.TIMEOUT()
+                raise MODULE.pexpect.TIMEOUT("timed out")
             self.match = FakeMatch(self.timing_output)
             self.timing_output = None
 

--- a/tests/common/unit_tests/connections/unit_test_linecard_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_linecard_console_conn.py
@@ -1,6 +1,6 @@
 """Unit tests for the linecard console connection."""
 
-import importlib.util
+from importlib import import_module, util
 from pathlib import Path
 import sys
 import types
@@ -12,16 +12,16 @@ MODULE_PATH = (
     / "linecard_console_conn.py"
 )
 try:
-    import pexpect  # noqa: F401
+    import_module("pexpect")
 except ImportError:
     pexpect_stub = types.ModuleType("pexpect")
     pexpect_stub.TIMEOUT = type("TIMEOUT", (Exception,), {})
     pexpect_stub.EOF = type("EOF", (Exception,), {})
     sys.modules["pexpect"] = pexpect_stub
-SPEC = importlib.util.spec_from_file_location(
+SPEC = util.spec_from_file_location(
     "unit_target_linecard_console_conn", MODULE_PATH
 )
-MODULE = importlib.util.module_from_spec(SPEC)
+MODULE = util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 LinecardConsoleConn = MODULE.LinecardConsoleConn
 

--- a/tests/dut_console/test_console_stress.py
+++ b/tests/dut_console/test_console_stress.py
@@ -33,11 +33,12 @@ def test_console_stress_output(duthost_console):
     # Each line: "LINE_XXXX: " + 10 blocks of '0123456789' (110 chars per line)
     # Generate 1000 lines = 110,000 chars total
     num_lines = 1000
-    # Disable echo verification: the wrapped 9600-baud echo never matches and a half-typed command leaves a PS2 prompt.
+    # Disable echo verification because the serial echo wraps across lines.
     output = duthost_console.send_command(
         f"python3 -c \"for i in range({num_lines}): print(f'LINE_{{i:04d}}: ' + '0123456789' * 10)\"",  # noqa: E231
-        max_loops=300,
+        read_timeout=300,
         expect_string=PROMPT_PATTERN,
+        cmd_verify=False,
     )
 
     # Parse output into lines


### PR DESCRIPTION
### Description of PR

Summary:
Restore the explicit long read timeout and disabled command-echo verification required by the large serial-console output test. Make the pexpect-backed conserver and linecard console implementations accept the same command arguments, and add the timing API required by the linecard input-stress path.

Fixes #26767

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #26767
Failure type: regression

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: 4 targeted console-connection unit tests passed; changed files passed flake8 and syntax checks.
- 202605: `SONiC.20260510.09`, Arista-7260CX3-C64 / t1-64-lag — [Elastictest plan 6a71e47af481df03c4e5a7ab](https://elastictest.org/scheduler/testplan/6a71e47af481df03c4e5a7ab): `dut_console/test_console_stress.py` 2/2 passed; full run 19 passed, 2 skipped, 0 failed/errors.

### Approach
#### What is the motivation for this PR?

PR #25904 fixed the 9600-baud console stress test with `read_timeout=300` and `cmd_verify=False`. PR #26490 replaced those arguments with `max_loops=300` for conserver compatibility, but Netmiko 4 no longer uses `max_loops` to extend the effective 10-second read timeout. The test emits about 110 KB, times out near `LINE_0084`, and leaves unread output that contaminates the following input-integrity test.

#### How did you do it?

- Restore `read_timeout=300` and `cmd_verify=False` in the output-stress command.
- Accept Netmiko-compatible `read_timeout` and `cmd_verify` arguments in `ConserverConsoleConn.send_command()` and `LinecardConsoleConn.send_command()` while retaining `max_loops` compatibility.
- Add `LinecardConsoleConn.send_command_timing()` so the input-stress test is supported by every backend returned by `duthost_console`.
- Add targeted unit coverage for timeout mapping, output preservation, legacy `max_loops`, and the linecard timing path.

#### How did you verify/test it?

The targeted unit tests pass with the real pexpect 4.9.0 implementation. Physical validation on internal-202605 passed both console stress cases on a 9600-baud Arista 7260 console; pretest and posttest also completed without failures.

#### Any platform specific information?

Reproduced and validated on Arista-7260CX3-C64 with Broadcom ASIC. The compatibility changes apply to Netmiko, conserver, and modular linecard console backends.

#### Supported testbed topology if it's a new test case?

N/A — existing test coverage.

### Documentation

N/A — no user-facing documentation changes.