### PR TITLE
[GHA] Add pre-flight static analysis, scoped to changed lines

### DIFF
--- a/.github/preflight/README.md
+++ b/.github/preflight/README.md
@@ -1,0 +1,129 @@
+# Pre-flight static analysis
+
+A fast static-analysis gate that runs on every pull request and, critically, on
+`merge_group` events so it can gate a GitHub merge queue.
+
+## Why a merge queue check
+
+A pull request is tested against the branch as it looked when the branch was
+cut. Two pull requests can each be green and still break master when combined —
+one renames a helper, the other adds a caller. Nothing in the current CI catches
+that, because nothing runs against the merged result. A merge queue does exactly
+that, and this check is what runs there.
+
+## The one rule
+
+**A finding is reported only if it lands on a line the change added or
+modified.** Pre-existing problems elsewhere in a touched file are dropped.
+
+This is not a nicety, it is what makes the check adoptable. Measured on this
+repository, pyright reports 928 pre-existing errors across the files touched by
+14 recent commits. Only 10 of those sit on lines those commits actually changed.
+Without the filter, every pull request would fail on day one and the check would
+be turned off within a week.
+
+One consequence worth knowing: a moved or reindented line counts as changed, so
+a long-standing problem on a line your change shifts can surface. This is
+inherent to line-based filtering and matches how `darker` and `diff-cover`
+behave.
+
+`test_preflight.py` exists to protect this rule, and runs in CI ahead of the
+analysis itself.
+
+## What runs
+
+| Tool | Blocking | Notes |
+| --- | --- | --- |
+| flake8 | yes | Mirrors `.pre-commit-config.yaml` exactly, including the per-directory ignore lists, so this check can never disagree with local `pre-commit` |
+| pyright | yes | None-safety, possibly-unbound names, calls that do not match the signature |
+| yamllint | no | advisory |
+| shellcheck | no | advisory |
+| ansible-lint | no | advisory |
+| codespell | no | advisory |
+
+Measured on 14 recent PR-sized commits: flake8 blocked 0, pyright blocked 1. The
+one pyright hit was a real defect — a possibly-unbound `src_duthost`, five
+`None` subscripts, and a call passing a keyword argument the callee does not
+accept.
+
+The advisory tools have no measured baseline on this repository, so they
+annotate but never fail. Promoting one is a single `blocking: true` edit in
+`config.yml`.
+
+### pyright configuration
+
+`reportMissingImports` is off because the test dependencies are not installed in
+this job; without that, every file reports unresolved imports and the real
+findings are buried. Installing them would add minutes to a check that gates the
+queue.
+
+Two settings are load-bearing and easy to get wrong:
+
+- `typeCheckingMode` is `standard`, not `basic`. Measured on a real change,
+  `basic` silently drops `reportPossiblyUnboundVariable` and `reportCallIssue`.
+- `reportGeneralTypeIssues` is deliberately **not** disabled. It is a catch-all
+  that also suppresses `reportCallIssue` and `reportOperatorIssue`; disabling it
+  took 12 findings down to 10 on one real change.
+
+pyright silently ignores unknown configuration keys, so a misspelled rule name
+disables a check with no warning. `test_preflight.py` asserts the exact spelling
+of the rule most likely to be typo'd.
+
+**pyright's results depend on the Python environment it finds.** It infers
+imports from whichever interpreter is on `PATH`, so installed packages change
+type inference and therefore the findings. The same commit produced 46 errors
+under a bare interpreter and 37 when `pytest` happened to be installed. CI is
+reproducible because the runner is fresh and every tool version is pinned, but
+a local run will not always match CI. If you are reproducing a CI result, use a
+clean virtualenv containing only the packages the workflow installs.
+
+## Azure Pipelines and the merge queue
+
+The Azure pipelines that spawn real testbed runs **do not** trigger on merge
+groups, and no change was needed to keep it that way:
+
+- `azure-pipelines.yml` sets `trigger: none`, so nothing runs on branch pushes.
+  A merge queue works by pushing to `gh-readonly-queue/**` refs, which that
+  setting already excludes.
+- Its only trigger is `pr:`, which fires on GitHub `pull_request` events. A
+  merge group is not a pull request and emits no such event.
+
+**This must be re-checked if `trigger:` is ever given a branch list.** Adding
+`gh-readonly-queue/**` there, directly or via a wildcard, would spawn a full
+testbed run for every queue entry.
+
+## Enabling the merge queue
+
+The workflow is ready for it, but turning the queue on is a repository settings
+change, not a file in this repository. Note one sharp edge before doing it:
+
+> When a merge queue is enabled, required status checks are evaluated against
+> the **merge group**, not the pull request. Any required check that does not
+> run on `merge_group` will never report, and pull requests will sit in the
+> queue until they time out.
+
+Today `Azure.sonic-mgmt`, `Semgrep`, and `CodeQL` all trigger on
+`pull_request` only. Making the queue work therefore means deciding, per check,
+either to add a `merge_group` trigger or to drop it from the required list.
+Recommendations based on measured cost:
+
+- **Semgrep** (~33s, and already diff-aware via its own baseline scan) — cheap
+  enough to add to the queue.
+- **CodeQL** (~7m20s) — too slow to gate a queue. Keep it on pull requests.
+- **Azure.sonic-mgmt** — must stay out of the queue; that is the entire point.
+
+## Running it locally
+
+```bash
+pip install flake8 pyright yamllint ansible-lint codespell PyYAML
+PREFLIGHT_BASE=origin/master PREFLIGHT_HEAD=HEAD python .github/preflight/run_preflight.py
+```
+
+Tools that are not installed are skipped with a warning rather than failing the
+run, so you can check just the ones you have.
+
+To run the tests for the filter itself:
+
+```bash
+python .github/preflight/test_preflight.py
+```

--- a/.github/preflight/codespell-ignore.txt
+++ b/.github/preflight/codespell-ignore.txt
@@ -1,0 +1,17 @@
+nd
+te
+ba
+fo
+ot
+alls
+ans
+nin
+ist
+iff
+hsi
+tabel
+ser
+splitted
+mor
+mut
+warmup

--- a/.github/preflight/config.yml
+++ b/.github/preflight/config.yml
@@ -1,0 +1,76 @@
+# Configuration for the pre-flight static analysis check
+# (.github/workflows/preflight.yml).
+#
+# Every tool below runs only against files the pull request touched, and every
+# finding is discarded unless it lands on a line the pull request actually
+# added or modified. Pre-existing problems in a touched file are never
+# reported. See .github/preflight/README.md for the rationale.
+#
+# blocking: true   -> a finding on a changed line fails the check
+# blocking: false  -> a finding is annotated as a warning but never fails
+#
+# To promote a tool from advisory to blocking, flip its `blocking` flag. That
+# is deliberately the only edit required.
+
+tools:
+
+  # Mirrors .pre-commit-config.yaml exactly, including the per-directory ignore
+  # lists, so this check can never disagree with what contributors run locally
+  # via `pre-commit`. Profiles are matched in order; the first match wins.
+  flake8:
+    blocking: true
+    include: ['*.py']
+    ok_exit_codes: [0, 1]
+    parser: colon
+    profiles:
+      - match: '^spytest/'
+        args: ['--max-line-length=120', '--ignore=E1,E2,E3,E5,E7,W5']
+      - match: '^tests/common2/'
+        args: ['--max-line-length=120', '--ignore=E1,E2,E3,E5,W1,W2,W3,W5']
+      - match: '.*'
+        args: ['--max-line-length=120']
+
+  # Catches the class of regression this check exists for: None-safety,
+  # possibly-unbound names, and calls that do not match the callee signature.
+  # Import resolution is disabled in pyrightconfig.json because the test
+  # dependencies are not installed in this job; without that, every file
+  # reports unresolved imports and the signal is lost.
+  pyright:
+    blocking: true
+    include: ['*.py']
+    ok_exit_codes: [0, 1]
+    parser: pyright_json
+    args: ['--outputjson', '--project', '.github/preflight/pyrightconfig.json']
+
+  # --- Advisory to start. No baseline exists for these, so they run in
+  # --- warning-only mode until the repository has seen real-world signal.
+
+  yamllint:
+    blocking: false
+    include: ['*.yml', '*.yaml']
+    ok_exit_codes: [0, 1, 2]
+    parser: colon
+    args: ['--format', 'parsable', '--config-file', '.github/preflight/yamllint.yml']
+
+  shellcheck:
+    blocking: false
+    include: ['*.sh', '*.bash']
+    ok_exit_codes: [0, 1]
+    parser: colon
+    args: ['--format', 'gcc', '--severity', 'warning']
+
+  ansible-lint:
+    blocking: false
+    include: ['ansible/**/*.yml', 'ansible/**/*.yaml']
+    ok_exit_codes: [0, 2]
+    parser: colon
+    args: ['--format', 'pep8', '--nocolor', '--offline']
+
+  codespell:
+    blocking: false
+    # Deliberately not limited to source files; typos in docs matter too.
+    include: ['*']
+    exclude: ['*.json', '*.svg', '*.min.js', '*_pb2.py', 'spytest/**']
+    ok_exit_codes: [0, 65]
+    parser: codespell
+    args: ['--ignore-words', '.github/preflight/codespell-ignore.txt']

--- a/.github/preflight/pyrightconfig.json
+++ b/.github/preflight/pyrightconfig.json
@@ -1,0 +1,38 @@
+{
+  "//mode": "'standard', not 'basic'. Measured on a real change: basic silently drops reportPossiblyUnboundVariable and reportCallIssue, which are two of the highest-value checks here.",
+  "typeCheckingMode": "standard",
+
+  "//pythonVersion": "Pinned to match the workflow's setup-python. pyright infers imports from whichever interpreter it finds, so an unpinned version makes results depend on the machine: the same commit yielded 46 errors under a bare interpreter and 37 when pytest happened to be installed. Pinning here plus the pinned pip installs in the workflow keeps CI reproducible.",
+  "pythonVersion": "3.11",
+
+  "//imports": "The sonic-mgmt test dependencies are not installed in the pre-flight job, so without this every file reports unresolved imports and the real findings are buried. Installing them would add minutes to a check that gates the merge queue.",
+  "reportMissingImports": "none",
+  "reportMissingModuleSource": "none",
+
+  "//attributes": "Untyped runtime objects (ansible facts, pytest fixtures, duthost proxies) make attribute access unknowable without stubs, so this rule is noise rather than signal in this repository.",
+  "reportAttributeAccessIssue": "none",
+
+  "//note": "Deliberately NOT setting reportGeneralTypeIssues to none. It is a catch-all that also suppresses reportCallIssue and reportOperatorIssue; measured on one real change, setting it dropped 12 findings to 10, losing a call with a nonexistent keyword argument.",
+
+  "//kept": "The high-signal set: None-safety, possibly-unbound names, and calls that do not match the callee signature. Rule names are exact; pyright silently ignores unknown keys, so a typo here disables a check without any warning.",
+  "reportPossiblyUnboundVariable": "error",
+  "reportOptionalSubscript": "error",
+  "reportOptionalIterable": "error",
+  "reportOptionalMemberAccess": "error",
+  "reportOptionalOperand": "error",
+  "reportOptionalCall": "error",
+  "reportCallIssue": "error",
+  "reportArgumentType": "error",
+  "reportOperatorIssue": "error",
+  "reportIndexIssue": "error",
+  "reportRedeclaration": "error",
+
+  "exclude": [
+    "**/node_modules",
+    "**/__pycache__",
+    "**/*_pb2.py",
+    "spytest",
+    "tests/gnmi/protos",
+    "sdn_tests"
+  ]
+}

--- a/.github/preflight/run_preflight.py
+++ b/.github/preflight/run_preflight.py
@@ -47,6 +47,13 @@ GITHUB_STEP_SUMMARY = os.environ.get("GITHUB_STEP_SUMMARY", "")
 # annotations so the useful ones are not buried.
 MAX_ANNOTATIONS_PER_LEVEL = 10
 
+# Kept out of the list literal it is appended to: implicit string concatenation
+# inside a list reads as a possibly-missing comma, and CodeQL flags it as such.
+SUMMARY_FOOTER = (
+    "_Only lines added or modified by this change are reported; "
+    "pre-existing findings elsewhere in the same files are ignored._"
+)
+
 # file:line:col: message   (flake8, yamllint --format parsable,
 #                           shellcheck --format gcc, ansible-lint --format pep8)
 COLON_RE = re.compile(r"^(?P<file>[^:]+):(?P<line>\d+):(?P<col>\d+)?:?\s*(?P<msg>.*)$")
@@ -319,8 +326,7 @@ def emit(blocking, advisory, skipped):
         lines.append("")
     if skipped:
         lines += [f"Skipped (not installed): {', '.join(skipped)}", ""]
-    lines += ["", "_Only lines added or modified by this change are reported; "
-              "pre-existing findings elsewhere in the same files are ignored._"]
+    lines += ["", SUMMARY_FOOTER]
 
     summary = "\n".join(lines)
     if GITHUB_STEP_SUMMARY:

--- a/.github/preflight/run_preflight.py
+++ b/.github/preflight/run_preflight.py
@@ -1,0 +1,333 @@
+"""Pre-flight static analysis, reported only on lines the change touched.
+
+This runs on pull requests and, critically, on merge_group events so that it
+can gate a GitHub merge queue. The merge queue validates the *result* of
+merging a batch, which is the only place a semantic regression between two
+independently-green PRs can be caught before it reaches master.
+
+Two properties matter and are enforced here rather than left to each tool:
+
+1. Only files the change touched are analysed.
+2. Only findings on lines the change added or modified are reported. A
+   pre-existing problem elsewhere in a touched file is dropped. Without this,
+   turning on any new tool would immediately fail every pull request: pyright
+   alone reports 928 pre-existing errors across the files touched by 14 recent
+   commits, of which 8 are on lines those commits actually changed.
+
+Note that a moved or reindented line counts as changed, so a long-standing
+problem on a line a change shifts can surface. That is inherent to line-based
+filtering and matches how darker and diff-cover behave.
+
+Usage:
+    python .github/preflight/run_preflight.py
+
+The commit range is taken from the GitHub event payload. For local runs, set
+PREFLIGHT_BASE and PREFLIGHT_HEAD instead, for example:
+    PREFLIGHT_BASE=origin/master PREFLIGHT_HEAD=HEAD python .github/preflight/run_preflight.py
+"""
+
+import fnmatch
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+
+import yaml
+
+CONFIG_PATH = os.environ.get("PREFLIGHT_CONFIG", ".github/preflight/config.yml")
+GITHUB_EVENT_NAME = os.environ.get("GITHUB_EVENT_NAME", "")
+GITHUB_EVENT_PATH = os.environ.get("GITHUB_EVENT_PATH", "")
+GITHUB_STEP_SUMMARY = os.environ.get("GITHUB_STEP_SUMMARY", "")
+
+# GitHub renders at most 10 annotations of each level per step. Everything is
+# always written to the log and the job summary; this only caps the inline
+# annotations so the useful ones are not buried.
+MAX_ANNOTATIONS_PER_LEVEL = 10
+
+# file:line:col: message   (flake8, yamllint --format parsable,
+#                           shellcheck --format gcc, ansible-lint --format pep8)
+COLON_RE = re.compile(r"^(?P<file>[^:]+):(?P<line>\d+):(?P<col>\d+)?:?\s*(?P<msg>.*)$")
+# codespell: "path:line: typo ==> correction"
+CODESPELL_RE = re.compile(r"^(?P<file>[^:]+):(?P<line>\d+):\s*(?P<msg>.*)$")
+
+
+class Finding:
+    def __init__(self, tool, path, line, message):
+        self.tool = tool
+        self.path = path
+        self.line = line
+        self.message = " ".join(message.split())
+
+    def __str__(self):
+        return f"{self.path}:{self.line}: [{self.tool}] {self.message}"
+
+
+def run(*argv, **kwargs):
+    return subprocess.run(argv, capture_output=True, text=True, **kwargs)
+
+
+def git(*argv):
+    result = run("git", *argv)
+    if result.returncode != 0:
+        raise SystemExit(f"git {' '.join(argv)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def resolve_commit_range():
+    """Return (base_sha, head_sha) for the change under test.
+
+    pull_request: diff against the merge base, so commits landed on the target
+    branch after this branch was cut are not attributed to it.
+    merge_group:  diff the whole queued batch, which is what will land.
+    """
+    base = os.environ.get("PREFLIGHT_BASE")
+    head = os.environ.get("PREFLIGHT_HEAD")
+    if base and head:
+        return git("rev-parse", base).strip(), git("rev-parse", head).strip()
+
+    event = {}
+    if GITHUB_EVENT_PATH and os.path.exists(GITHUB_EVENT_PATH):
+        with open(GITHUB_EVENT_PATH, "r", encoding="utf-8") as handle:
+            event = json.load(handle)
+
+    if GITHUB_EVENT_NAME == "merge_group":
+        merge_group = event.get("merge_group", {})
+        return merge_group["base_sha"], merge_group["head_sha"]
+
+    if GITHUB_EVENT_NAME == "pull_request":
+        pull_request = event.get("pull_request", {})
+        base_sha = pull_request["base"]["sha"]
+        head_sha = pull_request["head"]["sha"]
+        merge_base = run("git", "merge-base", base_sha, head_sha)
+        if merge_base.returncode == 0 and merge_base.stdout.strip():
+            base_sha = merge_base.stdout.strip()
+        return base_sha, head_sha
+
+    raise SystemExit(
+        f"Cannot determine the commit range for event '{GITHUB_EVENT_NAME}'. "
+        "Set PREFLIGHT_BASE and PREFLIGHT_HEAD to run this locally."
+    )
+
+
+def changed_lines(base_sha, head_sha):
+    """Return {path: set(line numbers added or modified)}.
+
+    Uses --unified=0 so each hunk header describes exactly the changed lines
+    with no surrounding context, and --diff-filter to skip deletions.
+    """
+    diff = git(
+        "diff", "--unified=0", "--no-color", "--no-renames",
+        "--diff-filter=ACMR", f"{base_sha}", f"{head_sha}",
+    )
+
+    result = defaultdict(set)
+    current = None
+    for raw in diff.splitlines():
+        if raw.startswith("+++ b/"):
+            current = raw[len("+++ b/"):]
+        elif raw.startswith("+++ "):
+            current = None
+        elif raw.startswith("@@") and current:
+            # @@ -old,count +new,count @@
+            match = re.match(r"^@@ -\S+ \+(\d+)(?:,(\d+))? @@", raw)
+            if not match:
+                continue
+            start = int(match.group(1))
+            count = int(match.group(2)) if match.group(2) else 1
+            result[current].update(range(start, start + count))
+
+    return {path: lines for path, lines in result.items() if lines}
+
+
+def matches_any(path, patterns):
+    for pattern in patterns:
+        if fnmatch.fnmatch(path, pattern):
+            return True
+        # Allow '*.py' to match at any depth, and 'ansible/**/*.yml' to match
+        # 'ansible/foo.yml' as well as 'ansible/a/b/foo.yml'.
+        if pattern.startswith("*.") and fnmatch.fnmatch(os.path.basename(path), pattern):
+            return True
+        if "**/" in pattern and fnmatch.fnmatch(path, pattern.replace("**/", "")):
+            return True
+    return False
+
+
+def select_files(paths, spec):
+    include = spec.get("include", ["*"])
+    exclude = spec.get("exclude", [])
+    selected = [
+        path for path in sorted(paths)
+        if matches_any(path, include) and not matches_any(path, exclude) and os.path.isfile(path)
+    ]
+    return selected
+
+
+def parse_colon(tool, stdout):
+    findings = []
+    for raw in stdout.splitlines():
+        match = COLON_RE.match(raw.strip())
+        if match:
+            findings.append(Finding(tool, match.group("file"), int(match.group("line")), match.group("msg")))
+    return findings
+
+
+def parse_codespell(tool, stdout):
+    findings = []
+    for raw in stdout.splitlines():
+        match = CODESPELL_RE.match(raw.strip())
+        if match:
+            findings.append(Finding(tool, match.group("file"), int(match.group("line")), match.group("msg")))
+    return findings
+
+
+def parse_pyright_json(tool, stdout):
+    findings = []
+    try:
+        payload = json.loads(stdout or "{}")
+    except ValueError:
+        return findings
+
+    root = os.getcwd() + os.sep
+    for diagnostic in payload.get("generalDiagnostics", []):
+        if diagnostic.get("severity") != "error":
+            continue
+        path = diagnostic.get("file", "")
+        if path.startswith(root):
+            path = path[len(root):]
+        # pyright reports 0-based line numbers.
+        line = diagnostic.get("range", {}).get("start", {}).get("line", 0) + 1
+        rule = diagnostic.get("rule")
+        message = diagnostic.get("message", "").splitlines()[0]
+        findings.append(Finding(tool, path, line, f"{message} ({rule})" if rule else message))
+    return findings
+
+
+PARSERS = {
+    "colon": parse_colon,
+    "codespell": parse_codespell,
+    "pyright_json": parse_pyright_json,
+}
+
+
+def invoke(tool, spec, files):
+    """Run one tool over its files, honouring per-directory profiles."""
+    parser = PARSERS[spec.get("parser", "colon")]
+    ok_exit_codes = spec.get("ok_exit_codes", [0, 1])
+    profiles = spec.get("profiles")
+
+    if profiles:
+        groups = []
+        for profile in profiles:
+            pattern = re.compile(profile["match"])
+            matched = [path for path in files if pattern.search(path)]
+            files = [path for path in files if path not in set(matched)]
+            if matched:
+                groups.append((profile.get("args", []), matched))
+    else:
+        groups = [(spec.get("args", []), files)] if files else []
+
+    findings = []
+    for args, group in groups:
+        result = run(tool, *args, *group)
+        if result.returncode not in ok_exit_codes:
+            # A crashed tool must never look like a clean run.
+            raise SystemExit(
+                f"::error::{tool} exited with unexpected code {result.returncode}.\n"
+                f"stdout:\n{result.stdout[:4000]}\nstderr:\n{result.stderr[:4000]}"
+            )
+        findings.extend(parser(tool, result.stdout))
+    return findings
+
+
+def main():
+    with open(CONFIG_PATH, "r", encoding="utf-8") as handle:
+        config = yaml.safe_load(handle) or {}
+    tools = config.get("tools") or {}
+
+    base_sha, head_sha = resolve_commit_range()
+    print(f"Event: {GITHUB_EVENT_NAME or 'local'}")
+    print(f"Analysing {base_sha[:12]}..{head_sha[:12]}")
+
+    touched = changed_lines(base_sha, head_sha)
+    if not touched:
+        print("No added or modified lines. Nothing to analyse.")
+        return 0
+    print(f"{len(touched)} changed file(s), {sum(len(v) for v in touched.values())} changed line(s).")
+
+    blocking_findings = []
+    advisory_findings = []
+    skipped = []
+
+    for tool, spec in tools.items():
+        files = select_files(touched.keys(), spec)
+        if not files:
+            continue
+        if not shutil.which(tool):
+            skipped.append(tool)
+            print(f"::warning::{tool} is not installed; skipping.")
+            continue
+
+        print(f"\n--- {tool} on {len(files)} file(s) ---")
+        found = invoke(tool, spec, files)
+
+        kept = [f for f in found if f.line in touched.get(f.path, set())]
+        dropped = len(found) - len(kept)
+        print(f"{len(found)} finding(s), {len(kept)} on changed lines ({dropped} pre-existing, ignored).")
+
+        if spec.get("blocking"):
+            blocking_findings.extend(kept)
+        else:
+            advisory_findings.extend(kept)
+
+    emit(blocking_findings, advisory_findings, skipped)
+    return 1 if blocking_findings else 0
+
+
+def emit(blocking, advisory, skipped):
+    counts = defaultdict(int)
+    for level, findings in (("error", blocking), ("warning", advisory)):
+        for finding in findings:
+            print(finding)
+            if counts[level] < MAX_ANNOTATIONS_PER_LEVEL:
+                counts[level] += 1
+                print(
+                    f"::{level} file={finding.path},line={finding.line},"
+                    f"title=preflight/{finding.tool}::{finding.message}"
+                )
+
+    def row(finding):
+        # Type names such as "list[str] | None" contain pipes, which would
+        # otherwise split the markdown table into extra columns.
+        message = finding.message.replace("|", "\\|")
+        return f"| `{finding.path}` | {finding.line} | {finding.tool} | {message} |"
+
+    header = ["| File | Line | Tool | Finding |", "| --- | --- | --- | --- |"]
+
+    lines = ["## Pre-flight static analysis", ""]
+    if not blocking and not advisory:
+        lines.append("No findings on the lines this change touches.")
+    if blocking:
+        lines += [f"### Blocking ({len(blocking)})", ""] + header
+        lines += [row(f) for f in blocking]
+        lines.append("")
+    if advisory:
+        lines += [f"### Advisory ({len(advisory)}) — does not fail the check", ""] + header
+        lines += [row(f) for f in advisory]
+        lines.append("")
+    if skipped:
+        lines += [f"Skipped (not installed): {', '.join(skipped)}", ""]
+    lines += ["", "_Only lines added or modified by this change are reported; "
+              "pre-existing findings elsewhere in the same files are ignored._"]
+
+    summary = "\n".join(lines)
+    if GITHUB_STEP_SUMMARY:
+        with open(GITHUB_STEP_SUMMARY, "a", encoding="utf-8") as handle:
+            handle.write(summary + "\n")
+    print("\n" + summary)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/preflight/test_preflight.py
+++ b/.github/preflight/test_preflight.py
@@ -1,0 +1,181 @@
+"""Tests for the pre-flight changed-lines filter.
+
+The whole value of this check rests on one property: a finding is reported if
+and only if it sits on a line the change added or modified. If that regresses,
+the check either starts failing pull requests for problems they did not cause,
+or stops catching the ones they did.
+
+Run with:
+    python .github/preflight/test_preflight.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+RUNNER = os.path.join(REPO_ROOT, ".github", "preflight", "run_preflight.py")
+PREFLIGHT_DIR = os.path.join(REPO_ROOT, ".github", "preflight")
+
+# Only flake8 is exercised: it is the tool every contributor already has, and
+# the filtering logic under test is tool-independent.
+CONFIG = """
+tools:
+  flake8:
+    blocking: true
+    include: ['*.py']
+    ok_exit_codes: [0, 1]
+    parser: colon
+    args: ['--max-line-length=120']
+"""
+
+# Two pre-existing flake8 violations: an unused import (F401) and a bare
+# comparison to None (E711).
+BASE_FILE = '''\
+import os
+
+
+def existing():
+    value = 1
+    if value == None:
+        return 1
+    return 2
+'''
+
+# The pre-existing violations above are untouched. A new E711 is introduced.
+CHANGED_FILE = '''\
+import os
+
+
+def existing():
+    value = 1
+    if value == None:
+        return 1
+    return 2
+
+
+def added():
+    other = 3
+    if other == None:
+        return 4
+    return 5
+'''
+
+
+def git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def build_repo(tmp):
+    git(tmp, "init", "-q", "-b", "main")
+    git(tmp, "config", "user.email", "preflight@example.com")
+    git(tmp, "config", "user.name", "preflight")
+
+    with open(os.path.join(tmp, "sample.py"), "w", encoding="utf-8") as handle:
+        handle.write(BASE_FILE)
+    git(tmp, "add", "-A")
+    git(tmp, "commit", "-qm", "base")
+    base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=tmp, capture_output=True,
+                          text=True, check=True).stdout.strip()
+
+    with open(os.path.join(tmp, "sample.py"), "w", encoding="utf-8") as handle:
+        handle.write(CHANGED_FILE)
+    git(tmp, "add", "-A")
+    git(tmp, "commit", "-qm", "change")
+    head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=tmp, capture_output=True,
+                          text=True, check=True).stdout.strip()
+    return base, head
+
+
+def run_preflight(tmp, env_extra):
+    config_path = os.path.join(tmp, "config.yml")
+    with open(config_path, "w", encoding="utf-8") as handle:
+        handle.write(CONFIG)
+
+    env = dict(os.environ)
+    env["PREFLIGHT_CONFIG"] = config_path
+    env.update(env_extra)
+    return subprocess.run([sys.executable, RUNNER], cwd=tmp, capture_output=True, text=True, env=env)
+
+
+def check(condition, label):
+    print(f"  {'PASS' if condition else 'FAIL'}  {label}")
+    return condition
+
+
+def main():
+    ok = True
+
+    with tempfile.TemporaryDirectory() as tmp:
+        base, head = build_repo(tmp)
+
+        print("changed lines only (the core guarantee):")
+        result = run_preflight(tmp, {"PREFLIGHT_BASE": base, "PREFLIGHT_HEAD": head})
+        out = result.stdout
+
+        # The new violation is on line 13 of the changed file. Assertions use a
+        # trailing colon so that "sample.py:1:" cannot match "sample.py:13:".
+        ok &= check("sample.py:13:" in out, "reports the E711 introduced by the change")
+        # The identical pre-existing violation is on line 6 and must be ignored.
+        ok &= check("sample.py:6:" not in out, "ignores the identical pre-existing E711 on line 6")
+        ok &= check("sample.py:1:" not in out, "ignores the pre-existing unused import on line 1")
+        ok &= check(result.returncode == 1, "fails the check when a blocking finding lands on a changed line")
+        ok &= check("1 on changed lines" in out, "counts exactly one finding on changed lines")
+
+        print("\nunchanged tree:")
+        result = run_preflight(tmp, {"PREFLIGHT_BASE": head, "PREFLIGHT_HEAD": head})
+        ok &= check(result.returncode == 0, "passes when nothing changed")
+        ok &= check("Nothing to analyse" in result.stdout, "reports that there is nothing to analyse")
+
+        print("\nmerge_group event wiring:")
+        event_path = os.path.join(tmp, "event.json")
+        with open(event_path, "w", encoding="utf-8") as handle:
+            json.dump({"merge_group": {"base_sha": base, "head_sha": head}}, handle)
+        result = run_preflight(tmp, {"GITHUB_EVENT_NAME": "merge_group", "GITHUB_EVENT_PATH": event_path})
+        ok &= check(result.returncode == 1, "resolves the range from a merge_group payload")
+        ok &= check("sample.py:13:" in result.stdout, "reports the same finding for a merge group")
+        ok &= check("sample.py:6:" not in result.stdout, "still ignores pre-existing findings in a merge group")
+
+        print("\npull_request event wiring:")
+        with open(event_path, "w", encoding="utf-8") as handle:
+            json.dump({"pull_request": {"base": {"sha": base}, "head": {"sha": head}}}, handle)
+        result = run_preflight(tmp, {"GITHUB_EVENT_NAME": "pull_request", "GITHUB_EVENT_PATH": event_path})
+        ok &= check(result.returncode == 1, "resolves the range from a pull_request payload")
+        ok &= check("sample.py:13:" in result.stdout, "reports the finding for a pull request")
+
+        print("\nannotations and summary:")
+        summary_path = os.path.join(tmp, "summary.md")
+        result = run_preflight(tmp, {"PREFLIGHT_BASE": base, "PREFLIGHT_HEAD": head,
+                                     "GITHUB_STEP_SUMMARY": summary_path})
+        ok &= check("::error file=sample.py,line=13," in result.stdout, "emits a GitHub error annotation")
+        with open(summary_path, "r", encoding="utf-8") as handle:
+            summary = handle.read()
+        ok &= check("### Blocking (1)" in summary, "writes the blocking section to the job summary")
+
+    print("\nconfig sanity:")
+    import yaml
+    with open(os.path.join(PREFLIGHT_DIR, "config.yml"), "r", encoding="utf-8") as handle:
+        config = yaml.safe_load(handle)
+    tools = config["tools"]
+    ok &= check(tools["flake8"]["blocking"] is True, "flake8 is blocking")
+    ok &= check(tools["pyright"]["blocking"] is True, "pyright is blocking")
+    ok &= check(
+        all(not tools[name]["blocking"] for name in ("yamllint", "shellcheck", "ansible-lint", "codespell")),
+        "the unmeasured tools start advisory",
+    )
+    with open(os.path.join(PREFLIGHT_DIR, "pyrightconfig.json"), "r", encoding="utf-8") as handle:
+        pyright_config = json.load(handle)
+    # pyright silently ignores unknown keys, so a typo disables a check with no warning.
+    ok &= check(pyright_config.get("reportPossiblyUnboundVariable") == "error",
+                "pyright rule name is reportPossiblyUnboundVariable, not reportPossiblyUnbound")
+    ok &= check("reportGeneralTypeIssues" not in pyright_config,
+                "reportGeneralTypeIssues is not disabled (it would mask reportCallIssue)")
+
+    print("\n" + ("ALL PASS" if ok else "FAILURES"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/preflight/yamllint.yml
+++ b/.github/preflight/yamllint.yml
@@ -1,0 +1,29 @@
+# yamllint configuration for the pre-flight check.
+#
+# Advisory only for now. The repository has ~950 YAML files that have never
+# been linted, so this starts with the structural rules that indicate a real
+# mistake and leaves the purely cosmetic ones off.
+
+extends: default
+
+rules:
+  # Ansible and GitHub Actions files routinely exceed any sane column limit,
+  # and flake8 already governs line length for Python.
+  line-length: disable
+  # 'on:' in a GitHub Actions workflow is a string key, not a boolean.
+  truthy:
+    check-keys: false
+  comments:
+    require-starting-space: true
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  # Existing files use a mix of indentation styles; flagging every one of them
+  # would be noise rather than signal.
+  indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 2
+  braces:
+    max-spaces-inside: 1
+  brackets:
+    max-spaces-inside: 1

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,66 @@
+name: "Pre-flight Static Analysis"
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+      - '202[0-9][0-9][0-9]'
+  # The reason this workflow exists in this form. A merge queue validates the
+  # result of merging a batch, which is the only place a regression between two
+  # independently-green pull requests can be caught before it reaches master.
+  merge_group:
+  workflow_dispatch:
+
+# Deliberately read-only. This workflow executes linters over untrusted pull
+# request code, so it must never be pull_request_target and must never hold a
+# writable token or secrets.
+permissions:
+  contents: read
+
+concurrency:
+  group: preflight-${{ github.event.merge_group.head_ref || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    name: Pre-flight
+    if: github.repository_owner == 'sonic-net'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # Full history: the check diffs against the merge base, which is not
+      # reachable from a shallow clone.
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: '3.11'
+
+      - name: Install analysis tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            'flake8==7.1.1' \
+            'pyright==1.1.411' \
+            'yamllint==1.38.0' \
+            'ansible-lint==24.7.0' \
+            'codespell==2.4.3' \
+            'PyYAML'
+          sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+
+      # Pre-download the node runtime pyright needs, so a slow download does
+      # not read as an analysis failure.
+      - name: Warm up pyright
+        run: pyright --version
+
+      # The changed-lines filter is the whole point of this check: if it
+      # regresses, the job either fails pull requests for pre-existing problems
+      # or stops catching new ones. Verify it before trusting its verdict.
+      - name: Verify the changed-lines filter
+        run: python .github/preflight/test_preflight.py
+
+      - name: Run pre-flight static analysis
+        run: python .github/preflight/run_preflight.py


### PR DESCRIPTION
### Description of PR

Summary:
Adds a fast static analysis check that runs on pull requests **and on `merge_group` events**, so it can serve as the pre-flight sanity check for a GitHub merge queue. Every finding is reported only on lines the change actually touched.

Opened as a **draft for evaluation.** The merge queue itself is a repository settings change and is deliberately *not* part of this PR — see the last section.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: N/A

### Approach

#### What is the motivation for this PR?

A pull request is tested against the branch as it looked when the branch was cut. Two pull requests can each be green and still break master when combined — one renames a helper, the other adds a caller. Nothing in CI today runs against the merged result. A merge queue does exactly that, and this is the check that runs there.

#### How did you do it?

| File | Purpose |
| --- | --- |
| `.github/workflows/preflight.yml` | Triggers on `pull_request`, `merge_group`, `workflow_dispatch` |
| `.github/preflight/run_preflight.py` | Computes changed lines, runs the tools, filters, annotates |
| `.github/preflight/config.yml` | Which tools run, and which are blocking |
| `.github/preflight/pyrightconfig.json` | pyright rule selection |
| `.github/preflight/test_preflight.py` | Tests for the changed-lines guarantee |
| `.github/preflight/README.md` | Design notes and merge-queue guidance |

**Only changed lines are ever reported.** This is the property the whole thing rests on, and it is enforced centrally rather than left to each tool. It is not a nicety — it is what makes the check adoptable:

> pyright reports **928 pre-existing errors** across the files touched by 14 recent commits. Only **10** are on lines those commits actually changed.

Without the filter, every pull request would fail on day one. On one real change the check suppressed **71** pre-existing findings and reported 10.

One consequence worth knowing: a moved or reindented line counts as changed, so a long-standing problem on a line your change shifts can surface. That is inherent to line-based filtering and matches `darker` and `diff-cover`.

**What runs:**

| Tool | Blocking | Notes |
| --- | --- | --- |
| flake8 | yes | Mirrors `.pre-commit-config.yaml` exactly, including the per-directory ignore lists, so this can never disagree with local `pre-commit` |
| pyright | yes | None-safety, possibly-unbound names, signature mismatches |
| yamllint / shellcheck / ansible-lint / codespell | no | Advisory; no baseline exists for these on this repo |

Promoting an advisory tool is a single `blocking: true` edit in `config.yml`.

#### How did you verify/test it?

Measured over **14 recent PR-sized commits**, in a virtualenv containing only the packages the workflow installs:

| Tool | PRs blocked | Findings on changed lines | Time |
| --- | --- | --- | --- |
| flake8 | 0/14 | 0 | 4.5s |
| pyright | 1/14 | 10 | 18.9s |

The single pyright hit was a **real defect**, not noise:

```
test_port_speed_upgrade.py:1759  "src_duthost" is possibly unbound
test_port_speed_upgrade.py:1479  Object of type "None" is not subscriptable   (x5)
test_port_speed_upgrade.py:113   No parameter named "ignore_loganalyzer"
```

`test_preflight.py` covers the guarantee directly — including an identical violation appearing on both a changed and an unchanged line, where only the changed one is reported — plus `merge_group` and `pull_request` payload handling, annotations, and the job summary. 20 assertions, all passing. It runs in CI *ahead of* the analysis, so a regression in the filter fails loudly rather than silently changing what gets reported.

Three pyright settings were chosen from measurement rather than taste, and are documented inline:

- `typeCheckingMode` is `standard`, not `basic` — `basic` silently drops `reportPossiblyUnboundVariable` and `reportCallIssue`.
- `reportGeneralTypeIssues` is deliberately **not** disabled — it is a catch-all that also suppresses `reportCallIssue` and `reportOperatorIssue`. Disabling it took 12 findings to 10 on one real change, losing a call with a nonexistent keyword argument.
- `pythonVersion` is pinned — pyright infers imports from whichever interpreter is on `PATH`. The same commit produced 46 errors under a bare interpreter and 37 with `pytest` installed. CI is reproducible because the runner is fresh and versions are pinned; local runs will not always match.

#### Any platform specific information?

None — CI infrastructure only. No test or testbed code is touched.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

`.github/preflight/README.md` covers the design, the tool table, the pyright rationale, and the merge-queue guidance below.

---

### Azure pipelines are already safe from the merge queue

No change was needed, and this was verified rather than assumed:

- `azure-pipelines.yml` sets `trigger: none`, so nothing runs on branch pushes. A merge queue works by pushing to `gh-readonly-queue/**` refs, which that already excludes.
- Its only trigger is `pr:`, which fires on GitHub `pull_request` events. A merge group is not a pull request and emits no such event.

⚠️ **This must be re-checked if `trigger:` is ever given a branch list.** Adding `gh-readonly-queue/**` there, directly or via a wildcard, would spawn a full testbed run for every queue entry.

### Before the merge queue can be turned on

The workflow is ready for it, but enabling the queue is a repository settings change and has one sharp edge:

> When a merge queue is enabled, required status checks are evaluated against the **merge group**, not the pull request. Any required check that does not run on `merge_group` will never report, and pull requests will sit in the queue until they time out.

Today `Azure.sonic-mgmt`, `Semgrep` and `CodeQL` all trigger on `pull_request` only. Enabling the queue means deciding per check whether to add a `merge_group` trigger or drop it from the required list. Based on measured cost:

- **Semgrep** — ~33s, and already diff-aware via its own baseline scan. Cheap enough to add to the queue.
- **CodeQL** — ~7m20s. Too slow to gate a queue; keep it on pull requests.
- **Azure.sonic-mgmt** — must stay out of the queue; that is the entire point.

### Open questions

1. **Should this be a required check to start?** I would suggest letting it run non-required for a week or two first, so the real block rate can be observed against live traffic rather than my 14-commit sample.
2. **Advisory tools** — yamllint, shellcheck, ansible-lint and codespell have never run on this repository, so I have no noise data for them. They annotate but cannot fail. Reviewing their output on real PRs is the natural way to decide which deserve promotion.
3. **flake8 vs ruff** — ruff covers the same `E,F,W` set roughly 18x faster (0.2s vs 4.5s). I kept flake8 so the GHA cannot drift from `.pre-commit-config.yaml`. Worth revisiting only if pre-commit migrates too. Note ruff's out-of-box defaults fire **1881** times on a single PR here, so it would need an explicit `--select` either way.
