### PR TITLE
fix link local by enable use-link-local-only

### DIFF
--- a/tests/bgp/test_bgp_link_local.py
+++ b/tests/bgp/test_bgp_link_local.py
@@ -392,7 +392,10 @@ def configure_unnumbered_eos(neigh_host, neigh_asn, dut_asn,
     # Call 1: Enable IPv6 RAs + global RFC 5549
     logger.info("Enable IPv6 RAs on EOS %s + RFC 5549", eos_intf)
     neigh_host.eos_config(
-        lines=["no ipv6 nd ra disabled"],
+        lines=[
+            "no ipv6 nd ra disabled",
+            "ipv6 nd ra interval 10",
+        ],
         parents="interface {}".format(eos_intf))
     neigh_host.eos_config(lines=["ip routing ipv6 interfaces"])
 
@@ -612,6 +615,12 @@ def configure_unnumbered_bgp(request, setup_info):
         facts = duthost.bgp_facts()['ansible_facts']
         return neigh_ipv4 not in facts.get('bgp_neighbors', {})
     wait_until(30, 3, 0, old_neighbor_removed)
+
+    # Keep the SAI RIF when the last global address is removed. Without this,
+    # SONiC deletes the INTERFACE/PORTCHANNEL_INTERFACE entry and orchagent
+    # removes the RIF, so hardware stops receiving IPv6 RAs and FRR unnumbered
+    # peers stay in Idle state.
+    duthost.shell(f"sudo config interface ipv6 enable use-link-local-only {dut_intf}")
 
     # Remove IPv4/IPv6 addresses from DUT interface to prevent
     # FRR numbered fallback. Use the actual prefix length captured from


### PR DESCRIPTION
### Description of PR

Summary:
Fixes a bug introduced by https://github.com/sonic-net/sonic-mgmt/pull/24242

test_bgp_link_local[portchannel-frrtest] removes both global IPs from PortChannel101 without first enabling ipv6_use_link_local_only. SONiC deletes the PORTCHANNEL_INTERFACE entry when the last global address goes unless that flag is set (sonic-utilities config/main.py, ip remove → get_intf_ipv6_link_local_mode). intfmgr then withdraws APPL_DB INTF_TABLE and orchagent removes the SAI RIF — matching the sysdump: has_rif False for PC101 only, ND RA sent: 26 rcvd: 0, BGP Idle (unspec). A kernel fe80 alone is not enough on hardware; KVM has no RIF, which is why this passed on VS.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
tested on master
<img width="940" height="204" alt="image" src="https://github.com/user-attachments/assets/372fcf57-41ec-4fd2-bbcd-ece45c06f08e" />


### Approach
#### What is the motivation for this PR?
To fix wrong process to config bgp link local
#### How did you do it?
Enable use-link-local-only on the interface before removing globals, for both the portchannel and ethernet paths. Also set ipv6 nd ra interval on the EOS peer — it defaults to 200s while the test waits 120s, making peer discovery a race on its own, optimize it to 10s.
#### How did you verify/test it?
Run the test with the fix and it passes
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
