### PR TITLE
[202511][ssh/test_ssh_limit]: Switch AAA login to local after opening the admin session (#26608)

### DIFF
--- a/tests/ssh/test_ssh_limit.py
+++ b/tests/ssh/test_ssh_limit.py
@@ -67,10 +67,12 @@ def modify_templates(duthost, tacacs_creds, creds):     # noqa F811
 
     sonic_admin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get(
         "ansible_altpassword")
-    # Duthost shell not support run command with J2 template in command text.
-    admin_session = paramiko_ssh(ip_address=dut_ip, username=creds['sonicadmin_user'],
-                                 passwords=[creds['sonicadmin_password'], sonic_admin_alt_password]
-                                 + creds["ansible_altpasswords"])
+    # Connect over SSH as admin (duthost.shell can't run commands containing J2 templates).
+    # This runs before AAA login is switched to local, so the admin credentials are still valid.
+    admin_session = paramiko_ssh(
+        ip_address=dut_ip, username=creds['sonicadmin_user'],
+        passwords=[creds['sonicadmin_password'], sonic_admin_alt_password]
+        + creds["ansible_altpasswords"])
 
     # Backup and change /usr/share/sonic/templates/pam_limits.j2
     additional_content = "session  required  pam_limits.so"
@@ -117,15 +119,19 @@ def setup_limit(duthosts, rand_one_dut_hostname, tacacs_creds, creds):      # no
     template_file_exist = limit_template_exist(duthost)
     aaa_login_disabled = False
     if template_file_exist:
+        setup_local_user(duthost, tacacs_creds)
+
+        # Modify templates and restart hostcfgd to render config files.
+        # modify_templates opens a new admin SSH session, so it must run before AAA login is
+        # switched to local: where admin is a TACACS user it has no local password and the
+        # admin login would be rejected after the switch.
+        modify_templates(duthost, tacacs_creds, creds)
+
         # If AAA authentication enabled, disable it to allow local user login
         if get_aaa_sub_options_value(duthost, "authentication", "login") == "tacacs+":
             duthost.shell("sudo config aaa authentication login default")
             aaa_login_disabled = True
 
-        setup_local_user(duthost, tacacs_creds)
-
-        # Modify templates and restart hostcfgd to render config files
-        modify_templates(duthost, tacacs_creds, creds)
         restart_hostcfgd(duthost)
 
     yield


### PR DESCRIPTION
### Description of PR

Summary:
`test_ssh_limits` intermittently fails in setup with `Failed to establish admin SSH session ... after AAA change`.

`setup_limit` switched AAA login to local (`config aaa authentication login default`) and then opened a new admin SSH session to edit the J2 templates. Where AAA login is `tacacs+`, `admin` authenticates via TACACS and has no matching local password, so after the switch the admin login is rejected by `pam_unix` and never recovers. This reorders setup so the admin session is opened before the switch.

Cherry-pick of #26608 to 202511. The buildbot could not create it automatically (`Cherry Pick Conflict_202511`) and asked for a manual one: https://github.com/sonic-net/sonic-mgmt/pull/26608#issuecomment-5193627022

Fixes: Microsoft ADO work item 38920641

#### Cherry-pick notes

Picked with `git cherry-pick -x 2ae06a03`, so the commit keeps the original message and the provenance line.

`setup_limit`, which carries the actual reorder, applied cleanly. The only conflict was in `modify_templates`. On master that same commit also removes the `wait_until` retry that #25617 had added around the admin `paramiko_ssh` call, and #25617 was never taken on 202511, so there is no retry here to remove. What was left to reconcile was the comment above the call and how the call is wrapped.

Resolved by taking master's side, so `setup_limit` and `modify_templates` now match master exactly. After this change the whole file is identical to master apart from `pytest.mark.device_type("vpp")`, which does not exist on 202511 and is unrelated to this fix.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Nothing further to request. This PR targets 202511 directly, 202605 was cherry-picked automatically in #26804, and master has carried the change since 2026-08-05.

### Tested branch
- [ ] master
- [x] 202511
- [ ] 202605

### Test result

4-ASIC KVM virtual switch, `t1-8-lag`, 202511 image `173862701`. AAA login was `tacacs+`, so the failing path was exercised: `ssh/test_ssh_limit.py` **1 passed**, module PASSED, 17 passed / 4 skipped / 0 failed / 0 errors overall.
https://elastictest.org/scheduler/testplan/6a71e74ab103fcbd8adfc500

That run predates re-creating this as a proper `cherry-pick -x`. The difference between the code that ran and the code in this PR is the comment wording and the line wrapping of the `paramiko_ssh(...)` call, nothing executable, so the result still applies.

On 202511 the unpatched code has no retry at all, so it fails setup with a raw `paramiko AuthenticationException` on TACACS-backed testbeds.

### Approach
#### What is the motivation for this PR?

`test_ssh_limits` errors during setup on testbeds where AAA login is `tacacs+`, so the SSH session-limit check never runs. 202511 is one of the lines where this was seen repeatedly.

#### How did you do it?

Moved `config aaa authentication login default` to after `setup_local_user` and `modify_templates`. That switch only exists so the local test user can log in during the test body, so it does not need to happen before the template edits.

- before: AAA -> local, `setup_local_user`, `modify_templates`, `restart_hostcfgd`
- after: `setup_local_user`, `modify_templates`, AAA -> local, `restart_hostcfgd`

`restart_hostcfgd` is still last, teardown is unchanged, and the assertions and template contents are untouched, so the state the test body sees at `yield` is the same. Nothing is masked: the failures this removes were setup errors, not `maxlogins` assertion failures.

#### How did you verify/test it?

See Test result. The root cause was confirmed on a DUT: after the switch, admin auth never recovered within 200s (`pam_unix(sshd:auth): authentication failure ... user=admin`), restarting `hostcfgd` did not help, and restoring `tacacs+` restored the admin login immediately, so it is a credential-path problem rather than timing.

#### Any platform specific information?

Only affects testbeds where AAA login is `tacacs+`. Seen mostly on virtual switches, but also on physical testbeds with that setting.

#### Supported testbed topology if it's a new test case?

N/A, existing test, no topology change.

### Documentation

N/A
