### PR TITLE
[acl]: Exclude PortChannel members from LT2 ACL bindings

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -525,9 +525,15 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
         # For LT2, add portchannels for downstream links
         for k, v in list(port_channels.items()):
             acl_table_ports[v['namespace']].append(k)
-        # Add RIF for upstream links
+        # Add standalone RIFs for upstream links. PortChannel members cannot
+        # also be bound to the ACL table as physical interfaces.
+        pc_members = defaultdict(set)
+        for pc in port_channels.values():
+            pc_members[pc['namespace']].update(pc.get('members', []))
         for namespace, port in list(upstream_ports.items()):
-            acl_table_ports[namespace] += port
+            acl_table_ports[namespace] += [
+                interface for interface in port if interface not in pc_members[namespace]
+            ]
     elif topo in ("urh", "lrh"):
         # For URH/LRH, ports may be in portchannels — raw PC member interfaces
         # cannot bind ACLs, so add PortChannel names and filter out ports in portchannels.


### PR DESCRIPTION
### Description of PR

Summary:
Prevent LT2 ACL table creation from binding physical interfaces that are already members of PortChannels.

Fixes # N/A

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

On LT2 topologies, the ACL setup included both PortChannel names and their physical member interfaces as ACL bind points. SONiC rejects those configurations with errors such as `Cannot bind ACL to specified port Ethernet620`, causing all ACL cases that use the shared setup fixture to fail.

#### How did you do it?

Build a namespace-aware set of PortChannel members and exclude those interfaces when adding standalone upstream RIFs to the LT2 ACL bind list. PortChannel names remain bound as before.

#### How did you verify/test it?

Validated the targeted ACL case on `vms13-lt2-nh4210-1` (`lt2-u32d128`, `str4-nh4210-01`):

`acl/test_acl.py::TestBasicAcl::test_ingress_unmatched_blocked[ipv4-ingress-downlink->uplink-default-no_vlan]`

The test passed.

#### Any platform specific information?

Validated on NH-4210 LT2. The change is scoped to the existing `topo == \"lt2\"` path.

#### Supported testbed topology if it's a new test case?

Not a new test case. The affected topology is LT2.

### Documentation

N/A; no user-facing behavior or new test interface.