### PR TITLE
Skip CPO transceiver-type check for non-CPO ports in test_check_sfp_eeprom

### DIFF
--- a/tests/platform_tests/mellanox/conftest.py
+++ b/tests/platform_tests/mellanox/conftest.py
@@ -55,3 +55,24 @@ def is_cpo_supported(duthosts, rand_one_dut_hostname):
             if hwsku_info['interfaces'][intf].get('port_type') == CPO_PORT_TYPE:
                 return True
     return False
+
+
+def get_non_cpo_ports(duthost):
+    """Return the set of port names whose port_type is NOT CPO in hwsku.json.
+
+    A port is considered non-CPO if its `port_type` field is missing or set
+    to anything other than CPO. Returns an empty set if hwsku.json doesn't
+    exist (no information to filter on).
+    """
+    platform = duthost.facts["platform"]
+    hwsku = duthost.facts['hwsku']
+    f_path = HWSKU_JSON_PATH.format(platform, hwsku)
+    if not duthost.stat(path=f_path)["stat"]["exists"]:
+        return set()
+    output = duthost.command(f"cat {f_path}")["stdout"]
+    hwsku_info = json.loads(output)
+    non_cpo_ports = set()
+    for intf, intf_info in (hwsku_info.get('interfaces') or {}).items():
+        if intf_info.get('port_type') != CPO_PORT_TYPE:
+            non_cpo_ports.add(intf)
+    return non_cpo_ports

--- a/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
@@ -7,7 +7,7 @@ from tests.common.platform.transceiver_utils import parse_sfp_eeprom_infos
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.processes_utils import check_pmon_uptime_minutes
-from tests.platform_tests.mellanox.conftest import CPO_PORT_TYPE
+from tests.platform_tests.mellanox.conftest import CPO_PORT_TYPE, get_non_cpo_ports
 import logging
 
 pytestmark = [
@@ -67,11 +67,14 @@ def test_check_sfp_eeprom_with_option_dom(duthosts, rand_one_dut_hostname, show_
         assert sfp_info_dict, "No SFP EEPROM info found"
 
     with allure.step("Check results for {}".format(show_eeprom_cmd)):
+        non_cpo_ports = set()
         if is_cpo_supported:
             with allure.step("Run: {} to get interface status".format(SHOW_INTF_STATUS_CMDS)):
                 intf_status = duthost.show_and_parse(SHOW_INTF_STATUS_CMDS)
                 assert intf_status["rc"] == 0, "Failed to read interface status"
                 intf_status_dict = {row["interface"]: row for row in intf_status}
+            non_cpo_ports = get_non_cpo_ports(duthost)
+            logging.info(f"Non-CPO ports per hwsku.json (CPO checks skipped): {sorted(non_cpo_ports)}")
 
         for intf, inft_support_dom in list(sfp_test_intfs_to_dom_map.items()):
             if intf in sfp_info_dict:
@@ -83,7 +86,13 @@ def test_check_sfp_eeprom_with_option_dom(duthosts, rand_one_dut_hostname, show_
                     check_sfp_eeprom_info(
                         duthost, sfp_info_dict[intf], inft_support_dom, show_eeprom_cmd, is_flat_memory)
 
+                # Skip CPO transceiver-type checks for ports whose port_type in hwsku.json
+                # is not CPO. Some platforms (e.g. SN6810_LD) have a mix of CPO and non-CPO
+                # ports (e.g. management/SDK 25G ports) on the same DUT.
                 if is_cpo_supported:
+                    if intf in non_cpo_ports:
+                        logging.info(f"Skip CPO identifier check for non-CPO port {intf}")
+                        continue
                     with allure.step("Check {} identifier type".format(intf)):
                         cmd = f'sonic-db-cli STATE_DB hget "TRANSCEIVER_INFO|{intf}" "type"'.format(intf)
                         transceiver_type = duthost.command(cmd)["stdout"]

--- a/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
@@ -67,7 +67,6 @@ def test_check_sfp_eeprom_with_option_dom(duthosts, rand_one_dut_hostname, show_
         assert sfp_info_dict, "No SFP EEPROM info found"
 
     with allure.step("Check results for {}".format(show_eeprom_cmd)):
-        non_cpo_ports = set()
         if is_cpo_supported:
             with allure.step("Run: {} to get interface status".format(SHOW_INTF_STATUS_CMDS)):
                 intf_status = duthost.show_and_parse(SHOW_INTF_STATUS_CMDS)


### PR DESCRIPTION
### Description of PR
Skip CPO transceiver-type check for non-CPO ports in test_check_sfp_eeprom
On platforms that mix CPO and non-CPO ports on the same DUT (e.g. SN6810_LD,
where Ethernet512/513 are 1x25G management/SDK ports without port_type=CPO
in hwsku.json), test_check_sfp_eeprom_with_option_dom incorrectly asserted
the CPO transceiver type for every port whenever the system-level
is_cpo_supported fixture was True, leading to AssertionError on the non-CPO
ports.


Summary:
Fixes # (issue)


### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605


### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A


### Approach
#### What is the motivation for this PR?
Skip CPO transceiver-type check for non-CPO ports in test_check_sfp_eeprom

#### How did you do it?
When ports are non-cpo port, skip the relevant check on platform supporting CPO

#### How did you verify/test it?
Run test_check_sfp_eeprom in platform supporting CPO

#### Any platform specific information?
platform supporting CPO

#### Supported testbed topology if it's a new test case?

### Documentation
N/A
