### PR TITLE
[dhcp_relay] Give each PTF run a unique log file in test_dhcpv4_relay.py

### DIFF
--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -256,7 +256,9 @@ def test_dhcpv4_relay_disabled_validation(ptfhost, dut_dhcp_relay_data, validate
                                "relay_agent": "sonic-relay-agent",
                                "downlink_vlan_iface_name": str(dhcp_relay['downlink_vlan_iface']['name'])
                                },
-                       log_file="/tmp/test_dhcpv4_relay_disabled_no_process_no_response.DHCPTest.log", is_python3=True)
+                       log_file=("/tmp/test_dhcpv4_relay_disabled_no_process_no_response.DHCPTest.{}.log"
+                                 .format(dhcp_relay['downlink_vlan_iface']['name'])),
+                       is_python3=True)
 
     except LogAnalyzerError as err:
         logger.error("Unable to find expected log in syslog")
@@ -344,7 +346,9 @@ def test_dhcp_relay_option82_suboptions(ptfhost, dut_dhcp_relay_data, validate_d
                                "link_selection_ip": str(dhcp_relay['downlink_vlan_iface']['link_selection_ip']),
                                "downlink_vlan_iface_name": str(dhcp_relay['downlink_vlan_iface']['name'])
                                },
-                       log_file="/tmp/test_dhcp_relay_option82_suboptions.DHCPTest.log", is_python3=True)
+                       log_file=("/tmp/test_dhcp_relay_option82_suboptions.DHCPTest.{}.{}.log"
+                                 .format(testcase, vlan)),
+                       is_python3=True)
     except LogAnalyzerError as err:
         logger.error("Unable to find expected log in syslog")
         raise err
@@ -424,7 +428,8 @@ def test_dhcp_relay_agent_mode(
                     "agent_relay_mode": test_mode,
                     "downlink_vlan_iface_name": str(dhcp_relay['downlink_vlan_iface']['name']),
                 },
-                log_file="/tmp/test_dhcp_relay_agent_mode.log",
+                log_file=("/tmp/test_dhcp_relay_agent_mode.DHCPTest.{}.{}.log"
+                          .format(test_mode, vlan)),
                 is_python3=True
             )
 
@@ -609,7 +614,9 @@ def test_dhcp_relay_with_non_default_vrf(
                                "link_selection_ip": str(dhcp_relay['downlink_vlan_iface']['link_selection_ip']),
                                "downlink_vlan_iface_name": str(dhcp_relay['downlink_vlan_iface']['name'])
                                },
-                       log_file="/tmp/test_dhcp_relay_with_non_default_vrf.DHCPTest.log", is_python3=True)
+                       log_file=("/tmp/test_dhcp_relay_with_non_default_vrf.DHCPTest.{}.{}.log"
+                                 .format(testcase, vlan_iface)),
+                       is_python3=True)
     except LogAnalyzerError as err:
         logger.error("Unable to find expected log in syslog")
         raise err
@@ -811,7 +818,9 @@ def test_dhcp_relay_with_different_non_default_vrf(
                                "link_selection": True,
                                "portchannels_ip_list": dhcp_relay['portchannels_ip_list'],
                                "downlink_vlan_iface_name": str(dhcp_relay['downlink_vlan_iface']['name'])},
-                       log_file="/tmp/test_dhcp_relay_with_different_non_default_vrf.DHCPTest.log", is_python3=True)
+                       log_file=("/tmp/test_dhcp_relay_with_different_non_default_vrf.DHCPTest.{}.log"
+                                 .format(vlan_iface)),
+                       is_python3=True)
 
     except LogAnalyzerError as err:
         logger.error("Unable to find expected log in syslog")
@@ -903,7 +912,8 @@ def test_dhcp_max_hop_count(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                     "max_hop_count": max_hop_count,
                     "downlink_vlan_iface_name": str(dhcp_relay['downlink_vlan_iface']['name']),
                 },
-                log_file="/tmp/test_dhcp_relay_agent_mode.log",
+                log_file=("/tmp/test_dhcp_max_hop_count.DHCPTest.{}.{}.log"
+                          .format(max_hop_count, vlan)),
                 is_python3=True
             )
 


### PR DESCRIPTION
### Description of PR

`ptf_runner` truncates its `log_file` on every invocation. In `tests/dhcp_relay/test_dhcpv4_relay.py`, fixed log paths caused later runs to overwrite earlier ones — parametrized variants of the same test, and (for `test_dhcp_max_hop_count`) a different test entirely.

Give each PTF run a unique log file by including the parametrized scenario and VLAN name, following the same per-VLAN convention already used in `tests/dhcp_relay/test_dhcp_relay.py` (e.g. `dhcp_relay_test.DHCPTest.default.Vlan1000.log`). No test logic changes.

#### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework (new/improvement)
- [x] Test case (new/improvement)

#### Back port request

- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach

#### What is the motivation for this PR?

While debugging DHCP relay failures, the PTF log for an earlier parametrized variant (e.g. `source_intf`) had already been overwritten by a later one (`server_id_override`), making the failure undebuggable. `test_dhcp_max_hop_count` also reused `test_dhcp_relay_agent_mode`'s log path.

#### How did you do it?

Replaced six fixed `log_file` strings with names that include scenario and/or VLAN, matching the pattern in `test_dhcp_relay.py`.

#### How did you verify/test it?

- `flake8 --max-line-length=120` and `py_compile` on the modified file.
- Confirmed distinct log files are produced per variant on KVM (e.g. `...source_intf.Vlan1000.log` vs `...server_id_override.Vlan1000.log`).

#### Any platform specific information?

No.

### Documentation

No documentation changes required.
