### PR TITLE
[macsec] suppress expected 'Reject distributed SAK' loganalyzer error in dirty-restart tests

### DIFF
--- a/tests/macsec/test_macsec_recovery.py
+++ b/tests/macsec/test_macsec_recovery.py
@@ -29,6 +29,10 @@ def macsec_loganalyzer_ignore(loganalyzer, macsec_duthost):
       deletes a stale SA; the DNX platform logs this transiently.
     - 'KaY: The key server is not in my live peers list': wpa_supplicant logs
       this while MKA re-negotiates after the macsec container is killed.
+    - 'KaY: Reject distributed SAK since I'm a key server': during dirty
+      restart, the peer may briefly win KS election and distribute a SAK;
+      when the DUT comes back with its original priority it rejects the
+      incoming SAK because it is now key server again.  Transient and expected.
     - 'e1000 ... Reset adapter': KVM virtual NIC resets when the macsec
       container is SIGKILL'd; this is a VTB environment artifact.
     """
@@ -36,6 +40,7 @@ def macsec_loganalyzer_ignore(loganalyzer, macsec_duthost):
         loganalyzer[macsec_duthost.hostname].ignore_regex.extend([
             r".*SAI_API_MACSEC:brcm_sai_dnx_get_macsec_sa_attribute.*Invalid object ID.*",
             r".*macsec\d*#wpa_supplicant.*KaY: The key server is not in my live peers list.*",
+            r".*macsec\d*#wpa_supplicant.*KaY: Reject distributed SAK since I'm a key server.*",
             r".*kernel:.*e1000.*Reset adapter.*",
         ])
 


### PR DESCRIPTION
### What I did

Added `KaY: Reject distributed SAK since I'm a key server` to the `macsec_loganalyzer_ignore` autouse fixture in `test_macsec_recovery.py`.

### Why I did it

During dirty macsec container kill recovery, the peer briefly wins MKA Key Server election while the DUT is down. When the DUT respawns with its original (higher) priority it reclaims KS and rejects the peer's SAK distribution, logging:

```
ERR macsec#wpa_supplicant: KaY: Reject distributed SAK since I'm a key server
```

This is the expected and correct control-plane behavior — the DUT is asserting its KS role after restart. However, the `loganalyzer` fixture catches it as an unexpected ERR and fails the teardown even though the test body passed.

The `macsec_loganalyzer_ignore` fixture already suppresses two other expected ERR patterns from the same recovery scenario (`KaY: The key server is not in my live peers list`, DNX SAI Invalid object ID). The new entry belongs in the same list.

### How I verified it

Reproduced the teardown failure on a live testbed run of `test_dirty_container_kill_preserves_sak_consistency`. The pattern matches exactly the log line emitted by wpa_supplicant when a non-KS tries to distribute a SAK to a KS peer.

### Supported testbed topology

Existing topology (`t0`, `t2`, `t0-sonic`, `any`). No topology changes.