### PR TITLE
[bgp/test_bgp_router_id]: Scope BGP restart to target ASIC

### DIFF
--- a/tests/bgp/test_bgp_router_id.py
+++ b/tests/bgp/test_bgp_router_id.py
@@ -168,16 +168,18 @@ def loopback_ipv6(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index
     yield loopback_ip
 
 
-def restart_bgp(duthost, tbinfo):
-    duthost.reset_service("bgp")
-    duthost.restart_service("bgp")
-    pytest_assert(wait_until(100, 10, 10, duthost.is_service_fully_started_per_asic_or_host, "bgp"), "BGP not started.")
+def restart_bgp(duthost, enum_asic_index, tbinfo):
+    asichost = duthost.asic_instance(enum_asic_index)
+
+    asichost.reset_service("bgp")
+    asichost.restart_service("bgp")
+    pytest_assert(
+        wait_until(100, 10, 10, asichost.is_container_running, "bgp"),
+        "BGP not started.",
+    )
     pytest_assert(wait_until(100, 10, 10, duthost.check_default_route,
                              ipv4=not is_ipv6_only_topology(tbinfo)), "Default route not ready")
-    # wait_bgp_sessions polls per-ASIC BGP state
-    # (multi-ASIC aware, default 120s, auto-extended to 900s on modular chassis) so verification
-    # only runs once sessions have actually re-established.
-    wait_bgp_sessions(duthost)
+    wait_bgp_sessions(duthost, asic_index=enum_asic_index)
 
 
 @pytest.fixture()
@@ -186,13 +188,13 @@ def router_id_setup_and_teardown(duthosts, enum_frontend_dut_hostname, enum_fron
     run_config_db_cmd(duthost, enum_frontend_asic_index,
                       "hset \"DEVICE_METADATA|localhost\" \"bgp_router_id\" \"{}\""
                       .format(CUSTOMIZED_BGP_ROUTER_ID))
-    restart_bgp(duthost, tbinfo)
+    restart_bgp(duthost, enum_frontend_asic_index, tbinfo)
 
     yield
 
     run_config_db_cmd(duthost, enum_frontend_asic_index,
                       "hdel \"DEVICE_METADATA|localhost\" \"bgp_router_id\"")
-    restart_bgp(duthost, tbinfo)
+    restart_bgp(duthost, enum_frontend_asic_index, tbinfo)
 
 
 @pytest.fixture(scope="function")
@@ -205,7 +207,7 @@ def router_id_loopback_setup_and_teardown(duthosts, enum_frontend_dut_hostname, 
     run_config_db_cmd(duthost, enum_frontend_asic_index,
                       "del \"LOOPBACK_INTERFACE|Loopback0|{}/32\"".format(loopback_ip),
                       module_ignore_errors=False)
-    restart_bgp(duthost, tbinfo)
+    restart_bgp(duthost, enum_frontend_asic_index, tbinfo)
 
     yield
 
@@ -214,7 +216,7 @@ def router_id_loopback_setup_and_teardown(duthosts, enum_frontend_dut_hostname, 
     run_config_db_cmd(duthost, enum_frontend_asic_index,
                       "hset \"LOOPBACK_INTERFACE|Loopback0|{}/32\" \"NULL\" \"NULL\""
                       .format(loopback_ip))
-    restart_bgp(duthost, tbinfo)
+    restart_bgp(duthost, enum_frontend_asic_index, tbinfo)
 
 
 def test_bgp_router_id_default(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, nbrhosts, request,

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -789,17 +789,27 @@ def check_bgp_router_id(duthost, mgFacts):
         logger.error("Error loading BGP routerID - {}".format(e))
 
 
-def wait_bgp_sessions(duthost, timeout=120):
+def wait_bgp_sessions(duthost, timeout=120, asic_index=None):
     """
     A helper function to wait bgp sessions on DUT
     """
-    bgp_neighbors = duthost.get_bgp_neighbors_per_asic(state="all")
+    if asic_index is None:
+        bgp_neighbors = duthost.get_bgp_neighbors_per_asic(state="all")
+        check_bgp_session_state = duthost.check_bgp_session_state_all_asics
+    else:
+        asichost = duthost.asic_instance(asic_index)
+        bgp_neighbors = [
+            neighbor_ip.lower()
+            for neighbor_ip in asichost.bgp_facts()["ansible_facts"]["bgp_neighbors"].keys()
+        ]
+        check_bgp_session_state = asichost.check_bgp_session_state
+
     if duthost.get_facts().get("modular_chassis"):
         timeout = 900
     logging.info("Wait until all bgp sessions are up in {} sec"
                  .format(timeout))
     pt_assert(
-        wait_until(timeout, 10, 0, duthost.check_bgp_session_state_all_asics, bgp_neighbors),
+        wait_until(timeout, 10, 0, check_bgp_session_state, bgp_neighbors),
         "Not all bgp sessions are established after config reload",
     )
 


### PR DESCRIPTION
### Description of PR

Summary:
Scope BGP restart and convergence checks in `test_bgp_router_id` to the ASIC whose router ID is being changed.

ADO: 39099510
Fixes # N/A

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: regression

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `SONiC.master-28759.1180611-87cd8b532`
  - Fleet failure: https://elastictest.org/scheduler/testplan/6a6d5db8101ed2146e809ad6?searchTestCase=router&testcase=bgp%2Ftest_bgp_router_id.py%7C%7C%7C1&type=console
  - Baseline ASIC1 case restarted both services:
    - `bgp@0`: `13791733120` to `15657105924`
    - `bgp@1`: `13801081036` to `15719291065`
  - With this change, the same ASIC1 case restarted only `bgp@1`:
    - `bgp@0`: remained `15657105924`
    - `bgp@1`: `15719291065` to `17113134098`
  - Both ASIC1 BGP neighbors re-established after the scoped restart.
  - `python3 -m py_compile tests/bgp/test_bgp_router_id.py`

### Approach
#### What is the motivation for this PR?

The router-ID test configures and verifies one ASIC at a time, but its restart helper restarts BGP on every ASIC. On modular multi-ASIC systems this unnecessarily churns unrelated sessions and expands the convergence surface. Fleet failures started after router-ID configuration and verification became ASIC-aware while restart behavior remained host-wide. The observed failure signature is an intermittent `bgp_facts` timeout or sessions not re-establishing after restart.

#### How did you do it?

- Resolve the selected ASIC with `duthost.asic_instance(enum_asic_index)`.
- Capture that ASIC's BGP neighbor addresses before restarting the service.
- Reset and restart only that ASIC's BGP service.
- Wait for only that ASIC's container and captured neighbors to recover.
- Preserve the existing modular-chassis timeout and default-route check.
- Pass `enum_frontend_asic_index` through all setup and teardown restart calls.

#### How did you verify/test it?

The focused ASIC1 case exercised both setup and teardown. Service timestamps prove the baseline restarted both ASICs while this change left ASIC0 untouched and restarted only ASIC1. Both target-ASIC neighbors were Established afterward.

The final neighbor router-ID assertion in the reconstructed local testbed was blocked by an unrelated cEOS mapping artifact: the pytest fixture queried `VRF ARISTA06T3` on a non-converged cEOS container where that VRF does not exist. The DUT-side router-ID change, scoped restart, cleanup, and BGP reconvergence completed before that harness-only assertion.

#### Any platform specific information?

This primarily affects modular multi-ASIC systems. Single-ASIC behavior remains equivalent.

#### Supported testbed topology if it's a new test case?

Not a new test case. Reproduced and validated on `t2_2lc_min_ports-masic`.

### Documentation

No documentation changes are required.
