### PR TITLE
Fix EOS fanout speed parsing

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -690,12 +690,11 @@ class EosHost(AnsibleHostBase):
 
     def get_speed(self, interface_name):
         output = self.eos_command(commands=['show interfaces %s transceiver properties' % interface_name])
-        found_txt = re.search(r'Operational Speed: (\S+)', output['stdout'][0])
+        found_txt = re.search(r'Operational speed:\s*(\d+)\s*G\b', output['stdout'][0], re.IGNORECASE)
         if found_txt is None:
             _raise_err('Not able to extract interface %s speed from output: %s' % (interface_name, output['stdout']))
 
-        v = found_txt.groups()[0]
-        return v[:-1] + '000'
+        return found_txt.group(1) + '000'
 
     def _has_cli_cmd_failed(self, cmd_output_obj):
         err_out = False


### PR DESCRIPTION
### Description of PR
Fix EOS fanout speed parsing for `show interfaces <port> transceiver properties` output where EOS reports `Operational speed: 100G(forced)`. The previous parser required `Operational Speed` with an uppercase `S`, so it did not match current EOS output at all, and it assumed the captured token was exactly `<num>G`.

Fixes ADO PBI 39143085.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39143085
Failure type: regression

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

master: static + parser validation on this head (`80ff8b0`)
- `python -m py_compile tests/common/devices/eos.py` — passes
- `python -m flake8 --max-line-length=120 tests/common/devices/eos.py` — passes
- Parser comparison on representative EOS strings (old regex vs. the one in this PR):

  | `show interfaces <port> transceiver properties` line | old parser | this PR |
  | --- | --- | --- |
  | `Operational speed: 100G(forced)` | raises `_raise_err` | `100000` |
  | `Operational speed: 100G (forced)` | raises `_raise_err` | `100000` |
  | `Operational Speed: 40G` | `40000` | `40000` |
  | `Operational speed: 25G` | raises `_raise_err` | `25000` |
  | `Operational speed: 10G(auto)` | raises `_raise_err` | `10000` |
  | `Operational Speed: 400G` | `400000` | `400000` |
  | `Operational speed: unknown` | raises `_raise_err` | raises `_raise_err` |

  The previously working uppercase `<num>G` form is unchanged, the un-parseable
  case still errors out instead of returning a bogus speed, and the return value
  stays the same `<gbps>000` string, so `fanout.get_speed()` callers such as
  `tests/platform_tests/test_auto_negotiation.py` see an unchanged contract.
- Azure.sonic-mgmt on this head: 28/28 checks green, including all KVM lanes.

202511: `tests/common/devices/eos.py` on `202511` still carries the identical
pre-fix parser (`re.search(r'Operational Speed: (\S+)', output['stdout'][0])`),
so the defect and this fix apply unchanged there. No testbed run was performed
on 202511; the evidence above is the master run plus that code-state check.

### Approach
#### What is the motivation for this PR?
Nightly `platform_tests/test_auto_negotiation.py::test_auto_negotiation_fanout_advertises_each_speed` failed during setup because `EosHost.get_speed()` could not parse EOS output like `Operational speed: 100G(forced)`.

#### How did you do it?
Make the EOS speed parser case-insensitive and capture the numeric Gbps value before any optional mode suffix, instead of capturing the whole whitespace-delimited token and trimming its last character.

#### How did you verify/test it?
See **Test result** above.

#### Any platform specific information?
Observed with Mellanox-SN2700 DUT connected to an EOS fanout on T0.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
