### PR TITLE
Add a Mellanox default balance range for hash test

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -39,6 +39,7 @@ class HashTest(BaseTest):
     # Class variables
     # ---------------------------------------------------------------------
     DEFAULT_BALANCING_RANGE = 0.25
+    MELLANOX_DEFAULT_BALANCING_RANGE = 0.3
     RELAXED_BALANCING_RANGE = 0.8
     RELAXED_BALANCING_RANGE_MAXTOPO = 1.5
     BALANCING_TEST_TIMES = 250
@@ -95,8 +96,14 @@ class HashTest(BaseTest):
         self.hash_keys = self.test_params.get(
             'hash_keys', ['src-ip', 'dst-ip', 'src-port', 'dst-port'])
         self.src_ports = [int(port) for port in self.ptf_test_port_map.keys()]
+        self.asic_type = self.test_params.get('asic_type', '')
+        default_balancing_range = (
+            self.MELLANOX_DEFAULT_BALANCING_RANGE
+            if self.asic_type == 'mellanox'
+            else self.DEFAULT_BALANCING_RANGE
+        )
         self.balancing_range = self.test_params.get(
-            'balancing_range', self.DEFAULT_BALANCING_RANGE)
+            'balancing_range', default_balancing_range)
         self.balancing_test_times = self.test_params.get(
             'balancing_test_times', self.BALANCING_TEST_TIMES)
         self.switch_type = self.test_params.get(

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -585,6 +585,7 @@ def test_hash(add_default_route_to_dut, duthosts, tbinfo, setup_vlan,      # noq
             "ignore_ttl": ignore_ttl,
             "single_fib_for_duts": single_fib_for_duts,
             "switch_type": switch_type,
+            "asic_type": duthosts[0].facts["asic_type"],
             "is_active_active_dualtor": is_active_active_dualtor,
             "topo_name": updated_tbinfo['topo']['name'],
             "topo_type": updated_tbinfo['topo']['type'],


### PR DESCRIPTION

### Description of PR
Add a Mellanox default balance range for hash test
Currently the DEFAULT_BALANCING_RANGE is not fittable for Mellanox platform due to there would be a very low possibility that the hash result would slightly exceed the DEFAULT_BALANCING_RANGE.
As a result, introducing a new DEFAULT_BALANCING_RANGE.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
Run pass on the 202511 latest RC image

### Approach
#### What is the motivation for this PR?
Fix the flaky issue
#### How did you do it?
Introduced a new DEFAULT_BALANCING_RANGE
#### How did you verify/test it?
Run the test on the latest 202511 RC image

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
