### PR TITLE
[202605] Restore config_facts in critical_services_tracking_list (#26372)

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -82,22 +82,24 @@ class MultiAsicSonicHost(object):
                 active_asics = []
         service_list += self._DEFAULT_SERVICES
 
+        config_facts = self.config_facts(host=self.hostname, source="running")['ansible_facts']
         # NOTE: Add mux to critical services for dualtor
         if (
-            self.facts.get('router_subtype', '') == 'DualToR' and
-            self.facts.get('features', {}).get('mux', {}).get('state', '') == 'enabled'
+            "DEVICE_METADATA" in config_facts and
+            "localhost" in config_facts["DEVICE_METADATA"] and
+            "subtype" in config_facts["DEVICE_METADATA"]["localhost"] and
+                config_facts["DEVICE_METADATA"]["localhost"]["subtype"] == "DualToR" and
+            "mux" in config_facts["FEATURE"] and config_facts["FEATURE"]["mux"]["state"] == "enabled"
         ):
             service_list.append("mux")
 
-        _features = self.facts.get('features', {})
-
-        if _features.get('dhcp_relay', {}).get('state', '') == 'enabled':
+        if "dhcp_relay" in config_facts["FEATURE"] and config_facts["FEATURE"]["dhcp_relay"]["state"] == "enabled":
             service_list.append("dhcp_relay")
 
-        if _features.get('dhcp_server', {}).get('state', '') == 'enabled':
+        if "dhcp_server" in config_facts["FEATURE"] and config_facts["FEATURE"]["dhcp_server"]["state"] == "enabled":
             service_list.append("dhcp_server")
 
-        is_dpu = self.facts.get('switch_type', '') == 'dpu'
+        is_dpu = config_facts['DEVICE_METADATA']['localhost'].get('switch_type', '') == 'dpu'
         if is_dpu and 'snmp' in service_list:
             service_list.remove('snmp')
 
@@ -113,11 +115,11 @@ class MultiAsicSonicHost(object):
             if service == 'teamd' and is_dpu:
                 logger.info("Removing teamd from default services for switch_type DPU")
                 continue
-            if service not in _features:
+            if service not in config_facts['FEATURE']:
                 continue
-            if _features.get(service, {}).get('has_per_asic_scope', '') == "False":
+            if config_facts['FEATURE'][service]['has_per_asic_scope'] == "False":
                 continue
-            if _features.get(service, {}).get('state', '') == "disabled":
+            if config_facts['FEATURE'][service]['state'] == "disabled":
                 continue
             filtered_asic_services.append(service)
         self.sonichost.DEFAULT_ASIC_SERVICES = filtered_asic_services


### PR DESCRIPTION
### Description of PR

Manual cherry-pick of #26372 to **202605** (the automatic cherry-pick hit a code conflict — label `Cherry Pick Conflict_202605`).

Summary: After `boot_into_base_image`, `critical_services_fully_started` fails because services like `bmp` that exist on the original image but not on the base image remain in the list. #21442 changed `critical_services_tracking_list` to read feature state from `self.facts` (gathered once at init), causing stale feature data after reboot/upgrade/config reload. This restores live `config_facts` querying each time.

**Conflict resolution:** The master change to `test_mgmt_ipv6_only` (`duthosts.reset()` → `duthosts.meta("reset_connection")` + `set_ansible_hosts(...)`) is **intentionally omitted** — 202605 does not have the `meta("reset_connection")` API or `set_ansible_hosts`, and its existing `duthosts.reset()` already performs the equivalent connection refresh. Only the `multi_asic.py` `config_facts` fix is carried over.

Fixes #26166

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request

- [x] 202605

### Tested branch (Please provide the tested image version)

- [x] 202605

### Test result

Cherry-picked from master #26372 (already tested + `Tested for 202605 branch` on the original). Backport diff is limited to `tests/common/devices/multi_asic.py`; `py_compile` + targeted `flake8 --max-line-length=120` pass (the two E721 warnings are pre-existing on 202605, unrelated to this change).

### Approach

Manual cherry-pick of the merged master commit `f030842`, resolving the `duthost_utils.py` conflict by keeping the 202605 behavior as described above.

##### Work item tracking
- Microsoft ADO (number only): 39070102
