### PR TITLE
[macsec]: Skip per-interface tests before setup

### DIFF
--- a/tests/macsec/conftest.py
+++ b/tests/macsec/conftest.py
@@ -16,6 +16,13 @@ def pytest_collection_modifyitems(config, items):
             if "macsec_required" in item.keywords:
                 item.add_marker(skip_macsec)
 
+    if not config.getoption("per_interface_macsec"):
+        skip_per_interface = pytest.mark.skip(
+            reason="Requires --per_interface_macsec")
+        for item in items:
+            if item.path.name == "test_per_interface_profile.py":
+                item.add_marker(skip_per_interface)
+
 
 @pytest.fixture(scope="module")
 def profile_name(macsec_profile):


### PR DESCRIPTION
### Description of PR

Summary:

Skip `test_per_interface_profile.py` during collection when `--per_interface_macsec` is absent.

The test functions already call:

```python
pytest.skip("Requires --per_interface_macsec")
```

but pytest resolves module-scoped autouse fixtures before entering the test body. The shared MACsec setup therefore runs first and can fail with:

```text
RuntimeError: Process <Process ... started> timeout 300
```

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: Test selection/fixture ordering

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: exact KVM pytest invocation without `--per_interface_macsec` completed with 6 skipped tests in 1.60 seconds.
- No MACsec setup or cleanup operation ran.
- `python3 -m py_compile tests/macsec/conftest.py`
- `flake8 tests/macsec/conftest.py`

### Approach

#### What is the motivation for this PR?

`test_per_interface_profile.py` is only meaningful when `--per_interface_macsec` is enabled. Skipping inside each test body is too late because module fixtures execute first.

#### How did you do it?

Add a collection-time skip marker to every item from `test_per_interface_profile.py` when the option is absent. Pytest then skips the item before resolving the MACsec module fixtures.

#### How did you verify/test it?

Ran the same module command used by the failing KVM job, without `--per_interface_macsec`. All six parametrized cases skipped immediately and the run completed in 1.60 seconds.

#### Any platform specific information?

The failure was observed on VS KVM runs, but the fixture-ordering issue is platform-independent.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
