### PR TITLE
[dualtor_io] Improve reboot disruption sampling

### DIFF
--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -110,7 +110,7 @@ def test_active_tor_reboot_downstream_standby(
     setup_loganalyzer(upper_tor_host, collect_only=True, collect_from_bootup=True)
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=toggle_upper_tor_pdu, stop_after=60
+        action=toggle_upper_tor_pdu, stop_after=60, send_interval=0.01
     )
     wait_for_device_reachable(upper_tor_host)
     wait_for_mux_container(upper_tor_host)


### PR DESCRIPTION
### Description of PR

Summary:
Use a shorter traffic send interval in `test_active_tor_reboot_downstream_standby` so disruption duration is measured accurately on high-port-count dualtor testbeds.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38666763

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38666763
Failure type: other

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

- Static validation: `pre-commit run --files tests/dualtor_io/test_tor_failure.py` passed.
- Runtime validation is pending on the affected dualtor testbed.

### Approach
#### What is the motivation for this PR?

The downstream active-ToR reboot test sends traffic across all server-facing ports with a global 100 ms send interval. On the affected 56-port topology, each server is sampled only about every 5.6 seconds. This coarse sampling repeatedly reports disruption near 33.9 seconds and exceeds the 30-second limit even though the log timeline shows the mux transition completes in about 15 seconds.

#### How did you do it?

Set `send_interval=0.01` for this test. The resulting per-server sampling interval is about 0.56 seconds on a 56-port topology, while the existing disruption threshold and test behavior remain unchanged.

#### How did you verify/test it?

Reviewed the traffic generator scheduling and the affected ElasticTest logs. The failure duration is consistently quantized near 33.9 seconds across repeated runs, matching the 100 ms global interval multiplied by 56 server flows. The changed file also passed all configured pre-commit hooks.

#### Any platform specific information?

Observed on Arista-7260CX3-D108C8 with 56 server-facing dualtor flows. The fix applies generically to high-port-count dualtor topologies.

#### Supported testbed topology if it's a new test case?

Not a new test case. Existing `dualtor` topology.

### Documentation

N/A.
