### PR TITLE
fix(ptf): backport restart-ptf SSH reachability fix to 202511

### DIFF
--- a/ansible/roles/vm_set/tasks/ptf_change_mac.yml
+++ b/ansible/roles/vm_set/tasks/ptf_change_mac.yml
@@ -10,6 +10,13 @@
     groups:
       - ptf
 
+# If container is restarted, the upstream ARP entry may become stale. Send ARP request to flush the stale entry.
+- name: Send ARP request to mgmt gateway to flush stale upstream ARP
+  command: docker exec -i ptf_{{ vm_set_name }} arping -c 2 {{ mgmt_gw }}
+  become: yes
+  ignore_errors: yes
+  when: mgmt_gw is defined
+
 - name: wait until ptf is reachable
   wait_for:
     port: 22


### PR DESCRIPTION
### Description of PR

Summary: Backport #24613 to the `202511` branch.

This fixes the recurring restart-PTF failure observed in test plan `6a701304f481df03c4e5a4f1`:

```text
TASK [vm_set : wait until ptf is reachable] ************************************
fatal: [STR4-ACS-SERV-13 -> localhost]: FAILED! => {"changed": false, "elapsed": 300, "msg": "Timeout when waiting for 10.64.247.153:22"}
```

During `restart-ptf`, the PTF container is recreated with the same management IP but a new MAC address. The upstream gateway can retain the stale ARP entry, so the subsequent wait for TCP/22 times out even though the new container is running.

The original commit conflicts with `202511` because its parent contains an earlier GARP task that is absent from this branch. The conflict was resolved by backporting only #24613's gateway ARP refresh immediately before the existing SSH wait.

ADO: https://dev.azure.com/msazure/One/_workitems/edit/39078609/

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/39078609/
Failure type: other - recurring stale gateway ARP state after PTF container recreation

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: The original fix was physically validated in #24613.
- internal-202511: Test plan `6a701304f481df03c4e5a4f1` reproduced the failure twice, each time timing out for 300 seconds while waiting for PTF `10.64.247.153:22`.
- 202511: Runtime validation is pending after the backport is merged.

### Approach
#### What is the motivation for this PR?

Prevent restart-PTF from failing when the management gateway still maps the reused PTF IP to the deleted container's MAC address.

#### How did you do it?

Cherry-picked commit `ee026500dbd5dacbad665505a0252ad3bd470ad8` with provenance and resolved its contextual conflict by retaining only the gateway ARP request added by #24613.

#### How did you verify/test it?

Confirmed the resulting diff matches #24613's seven-line gateway ARP refresh, parses as valid YAML, and contains no whitespace errors. The original change was physically validated in #24613.

#### Any platform specific information?

The failure was observed on physical multi-server testbeds. The change is generic to PTF management networking.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
