### PR TITLE
Fix testQosSaiHeadroomPoolSize on TH5 platform

### DIFF
--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -219,7 +219,7 @@ qos_params:
                     dscps: [3, 4]
                     dst_port_id: 0
                     ecn: 1
-                    margin: 4
+                    margin: 40
                     pgs: [3, 4]
                     pgs_num: 13
                     pkts_num_hdrm_full: 2853
@@ -339,16 +339,16 @@ qos_params:
                     dscps: [3, 4]
                     dst_port_id: 0
                     ecn: 1
-                    margin: 4
+                    margin: 40
                     pgs: [3, 4]
-                    pgs_num: 24
+                    pgs_num: 22
                     pkts_num_hdrm_full: 2853
                     pkts_num_hdrm_partial: 701
                     pkts_num_trig_pfc: 125589
                     pkts_num_trig_pfc_multi: [125589, 62811, 31423, 15728, 7881, 3958,
                         1996, 1015, 524, 279, 157, 95, 65, 49, 42, 38, 36, 35, 34,
-                        34, 34, 34, 34, 34]
-                    src_port_ids: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+                        34, 34, 34]
+                    src_port_ids: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
                 lossy_queue_1:
                     dscp: 8
                     ecn: 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix https://github.com/aristanetworks/sonic-qual.msft/issues/1383
This PR is to fix `testQosSaiHeadroomPoolSize` on TH5 platform, topo `lt2_p32o64` and `ft2-64` specifically.

- For topo `lt2_p32o64`
1.  Change `src_port_ids` from `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]` because port `12` is mapped to a disabled port on this topo. As a result, the next available port (Ethernet128) is selected as a replacement. However, port Ethernet128 is on another ITM, and this caused test failure.
```
Traceback (most recent call last):
  File "/root/saitests/py3/sai_qos_tests.py", line 4144, in runTest
    sys.exit("Too many pkts needed to trigger pfc: %d" % (pkt_cnt))
SystemExit: Too many pkts needed to trigger pfc: 10
```
2. Change `margin` from `4` to `40`. This is to workaround some noise packet drop, which is not caused by the test. The failure is 
```
Traceback (most recent call last):
  File "/root/saitests/py3/sai_qos_tests.py", line 4210, in runTest
    recv_counters[cntr] - recv_counters_bases[sidx_dscp_pg_tuples[i][0]][cntr] <= margin)
```

- For topo `ft2_p64`
Change `margin` from `4` to `40`. This is to workaround some noise packet drop, which is not caused by the test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202511 - test passed
202605 - test passed

### Approach
#### What is the motivation for this PR?
This PR is to fix `testQosSaiHeadroomPoolSize` on TH5 platform, topo `lt2_p32o64` and `ft2-64` specifically.

#### How did you do it?
Please see PR description.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
The change is verified on physical testebds.
```
collected 5 items                                                                                                                                                                                                             

qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[single_asic]  ^H
------------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------------
WARNING  tests.qos.qos_sai_base:qos_sai_base.py:3088 permit_only_test_traffic_on_fanout: lacpd stop may have failed (rc=1), proceeding anyway
 ^H ^H ^H ^H ^HPASSED                                                                                                                                                                                                                  [ 20%]
------------------------------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------------------------------
WARNING  tests.common.plugins.memory_utilization.memory_utilization:memory_utilization.py:64 Skipping memory check for docker-lldp due to zero value

qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[single_dut_multi_asic] SKIPPED (Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests)                               [ 40%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[multi_dut_longlink_to_shortlink] SKIPPED (Don't have 2 frontend nodes - so can't run multi_dut tests)                                                       [ 60%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[multi_dut_shortlink_to_shortlink] SKIPPED (Don't have 2 frontend nodes - so can't run multi_dut tests)                                                      [ 80%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[multi_dut_shortlink_to_longlink] SKIPPED (Don't have 2 frontend nodes - so can't run multi_dut tests)                                                       [100%]

```
#### Any platform specific information?
Broadcom TH5 specific.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
