### PR TITLE
Change the topology from bmc to any for liquid cooling case

### DIFF
--- a/tests/platform_tests/api/test_liquid_cooling_leakage.py
+++ b/tests/platform_tests/api/test_liquid_cooling_leakage.py
@@ -11,7 +11,7 @@ from tests.common.platform.device_utils import start_platform_api_service    # n
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('bmc'),
+    pytest.mark.topology('any'),
     pytest.mark.device_type('physical')
 ]
 


### PR DESCRIPTION
### Description of PR
liquid cooling is not related to topology, if system does not support LD, case can be skip, so change pytest.mark.topology('bmc') to pytest.mark.topology('any'). issue is introduced by pr of https://github.com/sonic-net/sonic-mgmt/pull/24453/

Summary:
Fixes # (issue)

### Type of change
- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605


### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A


### Approach
#### What is the motivation for this PR?
Change the topology to any, so any topology has the device support LD can run the test


#### How did you do it?
change pytest.mark.topology('bmc') to pytest.mark.topology('any')

#### How did you verify/test it?
Run api/test_liquid_cooling_leakage.py 

#### Any platform specific information?
Device supporting LD

#### Supported testbed topology if it's a new test case?

### Documentation
N/A
