### PR TITLE
add wait_for_crm_counter_update in test_acl_counter to handle edge ca…

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -1368,13 +1368,13 @@ def test_acl_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_f
                                 crm_stats_acl_counter_available"\
                                     .format(db_cli=asichost.sonic_db_cli,
                                             acl_tbl_key=acl_tbl_key)
-    
+
     wait_for_crm_counter_update(
         get_acl_counter_stats, duthost,
         expected_used=crm_stats_acl_counter_used + 2,
         oper_used=">=", timeout=60, interval=2,
     )
-    
+
     new_crm_stats_acl_counter_used, new_crm_stats_acl_counter_available = \
         get_crm_stats(get_acl_counter_stats, duthost)
 

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -1368,6 +1368,13 @@ def test_acl_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_f
                                 crm_stats_acl_counter_available"\
                                     .format(db_cli=asichost.sonic_db_cli,
                                             acl_tbl_key=acl_tbl_key)
+    
+    wait_for_crm_counter_update(
+        get_acl_counter_stats, duthost,
+        expected_used=crm_stats_acl_counter_used + 2,
+        oper_used=">=", timeout=60, interval=2,
+    )
+    
     new_crm_stats_acl_counter_used, new_crm_stats_acl_counter_available = \
         get_crm_stats(get_acl_counter_stats, duthost)
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes a race condition in `test_acl_counter` (`crm/test_crm.py`). After ACL counters are created, the test read the CRM ACL counter stats immediately, before the ACL counter resources had converged in the ASIC. This caused intermittent failures/incorrect reads for this case. This change polls `COUNTERS_DB` for `crm_stats_acl_counter_used` to reach the expected value (`baseline + 2`) before reading and asserting on the counters.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
fix edge case where counters are polled for immediately after being updated (<1ms of wait) causing a false failure as there was not enough time for counters to be properly updated.
#### How did you do it?
added a polling count to check for counters updating more comprehensively (matches all other CRM functions)
#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

ran with change and confirmed issue is not seen anymore - 202605
```
---------------------------------------------------------------------------------------- generated xml file: /run_logs/isiddeeq/tr_2026-08-03-20-57-09.xml -----------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------------------------------
03/08/2026 21:19:03 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
============================================================================================================= short test summary info ==============================================================================================================
SKIPPED [1] crm/test_crm.py:1422: Unsupported topology, expected to run only on 'T0*' or 'M0/MX' topology
============================================================================================ 10 passed, 1 skipped, 1261 warnings in 1306.87s (0:21:46) ===============================================
```

202511
<img width="742" height="70" alt="image" src="https://github.com/user-attachments/assets/c209fb1d-a0c9-408a-b105-bbebce184cdd" />

master 
<img width="742" height="70" alt="image" src="https://github.com/user-attachments/assets/dd0238a1-1ca1-4157-8696-d81f865cb161" />

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
