### PR TITLE
Add QoS parameter support for topo-lt2-o128 topology

### DIFF
--- a/tests/qos/files/qos_params.th6.yaml
+++ b/tests/qos/files/qos_params.th6.yaml
@@ -1423,3 +1423,216 @@ qos_params:
         topo-lt2-min:  *topo-t0-standalone
         topo-any:  *topo-t0-standalone
         topo-t1-8:  *topo-t0-standalone
+        topo-lt2-o128:
+            400000_30m:
+                hdrm_pool_size:
+                    dscps:
+                    - 3
+                    - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 4
+                    pgs:
+                    - 3
+                    - 4
+                    pgs_num: 36
+                    pkts_num_hdrm_full: 1425
+                    pkts_num_hdrm_partial: 3326
+                    pkts_num_trig_pfc: 227966
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 95
+                    pkts_num_trig_egr_drp: 227944
+                pkts_num_egr_mem: 374
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 229391
+                    pkts_num_trig_pfc: 227966
+                wm_pg_shared_lossless:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 44
+                    pkts_num_margin: 95
+                    pkts_num_trig_pfc: 227966
+                wm_pg_shared_lossy:
+                    cell_size: 420
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 95
+                    pkts_num_trig_egr_drp: 227944
+                wm_q_shared_lossless:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 233000
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 420
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 22
+                    pkts_num_margin: 5000
+                    pkts_num_trig_egr_drp: 232800
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 229391
+                    pkts_num_trig_pfc: 227966
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 229391
+                    pkts_num_trig_pfc: 227966
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 600
+                    pkts_num_trig_pfc: 227966
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 600
+                    pkts_num_trig_pfc: 227966
+            400000_500m:
+                hdrm_pool_size:
+                    dscps:
+                    - 3
+                    - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 4
+                    pgs:
+                    - 3
+                    - 4
+                    pgs_num: 36
+                    pkts_num_hdrm_full: 5097
+                    pkts_num_hdrm_partial: 3326
+                    pkts_num_trig_pfc: 227966
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 95
+                    pkts_num_trig_egr_drp: 227944
+                pkts_num_egr_mem: 374
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 233063
+                    pkts_num_trig_pfc: 227966
+                wm_pg_shared_lossless:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 44
+                    pkts_num_margin: 95
+                    pkts_num_trig_pfc: 227966
+                wm_pg_shared_lossy:
+                    cell_size: 420
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 95
+                    pkts_num_trig_egr_drp: 227944
+                wm_q_shared_lossless:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 400
+                    pkts_num_trig_ingr_drp: 233000
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 420
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 22
+                    pkts_num_margin: 5000
+                    pkts_num_trig_egr_drp: 232800
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 233063
+                    pkts_num_trig_pfc: 227966
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 233063
+                    pkts_num_trig_pfc: 227966
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 600
+                    pkts_num_trig_pfc: 227966
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 600
+                    pkts_num_trig_pfc: 227966
+            cell_size: 420
+            hdrm_pool_wm_multiplier: 1
+            wrr:
+                ecn: 1
+                limit: 80
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                q7_num_of_pkts: 140
+            wrr_chg:
+                ecn: 1
+                limit: 80
+                lossless_weight: 30
+                lossy_weight: 8
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                q7_num_of_pkts: 80

--- a/tests/qos/files/qos_params.th6.yaml
+++ b/tests/qos/files/qos_params.th6.yaml
@@ -1423,3 +1423,216 @@ qos_params:
         topo-lt2-min:  *topo-t0-standalone
         topo-any:  *topo-t0-standalone
         topo-t1-8:  *topo-t0-standalone
+        topo-lt2-o128:
+            400000_30m:
+                hdrm_pool_size:
+                    dscps:
+                    - 3
+                    - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 4
+                    pgs:
+                    - 3
+                    - 4
+                    pgs_num: 36
+                    pkts_num_hdrm_full: 1425
+                    pkts_num_hdrm_partial: 3326
+                    pkts_num_trig_pfc: 228340
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 95
+                    pkts_num_trig_egr_drp: 228318
+                pkts_num_egr_mem: 0
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 229765
+                    pkts_num_trig_pfc: 228340
+                wm_pg_shared_lossless:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 44
+                    pkts_num_margin: 95
+                    pkts_num_trig_pfc: 228340
+                wm_pg_shared_lossy:
+                    cell_size: 420
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 95
+                    pkts_num_trig_egr_drp: 228318
+                wm_q_shared_lossless:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 233000
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 420
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 22
+                    pkts_num_margin: 5000
+                    pkts_num_trig_egr_drp: 232800
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 229765
+                    pkts_num_trig_pfc: 228340
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 229765
+                    pkts_num_trig_pfc: 228340
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 600
+                    pkts_num_trig_pfc: 228340
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 600
+                    pkts_num_trig_pfc: 228340
+            400000_500m:
+                hdrm_pool_size:
+                    dscps:
+                    - 3
+                    - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 4
+                    pgs:
+                    - 3
+                    - 4
+                    pgs_num: 36
+                    pkts_num_hdrm_full: 5097
+                    pkts_num_hdrm_partial: 3326
+                    pkts_num_trig_pfc: 228340
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 95
+                    pkts_num_trig_egr_drp: 228318
+                pkts_num_egr_mem: 0
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 233437
+                    pkts_num_trig_pfc: 228340
+                wm_pg_shared_lossless:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 44
+                    pkts_num_margin: 95
+                    pkts_num_trig_pfc: 228340
+                wm_pg_shared_lossy:
+                    cell_size: 420
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 95
+                    pkts_num_trig_egr_drp: 228318
+                wm_q_shared_lossless:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 400
+                    pkts_num_trig_ingr_drp: 233000
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 420
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 22
+                    pkts_num_margin: 5000
+                    pkts_num_trig_egr_drp: 232800
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 233437
+                    pkts_num_trig_pfc: 228340
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 95
+                    pkts_num_trig_ingr_drp: 233437
+                    pkts_num_trig_pfc: 228340
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 600
+                    pkts_num_trig_pfc: 228340
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 600
+                    pkts_num_trig_pfc: 228340
+            cell_size: 420
+            hdrm_pool_wm_multiplier: 1
+            wrr:
+                ecn: 1
+                limit: 80
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                q7_num_of_pkts: 140
+            wrr_chg:
+                ecn: 1
+                limit: 80
+                lossless_weight: 30
+                lossy_weight: 8
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                q7_num_of_pkts: 80


### PR DESCRIPTION
Change-Id: I8e0f82652181caf9363ea239335c6dea945a2cd5

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes (https://github.com/sonic-net/sonic-mgmt/issues/26800)

This commit adds a new topology entry 'topo-lt2-o128' to qos_params.th6.yaml, enabling QoS test coverage for the lt2-o128 testbed configuration.

Changes:
- Added 'topo-lt2-o128' under qos_params with complete test parameters.
- Added per-speed profile entries for 400000_30m and 400000_500m.
- No modifications to existing topologies or test logic.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
Validated the new qos_params entries by running the following QoS test suites on a lt2-o128 testbed:
- All test cases referencing the above test suites executed successfully.
- No KeyError or missing parameter issues observed
- Test results matched expected behavior for the new topology.

SONiC Software Version: SONiC.HEAD.0-dirty-20260310.044347

### Approach
#### What is the motivation for this PR?
To extend QoS test coverage to the lt2-o128 testbed topology. The current qos_params.th6.yaml does not include this topology, preventing QoS tests from running on lt2-o128 setups.
#### How did you do it?
Added the necessary parameter sections for each QoS test scenario, following the same structure and naming conventions used by existing topologies (e.g., topo-t0-standalone, topo-lt2-min). The parameter values were derived from hardware specifications and validated against the DUT.
#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran the relevant QoS test suites on an lt2-o128 testbed. Confirmed all tests that use the newly added parameters pass without parameter-related failures.

Passed testQosSaiDwrrWeightChange[single_asic]
Passed testQosSaiLossyQueue[single_asic]
Passed testQosSaiPfcXoffLimit[single_asic-xoff_1]
Passed testQosSaiPfcXoffLimit[single_asic-xoff_2]
Passed testQosSaiPfcXonLimit[single_asic-xon_1]
Passed testQosSaiPfcXonLimit[single_asic-xon_2]
Passed testQosSaiPgHeadroomWatermark[single_asic]
Passed testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossless]
Passed testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossy]
Passed testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossless]
Passed testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossy]
 
#### Any platform specific information?
This topology entry is specific to the th6 lt2-o128 testbed configuration. It does not affect other platforms or topologies.
#### Supported testbed topology if it's a new test case?
topo-lt2-o128
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
NA