### PR TITLE
vxlan/test_vxlan_decap_ttl: Fix teardown logic

### DIFF
--- a/tests/common/vxlan_ecmp_utils.py
+++ b/tests/common/vxlan_ecmp_utils.py
@@ -391,7 +391,7 @@ class Ecmp_Utils(object):
            vxlan_sport: The base UDP source port for VxLAN sport entropy.
            vxlan_mask : The number of bits to vary in the source port range.
         '''
-        if dutmac is None:
+        if not dutmac:
             dutmac = "aa:bb:cc:dd:ee:ff"
 
         switch_fields = {

--- a/tests/vxlan/test_vxlan_decap_ttl.py
+++ b/tests/vxlan/test_vxlan_decap_ttl.py
@@ -53,10 +53,11 @@ def configure_vxlan_global(duthost):
     yield
     if prev_vxlan_port:
         ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=int(prev_vxlan_port), dutmac=prev_vxlan_router_mac)
-    else:
+    elif prev_vxlan_router_mac:
         ecmp_utils.configure_vxlan_switch(duthost, dutmac=prev_vxlan_router_mac)
         duthost.shell("sonic-db-cli APPL_DB HDEL 'SWITCH_TABLE:switch' 'vxlan_port'")
-    if not prev_vxlan_router_mac:
+    else:
+        duthost.shell("sonic-db-cli APPL_DB HDEL 'SWITCH_TABLE:switch' 'vxlan_port'")
         duthost.shell("sonic-db-cli APPL_DB HDEL 'SWITCH_TABLE:switch' 'vxlan_router_mac'")
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
During teardown of test_vxlan_decap_ttl, we see following errors on DUT:
2026 Aug  5 23:54:02.222729 cmono-t0-dut INFO swss#supervisord: orchagent 
2026 Aug  5 23:54:02.222729 cmono-t0-dut INFO swss#supervisord: orchagent terminate called after throwing an instance of 'std::invalid_argument'
2026 Aug  5 23:54:02.222729 cmono-t0-dut INFO swss#supervisord: orchagent   what():  can't parse mac address ''

This is because during cleanup, the test makes a set call with empty string and as a result, orchagent crashes while parsing this empty string. Made following fixes to handle this cleanup issue:
1. test_vxlan_decap_ttl.py: Fix configure_vxlan_global fixture teardown to handle three explicit cases: restore vxlan_port if it existed, restore only router_mac if port was absent, or clean up both DB entries if neither was previously set. Prevents calling configure_vxlan_switch with a None dutmac during teardown.
2. vxlan_ecmp_utils.py: Replace `dutmac is None` with `not dutmac` in configure_vxlan_switch to also handle empty string inputs.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
3. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Tested on Cisco 8101 platform:
[test_vxlan_decap_ttl_2026-08-06-00-55-42.log](https://github.com/user-attachments/files/30768290/test_vxlan_decap_ttl_2026-08-06-00-55-42.log)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
