### PR TITLE
Use platform metadata to classify SFP thermal sensors

### DIFF
--- a/tests/platform_tests/test_sfp_thermal_state_db.py
+++ b/tests/platform_tests/test_sfp_thermal_state_db.py
@@ -89,8 +89,7 @@ class TestSfpThermalStateDb:
         Matches patterns like 'xSFP module N Temp'.
         """
         sensor_lower = sensor_name.lower()
-        return ("sfp" in sensor_lower or "transceiver" in sensor_lower or
-                "optic" in sensor_lower)
+        return ("sfp" in sensor_lower or "transceiver" in sensor_lower)
 
     def test_sfp_temperature_present_in_show_platform_temperature(
             self, duthosts, enum_rand_one_per_hwsku_hostname):
@@ -469,7 +468,7 @@ class TestSfpThermalStateDb:
         keys = result["stdout"].strip().split("\n")
         sfp_keys = [
             k for k in keys
-            if any(pattern in k.lower() for pattern in ["sfp", "transceiver", "xsfp", "optic"])
+            if any(pattern in k.lower() for pattern in ["sfp", "transceiver", "xsfp"])
         ]
 
         logger.info("TEMPERATURE_INFO keys: %d total, %d SFP-related",
@@ -509,7 +508,7 @@ class TestSfpThermalStateDb:
 
         non_sfp_sensors = [
             name for name in sensor_names
-            if not any(p in name.lower() for p in ["sfp", "transceiver", "xsfp", "optic"])
+            if not any(p in name.lower() for p in ["sfp", "transceiver", "xsfp"])
         ]
 
         pytest_assert(

--- a/tests/platform_tests/test_sfp_thermal_state_db.py
+++ b/tests/platform_tests/test_sfp_thermal_state_db.py
@@ -31,6 +31,8 @@ class TestSfpThermalStateDb:
         r"\bxsfp\s+module\s+\d+\b|transceiver|optic",
         re.IGNORECASE
     )
+    COMPONENT_FIELD = "component"
+    SFP_COMPONENT = "sfp"
 
     def _get_sfp_ports_with_dom_temperature(self, duthost):
         """Return list of port names that have TRANSCEIVER_DOM_TEMPERATURE entries."""
@@ -90,12 +92,73 @@ class TestSfpThermalStateDb:
                 flags[field] = None
         return flags
 
-    def _is_sfp_sensor(self, sensor_name):
+    def _get_platform_thermal_component_map(self, duthost):
+        """
+        Return platform.json thermal component metadata keyed by sensor name.
+
+        Only explicit, non-empty string component values are returned. Missing
+        or invalid values intentionally fall back to the legacy name matcher.
+        """
+        chassis_facts = duthost.facts.get("chassis") or {}
+        thermal_facts = chassis_facts.get("thermals") or []
+        thermal_component_map = {}
+
+        for thermal in thermal_facts:
+            sensor_name = thermal.get("name")
+            if not sensor_name or self.COMPONENT_FIELD not in thermal:
+                continue
+
+            component = thermal.get(self.COMPONENT_FIELD)
+            if isinstance(component, str) and component.strip():
+                thermal_component_map[sensor_name] = component
+
+        return thermal_component_map
+
+    def _sensor_is_sfp_by_name(self, sensor_name):
         """
         Determine if a sensor name refers to an SFP/transceiver temperature.
-        Matches canonical 'xSFP module N Temp' names and transceiver/optic aliases.
+        Matches legacy SFP/transceiver name patterns.
         """
         return bool(self.SFP_SENSOR_PATTERN.search(sensor_name))
+
+    def _sensor_is_sfp(self, sensor_name, platform_thermal_component_map):
+        """
+        Determine if a sensor is an SFP thermal sensor.
+
+        Explicit platform.json metadata takes precedence. If platform.json does
+        not provide an explicit component value for the sensor, use the legacy
+        name matcher for backward compatibility.
+        """
+        if sensor_name in platform_thermal_component_map:
+            component = platform_thermal_component_map[sensor_name]
+            sensor_is_sfp = component.strip().lower() == self.SFP_COMPONENT
+            logger.info(
+                "Sensor '%s' classified as %s by explicit platform thermal "
+                "component metadata (component='%s')",
+                sensor_name, "SFP" if sensor_is_sfp else "non-SFP", component
+            )
+            return sensor_is_sfp
+
+        sensor_is_sfp = self._sensor_is_sfp_by_name(sensor_name)
+        if sensor_is_sfp:
+            logger.info(
+                "Sensor '%s' classified as SFP by legacy name matching",
+                sensor_name
+            )
+        return sensor_is_sfp
+
+    def _get_sfp_rows(self, duthost, temp_output):
+        platform_thermal_component_map = self._get_platform_thermal_component_map(duthost)
+        sfp_rows = [
+            row for row in temp_output
+            if self._sensor_is_sfp(row.get("sensor", ""), platform_thermal_component_map)
+        ]
+        logger.info(
+            "Classified %d SFP sensor rows using platform thermal metadata "
+            "and legacy name matching",
+            len(sfp_rows)
+        )
+        return sfp_rows
 
     def test_sfp_temperature_present_in_show_platform_temperature(
             self, duthosts, enum_rand_one_per_hwsku_hostname):
@@ -116,9 +179,7 @@ class TestSfpThermalStateDb:
         pytest_assert(len(temp_output) > 0,
                       "'show platform temperature' returned no data")
 
-        sfp_rows = [row for row in temp_output if self._is_sfp_sensor(row.get("sensor", ""))]
-
-        logger.info("Found %d SFP sensor rows in 'show platform temperature'", len(sfp_rows))
+        sfp_rows = self._get_sfp_rows(duthost, temp_output)
 
         pytest_assert(
             len(sfp_rows) > 0,
@@ -158,7 +219,7 @@ class TestSfpThermalStateDb:
             pytest.skip("No TRANSCEIVER_DOM_TEMPERATURE entries found")
 
         temp_output = duthost.show_and_parse("show platform temperature")
-        sfp_rows = [row for row in temp_output if self._is_sfp_sensor(row.get("sensor", ""))]
+        sfp_rows = self._get_sfp_rows(duthost, temp_output)
 
         if not sfp_rows:
             pytest.skip("No SFP rows in 'show platform temperature' output")
@@ -264,7 +325,7 @@ class TestSfpThermalStateDb:
             pytest.skip("No TRANSCEIVER_DOM_TEMPERATURE entries found")
 
         temp_output = duthost.show_and_parse("show platform temperature")
-        sfp_rows = [row for row in temp_output if self._is_sfp_sensor(row.get("sensor", ""))]
+        sfp_rows = self._get_sfp_rows(duthost, temp_output)
 
         if not sfp_rows:
             pytest.skip("No SFP rows in 'show platform temperature' output")
@@ -428,7 +489,7 @@ class TestSfpThermalStateDb:
             pytest.skip("No TRANSCEIVER_DOM_TEMPERATURE entries found")
 
         temp_output = duthost.show_and_parse("show platform temperature")
-        sfp_rows = [row for row in temp_output if self._is_sfp_sensor(row.get("sensor", ""))]
+        sfp_rows = self._get_sfp_rows(duthost, temp_output)
 
         if not sfp_rows:
             pytest.skip("No SFP rows in 'show platform temperature' output")
@@ -503,7 +564,14 @@ class TestSfpThermalStateDb:
         )
 
         keys = result["stdout"].strip().split("\n")
-        sfp_keys = [k for k in keys if self._is_sfp_sensor(k)]
+        platform_thermal_component_map = self._get_platform_thermal_component_map(duthost)
+        sfp_keys = [
+            k for k in keys
+            if self._sensor_is_sfp(
+                k.split("|", 1)[1],
+                platform_thermal_component_map
+            )
+        ]
 
         logger.info("TEMPERATURE_INFO keys: %d total, %d SFP-related",
                     len(keys), len(sfp_keys))
@@ -540,9 +608,10 @@ class TestSfpThermalStateDb:
             "(ASIC, CPU, PSU, etc.)"
         )
 
+        platform_thermal_component_map = self._get_platform_thermal_component_map(duthost)
         non_sfp_sensors = [
             name for name in sensor_names
-            if not self._is_sfp_sensor(name)
+            if not self._sensor_is_sfp(name, platform_thermal_component_map)
         ]
 
         pytest_assert(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Update SFP thermal state DB tests to classify SFP thermal sensors using explicit platform.json thermal metadata when available.

The tests now read the is_sfp_sensor field from chassis thermal facts and use that value as the source of truth for sensor classification. When the metadata is missing or invalid, the existing sensor-name matching logic is used as a
backward-compatible fallback.

The current string matching mechanism is very broad and misclassifies sensors that may use these keywords but are not SFP sensors.

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
This test fails on devices that expose non-xcvr sensors that contain the substring "optic" in them. It treats any key containing "optic" as an SFP entry. “Optics” can describe a board area, rail, regulator, power domain, or ambient zone. It does not necessarily mean “transceiver DOM sensor managed by xcvrd” as assumed in the test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
The motivation of this PR is to refactor _is_sfp_sensor to use a more structured mechanism to determine SFP sensors using platform.json

#### How did you do it?
Added logic to read a platform.json thermal data and fallback to existing mechanism when it is not available.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
TODO after discussion on the design

#### Any platform specific information?
All vendors can change their platform files if they require a more fine grained control of which sensors should classify as SFP thermal sensors.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
NA
