### PR TITLE
Add support for 'uma' and 'lma' topology types in announce routes

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -635,13 +635,9 @@ def fib_lma(topo, ptf_ip, action="announce", topo_routes=None):
     common_config = topo['configuration_properties'].get('common', {})
     nhipv4 = common_config.get("nhipv4", NHIPV4)
     nhipv6 = common_config.get("nhipv6", NHIPV6)
-
-    vms = topo['topology']['VMs']
     vms_config = topo['configuration']
-
     for k, v in vms_config.items():
         port, port6 = get_change_routes_ports(k, topo)
-
         routes_v4 = []
         routes_v6 = []
         # The upstream UpperMgmtAggregator (UMA) neighbors originate the default
@@ -650,7 +646,6 @@ def fib_lma(topo, ptf_ip, action="announce", topo_routes=None):
         if "core" in v["properties"]:
             routes_v4 = [("0.0.0.0/0", nhipv4, None)]
             routes_v6 = [("::/0", nhipv6, None)]
-
         topo_routes[k] = {}
         topo_routes[k][IPV4] = routes_v4
         topo_routes[k][IPV6] = routes_v6
@@ -663,13 +658,9 @@ def fib_uma(topo, ptf_ip, action="announce", topo_routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     nhipv4 = common_config.get("nhipv4", NHIPV4)
     nhipv6 = common_config.get("nhipv6", NHIPV6)
-
-    vms = topo['topology']['VMs']
     vms_config = topo['configuration']
-
     for k, v in vms_config.items():
         port, port6 = get_change_routes_ports(k, topo)
-
         routes_v4 = []
         routes_v6 = []
         # The upstream RegionalWANAggregator (RWA) neighbors originate the default
@@ -678,7 +669,6 @@ def fib_uma(topo, ptf_ip, action="announce", topo_routes={}):
         if "core" in v["properties"]:
             routes_v4 = [("0.0.0.0/0", nhipv4, None)]
             routes_v6 = [("::/0", nhipv6, None)]
-
         topo_routes[k] = {}
         topo_routes[k][IPV4] = routes_v4
         topo_routes[k][IPV6] = routes_v6

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -161,7 +161,7 @@ def get_change_routes_ports(vm, topo):
 
 def get_topo_type(topo_name):
     pattern = re.compile(
-        r'^(t0-mclag|t0|t1|ptf|fullmesh|dualtor|t2|mgmttor|m0|mc0|mx|m1|c0|dpu|smartswitch-t1|lt2|ft2|lrh|urh)')
+        r'^(t0-mclag|t0|t1|ptf|fullmesh|dualtor|t2|mgmttor|m0|mc0|mx|m1|c0|dpu|smartswitch-t1|lt2|ft2|lrh|urh|uma|lma)')
     match = pattern.match(topo_name)
     if not match:
         return "unsupported"
@@ -629,6 +629,62 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
         next_group_index = (index + 1) * upstream_neighbor_groups // vms_len
         if group_index != next_group_index:
             current_routes_offset += last_suffix
+
+
+def fib_lma(topo, ptf_ip, action="announce", topo_routes=None):
+    common_config = topo['configuration_properties'].get('common', {})
+    nhipv4 = common_config.get("nhipv4", NHIPV4)
+    nhipv6 = common_config.get("nhipv6", NHIPV6)
+
+    vms = topo['topology']['VMs']
+    vms_config = topo['configuration']
+
+    for k, v in vms_config.items():
+        port, port6 = get_change_routes_ports(k, topo)
+
+        routes_v4 = []
+        routes_v6 = []
+        # The upstream UpperMgmtAggregator (UMA) neighbors originate the default
+        # route toward the LowerMgmtAggregator DUT. Downstream leaf(M2/M3)
+        # neighbors advertise only their own loopbacks via their own BGP.
+        if "core" in v["properties"]:
+            routes_v4 = [("0.0.0.0/0", nhipv4, None)]
+            routes_v6 = [("::/0", nhipv6, None)]
+
+        topo_routes[k] = {}
+        topo_routes[k][IPV4] = routes_v4
+        topo_routes[k][IPV6] = routes_v6
+        if action != GENERATE_WITHOUT_APPLY:
+            change_routes(action, ptf_ip, port, routes_v4)
+            change_routes(action, ptf_ip, port6, routes_v6)
+
+
+def fib_uma(topo, ptf_ip, action="announce", topo_routes={}):
+    common_config = topo['configuration_properties'].get('common', {})
+    nhipv4 = common_config.get("nhipv4", NHIPV4)
+    nhipv6 = common_config.get("nhipv6", NHIPV6)
+
+    vms = topo['topology']['VMs']
+    vms_config = topo['configuration']
+
+    for k, v in vms_config.items():
+        port, port6 = get_change_routes_ports(k, topo)
+
+        routes_v4 = []
+        routes_v6 = []
+        # The upstream RegionalWANAggregator (RWA) neighbors originate the default
+        # route toward the UpperMgmtAggregator DUT. Downstream leaf (LMA/M1)
+        # neighbors advertise only their own loopbacks via their own BGP.
+        if "core" in v["properties"]:
+            routes_v4 = [("0.0.0.0/0", nhipv4, None)]
+            routes_v6 = [("::/0", nhipv6, None)]
+
+        topo_routes[k] = {}
+        topo_routes[k][IPV4] = routes_v4
+        topo_routes[k][IPV6] = routes_v6
+        if action != GENERATE_WITHOUT_APPLY:
+            change_routes(action, ptf_ip, port, routes_v4)
+            change_routes(action, ptf_ip, port6, routes_v6)
 
 
 def is_backend_neighbor(properties):
@@ -1910,6 +1966,12 @@ def main():
         elif topo_type == "ft2":
             fib_ft2_routes(topo, ptf_ip, action=action, topo_routes=topo_routes)
             module.exit_json(change=True, topo_routes=convert_routes_to_str(topo_routes))
+        elif topo_type == "lma":
+            fib_lma(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(changed=True, topo_routes=convert_routes_to_str(topo_routes))
+        elif topo_type == "uma":
+            fib_uma(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(changed=True, topo_routes=convert_routes_to_str(topo_routes))
         else:
             module.exit_json(
                 msg='Unsupported topology "{}" - skipping announcing routes'.format(topo_name))


### PR DESCRIPTION
This pull request adds support for two new topology types, `lma` (LowerMgmtAggregator) and `uma` (UpperMgmtAggregator), to the `announce_routes.py` script. It introduces dedicated route announcement logic for these topologies and updates the main execution path to handle them.

**Support for new topology types:**

* Updated the topology type detection in `get_topo_type` to recognize `lma` and `uma` as supported types.

**Route announcement logic:**

* Added new functions `fib_lma` and `fib_uma` to define how default routes are announced for the `lma` and `uma` topologies, respectively. These functions handle both IPv4 and IPv6 default route announcements based on VM properties.

**Main execution flow:**

* Updated the `main` function to call the new `fib_lma` and `fib_uma` functions when the topology type is `lma` or `uma`, ensuring correct route announcement and result reporting for these cases.<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
