### PR TITLE
Increase timeout for zero routes after shutting down bgp on large topos

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -302,9 +302,9 @@ def duthost_shutdown_ebgp(duthost):
     v6_routes_count = sumv6.get('ebgp', {'routes': 0})['routes']
     if v4_routes_count > 10000 or v6_routes_count > 10000:
         orch_cpu_timeout = 120
-        if len(duthost.get_admin_up_ports()) > 32:
-            # On topos with a large number of ports and routes it may take longer for routes to reach 0
-            routes_zero_timeout = 120
+        # We saw a 64-port T2 take ~90s for all bgp paths to go to zero routes.
+        # So use that as our timeout benchmark plus a buffer and take 2s per port (min 60s).
+        routes_zero_timeout = max(len(duthost.get_admin_up_ports()) * 2, routes_zero_timeout)
 
 
     # Shutdown all eBGP neighbors

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -306,7 +306,6 @@ def duthost_shutdown_ebgp(duthost):
         # So use that as our timeout benchmark plus a buffer and take 2s per port (min 60s).
         routes_zero_timeout = max(len(duthost.get_admin_up_ports()) * 2, routes_zero_timeout)
 
-
     # Shutdown all eBGP neighbors
     duthost.command("sudo config bgp shutdown all")
 

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -295,18 +295,23 @@ def duthost_shutdown_ebgp(duthost):
     orch_cpu_threshold = 10
 
     orch_cpu_timeout = 60
+    routes_zero_timeout = 60
     # Get the original number of eBGP v4 and v6 routes on the DUT.
     sumv4, sumv6 = duthost.get_ip_route_summary()
     v4_routes_count = sumv4.get('ebgp', {'routes': 0})['routes']
     v6_routes_count = sumv6.get('ebgp', {'routes': 0})['routes']
     if v4_routes_count > 10000 or v6_routes_count > 10000:
         orch_cpu_timeout = 120
+        if len(duthost.get_admin_up_ports()) > 32:
+            # On topos with a large number of ports and routes it may take longer for routes to reach 0
+            routes_zero_timeout = 120
+
 
     # Shutdown all eBGP neighbors
     duthost.command("sudo config bgp shutdown all")
 
     # Verify that the total eBGP routes are 0.
-    pt_assert(wait_until(60, 2, 5, check_ebgp_routes, 0, 0, duthost),
+    pt_assert(wait_until(routes_zero_timeout, 2, 5, check_ebgp_routes, 0, 0, duthost),
               "eBGP routes are not 0 after shutting down all neighbors on {}".format(duthost))
     pt_assert(wait_until(orch_cpu_timeout, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
               "Orch CPU utilization {} > orch cpu threshold {} after shutdown all eBGP"


### PR DESCRIPTION
### Description of PR
We've seen timeouts on large topos like `t2_single_node_max_64p_v2` where it takes slightly longer than `60s` for all the routes to be removed after shutting down bgp.

Details in: https://github.com/sonic-net/sonic-mgmt/issues/26854

Summary:
Fixes #26854 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- latest 202605 image

### Approach
#### What is the motivation for this PR?
To give the system longer to reach 0 routes on large topos

#### How did you do it?
If any topo has more than 32 ports and more than 10K V4/V6 routes we'll wait 120s instead of 60s

#### How did you verify/test it?
Saw the test pass on `t2_single_node_max_64p_v2` topo even though it took >60s for the routes to reach 0

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A