### PR TITLE
Fix lldp test_lldp_syncd: exclude mgmt interface in wait_until_lldp_populated

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -462,7 +462,12 @@ def verify_all_interfaces_lldp_content(db_instance, lldp_entry_keys, lldpctl_out
 def wait_until_lldp_populated(duthost, db_instance, after_event_str):
     keys_match = wait_until(90, 2, 0, check_lldp_table_keys, duthost, db_instance)
     pytest_assert(keys_match, "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output")
-    lldp_entry_keys = get_lldp_entry_keys(db_instance)
+    # The management interface (e.g. eth0) can pick up a transient LLDP neighbor on the
+    # mgmt network whose LLDP_ENTRY_TABLE entry ages in and out independently, leaving a
+    # partial (single-field) entry that never fully populates. This is out of scope for
+    # front-panel LLDP verification and is why every other cross-source comparison in this
+    # file drops mgmt interfaces. Exclude it here as well so the check does not flap.
+    lldp_entry_keys = exclude_mgmt_interfaces(get_lldp_entry_keys(db_instance))
     # Wait until all interfaces are up and lldp entries are populated
     result = wait_until(300, 2, 0, verify_lldp_entry, db_instance, lldp_entry_keys)
     if not result:


### PR DESCRIPTION
### Description of PR

Summary:
Fixes flaky failure of `lldp.test_lldp_syncd::test_lldp_entry_table_after_syncd_orchagent` where the test asserts `After restart swss and syncd, not all LLDP_ENTRY_TABLE entries are not correct: {'eth0': {'lldp_rem_time_mark': '...'}}`.

`wait_until_lldp_populated()` verified **all** LLDP_ENTRY_TABLE keys, including the management interface `eth0`. On testbeds where the mgmt network has an LLDP-speaking neighbor (observed on Nokia-7215 / marvell-prestera mx), `eth0` gets a transient LLDP entry that ages in and out independently and is often only partially populated (a single field such as `lldp_rem_time_mark`). `verify_lldp_entry()` then keeps returning `False` and the test fails, even though all front-panel LLDP entries are healthy.

Every other cross-source comparison in this file already drops the management interface via `exclude_mgmt_interfaces()` for exactly this documented reason. `wait_until_lldp_populated()` was the only place still requiring the transient mgmt entry to be fully populated. This PR excludes mgmt interfaces there as well, so only front-panel LLDP entries are verified — consistent with `check_lldp_table_keys()` earlier in the same function, which already accepts an empty front-panel set.

ADO: 39100207

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): ADO 39100207
Failure type: day-one issue (test-only; management-interface handling was inconsistent within the module)

### Tested branch
- [x] master
- [ ] N/A

### Test result
Static/lint validation only (pre-commit: trailing-whitespace, end-of-file-fixer, check python ast, flake8 all Passed). The change is a surgical, test-only filter that reuses the module's existing `exclude_mgmt_interfaces()` helper; on affected testbeds the transient `eth0` entry is no longer treated as a required front-panel LLDP entry, while behavior on healthy platforms (100% pass on broadcom/cisco/mellanox) is unchanged.

### Approach
#### What is the motivation for this PR?
Remove a test-only false failure caused by the transient management-interface LLDP entry so the LLDP syncd/orchagent restart test reflects real front-panel LLDP health.

#### How did you do it?
In `wait_until_lldp_populated()`, wrap `get_lldp_entry_keys(db_instance)` with the existing `exclude_mgmt_interfaces()` helper so management interfaces (e.g. `eth0`) are not required to have a fully-populated LLDP_ENTRY_TABLE entry.

#### How did you verify/test it?
Ran repo pre-commit hooks on the changed file (all Passed). Confirmed the failing signature is driven solely by the `eth0` partial entry and that `check_lldp_table_keys()` (which already excludes mgmt) passed in the failing run, so restricting verification to front-panel interfaces is the correct, consistent behavior.

#### Any platform specific information?
Observed on Nokia-7215 (marvell-prestera) mx topology where the mgmt network has an LLDP neighbor; the fix is platform-agnostic.

#### Supported testbed topology if it's a new test case?
N/A (existing test).

### Documentation
N/A