### PR TITLE
Fix KeyError in LossyQueueTest when test_params does not contain 'cell_size'.

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -5055,14 +5055,15 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
 
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         pkts_num_trig_egr_drp = int(self.test_params['pkts_num_trig_egr_drp'])
-        cell_size = int(self.test_params['cell_size'])
-        # Special tuning for cisco gr2 lossy traffic: subtract egress_lossy_pool
-        # base watermark from pkts_num_trig_egr_drp. The value is in cells at
-        # this point (YAML provides bytes // cell_size), so bytes_per_unit = cell_size.
-        pkts_num_trig_egr_drp = adjust_lossy_pkts_for_cisco_gr2(
-            self, asic_type, dut_asic, pkts_num_trig_egr_drp,
-            cell_size,
-            param_name='pkts_num_trig_egr_drp')
+        if 'cell_size' in list(self.test_params.keys()):
+            cell_size = int(self.test_params['cell_size'])
+            # Special tuning for cisco gr2 lossy traffic: subtract egress_lossy_pool
+            # base watermark from pkts_num_trig_egr_drp. The value is in cells at
+            # this point (YAML provides bytes // cell_size), so bytes_per_unit = cell_size.
+            pkts_num_trig_egr_drp = adjust_lossy_pkts_for_cisco_gr2(
+                self, asic_type, dut_asic, pkts_num_trig_egr_drp,
+                cell_size,
+                param_name='pkts_num_trig_egr_drp')
         if 'packet_size' in list(self.test_params.keys()):
             packet_length = int(self.test_params['packet_size'])
             if packet_length != 64:


### PR DESCRIPTION
Change-Id: Id107e018f30432e1533dc00c62f2fd271491aa72

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # ([26794](https://github.com/sonic-net/sonic-mgmt/issues/26794))

The test previously accessed self.test_params['cell_size'] unconditionally, causing failure on configs (e.g., default qos.yml) where this key is absent. Now the adjustment call (adjust_lossy_pkts_for_cisco_gr2) is only executed when 'cell_size' is present; otherwise, it is skipped gracefully.

Changes:
- Wrapped cell_size retrieval and adjust_lossy_pkts_for_cisco_gr2 call inside a conditional check: if 'cell_size' in self.test_params.
- This prevents KeyError and allows the test to continue on configurations that do not define cell_size.
- No functional change for configs that already have cell_size defined.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
SONiC Software Version: SONiC.HEAD.0-dirty-20260310.044347
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
To avoid spurious test failures caused by missing `cell_size` in the test parameters. The `adjust_lossy_pkts_for_cisco_gr2` function is only relevant for Cisco platforms, and the `cell_size` parameter is not always present in all testbed configurations (e.g., qos_params.th6.yaml).

#### How did you do it?
Added a condition to check for the existence of `'cell_size'` in `self.test_params` before retrieving it and calling `adjust_lossy_pkts_for_cisco_gr2`. If absent, the adjustment is skipped entirely, which is safe because the adjustment is specific to Cisco GR2 hardware and not required for other platforms.

#### How did you verify/test it?
Ran `LossyQueueTest` on a setup missing `cell_size` – test passed.
Passed testQosSaiLossyQueue[single_asic]
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
The skipped adjustment is specific to Cisco GR2 lossy traffic. For other platforms, skipping it has no effect.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
NA