### PR TITLE
Wait for sensord restart after supervisorctl

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -125,7 +125,7 @@ def start_pmon_sensord_task(duthost):
     sensord_running_status, sensord_pid = check_sensord_status(duthost)
     if not sensord_running_status:
         duthost.command("docker exec pmon supervisorctl restart lm-sensors")
-        time.sleep(3)
+        wait_until(30, 1, 0, lambda: check_sensord_status(duthost)[0])
         sensord_running_status, sensord_pid = check_sensord_status(duthost)
         if sensord_running_status:
             logging.info("sensord task started, pid = {}".format(sensord_pid))
@@ -153,7 +153,7 @@ def psu_test_setup_teardown(duthosts, enum_rand_one_per_hwsku_hostname):
     sensord_running_status, sensord_pid = check_sensord_status(duthost)
     if not sensord_running_status:
         duthost.command("docker exec pmon supervisorctl restart lm-sensors")
-        time.sleep(3)
+        wait_until(30, 1, 0, lambda: check_sensord_status(duthost)[0])
         sensord_running_status, sensord_pid = check_sensord_status(duthost)
         if sensord_running_status:
             logging.info("sensord task restarted, pid = {}".format(sensord_pid))


### PR DESCRIPTION
### Description of PR
The sensord restart helper only waited 3 seconds after `supervisorctl restart lm-sensors` before checking for `/usr/sbin/sensord`.

On Mellanox SN2700 nightly runs, supervisorctl reports `lm-sensors: started`, but `lm-sensors.sh` / `/usr/bin/sensors` can still be running briefly and `sensord` appears a few seconds later. This makes daemon recovery tests fail in teardown even though sensord recovers.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Approach
#### What is the motivation for this PR?
Avoid false teardown failures in platform sensord daemon tests when sensord startup takes slightly longer than a fixed 3 second sleep.

#### How did you do it?
Replace fixed `time.sleep(3)` after `supervisorctl restart lm-sensors` with `wait_until(30, 1, 0, ...)` so the helper waits until sensord is actually visible in `ps -x`, while preserving the existing failure path if sensord does not start.

#### How did you verify/test it?
Ran `python -m py_compile tests/platform_tests/test_platform_info.py`.

#### Any platform specific information?
Observed on Mellanox-SN2700 T0 nightly PBI 39100211.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A