### PR TITLE
[route] Skip IPv4 static route config-reload test on IPv6-only topology

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -746,6 +746,10 @@ def test_static_route_removal_after_config_reload(rand_selected_dut, rand_unsele
     3. After config reload, the route is no longer in the kernel routing table
     4. The route is no longer advertised to BGP neighbors
     """
+    if is_ipv6_only_topology(tbinfo):
+        pytest.skip("Will not program IPv4 static route on IPv6-only topology; "
+                    "covered by test_static_route_removal_after_config_reload_ipv6")
+
     duthost = rand_selected_dut
     unselected_duthost = rand_unselected_dut
     is_dual_tor = 'dualtor' in tbinfo['topo']['name'] and unselected_duthost is not None


### PR DESCRIPTION
### What is the motivation for this PR
Fixes #25841.

`test_static_route_removal_after_config_reload` programs a hardcoded IPv4 static route. On IPv6-only T0 topologies there is no IPv4 VLAN address, so `get_nexthops()` returns `None` and `add_ipaddr()` crashes during setup with `TypeError: object of type 'NoneType' has no len()`. The test was introduced in #23606.

### How did you do it
Rather than adding an unconditional `skip`, this uses the existing `is_ipv6_only_topology()` guard pattern already used elsewhere in this module (e.g. the swss-consistency test). The IPv6-only removal-after-config-reload scenario is already fully covered by the companion `test_static_route_removal_after_config_reload_ipv6`, so no coverage is lost — the IPv4 variant simply does not apply on IPv6-only topologies.

### How did you verify/test it
KVM `vms-kvm-t0`: `test_static_route_removal_after_config_reload` (IPv4) and `::_ipv6` companion. (Results pending testbed run; will update.)

### Which release branch to backport (if applicable)
N/A