### PR TITLE
[redfish]: Read switch host CPU state via the platform API

### DIFF
--- a/tests/redfish/test_redfish_computer_reset.py
+++ b/tests/redfish/test_redfish_computer_reset.py
@@ -8,6 +8,11 @@ import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.platform_api import chassis, module as module_api
+from tests.common.platform.device_utils import (  # noqa: F401
+    platform_api_conn,
+    start_platform_api_service
+)
 from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
@@ -25,48 +30,88 @@ POLL_INTERVAL = 5         # seconds between CPU-state polls
 POWER_CYCLE_OFF_TIMEOUT = 30
 POWER_CYCLE_OFF_POLL = 1
 
-CPU_STATUS_CMD = "sudo switch_cpu_utils.sh status"
+SWITCH_HOST_MODULE_NAME = "SWITCH-HOST"
+MODULE_STATUS_ONLINE = "Online"
+MODULE_STATUS_OFFLINE = "Offline"
 
 
-def _cpu_running(bmc_exec):
-    """Return True iff the x86 host CPU is OUT OF RESET (running).
+@pytest.fixture(scope="function")
+def cpu_running(platform_api_conn):  # noqa: F811
+    """Return a callable reporting whether the x86 host CPU is out of reset.
 
-    Trusts the BMC-side switch_cpu_utils.sh output (which reads the hardware
-    reset pin).
+    Reads the hardware reset pin through the SWITCH-HOST module's
+    get_oper_status(), which is independent of the Redfish path under test.
     """
-    stdout, _, _ = bmc_exec(CPU_STATUS_CMD)
-    return "OUT OF RESET" in stdout
+    sw_idx = chassis.get_module_index(platform_api_conn, SWITCH_HOST_MODULE_NAME)
+    # The RPC layer returns None when the platform raises NotImplementedError,
+    # which is a different condition from the module genuinely being absent.
+    if sw_idx is None:
+        pytest.skip("Chassis does not implement get_module_index()")
+    if sw_idx < 0:
+        pytest.skip("Device does not expose a {} module".format(SWITCH_HOST_MODULE_NAME))
+
+    def _cpu_running():
+        status = module_api.get_oper_status(platform_api_conn, sw_idx)
+        normalized = status.lower() if isinstance(status, str) else status
+        if normalized == MODULE_STATUS_ONLINE.lower():
+            return True
+        if normalized == MODULE_STATUS_OFFLINE.lower():
+            return False
+        # Reading the reset register requires root, which the platform API server
+        # has. Anything other than Online/Offline here is a genuine read failure,
+        # not a privilege problem, so surface it instead of reporting "in reset".
+        pytest_assert(
+            False,
+            "SWITCH-HOST oper status is {!r}, expected {} or {}: the BMC failed to "
+            "read the switch host CPU reset register".format(
+                status, MODULE_STATUS_ONLINE, MODULE_STATUS_OFFLINE),
+        )
+
+    return _cpu_running
 
 
-def _cpu_state_matches(bmc_exec, want_running):
+def _cpu_running_or_unknown(cpu_running):
+    """Non-raising variant for teardown: an unreadable state counts as not-running.
+
+    pytest_assert raises pytest.fail.Exception, which derives from BaseException,
+    so it is caught explicitly alongside Exception (same as wait_until does).
+    """
+    try:
+        return cpu_running()
+    except (Exception, pytest.fail.Exception) as e:
+        logger.error("Could not read x86 CPU state: %s", e)
+        return False
+
+
+def _cpu_state_matches(cpu_running, want_running):
     """wait_until predicate: True iff the CPU running state matches want_running."""
-    running = _cpu_running(bmc_exec)
+    running = cpu_running()
     logger.info("CPU running=%s (waiting for running=%s)", running, want_running)
     return running == want_running
 
 
-def _ensure_system_on(redfish_client, bmc_exec):
+def _ensure_system_on(redfish_client, cpu_running):
     """Power on the x86 CPU if it is not currently running."""
-    if _cpu_running(bmc_exec):
+    if cpu_running():
         return
     logger.info("CPU is in reset, sending ResetType=On to restore")
     redfish_client.post(RESET_PATH, json={"ResetType": "On"})
     pytest_assert(
         wait_until(POWER_ON_TIMEOUT, POLL_INTERVAL, 0,
-                   _cpu_state_matches, bmc_exec, True),
+                   _cpu_state_matches, cpu_running, True),
         "x86 CPU did not come out of reset within {}s".format(POWER_ON_TIMEOUT),
     )
 
 
-def _ensure_system_in_reset(redfish_client, bmc_exec):
+def _ensure_system_in_reset(redfish_client, cpu_running):
     """Hold the x86 CPU in reset if it is currently running."""
-    if not _cpu_running(bmc_exec):
+    if not cpu_running():
         return
     logger.info("CPU is running, sending ResetType=GracefulShutdown to enter reset")
     redfish_client.post(RESET_PATH, json={"ResetType": "GracefulShutdown"})
     pytest_assert(
         wait_until(POWER_OFF_TIMEOUT, POLL_INTERVAL, 0,
-                   _cpu_state_matches, bmc_exec, False),
+                   _cpu_state_matches, cpu_running, False),
         "x86 CPU did not enter reset within {}s".format(POWER_OFF_TIMEOUT),
     )
 
@@ -74,7 +119,7 @@ def _ensure_system_in_reset(redfish_client, bmc_exec):
 class TestRedfishComputerReset:
 
     @pytest.fixture(autouse=True)
-    def _restore_cpu_on(self, redfish_client, bmc_exec):
+    def _restore_cpu_on(self, redfish_client, cpu_running):
         """Best-effort finalizer: never leave the x86 CPU held in reset.
 
         GracefulShutdown / PowerCycle power the CPU off and restore it before
@@ -84,22 +129,22 @@ class TestRedfishComputerReset:
         logging instead of asserting so it never masks the test's own failure.
         """
         yield
-        if _cpu_running(bmc_exec):
+        if _cpu_running_or_unknown(cpu_running):
             return
-        logger.warning("CPU left in reset after test; restoring with ResetType=On")
+        logger.warning("CPU left in reset (or unreadable) after test; restoring with ResetType=On")
         redfish_client.post(RESET_PATH, json={"ResetType": "On"})
         if not wait_until(POWER_ON_TIMEOUT, POLL_INTERVAL, 0,
-                          _cpu_state_matches, bmc_exec, True):
+                          _cpu_state_matches, cpu_running, True):
             logger.error("Failed to restore x86 CPU to running state in teardown")
 
-    def test_reset_on_when_already_on(self, redfish_client, bmc_exec):
+    def test_reset_on_when_already_on(self, redfish_client, cpu_running):
         """
         ResetType=On when the CPU is already running is a no-op.
 
         Brings the CPU to a running state first, then POST ResetType=On and
         verify the BMC accepts the request and the CPU stays running.
         """
-        _ensure_system_on(redfish_client, bmc_exec)
+        _ensure_system_on(redfish_client, cpu_running)
 
         response = redfish_client.post(RESET_PATH, json={"ResetType": "On"})
         logger.info("POST {} ResetType=On -> {}".format(RESET_PATH, response.status_code))
@@ -110,18 +155,18 @@ class TestRedfishComputerReset:
         )
 
         pytest_assert(
-            _cpu_running(bmc_exec),
+            cpu_running(),
             "x86 CPU should remain running after ResetType=On from a running state"
         )
 
-    def test_reset_on_when_in_reset(self, redfish_client, bmc_exec):
+    def test_reset_on_when_in_reset(self, redfish_client, cpu_running):
         """
         ResetType=On brings the CPU out of reset.
 
         Holds the CPU in reset first, then POST ResetType=On and verify the
         CPU transitions to OUT OF RESET (running).
         """
-        _ensure_system_in_reset(redfish_client, bmc_exec)
+        _ensure_system_in_reset(redfish_client, cpu_running)
 
         response = redfish_client.post(RESET_PATH, json={"ResetType": "On"})
         logger.info("POST {} ResetType=On -> {}".format(RESET_PATH, response.status_code))
@@ -132,18 +177,18 @@ class TestRedfishComputerReset:
         )
 
         reached = wait_until(POWER_ON_TIMEOUT, POLL_INTERVAL, 0,
-                             _cpu_state_matches, bmc_exec, True)
+                             _cpu_state_matches, cpu_running, True)
         pytest_assert(reached, "x86 CPU did not come out of reset within {}s".format(
             POWER_ON_TIMEOUT))
 
-    def test_reset_graceful_shutdown(self, redfish_client, bmc_exec):
+    def test_reset_graceful_shutdown(self, redfish_client, cpu_running):
         """
         Reset with valid ResetType "GracefulShutdown".
 
         Verifies the x86 CPU is held in reset after graceful shutdown, then
         restores it to running.
         """
-        _ensure_system_on(redfish_client, bmc_exec)
+        _ensure_system_on(redfish_client, cpu_running)
 
         response = redfish_client.post(RESET_PATH, json={"ResetType": "GracefulShutdown"})
         logger.info("POST {} ResetType=GracefulShutdown -> {}".format(
@@ -155,13 +200,13 @@ class TestRedfishComputerReset:
         )
 
         reached = wait_until(POWER_OFF_TIMEOUT, POLL_INTERVAL, 0,
-                             _cpu_state_matches, bmc_exec, False)
+                             _cpu_state_matches, cpu_running, False)
         pytest_assert(reached, "x86 CPU was not held in reset within {}s".format(
             POWER_OFF_TIMEOUT))
 
-        _ensure_system_on(redfish_client, bmc_exec)
+        _ensure_system_on(redfish_client, cpu_running)
 
-    def test_reset_power_cycle(self, redfish_client, bmc_exec):
+    def test_reset_power_cycle(self, redfish_client, cpu_running):
         """
         Reset with valid ResetType "PowerCycle".
 
@@ -169,7 +214,7 @@ class TestRedfishComputerReset:
         the test cannot pass trivially if the BMC silently no-ops the API and
         leaves the CPU running the whole time.
         """
-        _ensure_system_on(redfish_client, bmc_exec)
+        _ensure_system_on(redfish_client, cpu_running)
 
         response = redfish_client.post(RESET_PATH, json={"ResetType": "PowerCycle"})
         logger.info("POST {} ResetType=PowerCycle -> {}".format(RESET_PATH, response.status_code))
@@ -182,7 +227,7 @@ class TestRedfishComputerReset:
         # First observe the off-transition. The off-window is brief (~1-2s),
         # so poll faster than POLL_INTERVAL to avoid missing it.
         entered_reset = wait_until(POWER_CYCLE_OFF_TIMEOUT, POWER_CYCLE_OFF_POLL, 0,
-                                   _cpu_state_matches, bmc_exec, False)
+                                   _cpu_state_matches, cpu_running, False)
         pytest_assert(
             entered_reset,
             "x86 CPU did not enter reset after PowerCycle within {}s — "
@@ -191,7 +236,7 @@ class TestRedfishComputerReset:
 
         # Then wait for it to come back out.
         reached = wait_until(POWER_ON_TIMEOUT, POLL_INTERVAL, 0,
-                             _cpu_state_matches, bmc_exec, True)
+                             _cpu_state_matches, cpu_running, True)
         pytest_assert(reached,
                       "x86 CPU did not return to OUT OF RESET after PowerCycle within {}s".format(
                           POWER_ON_TIMEOUT))

--- a/tests/redfish/test_redfish_computer_reset.py
+++ b/tests/redfish/test_redfish_computer_reset.py
@@ -60,12 +60,10 @@ def cpu_running(platform_api_conn):  # noqa: F811
         # Reading the reset register requires root, which the platform API server
         # has. Anything other than Online/Offline here is a genuine read failure,
         # not a privilege problem, so surface it instead of reporting "in reset".
-        pytest_assert(
-            False,
+        raise AssertionError(
             "SWITCH-HOST oper status is {!r}, expected {} or {}: the BMC failed to "
             "read the switch host CPU reset register".format(
-                status, MODULE_STATUS_ONLINE, MODULE_STATUS_OFFLINE),
-        )
+                status, MODULE_STATUS_ONLINE, MODULE_STATUS_OFFLINE))
 
     return _cpu_running
 
@@ -73,8 +71,8 @@ def cpu_running(platform_api_conn):  # noqa: F811
 def _cpu_running_or_unknown(cpu_running):
     """Non-raising variant for teardown: an unreadable state counts as not-running.
 
-    pytest_assert raises pytest.fail.Exception, which derives from BaseException,
-    so it is caught explicitly alongside Exception (same as wait_until does).
+    pytest.fail.Exception derives from BaseException rather than Exception, so it
+    is caught explicitly alongside it (same as wait_until does).
     """
     try:
         return cpu_running()


### PR DESCRIPTION
### Description of PR

Summary:
`tests/redfish/test_redfish_computer_reset.py` used `sudo switch_cpu_utils.sh status` on the BMC as its independent oracle for the x86 host CPU reset pin, and decided the CPU state by grepping `"OUT OF RESET"` out of that script's stdout. That script is being removed from sonic-buildimage, so this test moves to the platform API.

Depends on / pairs with: https://github.com/sonic-net/sonic-buildimage/pull/28498

**This PR should merge before that one.** The platform API path works against both current and post-removal images, so there is no window where the test is broken. Merging the buildimage PR first would break this test until this lands.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A — no backport requested.
Failure type: other

### Tested branch

- [x] master

### Test result
Tested on nexthop platform, the testcases are passing.

### Approach

#### What is the motivation for this PR?

`switch_cpu_utils.sh` is a shell wrapper around a heredoc'd Python snippet that calls the `SwitchHostModule` platform API. It has no live programmatic consumer on the BMC, and its per-vendor copies had diverged in both command set and status wording, so sonic-buildimage is removing it. This test was its only real caller.

Grepping a phrase out of a shell script's stdout was also fragile in its own right: the script printed different wording per vendor, and it exited `0` on every status including `Fault`, so a failed register read was indistinguishable from "CPU is in reset".

#### How did you do it?

Added a `cpu_running` fixture that resolves the SWITCH-HOST module over `platform_api_conn` and returns a callable reading `module_api.get_oper_status()`:

- The module is resolved with `chassis.get_module_index('SWITCH-HOST')`, the same call `sonic-utilities` uses to read module oper status on a BMC. A `None` result (platform raised `NotImplementedError`) is reported separately from a negative index (module genuinely absent), so a skip says which happened.
- The status is treated as three-valued. Reading the reset register requires root, which the platform API server running under supervisord in pmon has, so anything other than `Online`/`Offline` is a genuine read failure and fails with a message naming the cause, rather than being collapsed into "CPU is in reset".
- Helpers still take a single callable, so call sites change only from `_cpu_running(bmc_exec)` to `cpu_running()`. `_restore_cpu_on` is documented never to raise, so it goes through a non-raising wrapper that treats an unreadable state as not-running and still attempts the restore.


#### How did you verify/test it?

Ran the full module on a BMC testbed against real hardware - 5/5 passed

#### Any platform specific information?

Applies to BMC platforms that model the switch host as a `ModuleBase` module named `SWITCH-HOST`, per the SONiC BMC pmon design. Platforms without it skip.

#### Supported testbed topology if it's a new test case?

Not a new test case. Existing `topology('bmc')` module; verified on `bmc-shared-mgmt`.

### Documentation

No documentation change. This swaps the internal mechanism the test uses to read CPU state; test coverage and behaviour are unchanged.
