### PR TITLE
[Mellanox] update skip condition for vxlan/test_vxlan_ecmp.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -6119,8 +6119,10 @@ vxlan/test_vxlan_decap_ttl.py::test_vxlan_decap_ttl\[v6-.*\]:
 vxlan/test_vxlan_ecmp.py:
   skip:
     reason: "VxLAN ECMP test is not yet supported on multi-ASIC platform. Also this test can only run on some platforms."
+    conditions_logical_operator: or
     conditions:
-      - "(is_multi_asic == True) or (platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0'])"
+      - "is_multi_asic == True"
+      - "(platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-8102_28fh_dpu_o-r0']) and (asic_type not in ['marvell-teralynx', 'mellanox'])"
 
 vxlan/test_vxlan_ecmp_switchover.py:
   skip:


### PR DESCRIPTION
### Description of PR
To avoid missing the test coverage, update skip condition for vxlan/test_vxlan_ecmp.py, when new mellanox platform is added, the test will not be skipped

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605


### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
master: Passed
202605: Passed

### Approach
#### What is the motivation for this PR?
update skip condition for vxlan/test_vxlan_ecmp.py, so new mellanox platform can run on the case automatically

#### How did you do it?
update skip condition for vxlan/test_vxlan_ecmp.py,

#### How did you verify/test it?
run vxlan/test_vxlan_ecmp.py on mellanox device

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation
N/A
