### PR TITLE
snappi: create the stats log directory before writing to it

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -9,6 +9,7 @@ import sys
 import random
 import pandas as pd
 from datetime import datetime
+from pathlib import Path
 from tests.common.utilities import (wait, wait_until)   # noqa: F401
 from tabulate import tabulate
 
@@ -1846,6 +1847,8 @@ def run_traffic_and_collect_stats(rx_duthost,
         flow_list.append(item.replace(' ', '_').lower())
     results = list(df_t.columns)
     fname = fname + '-' + datetime.now().strftime('%Y-%m-%d-%H-%M')
+    # Callers compose fname from nested log dirs that may not exist yet.
+    Path(fname).parent.mkdir(parents=True, exist_ok=True)
     with open(fname+'.txt', 'w') as f:
         f.write('Captured data for {} iterations at {} seconds interval \n'.format(m, stats_interval))
         test_stats = {}


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #26817

`run_traffic_and_collect_stats()` writes its per-run statistics to a path composed by the caller, but never creates the directory. Callers embed a relative directory in `test_def['test_type']` — every test in `snappi_tests/pfcwd/test_pfcwd_actions.py` uses paths like `logs/snappi_tests/pfcwd/One_Ingress_Egress_pfcwd_drop_uni_dist400Gbps`. If that directory does not exist, `open()` raises `FileNotFoundError` **after** the traffic run has completed and stats have been collected, discarding the run.

This creates the parent directory before the write. The later `df_t.to_csv(fname)` targets the same directory, so one `mkdir` covers both.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

No backport requested.

Failure type: day-one issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

Broadcom DNX (400G), image `202511.Nexthop.137667`, running `snappi_tests/pfcwd/test_pfcwd_actions.py` with `tests/logs/snappi_tests/` removed beforehand.

Before: every test reaching the stats write failed with `FileNotFoundError`. After: the directory is created, both artifacts are written, and the tests proceed to their own assertions.

flake8 clean; module parses.

### Approach

#### What is the motivation for this PR?

Tests fail on a fresh tree at the stats write, discarding a completed traffic run.

#### How did you do it?

```python
# Callers compose fname from nested log dirs that may not exist yet.
Path(fname).parent.mkdir(parents=True, exist_ok=True)
```

`pathlib` avoids the `os.path.dirname` + `os.makedirs` pair and its empty-dirname guard, since `Path('foo').parent` is `Path('.')`. `os` is not referenced elsewhere in the module, so no `import os` is added.

#### How did you verify/test it?

See **Test result**.

#### Any platform specific information?

None — shared snappi helper, platform independent.

#### Supported testbed topology if it's a new test case?

N/A — existing helper fix.

### Documentation

No documentation change.
