### PR TITLE
[Cherry-pick] [26777] [acl]: Exclude PortChannel members from LT2 ACL bindings

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -481,9 +481,15 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
         # For LT2, add portchannels for downstream links
         for k, v in list(port_channels.items()):
             acl_table_ports[v['namespace']].append(k)
-        # Add RIF for upstream links
+        # Add standalone RIFs for upstream links. PortChannel members cannot
+        # also be bound to the ACL table as physical interfaces.
+        pc_members = defaultdict(set)
+        for pc in port_channels.values():
+            pc_members[pc['namespace']].update(pc.get('members', []))
         for namespace, port in list(upstream_ports.items()):
-            acl_table_ports[namespace] += port
+            acl_table_ports[namespace] += [
+                interface for interface in port if interface not in pc_members[namespace]
+            ]
     else:
         for namespace, port in list(upstream_ports.items()):
             acl_table_ports[namespace] += port


### PR DESCRIPTION
### Description of PR
Summary:
Backport PR #26777 to the 202512 branch. Prevent LT2 ACL table creation from binding physical interfaces that are already members of PortChannels.
Fixes #26777

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512

### Approach
#### What is the motivation for this PR?
LT2 ACL setup can include physical interfaces that are already PortChannel members, causing invalid duplicate ACL bindings.

#### How did you do it?
Collected PortChannel members by namespace and excluded those interfaces when adding standalone upstream RIFs to the ACL table.

#### How did you verify/test it?
Resolved the 202512 cherry-pick conflict by retaining only the intended LT2 change. Verified the resulting diff and Python syntax.

#### Any platform specific information?
Applies to LT2 topologies.

#### Supported testbed topology if it is a new test case?
N/A; this is a fix to an existing ACL test.

### Documentation
N/A.
