### PR TITLE
[202511] Adding confed config to t2 topology: topo_t2_single_node_min.yml

### DIFF
--- a/ansible/vars/topo_t2_single_node_min.yml
+++ b/ansible/vars/topo_t2_single_node_min.yml
@@ -1,23 +1,23 @@
 topology:
   VMs:
-    ARISTA01T3:
+    VM01T3:
       vlans:
         - 6
       vm_offset: 0
-    ARISTA02T3:
+    VM02T3:
       vlans:
         - 12
       vm_offset: 1
-    ARISTA03T3:
+    VM03T3:
       vlans:
         - 13
       vm_offset: 2
-    ARISTA05LT2:
+    VM05LT2:
       vlans:
         - 24
         - 25
       vm_offset: 3
-    ARISTA07LT2:
+    VM07LT2:
       vlans:
         - 34
       vm_offset: 4
@@ -36,7 +36,9 @@ configuration_properties:
     tor_subnet_number: 8
     max_tor_subnet_number: 32
     tor_subnet_size: 128
-    dut_asn: 65100
+    dut_asn: 66000
+    dut_confed_asn: 65100
+    dut_confed_peers: 65300
     dut_type: UpperSpineRouter
     nhipv4: 10.10.246.254
     nhipv6: fc0a::ff
@@ -46,11 +48,12 @@ configuration_properties:
     swrole: leaf
 
 configuration:
-  ARISTA01T3:
+  VM01T3:
     properties:
       - common
       - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -69,11 +72,12 @@ configuration:
       ipv4: 10.10.246.1/24
       ipv6: fc0a::2/64
 
-  ARISTA02T3:
+  VM02T3:
     properties:
       - common
       - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -90,11 +94,12 @@ configuration:
       ipv4: 10.10.246.2/24
       ipv6: fc0a::4/64
 
-  ARISTA03T3:
+  VM03T3:
     properties:
       - common
       - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -113,14 +118,16 @@ configuration:
       ipv4: 10.10.246.3/24
       ipv6: fc0a::6/64
 
-  ARISTA05LT2:
+  VM05LT2:
     properties:
       - common
       - leaf
     bgp:
-      asn: 65012
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
           - 10.0.0.100
           - fc00::d
     interfaces:
@@ -138,14 +145,16 @@ configuration:
       ipv4: 10.10.246.103/24
       ipv6: fc0a::66/64
 
-  ARISTA07LT2:
+  VM07LT2:
     properties:
       - common
       - leaf
     bgp:
-      asn: 65013
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
           - 10.0.0.102
           - fc00::11
     interfaces:


### PR DESCRIPTION
Backport of #23604 to the **202511** branch.

Adds BGP confederation config to `topo_t2_single_node_min.yml`.

Cherry-picked from 71475a6bbc4e (master, #23604).