### PR TITLE
[qos] Skip IP-in-IP DSCP test when decap is disabled

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -91,24 +91,12 @@ def dscp_config(dscp_mode, rand_selected_dut, loganalyzer):
     """
     duthost = rand_selected_dut
     asic_type = duthost.facts['asic_type']
-    device_type = duthost.shell(
-        'redis-cli -n 4 HGET "DEVICE_METADATA|localhost" "type"'
+    ip_decap_status = duthost.shell(
+        "sonic-cfggen -d -v 'SYSTEM_DEFAULTS.ip_decap.status'",
+        module_ignore_errors=True
     )["stdout"].strip()
-    resource_type = duthost.shell(
-        'redis-cli -n 4 HGET "DEVICE_METADATA|localhost" "resource_type"'
-    )["stdout"].strip()
-    storage_device_exists = int(duthost.shell(
-        'redis-cli -n 4 HEXISTS "DEVICE_METADATA|localhost" "storage_device"'
-    )["stdout"])
-    backend_device_types = ("BackEndToRRouter", "BackEndLeafRouter", "BackEndSpineRouter")
-
-    if (
-        asic_type == "mellanox"
-        and device_type in backend_device_types
-        and resource_type == "ComputeAI"
-        and not storage_device_exists
-    ):
-        pytest.skip("IP-in-IP decap is disabled on Mellanox ComputeAI backend devices")
+    if ip_decap_status == "disabled":
+        pytest.skip("IP-in-IP decapsulation is disabled on this DUT")
 
     # global DSCP_TO_TC_MAP update is not supported on Broadcom platforms
     # Broadcom ASICs do not support inner DSCP-based queue remapping for IPIP pipe mode.

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -91,6 +91,24 @@ def dscp_config(dscp_mode, rand_selected_dut, loganalyzer):
     """
     duthost = rand_selected_dut
     asic_type = duthost.facts['asic_type']
+    device_type = duthost.shell(
+        'redis-cli -n 4 HGET "DEVICE_METADATA|localhost" "type"'
+    )["stdout"].strip()
+    resource_type = duthost.shell(
+        'redis-cli -n 4 HGET "DEVICE_METADATA|localhost" "resource_type"'
+    )["stdout"].strip()
+    storage_device_exists = int(duthost.shell(
+        'redis-cli -n 4 HEXISTS "DEVICE_METADATA|localhost" "storage_device"'
+    )["stdout"])
+    backend_device_types = ("BackEndToRRouter", "BackEndLeafRouter", "BackEndSpineRouter")
+
+    if (
+        asic_type == "mellanox"
+        and device_type in backend_device_types
+        and resource_type == "ComputeAI"
+        and not storage_device_exists
+    ):
+        pytest.skip("IP-in-IP decap is disabled on Mellanox ComputeAI backend devices")
 
     # global DSCP_TO_TC_MAP update is not supported on Broadcom platforms
     # Broadcom ASICs do not support inner DSCP-based queue remapping for IPIP pipe mode.


### PR DESCRIPTION
### Description of PR

Summary:
Skip the IP-in-IP DSCP mapping test when IP-in-IP decapsulation is explicitly disabled through `SYSTEM_DEFAULTS.ip_decap.status`. The test continues to run when the setting is enabled or undefined.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: Test failure on a DUT where IP-in-IP decapsulation is unsupported by design.

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

https://elastictest.org/scheduler/testplan/6a850a51a4d1c39d04745c2d

### Approach
#### What is the motivation for this PR?

Some platforms intentionally disable IP-in-IP decapsulation. On those DUTs, the DSCP mapping test cannot exercise the intended decapsulation behavior, so a failure does not indicate a QoS defect.

The original implementation inferred support from ASIC type and device metadata. This duplicated platform policy in the test and could become stale as platform support changes.

#### How did you do it?

Before configuring the DSCP mapping test, query the system default with:

```
sonic-cfggen -d -v 'SYSTEM_DEFAULTS.ip_decap.status'
```

If the returned status is `disabled`, skip the test. The command tolerates images that do not define this setting; an empty or undefined value does not skip the test, preserving backward compatibility and existing coverage.

#### How did you verify/test it?

Cherry-picked the change into the 202511 testbed checkout and verified that the updated test module compiles successfully with Python 3. Targeted DUT execution is still pending and is not claimed by this PR update.

Expected behavior:

- `ip_decap.status=disabled`: the IP-in-IP DSCP mapping test is skipped.
- `ip_decap.status=enabled`: the test runs normally.
- Setting absent or command unsupported: the test runs normally.

#### Any platform specific information?

The failure was observed on an NVIDIA/Mellanox ComputeAI backend device where IP-in-IP decapsulation is intentionally disabled. The fix is capability-based rather than tied to an ASIC, platform, HwSKU, device type, or resource type, so it applies to any DUT that explicitly disables IP-in-IP decapsulation.

#### Supported testbed topology if it's a new test case?

N/A. This is not a new test case. The existing test supports `t0` and `t1` topologies.

### Documentation

N/A
