### PR TITLE
Add LMA and UMA topology support in route announcement

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -161,7 +161,7 @@ def get_change_routes_ports(vm, topo):
 
 def get_topo_type(topo_name):
     pattern = re.compile(
-        r'^(t0-mclag|t0|t1|ptf|fullmesh|dualtor|t2|mgmttor|m0|mc0|mx|m1|c0|dpu|smartswitch-t1|lt2|ft2|lrh|urh)')
+        r'^(t0-mclag|t0|t1|ptf|fullmesh|dualtor|t2|mgmttor|m0|mc0|mx|m1|c0|dpu|smartswitch-t1|lt2|ft2|lrh|urh|uma|lma)')
     match = pattern.match(topo_name)
     if not match:
         return "unsupported"
@@ -629,6 +629,35 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
         next_group_index = (index + 1) * upstream_neighbor_groups // vms_len
         if group_index != next_group_index:
             current_routes_offset += last_suffix
+
+def fib_lma(topo, ptf_ip, action="announce", topo_routes={}):
+    common_config = topo['configuration_properties'].get('common', {})
+    nhipv4 = common_config.get("nhipv4", NHIPV4)
+    nhipv6 = common_config.get("nhipv6", NHIPV6)
+
+    vms = topo['topology']['VMs']
+    vms_config = topo['configuration']
+
+    for k, v in vms_config.items():
+        vm_offset = vms[k]['vm_offset']
+        port = IPV4_BASE_PORT + vm_offset
+        port6 = IPV6_BASE_PORT + vm_offset
+
+        routes_v4 = []
+        routes_v6 = []
+        # The upstream UpperMgmtAggregator (UMA) neighbors originate the default
+        # route toward the LowerMgmtAggregator DUT. Downstream leaf (MgmtToR)
+        # neighbors advertise only their own loopbacks via their own BGP.
+        if "core" in v["properties"]:
+            routes_v4 = [("0.0.0.0/0", nhipv4, None)]
+            routes_v6 = [("::/0", nhipv6, None)]
+
+        topo_routes[k] = {}
+        topo_routes[k][IPV4] = routes_v4
+        topo_routes[k][IPV6] = routes_v6
+        if action != GENERATE_WITHOUT_APPLY:
+            change_routes(action, ptf_ip, port, routes_v4)
+            change_routes(action, ptf_ip, port6, routes_v6)
 
 
 def is_backend_neighbor(properties):
@@ -1910,6 +1939,12 @@ def main():
         elif topo_type == "ft2":
             fib_ft2_routes(topo, ptf_ip, action=action, topo_routes=topo_routes)
             module.exit_json(change=True, topo_routes=convert_routes_to_str(topo_routes))
+        elif topo_type == "lma":
+            fib_lma(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(changed=True, topo_routes=convert_routes_to_str(topo_routes))
+        elif topo_type == "uma":
+            fib_lma(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(changed=True, topo_routes=convert_routes_to_str(topo_routes))
         else:
             module.exit_json(
                 msg='Unsupported topology "{}" - skipping announcing routes'.format(topo_name))

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -631,7 +631,9 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
             current_routes_offset += last_suffix
 
 
-def fib_lma(topo, ptf_ip, action="announce", topo_routes={}):
+def fib_lma(topo, ptf_ip, action="announce", topo_routes=None):
+    if topo_routes is None:
+        topo_routes = {}
     common_config = topo['configuration_properties'].get('common', {})
     nhipv4 = common_config.get("nhipv4", NHIPV4)
     nhipv6 = common_config.get("nhipv6", NHIPV6)

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -630,6 +630,7 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
         if group_index != next_group_index:
             current_routes_offset += last_suffix
 
+
 def fib_lma(topo, ptf_ip, action="announce", topo_routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     nhipv4 = common_config.get("nhipv4", NHIPV4)
@@ -646,7 +647,37 @@ def fib_lma(topo, ptf_ip, action="announce", topo_routes={}):
         routes_v4 = []
         routes_v6 = []
         # The upstream UpperMgmtAggregator (UMA) neighbors originate the default
-        # route toward the LowerMgmtAggregator DUT. Downstream leaf (MgmtToR)
+        # route toward the LowerMgmtAggregator DUT. Downstream leaf(M2/M3)
+        # neighbors advertise only their own loopbacks via their own BGP.
+        if "core" in v["properties"]:
+            routes_v4 = [("0.0.0.0/0", nhipv4, None)]
+            routes_v6 = [("::/0", nhipv6, None)]
+
+        topo_routes[k] = {}
+        topo_routes[k][IPV4] = routes_v4
+        topo_routes[k][IPV6] = routes_v6
+        if action != GENERATE_WITHOUT_APPLY:
+            change_routes(action, ptf_ip, port, routes_v4)
+            change_routes(action, ptf_ip, port6, routes_v6)
+
+
+def fib_uma(topo, ptf_ip, action="announce", topo_routes={}):
+    common_config = topo['configuration_properties'].get('common', {})
+    nhipv4 = common_config.get("nhipv4", NHIPV4)
+    nhipv6 = common_config.get("nhipv6", NHIPV6)
+
+    vms = topo['topology']['VMs']
+    vms_config = topo['configuration']
+
+    for k, v in vms_config.items():
+        vm_offset = vms[k]['vm_offset']
+        port = IPV4_BASE_PORT + vm_offset
+        port6 = IPV6_BASE_PORT + vm_offset
+
+        routes_v4 = []
+        routes_v6 = []
+        # The upstream RegionalWANAggregator (RWA) neighbors originate the default
+        # route toward the UpperMgmtAggregator DUT. Downstream leaf (LMA/M1)
         # neighbors advertise only their own loopbacks via their own BGP.
         if "core" in v["properties"]:
             routes_v4 = [("0.0.0.0/0", nhipv4, None)]
@@ -1943,7 +1974,7 @@ def main():
             fib_lma(topo, ptf_ip, action=action, topo_routes=topo_routes)
             module.exit_json(changed=True, topo_routes=convert_routes_to_str(topo_routes))
         elif topo_type == "uma":
-            fib_lma(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            fib_uma(topo, ptf_ip, action=action, topo_routes=topo_routes)
             module.exit_json(changed=True, topo_routes=convert_routes_to_str(topo_routes))
         else:
             module.exit_json(

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -642,9 +642,7 @@ def fib_lma(topo, ptf_ip, action="announce", topo_routes=None):
     vms_config = topo['configuration']
 
     for k, v in vms_config.items():
-        vm_offset = vms[k]['vm_offset']
-        port = IPV4_BASE_PORT + vm_offset
-        port6 = IPV6_BASE_PORT + vm_offset
+        port, port6 = get_change_routes_ports(k, topo)
 
         routes_v4 = []
         routes_v6 = []
@@ -672,9 +670,7 @@ def fib_uma(topo, ptf_ip, action="announce", topo_routes={}):
     vms_config = topo['configuration']
 
     for k, v in vms_config.items():
-        vm_offset = vms[k]['vm_offset']
-        port = IPV4_BASE_PORT + vm_offset
-        port6 = IPV6_BASE_PORT + vm_offset
+        port, port6 = get_change_routes_ports(k, topo)
 
         routes_v4 = []
         routes_v6 = []


### PR DESCRIPTION
This pull request extends route announcement support in `announce_routes.py` to two new topology types: "lma" (LowerMgmtAggregator) and "uma" (UpperMgmtAggregator). It does so by adding dedicated route announcement logic for these topologies and updating the topology type detection and main dispatch logic accordingly.

**Support for new topology types:**

* Added "lma" and "uma" to the list of recognized topology types in the `get_topo_type` function so they are properly detected and handled.

**Route announcement logic for new topologies:**

* Implemented the `fib_lma` function to handle default route announcements for the "lma" topology, originating default routes from "core" neighbors.
* Implemented the `fib_uma` function to handle default route announcements for the "uma" topology, also originating default routes from "core" neighbors.

**Main function dispatch updates:**

* Updated the main function to call the appropriate new route announcement functions (`fib_lma` and `fib_uma`) and return results when the topology type is "lma" or "uma".<!--


Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
