### PR TITLE
[Mellanox] Add qos sai config data for spc6

### DIFF
--- a/tests/qos/files/mellanox/special_qos_config.yml
+++ b/tests/qos/files/mellanox/special_qos_config.yml
@@ -72,3 +72,45 @@ qos_params:
             pkts_num_margin: 8
         wm_q_shared_lossy:
             packet_size: 1200
+    spc6:
+        profile:
+            pkts_num_leak_out: 1
+            xoff_1:
+                packet_size: 800
+                pkts_num_margin: 6
+            xoff_2:
+                packet_size: 800
+                pkts_num_margin: 6
+            xoff_3:
+                packet_size: 800
+                pkts_num_margin: 6
+            xoff_4:
+                packet_size: 800
+                pkts_num_margin: 6
+            wm_pg_headroom:
+                packet_size: 800
+                pkts_num_margin: 6
+            wm_q_shared_lossless:
+                packet_size: 700
+                pkts_num_margin: 20
+            hdrm_pool_size:
+                packet_size: 800
+        xon_1:
+            packet_size: 800
+        xon_2:
+            packet_size: 800
+        xon_3:
+            packet_size: 800
+        xon_4:
+            packet_size: 800
+        lossy_queue_1:
+            packet_size: 1200
+            pkts_num_margin: 5
+        wm_pg_shared_lossless:
+            packet_size: 800
+            pkts_num_margin: 7
+        wm_pg_shared_lossy:
+            packet_size: 1200
+            pkts_num_margin: 8
+        wm_q_shared_lossy:
+            packet_size: 1200

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -6453,7 +6453,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 assert (q_wm_res[queue] <= (margin + 1) * cell_size)
             elif pkts_num_fill_min:
                 assert (q_wm_res[queue] == 0)
-            elif 'cisco-8000' in asic_type or "SN56" in hwsku or "SN5400" in hwsku:
+            elif 'cisco-8000' in asic_type or "SN5" in hwsku or "SN6" in hwsku:
                 assert (q_wm_res[queue] <= (margin + 1) * cell_size)
             else:
                 if platform_asic and platform_asic == "broadcom-dnx":


### PR DESCRIPTION
### Description of PR
Add qos sai config data for spc6

Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605


### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
master: Passed
202605: Passed

### Approach
#### What is the motivation for this PR?
Add qos sai config data for spc6

#### How did you do it?
Add qos sai test data to tests/qos/files/mellanox/special_qos_config.yml

#### How did you verify/test it?
Run the tests on Spc6 platform 

#### Any platform specific information?
SPC6

#### Supported testbed topology if it's a new test case?

### Documentation
N/A
