### PR TITLE
Fix background RX_OK issue with new PFC counter test

### DIFF
--- a/tests/common/helpers/pfc_counters.py
+++ b/tests/common/helpers/pfc_counters.py
@@ -9,6 +9,7 @@ counter verification without cross-feature imports.
 from tests.common.platform.device_utils import eos_to_linux_intf, nxos_to_linux_intf, sonic_to_linux_intf
 from tests.common.helpers.drop_counters.drop_counters import GET_L2_COUNTERS, get_pkt_drops
 import os
+import random
 import time
 import pytest
 import logging
@@ -308,12 +309,12 @@ def run_rx_ok_isolation_test(fanouthosts, duthost, conn_graph_facts,       # noq
               counted as normal RX packets (RX_OK) or RX drops (RX_DRP) on the
               DUT interfaces.
 
-              Each active physical interface is exercised one at a time: a
-              baseline snapshot is taken, a burst of PFC frames is sent across
-              all priorities to that port, then the port's counters are read
-              back. The per-port measurement window keeps the RX_OK/RX_DRP
-              deltas within `margin` instead of accumulating background traffic
-              across the whole port scan.
+              A single active physical interface is chosen at random and
+              exercised: a baseline snapshot is taken, a burst of PFC frames is
+              sent across all priorities to that port, then the port's counters
+              are read back. The narrow measurement window keeps the
+              RX_OK/RX_DRP deltas within `margin` instead of accumulating
+              background traffic across a full port scan.
     @param duthost: The object for interacting with DUT through ansible
     @param conn_graph_facts: Testbed topology connectivity information
     @param leaf_fanouts: Leaf fanout switches
@@ -347,43 +348,43 @@ def run_rx_ok_isolation_test(fanouthosts, duthost, conn_graph_facts,       # noq
             "topology and fanout connectivity."
         )
 
-    """ Send frames and read back one port at a time so background traffic
-        cannot accumulate across the whole port scan """
-    failures = []
-    for intf in active_phy_intfs:
-        peer_device = conn_facts[intf]['peerdevice']
-        peer_port = conn_facts[intf]['peerport']
-        peerdev_ans = fanouthosts[peer_device]
-        peer_port_name, fanout_hwsku = _resolve_peer_port_name(
-            peerdev_ans, enum_fanout_graph_facts, peer_port)
+    """ Exercise a single randomly-chosen port so background traffic cannot
+        accumulate across a full port scan """
+    intf = random.choice(active_phy_intfs)
+    peer_device = conn_facts[intf]['peerdevice']
+    peer_port = conn_facts[intf]['peerport']
+    peerdev_ans = fanouthosts[peer_device]
+    peer_port_name, fanout_hwsku = _resolve_peer_port_name(
+        peerdev_ans, enum_fanout_graph_facts, peer_port)
+    logger.info(
+        "Selected interface %s (peer %s port %s) out of %d candidate(s) for "
+        "PFC RX_OK isolation test", intf, peer_device, peer_port, len(active_phy_intfs))
 
-        """ Baseline for this port immediately before sending """
-        baseline = get_rx_port_counters(duthost)
+    """ Baseline for this port immediately before sending """
+    baseline = get_rx_port_counters(duthost)
 
-        for priority in range(PRIO_COUNT):
-            send_pfc_frame(peerdev_ans, peer_port_name, fanout_hwsku,
-                           priority, pause_time, pkt_count)
+    for priority in range(PRIO_COUNT):
+        send_pfc_frame(peerdev_ans, peer_port_name, fanout_hwsku,
+                       priority, pause_time, pkt_count)
 
-        """ SONiC takes some time to update counters in database """
-        time.sleep(5)
-        after = get_rx_port_counters(duthost)
+    """ SONiC takes some time to update counters in database """
+    time.sleep(5)
+    after = get_rx_port_counters(duthost)
 
-        if intf not in baseline or intf not in after:
-            logger.warning(
-                "Interface %s missing from the %s counter snapshot; skipping its "
-                "RX_OK/RX_DRP validation", intf,
-                "baseline" if intf not in baseline else "post-send")
-            continue
-        rx_ok_delta = after[intf]['RX_OK'] - baseline[intf]['RX_OK']
-        rx_drp_delta = after[intf]['RX_DRP'] - baseline[intf]['RX_DRP']
-        if rx_ok_delta > margin or rx_drp_delta > margin:
-            failures.append((intf, rx_ok_delta, rx_drp_delta))
-            logger.error(
-                "Interface %s: RX_OK increased by %d, RX_DRP increased by %d "
-                "(allowed margin %d) after receiving %d PFC frames per priority",
-                intf, rx_ok_delta, rx_drp_delta, margin, pkt_count)
+    assert intf in baseline and intf in after, (
+        "Interface {} missing from the {} counter snapshot; cannot validate "
+        "its RX_OK/RX_DRP counters"
+    ).format(intf, "baseline" if intf not in baseline else "post-send")
 
-    assert len(failures) == 0, (
+    rx_ok_delta = after[intf]['RX_OK'] - baseline[intf]['RX_OK']
+    rx_drp_delta = after[intf]['RX_DRP'] - baseline[intf]['RX_DRP']
+    if rx_ok_delta > margin or rx_drp_delta > margin:
+        logger.error(
+            "Interface %s: RX_OK increased by %d, RX_DRP increased by %d "
+            "(allowed margin %d) after receiving %d PFC frames per priority",
+            intf, rx_ok_delta, rx_drp_delta, margin, pkt_count)
+
+    assert rx_ok_delta <= margin and rx_drp_delta <= margin, (
         "PFC frames were counted as RX_OK or RX_DRP beyond the allowed margin of {} "
-        "on the following interfaces [(intf, rx_ok_delta, rx_drp_delta)]: {}"
-    ).format(margin, failures)
+        "on interface {} (rx_ok_delta={}, rx_drp_delta={})"
+    ).format(margin, intf, rx_ok_delta, rx_drp_delta)

--- a/tests/common/helpers/pfc_counters.py
+++ b/tests/common/helpers/pfc_counters.py
@@ -308,11 +308,12 @@ def run_rx_ok_isolation_test(fanouthosts, duthost, conn_graph_facts,       # noq
               counted as normal RX packets (RX_OK) or RX drops (RX_DRP) on the
               DUT interfaces.
 
-              A large burst of PFC frames is sent across all priorities to every
-              active physical interface first; only then is a single counter
-              snapshot compared against the baseline (one stats retrieval pass).
-              The RX_OK and RX_DRP deltas must each stay within `margin` to
-              tolerate background control-plane traffic.
+              Each active physical interface is exercised one at a time: a
+              baseline snapshot is taken, a burst of PFC frames is sent across
+              all priorities to that port, then the port's counters are read
+              back. The per-port measurement window keeps the RX_OK/RX_DRP
+              deltas within `margin` instead of accumulating background traffic
+              across the whole port scan.
     @param duthost: The object for interacting with DUT through ansible
     @param conn_graph_facts: Testbed topology connectivity information
     @param leaf_fanouts: Leaf fanout switches
@@ -329,49 +330,44 @@ def run_rx_ok_isolation_test(fanouthosts, duthost, conn_graph_facts,       # noq
 
     conn_facts = conn_graph_facts['device_conn'].get(duthost.hostname, {})
     int_status = asic.show_interface(command="status")['ansible_facts']['int_status']
-    """ We only test active physical interfaces that have connection graph entries """
+    """ We only test active physical interfaces that have connection graph entries
+        and a reachable fanout """
     active_phy_intfs = [intf for intf in int_status if
                         intf.startswith('Ethernet') and
                         int_status[intf]['admin_state'] == 'up' and
                         int_status[intf]['oper_state'] == 'up' and
-                        intf in conn_facts]
+                        intf in conn_facts and
+                        conn_facts[intf]['peerdevice'] in fanouthosts]
 
-    """ Baseline RX counters for all ports in a single retrieval """
-    baseline = get_rx_port_counters(duthost)
+    """ Skip if nothing exercisable was found """
+    if len(active_phy_intfs) == 0:
+        pytest.skip(
+            "No active physical interfaces with a reachable fanout were exercised, so "
+            "PFC RX counter isolation could not be validated. Check the testbed "
+            "topology and fanout connectivity."
+        )
 
-    """ Send all PFC frames first, across all priorities and all ports """
-    tested_intfs = []
+    """ Send frames and read back one port at a time so background traffic
+        cannot accumulate across the whole port scan """
+    failures = []
     for intf in active_phy_intfs:
         peer_device = conn_facts[intf]['peerdevice']
         peer_port = conn_facts[intf]['peerport']
-
-        if peer_device not in fanouthosts:
-            continue
-
         peerdev_ans = fanouthosts[peer_device]
         peer_port_name, fanout_hwsku = _resolve_peer_port_name(
             peerdev_ans, enum_fanout_graph_facts, peer_port)
+
+        """ Baseline for this port immediately before sending """
+        baseline = get_rx_port_counters(duthost)
+
         for priority in range(PRIO_COUNT):
             send_pfc_frame(peerdev_ans, peer_port_name, fanout_hwsku,
                            priority, pause_time, pkt_count)
-        tested_intfs.append(intf)
 
-    """ Guard against an empty run masquerading as a pass """
-    assert len(tested_intfs) > 0, (
-        "No active physical interfaces with a reachable fanout were exercised, so "
-        "PFC RX counter isolation could not be validated. Check the testbed "
-        "topology and fanout connectivity."
-    )
+        """ SONiC takes some time to update counters in database """
+        time.sleep(5)
+        after = get_rx_port_counters(duthost)
 
-    """ SONiC takes some time to update counters in database """
-    time.sleep(5)
-
-    """ Validate RX counters in one single retrieval swoop """
-    after = get_rx_port_counters(duthost)
-
-    """ Validate every active interface, not only the ones we sent frames to """
-    failures = []
-    for intf in active_phy_intfs:
         if intf not in baseline or intf not in after:
             logger.warning(
                 "Interface %s missing from the %s counter snapshot; skipping its "


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #26831

Some devices have large amounts of background traffic on a large port scale. The PFC frame injection takes a long time to perform, causing background traffic to accumulate. 
Fix by instead selecting a random port to test. 

Performance comparison for Cisco-8223 device with 28 ports active:
- Original version (loop on all ports but read once): 133s
- With a single loop across all ports clearing each time: 322s
- Possible 8-threaded implementation: 87s
- Randomly selecting a port: 60 s

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

master: 961442ae225c48ff527121eca42d2c910b647a57- `Results (60.57s (0:01:00)):     1 passed`

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

Cisco-8223 testing. 
Likely appropriate to validate on Mellanox platform, per attached bug report. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
