### PR TITLE
[bgp] Restart PTF ExaBGP after DUT reboot in bgp suppress-fib test

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -963,6 +963,21 @@ def do_and_wait_reboot(duthost, localhost, reboot_type):
         )
 
 
+def restart_ptf_exabgp(ptfhost):
+    """
+    Restart ExaBGP instances on the PTF so their BGP sessions to the DUT re-establish
+    cleanly after a DUT reboot/config reload.
+
+    A DUT config reload restarts the BGP container and tears down the ExaBGP peering.
+    ExaBGP's HTTP API stays reachable, but it may not re-advertise its routes on its own,
+    so a subsequent announce is accepted (HTTP 200) yet never reaches FRR. Restarting
+    ExaBGP mirrors sanity recovery's re_announce_routes().
+    """
+    logger.info("Restart ExaBGP on the PTF to re-establish sessions after DUT reboot/reload")
+    ptfhost.shell("supervisorctl restart exabgpv4:*", module_ignore_errors=True)
+    ptfhost.shell("supervisorctl restart exabgpv6:*", module_ignore_errors=True)
+
+
 def param_reboot(request, duthost, localhost, loganalyzer):
     """
     Read reboot_type from option bgp_suppress_fib_reboot_type
@@ -1188,7 +1203,7 @@ def upstream_verification(duthost_up, ipv4_route_list, ipv6_route_list, exabgp_p
 
 @pytest.mark.parametrize("vrf_type", VRF_TYPES)
 def test_bgp_route_with_suppress(duthosts, enum_downstream_dut_hostname, enum_upstream_dut_hostname, tbinfo, nbrhosts,
-                                 ptfadapter, localhost, restore_bgp_suppress_fib,
+                                 ptfadapter, ptfhost, localhost, restore_bgp_suppress_fib,
                                  prepare_param, vrf_type, continuous_boot_times, generate_route_and_traffic_data,
                                  request, loganalyzer):
     duthost = duthosts[enum_upstream_dut_hostname]
@@ -1232,6 +1247,19 @@ def test_bgp_route_with_suppress(duthosts, enum_downstream_dut_hostname, enum_up
                 if multi_dut:
                     param_reboot(request, duthost_up, localhost, loganalyzer)
                     logger.debug("dd")
+
+                # Restart ExaBGP on the PTF once, after all DUT reboots, so its sessions
+                # re-establish and it re-advertises routes. Then re-check every rebooted
+                # DUT's BGP neighbors before announcing, so a slower (e.g. downstream)
+                # session cannot race the HTTP announce.
+                restart_ptf_exabgp(ptfhost)
+                for reboot_duthost in [duthost_down, duthost_up] if multi_dut else [duthost_down]:
+                    bgp_neighbors = reboot_duthost.get_bgp_neighbors_per_asic(state="all")
+                    pytest_assert(
+                        wait_until(180, 10, 0, reboot_duthost.check_bgp_session_state_all_asics, bgp_neighbors),
+                        "Not all bgp sessions are established on {} after ExaBGP restart".format(
+                            reboot_duthost.hostname)
+                    )
 
             for exabgp_port, exabgp_port_v6, recv_port in zip(exabgp_port_list, exabgp_port_list_v6, recv_port_list):
                 try:


### PR DESCRIPTION
### Description of PR

Summary: Restart the PTF ExaBGP instances after a DUT reboot/reload in `test_bgp_route_with_suppress` so that routes announced after the reload actually reach FRR.

Fixes #26857

`bgp/test_bgp_suppress_fib.py::test_bgp_route_with_suppress` calls `param_reboot()`, which performs a DUT `config reload` (or cold/warm/fast reboot). That restarts the DUT BGP container and tears down the ExaBGP peering on the PTF. The test then waits only for the DUT-side BGP sessions and immediately announces routes via ExaBGP's HTTP API. ExaBGP's HTTP API stays reachable (the announce returns HTTP 200), but ExaBGP does not always re-advertise its routes after the session flap, so the announced routes never reach FRR. The subsequent queued-state check then times out with:

```
Failed: Vrf:default - route:91.0.1.0/24 is not in queued state
```

This is intermittent and shows up mainly in long/large runs (nightly/sanity), while the test passes when run standalone.

### Type of change

- [x] Bug fix

### Tested branch

- [x] master

### Test result

- Standalone `test_bgp_route_with_suppress[default]` passes on a churchill/T1 setup.
- The targeted intermittent failure could not be reproduced on demand locally; the fix is based on root-cause analysis of the observed failure and reuses the same ExaBGP recovery already performed by sanity recovery. Full-module validation is in progress.

### Approach

#### What is the motivation for this PR?
Fix an intermittent, test-harness-caused failure (not a DUT / suppress-fib defect): after a DUT BGP restart, the PTF ExaBGP peering can be left HTTP-reachable but not re-advertising, so the test's post-reload announce silently does not reach FRR.

#### How did you do it?
- Added `restart_ptf_exabgp(ptfhost)` which restarts `exabgpv4:*` and `exabgpv6:*` on the PTF (`module_ignore_errors=True`).
- In the "Do reload" step, after all DUT reboots, restart ExaBGP once, then wait for every rebooted DUT's BGP sessions to re-establish before announcing routes. Doing the restart once (rather than inside per-DUT `param_reboot`) avoids re-flapping already-recovered sessions in the multi-DUT case, and the per-DUT re-check ensures a slower (e.g. downstream) session cannot race the announce.
- This mirrors the existing sanity recovery helper `re_announce_routes()` in `tests/common/plugins/sanity_check/recover.py` (`supervisorctl restart exabgpv4:*/exabgpv6:*`).

#### How did you verify/test it?
See Test result above. The change reuses the proven ExaBGP restart recovery pattern already used by sanity recovery.

#### Any platform specific information?
None. Applies to any topology using ExaBGP-backed neighbors with `bgp suppress-fib-pending`.

### Documentation
N/A