### PR TITLE
Fix reboot check mechnism for bcmctld test_bmc_reboot_does_not_affect_switch_host

### DIFF
--- a/tests/common/platform/bmc_utils.py
+++ b/tests/common/platform/bmc_utils.py
@@ -251,6 +251,14 @@ def get_host_uptime(host):
     return host.shell("uptime -s", module_ignore_errors=True).get('stdout', '').strip()
 
 
+def get_host_boot_id(host):
+    """Return the kernel boot ID; and '' on failure."""
+    return host.shell(
+        "cat /proc/sys/kernel/random/boot_id",
+        module_ignore_errors=True
+    ).get('stdout', '').strip()
+
+
 def wait_host_off(duthost, host, timeout=180, interval=10, delay=30):
     """Wait until the paired Switch-Host is powered off, as observed by the BMC.
 

--- a/tests/platform_tests/daemon/test_bmcctld.py
+++ b/tests/platform_tests/daemon/test_bmcctld.py
@@ -28,6 +28,7 @@ from tests.common.platform.bmc_utils import (
     BMC_EVENT_LOG,
     CAUSE_GRACEFUL_SHUTDOWN_FROM_BMC,
     CAUSE_POWER_DOWN_FROM_BMC,
+    get_host_boot_id,
     get_host_uptime,
     get_switch_host_or_skip_test,
     make_bmc_loganalyzer,
@@ -508,42 +509,29 @@ class TestBmcctldDaemon:
 
         Confirms BMC↔Switch-Host fault isolation: rebooting the BMC SONiC instance
         must not trigger any POWER_OFF/POWER_ON/POWER_CYCLE on the Switch-Host.
-        - BMC: uptime advances, reboot-cause history grows by one entry
-        - Switch-Host: uptime unchanged, reboot-cause history length unchanged
+        - BMC boot ID must change
+        - Switch-Host boot ID must remain unchanged
         """
 
         host = get_switch_host_or_skip_test(self.duthost)
 
-        # uptime -s reports boot time to the second, and NTP can step the clock by a
-        # second or two without any reboot. Compare the Switch-Host boot time at minute
-        # resolution so such a clock step can't be misread as "isolation broken".
-        sw_uptime_pre = get_host_uptime(host).rsplit(':', 1)[0]
-        sw_history_pre = host.show_and_parse('show reboot-cause history') or []
-        bmc_uptime_pre = get_host_uptime(self.duthost)
-        bmc_history_pre = self.duthost.show_and_parse('show reboot-cause history') or []
+        sw_boot_id_pre = get_host_boot_id(host)
+        bmc_boot_id_pre = get_host_boot_id(self.duthost)
 
         reboot(self.duthost, localhost, reboot_type=REBOOT_TYPE_COLD,
                wait_for_ssh=True, safe_reboot=True)
 
         wait_until(420, 10, 30, lambda: self.duthost.critical_services_fully_started())
 
-        bmc_uptime_post = get_host_uptime(self.duthost)
-        bmc_history_post = self.duthost.show_and_parse('show reboot-cause history') or []
-        pytest_assert(bmc_uptime_post and bmc_uptime_post != bmc_uptime_pre,
-                      f"BMC uptime did not advance after reboot: "
-                      f"pre={bmc_uptime_pre!r} post={bmc_uptime_post!r}")
-        pytest_assert(len(bmc_history_post) > len(bmc_history_pre),
-                      f"BMC reboot-cause history did not grow: "
-                      f"pre={len(bmc_history_pre)} post={len(bmc_history_post)}")
+        bmc_boot_id_post = get_host_boot_id(self.duthost)
+        sw_boot_id_post = get_host_boot_id(host)
 
-        sw_uptime_post = get_host_uptime(host).rsplit(':', 1)[0]
-        sw_history_post = host.show_and_parse('show reboot-cause history') or []
-        pytest_assert(sw_uptime_post == sw_uptime_pre,
-                      f"Switch-Host uptime advanced after BMC reboot — isolation broken: "
-                      f"pre={sw_uptime_pre!r} post={sw_uptime_post!r}")
-        pytest_assert(len(sw_history_post) == len(sw_history_pre),
-                      f"Switch-Host reboot-cause history grew after BMC reboot — "
-                      f"isolation broken: pre={len(sw_history_pre)} post={len(sw_history_post)}")
+        pytest_assert(bmc_boot_id_post != bmc_boot_id_pre,
+                      f"BMC boot ID did not change after cold reboot: "
+                      f"pre={bmc_boot_id_pre!r} post={bmc_boot_id_post!r}")
+        pytest_assert(sw_boot_id_post == sw_boot_id_pre,
+                      f"Switch-Host rebooted during BMC reboot — isolation broken: "
+                      f"pre_boot_id={sw_boot_id_pre!r} post_boot_id={sw_boot_id_post!r}")
         pytest_assert(host.critical_services_fully_started(),
                       "Switch-Host critical services not fully started after BMC reboot")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

platform_tests/daemon/test_bmcctld.py::TestBmcctldDaemon::test_bmc_reboot_does_not_affect_switch_host Tries to reboot the bmc, and test that there is no effect/reboots on switch-host.
It checks if the bmc or host has rebooted by checking the change in number in "show reboot-cause history" output.

The test fails with log `BMC reboot-cause history did not grow: pre=10 post=10 after bmc reboot`

RCA:
This method to check if platform is rebooted by checking number of entries in "show reboot-cause history" output is completely flawed, since the reboot history is capped at max 10 Entries and is supposed to be rolling over.

FIX:
Instead of reboot cause history , use `cat
/proc/sys/kernel/random/boot_id` to check if the system has rebooted or not.


<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608

Back Port required for msft-202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608
- [ ] N/A

Tested on msft-202608
### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
Kusto GUID: for the test run :  e529cef8-3fdf-4b01-91a8-9a3afc9462df
Logs for the passing test: [test_bmc_reboot_does_not_affect_switch_host.log](https://github.com/user-attachments/files/32450507/test_bmc_reboot_does_not_affect_switch_host.log)



### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
