### PR TITLE
[sonic-mgmt]: Fix oci flake retry check

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -8,6 +8,7 @@ import time
 import sys
 
 from collections import defaultdict
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 
 from ansible import constants as ansible_constants
@@ -472,15 +473,23 @@ class SonicHost(AnsibleHostBase):
         pattern = r"OCI runtime exec failed:.*(starting setns process|fork/exec /proc/self/fd)"
 
         def _is_oci(res):
-            if not (isinstance(res, dict) and res.get("rc") == 127):
+            if not (isinstance(res, Mapping) and res.get("rc") == 127):
                 return False
             output = (res.get("stdout") or "") + "\n" + (res.get("stderr") or "")
             return bool(re.search(pattern, output, flags=re.DOTALL))
 
         if not _is_oci(result):
             return result
+
+        retry = result
         for attempt in range(1, attempts + 1):
             time.sleep(delay)
+            logging.info(
+                "Executing OCI race retry attempt %d/%d for cmd: %s",
+                attempt,
+                attempts,
+                cmd,
+            )
             retry = self.shell(cmd, module_ignore_errors=True)
             if not _is_oci(retry):
                 logging.info(
@@ -488,7 +497,8 @@ class SonicHost(AnsibleHostBase):
                     attempt, cmd,
                 )
                 return retry
-        return result
+        # Return the final retried result
+        return retry
 
     def get_critical_group_and_process_lists(self, container_name):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix false positive recovery logging in `_retry_if_oci_exec_race` by replacing strict `isinstance(res, dict)` checks with `isinstance(res, Mapping)`, and enhance helper debug logging.
Fixes [26835](https://github.com/sonic-net/sonic-mgmt/issues/26835)
Fixes [qual-issue](https://github.com/aristanetworks/sonic-qual.msft/issues/1361)

Background context:
In modern `pytest-ansible` versions (e.g., v25.8.0+ running on Python 3.12 / Ansible 2.13 host manager path), `self.shell()` returns a `ModuleResult` object inheriting from `collections.UserDict` rather than built-in `dict`.

Because `_retry_if_oci_exec_race` used `isinstance(res, dict)`, retried results failed the `_is_oci` type check immediately. This caused `_is_oci(retry)` to return `False` even when the retried output still contained the identical Docker exec OCI race failure. Consequently, the helper logged a misleading `"Recovered from transient docker exec OCI race..."` message and passed the failing result downstream.

Reviewers should start at `tests/common/devices/sonic.py` in function `_retry_if_oci_exec_race`.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- 202605: Validated on Python 3.12 / pytest-ansible v25.8.0 with `ModuleResult` and standard `dict` objects. Retry loop now properly detects ongoing OCI failures across iterations and logs type/attempt details accurately.

#### Before Fix (False Positive Recovery):
On attempt 1, even though the command output still failed with `rc=127` and contained the OCI race error, `_is_oci(retry)` returned `False` due to the strict `dict` type guard. The runner logged a false positive recovery message and exited retries immediately:
```text
07/07/2026 06:31:33 base._run L0225 DEBUG | AnsibleModule::shell Result => {"failed": true, "changed": true, "stdout": "OCI runtime exec failed: exec failed: unable to start container process: error starting setns process: fork/exec /proc/self/fd/6: no such file or directory: unknown", "stderr": "", "rc": 127, "cmd": "docker exec bgp supervisorctl status", ...}
07/07/2026 06:31:33 sonic._retry_if_oci_exec_race L0651 INFO | Recovered from transient docker exec OCI race on attempt 1 for cmd: docker exec bgp supervisorctl status
```

### After Fix (Proper Bounded Retry Execution):
With `isinstance(res, Mapping)`, `ModuleResult` objects are correctly recognized. When the OCI race persists, the helper properly iterates through all bounded retry attempts (1/3, 2/3, 3/3) without falsely declaring recovery:
```text
03/08/2026 14:48:23 sonic._retry_if_oci_exec_race L0498 INFO | Executing OCI race retry attempt 1/3 for cmd: docker exec bgp bash -c "[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes"
03/08/2026 14:48:24 base._run L0234 DEBUG | AnsibleModule::shell Result => {"failed": true, "rc": 127, "stdout": "OCI runtime exec failed: exec failed: unable to start container process: error starting setns process: fork/exec /proc/self/fd/6: no such file or directory: unknown", ...}

03/08/2026 14:48:26 sonic._retry_if_oci_exec_race L0498 INFO | Executing OCI race retry attempt 2/3 for cmd: docker exec bgp bash -c "[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes"
03/08/2026 14:48:27 base._run L0234 DEBUG | AnsibleModule::shell Result => {"failed": true, "rc": 127, "stdout": "OCI runtime exec failed: exec failed: unable to start container process: error starting setns process: fork/exec /proc/self/fd/6: no such file or directory: unknown", ...}

03/08/2026 14:48:29 sonic._retry_if_oci_exec_race L0498 INFO | Executing OCI race retry attempt 3/3 for cmd: docker exec bgp bash -c "[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes"
03/08/2026 14:48:30 base._run L0234 DEBUG | AnsibleModule::shell Result => {"failed": true, "rc": 127, "stdout": "OCI runtime exec failed: exec failed: unable to start container process: error starting setns process: fork/exec /proc/self/fd/6: no such file or directory: unknown", ...}
```
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
To ensure transient Docker/runc OCI race conditions are accurately detected and retried when using `pytest-ansible`, preventing unrecovered errors from falsely logging as "Recovered" and causing downstream test failures with confusing context.

#### How did you do it?
1. Updated `_is_oci()` in `tests/common/devices/sonic.py` to use `isinstance(res, Mapping)` (from `collections.abc`) instead of `isinstance(res, dict)`, accommodating both standard dicts and `collections.UserDict` instances (`ModuleResult`).
2. Added detailed `logging.debug` calls inside `_is_oci()` to log object type (`type(res).__name__`), initial return code validation status, and regex match outcome.
3. Added `logging.info` inside the retry loop to explicitly track the attempt counter (`attempt/attempts`).

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Described in the section "After Fix" .

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
