### PR TITLE
Ignore benign omrelp connection error in syslog tests

### DIFF
--- a/tests/generic_config_updater/test_syslog.py
+++ b/tests/generic_config_updater/test_syslog.py
@@ -306,6 +306,7 @@ def test_syslog_server_tc1_suite(rand_selected_dut, cfg_facts, loganalyzer):
     if loganalyzer:
         ignoreRegex = [
             r".*omrelp\[.*\]: error 'error opening connection to remote peer'.*",
+            r".*omrelp: could not connect to remote server, librelp error \d+.*",
             r".*omrelp\[.*\]: error 'server closed relp session, session broken', object .* - action may not work as intended.*",  # noqa: E501
             r".*omrelp\[.*\]: error 'error waiting on required session state, session broken', object .* - action may not work as intended.*",  # noqa: E501
         ]

--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -24,6 +24,7 @@ def test_syslog(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server
     if loganalyzer:
         ignoreRegex = [
             r".*omrelp\[.*\]: error 'error opening connection to remote peer'.*",
+            r".*omrelp: could not connect to remote server, librelp error \d+.*",
             r".*omrelp\[.*\]: error 'server closed relp session, session broken', object .* - action may not work as intended.*",  # noqa: E501
             r".*omrelp\[.*\]: error 'error waiting on required session state, session broken', object .* - action may not work as intended.*",  # noqa: E501
         ]


### PR DESCRIPTION
### Description of PR

LogAnalyzer can fail syslog tests on a benign rsyslog omrelp retry message emitted while the tests add/remove dummy unreachable syslog servers:

`omrelp: could not connect to remote server, librelp error <code>`

The tested behavior is config update/rollback, not successful RELP delivery to the dummy destination. Ignore this expected message in both syslog test variants to prevent false teardown failures.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

PBI 39100199 tracks `generic_config_updater/test_syslog.py::test_syslog_server_tc1_suite` passing functionally but failing during LogAnalyzer teardown because rsyslog logs an expected omrelp connection failure to the dummy syslog endpoint.

#### How did you do it?

Added a targeted ignore regex for `omrelp: could not connect to remote server, librelp error \d+` beside the existing omrelp ignore patterns in both `tests/generic_config_updater/test_syslog.py` and `tests/syslog/test_syslog.py`.

#### How did you verify/test it?

- Ran `python -m py_compile tests/generic_config_updater/test_syslog.py tests/syslog/test_syslog.py`.
- Verified the regex matches the PBI failure signature and is scoped to omrelp connection retries.

#### Any platform specific information?

Observed on Nokia-7215 MX in 202605 nightly; the signature is test-induced and not platform-specific.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A