### PR TITLE
[Mellanox] update skip condition for bfd/test_bfd.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -299,7 +299,7 @@ bfd/test_bfd.py:
     reason: "Test not supported for platforms other than Nvidia 4280/4600c/4700/5600 and cisco-8102. Skipping the test / VS do not support bfd test"
     conditions_logical_operator: or
     conditions:
-      -  "(release in ['201811', '201911']) or (platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0', 'x86_64-kvm_x86_64-r0'])"
+      -  "(platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-8102_28fh_dpu_o-r0', 'x86_64-kvm_x86_64-r0']) and (asic_type not in ['mellanox']) "
       - "asic_type in ['vs']"
 
 bfd/test_bfd.py::test_bfd_basic:
@@ -307,7 +307,7 @@ bfd/test_bfd.py::test_bfd_basic:
     reason: "Test not supported on platforms other than Cisco 8101/8102, Nvidia 4280/4600c/4700/5600. VS platforms do not support bfd test"
     conditions_logical_operator: or
     conditions:
-      - "platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-8102_28fh_dpu_o-r0', 'x86_64-kvm_x86_64-r0'] and (asic_type not in ['mellanox']) "
       - "release in ['201811', '201911']"
       - "asic_type in ['vs']"
   xfail:
@@ -330,7 +330,7 @@ bfd/test_bfd.py::test_bfd_scale:
     reason: "Test is not supported for platforms other than Cisco 8102/8101, Nvidia 4280/4600c/4700/5600. VS platforms do not support bfd test"
     conditions_logical_operator: or
     conditions:
-      - "platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0',  'x86_64-8102_28fh_dpu_o-r0', 'x86_64-kvm_x86_64-r0'] and (asic_type not in ['mellanox']) "
       - "release in ['201811', '201911']"
       - "asic_type in ['vs']"
 


### PR DESCRIPTION
### Description of PR
To avoid missing the test coverage, update skip condition for bfd/test_bfd.py, when new mellanox platform is added, the test will not be skipped

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605


### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
master: Passed
202605: Passed

### Approach
#### What is the motivation for this PR?
To avoid missing the test coverage

#### How did you do it?
update skip condition for bfd/test_bfd.py, when new mellanox platform is added, the test will not be skipped

#### How did you verify/test it?
Run  vxlan/test_vxlan_crm.py on mellanox device

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation
N/A
