### PR TITLE
Skip reboot blocking-mode test on SmartSwitch

### DIFF
--- a/tests/reboot/test_reboot_blocking_mode.py
+++ b/tests/reboot/test_reboot_blocking_mode.py
@@ -11,7 +11,10 @@ pytestmark = [
 COMMAND_TIMEOUT = 90  # seconds
 
 
-def check_if_platform_reboot_enabled(duthost) -> bool:
+def check_if_custom_reboot_enabled(duthost) -> bool:
+    # SmartSwitch reboots DPUs before reaching the mocked /sbin/reboot.
+    if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch", False):
+        return True
     platform = get_command_result(duthost, "sonic-cfggen -H -v DEVICE_METADATA.localhost.platform")
     return check_if_dut_file_exist(duthost, "/usr/share/sonic/device/{}/platform_reboot".format(platform))
 
@@ -97,8 +100,8 @@ class TestRebootBlockingModeCLI:
         localhost
     ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        if check_if_platform_reboot_enabled(duthost):
-            pytest.skip("Skip test because platform reboot is enabled.")
+        if check_if_custom_reboot_enabled(duthost):
+            pytest.skip("Skip test because custom reboot handling is enabled.")
 
         mock_systemctl_reboot(duthost)
         yield
@@ -138,8 +141,8 @@ class TestRebootBlockingModeConfigFile:
         localhost
     ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        if check_if_platform_reboot_enabled(duthost):
-            pytest.skip("Skip test because platform reboot is enabled.")
+        if check_if_custom_reboot_enabled(duthost):
+            pytest.skip("Skip test because custom reboot handling is enabled.")
 
         mock_systemctl_reboot(duthost)
         yield


### PR DESCRIPTION
### Description of PR

Summary:
Skip the reboot blocking-mode test on SmartSwitch platforms. The test mocks only `/sbin/reboot`, while SmartSwitch reboot handling synchronously processes DPUs before reaching that mock, so its 90-second assertions do not measure blocking-mode behavior.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/39059747

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39059747
Failure type: day-one issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: `python -m py_compile` passed; targeted helper simulation passed for SmartSwitch, platform-reboot, and generic platforms; all changed-file pre-commit hooks passed.
- 202605: `20260510.08` reproduces the issue on `Mellanox-SN4280-O28`/`t1-28-lag`; the test file is identical to master before this change, so the patch applies without branch-specific changes. A post-fix hardware rerun is pending backport.

### Approach
#### What is the motivation for this PR?

On SmartSwitch, `/usr/local/bin/reboot` calls `handle_smart_switch` and waits for DPU reboot processing before reaching `/sbin/reboot`. The test replaces only `/sbin/reboot`, so both `reboot` and `reboot -b` timed out after 90 seconds while processing DPUs. This does not indicate a violation of the reboot blocking-mode semantics and also causes real DPU reboot side effects during the test.

#### How did you do it?

Treat SmartSwitch as custom reboot handling, alongside platforms that provide `platform_reboot`, and skip both blocking-mode test fixtures before modifying `/sbin/reboot`.

#### How did you verify/test it?

Ran Python syntax validation, a targeted helper simulation covering SmartSwitch and generic platform paths, and the repository pre-commit hooks for the changed file.

#### Any platform specific information?

The failure was reproduced on `Mellanox-SN4280-O28`. The skip applies to all SmartSwitch platforms because they share the same pre-`/sbin/reboot` DPU handling.

#### Supported testbed topology if it's a new test case?

Not a new test case. The reported failure used `t1-28-lag`.

### Documentation

N/A.
