### PR TITLE
[generic_config_updater] Fix test_bgp_prefix xfail index and cover emptying a bgp prefix leaf-list

### DIFF
--- a/tests/generic_config_updater/test_bgp_prefix.py
+++ b/tests/generic_config_updater/test_bgp_prefix.py
@@ -141,22 +141,27 @@ def bgp_prefix_tc1_add_config(duthost, community, community_table, cli_namespace
 def bgp_prefix_tc1_xfail(duthost, community_table, namespace=None):
     """ Test input with invalid prefixes
     """
+    # A remove op is resolved by index, not by value, so the index decides whether the op is
+    # expected to fail. Each leaf-list holds exactly one element here, so index 1 is out of range
+    # and is what actually exercises "remove an unexisting prefix". Index 0 would remove the last
+    # element instead, which is a supported operation and is covered by
+    # bgp_prefix_tc1_remove_last_prefix.
     xfail_input = [
-        ("add", "10.256.0.0/16", PREFIXES_V6_DUMMY),        # Invalid v4 prefix
-        ("add", PREFIXES_V4_DUMMY, "fc01:xyz::/64"),        # Invalid v6 prefix
-        ("remove", PREFIXES_V4_DUMMY, PREFIXES_V6_INIT),    # Unexisted v4 prefix
-        ("remove", PREFIXES_V4_INIT, PREFIXES_V6_DUMMY)     # Unexisted v6 prefix
+        ("add", 0, "10.256.0.0/16", PREFIXES_V6_DUMMY),        # Invalid v4 prefix
+        ("add", 0, PREFIXES_V4_DUMMY, "fc01:xyz::/64"),        # Invalid v6 prefix
+        ("remove", 1, PREFIXES_V4_DUMMY, PREFIXES_V6_INIT),    # Unexisted v4 prefix
+        ("remove", 1, PREFIXES_V4_INIT, PREFIXES_V6_DUMMY)     # Unexisted v6 prefix
     ]
-    for op, prefixes_v4, prefixes_v6 in xfail_input:
+    for op, index, prefixes_v4, prefixes_v6 in xfail_input:
         json_patch = [
             {
                 "op": op,
-                "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0{}/prefixes_v6/0".format(community_table),
+                "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0{}/prefixes_v6/{}".format(community_table, index),
                 "value": prefixes_v6
             },
             {
                 "op": op,
-                "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0{}/prefixes_v4/0".format(community_table),
+                "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0{}/prefixes_v4/{}".format(community_table, index),
                 "value": prefixes_v4
             }
         ]
@@ -229,6 +234,110 @@ def bgp_prefix_tc1_replace(duthost, community, community_table, cli_namespace_pr
         delete_tmpfile(duthost, tmpfile)
 
 
+def get_bgp_prefix_config_db_entry(duthost, community_table, cli_namespace_prefix):
+    """ Get the CONFIG_DB entry backing the bgp prefix config
+    """
+    cmds = 'sonic-db-cli {} CONFIG_DB hgetall "BGP_ALLOWED_PREFIXES|DEPLOYMENT_ID|0{}"'.format(
+        cli_namespace_prefix, community_table)
+    output = duthost.shell(cmds)
+    pytest_assert(not output['rc'], "'{}' failed with rc={}".format(cmds, output['rc']))
+    return output['stdout']
+
+
+def check_bgp_prefix_v4_withdrawn_v6_intact(duthost, community, cli_namespace_prefix):
+    """ Check the v4 prefix is withdrawn from FRR while the v6 prefix in the same entry survives
+
+    Both halves are matched against a single snapshot of the running config. The v6 half matters
+    because an invalid empty value left in prefixes_v4 makes bgpcfgd reject the whole
+    BGP_ALLOWED_PREFIXES entry, taking a valid prefixes_v6 down with it. Checking only that v4 is
+    gone would pass in exactly that case.
+    """
+    bgp_config = show_bgp_running_config(duthost, cli_namespace_prefix)
+    return (not re.search(PREFIXES_V4_RE.format(community, PREFIXES_V4_DUMMY), bgp_config) and
+            bool(re.search(PREFIXES_V6_RE.format(community, PREFIXES_V6_DUMMY), bgp_config)))
+
+
+def check_bgp_prefix_v4_programmed(duthost, community, cli_namespace_prefix):
+    """ Check the v4 prefix is programmed into FRR alongside the v6 prefix in the same entry
+    """
+    bgp_config = show_bgp_running_config(duthost, cli_namespace_prefix)
+    return (bool(re.search(PREFIXES_V4_RE.format(community, PREFIXES_V4_DUMMY), bgp_config)) and
+            bool(re.search(PREFIXES_V6_RE.format(community, PREFIXES_V6_DUMMY), bgp_config)))
+
+
+def bgp_prefix_tc1_remove_last_prefix(duthost, community, community_table, cli_namespace_prefix, namespace=None):
+    """ Test to remove the last element of a prefix leaf-list
+
+    CONFIG_DB cannot represent an empty leaf-list, so emptying prefixes_v4 has to drop the field
+    altogether. Leaving an empty value behind makes the entry read back as a list holding one empty
+    string, which corrupts the entry and blocks any later update of the same field.
+    See sonic-net/sonic-buildimage#27818.
+    """
+    json_patch = [
+        {
+            "op": "remove",
+            "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0{}/prefixes_v4/0".format(community_table)
+        }
+    ]
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
+
+    tmpfile = generate_tmpfile(duthost)
+    logger.info("tmpfile {}".format(tmpfile))
+
+    try:
+        output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+        expect_op_success(duthost, output)
+
+        config_db_entry = get_bgp_prefix_config_db_entry(duthost, community_table, cli_namespace_prefix)
+        pytest_assert("prefixes_v4" not in config_db_entry,
+                      "Emptied prefixes_v4 was not removed from CONFIG_DB: {}".format(config_db_entry))
+        pytest_assert(PREFIXES_V6_DUMMY in config_db_entry,
+                      "prefixes_v6 was not left untouched in CONFIG_DB: {}".format(config_db_entry))
+
+        pytest_assert(wait_until(60, 5, 0, check_bgp_prefix_v4_withdrawn_v6_intact, duthost, community,
+                                 cli_namespace_prefix),
+                      "BGP prefix v4 not withdrawn, or v6 in the same entry was dropped with it")
+
+    finally:
+        delete_tmpfile(duthost, tmpfile)
+
+
+def bgp_prefix_tc1_readd_prefix(duthost, community, community_table, cli_namespace_prefix, namespace=None):
+    """ Test to add a prefix leaf-list back after it was emptied
+
+    This is the follow up operation reported in sonic-net/sonic-buildimage#27818: once the leaf-list
+    had been emptied, adding a prefix back was rejected because the leftover empty value failed
+    validation.
+    """
+    json_patch = [
+        {
+            "op": "add",
+            "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0{}/prefixes_v4".format(community_table),
+            "value": [PREFIXES_V4_DUMMY]
+        }
+    ]
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
+
+    tmpfile = generate_tmpfile(duthost)
+    logger.info("tmpfile {}".format(tmpfile))
+
+    try:
+        output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+        expect_op_success(duthost, output)
+
+        config_db_entry = get_bgp_prefix_config_db_entry(duthost, community_table, cli_namespace_prefix)
+        pytest_assert(PREFIXES_V4_DUMMY in config_db_entry,
+                      "prefixes_v4 was not added back to CONFIG_DB: {}".format(config_db_entry))
+
+        pytest_assert(wait_until(60, 5, 0, check_bgp_prefix_v4_programmed, duthost, community, cli_namespace_prefix),
+                      "BGP prefix v4 config not added back successfully")
+
+    finally:
+        delete_tmpfile(duthost, tmpfile)
+
+
 def check_bgp_prefix_config_remove(duthost, community, cli_namespace_prefix):
     """ Check bgp prefix config for remove op
     """
@@ -293,4 +402,8 @@ def test_bgp_prefix_tc1_suite(rand_selected_front_end_dut, enum_rand_one_fronten
     bgp_prefix_tc1_xfail(rand_selected_front_end_dut, community_table, namespace=asic_namespace)
     bgp_prefix_tc1_replace(rand_selected_front_end_dut, community, community_table, cli_namespace_prefix,
                            namespace=asic_namespace)
+    bgp_prefix_tc1_remove_last_prefix(rand_selected_front_end_dut, community, community_table, cli_namespace_prefix,
+                                      namespace=asic_namespace)
+    bgp_prefix_tc1_readd_prefix(rand_selected_front_end_dut, community, community_table, cli_namespace_prefix,
+                                namespace=asic_namespace)
     bgp_prefix_tc1_remove(rand_selected_front_end_dut, community, cli_namespace_prefix, namespace=asic_namespace)


### PR DESCRIPTION
### Description of PR

Summary:
Related to sonic-net/sonic-buildimage#27818, sonic-net/sonic-utilities#4731, and sonic-net/sonic-mgmt#25549.

`generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite` fails on master now. The
sequence:

| date | event |
|---|---|
| 2026-08-03 | sonic-net/sonic-utilities#4731 merged as `4464c122`, fixing sonic-net/sonic-buildimage#27818 |
| 2026-08-04 | #26492 removed this test's conditional xfail on master (#26494 did the same on 202605) |
| 2026-08-06 | sonic-net/sonic-buildimage#28831 advanced the `src/sonic-utilities` submodule past `4464c122` |

So the fix is in master images, the xfail is gone, and the next nightly on a physical t1/t2 testbed
hits two failing steps. This PR is the test side of #4731.

It also adds the leaf-list coverage whose absence is the reason
sonic-net/sonic-buildimage#27818 was reported as a bug rather than caught as a test failure.

#### 1. `bgp_prefix_tc1_xfail` does not test what its comments say

Two of its four cases are labelled "Unexisted v4/v6 prefix" and have been unchanged since the suite
was introduced in #5268 (2022-03-14):

```python
("remove", PREFIXES_V4_DUMMY, PREFIXES_V6_INIT),    # Unexisted v4 prefix
("remove", PREFIXES_V4_INIT, PREFIXES_V6_DUMMY)     # Unexisted v6 prefix
```

The paths they build are hardcoded to index `0`:

```
remove /BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v6/0
remove /BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0
```

A JSON patch `remove` is resolved by index; the `"value"` carried alongside it is ignored. At this
point in the suite each leaf-list holds exactly one element, so index `0` exists and the patch
removes the **last element of both leaf-lists**. It never touches an unexisting prefix.

So this suite does empty a leaf-list today. That is easy to miss, because the only case that does it
is labelled as a negative test for something else.

It is also the case that produced sonic-net/sonic-buildimage#27818. On sonic-utilities before #4731,
running exactly this patch leaves CONFIG_DB in the corrupt state that issue reports:

```
xfail#3 remove idx 0   expect=fail  rc=2  OK   {'prefixes_v4@': '', 'prefixes_v6@': ''}
```

`expect_op_failure` only asserts the return code, so the case was recorded as a pass while writing
the invalid empty values that #27818 is about.

The case passed only because emptying a leaf-list was broken and `apply-patch` returned non zero,
which satisfied `expect_op_failure`. sonic-net/sonic-utilities#4731 fixed the underlying defect, so
the same patch now returns `0`, `expect_op_failure` fails with *"The command should fail with non
zero return code"*, and the leaf-lists really do get emptied, which then breaks
`bgp_prefix_tc1_replace` further down because the fields no longer exist.

Fix: carry the index in the parametrisation and point the remove cases at index `1`, which is out of
range while the leaf-lists hold a single element, so they exercise removal of an unexisting prefix as
intended.

This matches how the same directory already writes this kind of negative case:
`test_dhcp_relay_tc1_rm_nonexist` ("Test remove nonexisted dhcp server on default setup") removes
`/dhcp_servers/5` from a four element list, i.e. an out of range index, rather than naming a value
that is not present.

#### 2. Emptying a leaf-list is exercised, but never actually verified

sonic-net/sonic-buildimage#27818 was
[confirmed](https://github.com/sonic-net/sonic-buildimage/issues/27818#issuecomment-5207711303) to
have originated from this test file. That is consistent with the above: the suite reaches the buggy
state, but nothing in it can report the bug, because

- the only step that empties a leaf-list asserts failure and stops at the return code, and
- every other assertion in the suite is a regex match over `show runningconfiguration bgp`; no step
  inspects CONFIG_DB field state, which is where the bug's signature (`prefixes_v4@` present with an
  empty value) is visible.

No test empties a leaf-list and then asserts the resulting state:

| test | operation on a leaf-list | empties it? | asserts result? |
|---|---|---|---|
| `bgp_prefix_tc1_replace` | `replace /prefixes_v4/0` | no, swaps in place | FRR config only |
| `bgp_prefix_tc1_remove` | `remove /BGP_ALLOWED_PREFIXES` | no, drops the whole table | FRR config only |
| `test_bgp_sentinel` / `test_bgp_speaker` | `remove /ip_range/1` after adding a 2nd element | no | FRR config only |
| `test_cacl` | `replace /services/0` | no | iptables only |
| `test_dhcp_relay` | `remove /dhcp_servers/3` on a four element list | no | dhcp relay behaviour only |
| `bgp_prefix_tc1_xfail` | `remove /prefixes_v4/0` | **yes** | return code only |

Fix: add `bgp_prefix_tc1_remove_last_prefix`, which removes the only `prefixes_v4` element and
asserts the field is **absent from CONFIG_DB** rather than left behind as an empty value, and
`bgp_prefix_tc1_readd_prefix`, which adds the prefix back, the follow up operation
sonic-net/sonic-buildimage#27818 reported as failing.

Both also assert FRR state, and specifically that the `prefixes_v6` in the same entry is still
programmed. That matters because the documented harm of the leftover empty value is that bgpcfgd
rejects the **whole** `BGP_ALLOWED_PREFIXES` entry, taking a valid `prefixes_v6` down with it
([analysis in #27818](https://github.com/sonic-net/sonic-buildimage/issues/27818#issuecomment-5052662935)).
A check that only asserted v4 had gone would pass in exactly that failure mode, so v4-absent and
v6-present are matched against a single snapshot of the running config.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

Requested for 202605. sonic-net/sonic-utilities#4731 is now being cherry-picked to 202605 at
@dgsudharsan's request, and the fix has been confirmed both necessary and effective on a real 202605
`docker-sonic-vs`. 202605's `bgp_prefix_tc1_xfail` entry is byte identical to master's and #26494
already removed the 202605 xfail, so the moment #4731 lands on 202605 `test_bgp_prefix_tc1_suite`
breaks there in exactly the same way it would on master. This change therefore has to accompany it
on that branch.

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Test result

master: verified in detail below - the suite is green with both the changed xfail cases and the two
added steps.

202605: verified. The xfail index correction was validated on a physical T1 202605 testbed by
@StormLiangMS: pretest 12 passed, both `test_bgp_prefix_tc1_suite` parametrisations passed (2/2),
posttest 5 passed, with 0 failures and 0 errors, and the original empty-prefix LogAnalyzer signature
was absent ([evidence](https://github.com/sonic-net/sonic-mgmt/issues/25549#issuecomment-5289794690)).
The two added coverage steps assert the post-fix CONFIG_DB shape, whose prerequisites landed on
202605 on 2026-08-13 as sonic-net/sonic-utilities#4778 (`192f27f7`) and
sonic-net/sonic-utilities#4777 (`62c83973`). On a real 202605 `docker-sonic-vs` (`0b2faef94`) with
both applied, removing the last `prefixes_v4` element produces a single change and leaves the field
**absent** from CONFIG_DB - exactly the state `bgp_prefix_tc1_remove_last_prefix` asserts - and the
GCU unit suite runs 553 passed / 0 failed. Without them the field is left behind as `''`, which is
the failure that step is designed to catch.

> **Sequencing note.** `sonic-buildimage` 202605 still pins `src/sonic-utilities` at `d44ebfe6`,
> which predates both commits above, so 202605 images do not carry the fix yet. Until that submodule
> advances past `62c83973`, `bgp_prefix_tc1_remove_last_prefix` will fail on 202605 nightlies,
> because the emptied field is still written as `''` rather than removed. The xfail index correction
> on its own is safe in both states. If this needs to land before the submodule bump, cherry-picking
> only the index change first - the scope of #27058 - avoids that window.

#### master detail

Verified on a master based `docker-sonic-vs` that already contains the read-side fix
sonic-net/sonic-buildimage#28248, driving `config apply-patch` with exactly the patches this suite
builds, in suite order, for `community = "empty"`.

**sonic-utilities before #4731** - suite passes, which is the state 202605 is in today. Note the
CONFIG_DB state after `xfail#3`: the suite is silently creating the sonic-net/sonic-buildimage#27818
corruption and recording it as a pass.

```
add_config                     expect=success rc=0 OK {'prefixes_v4@': '10.20.0.0/16', 'prefixes_v6@': 'fc01:20::/64'}
xfail#1 add invalid v4 idx0    expect=fail    rc=2 OK {'prefixes_v4@': '10.20.0.0/16', 'prefixes_v6@': 'fc01:20::/64'}
xfail#2 add invalid v6 idx0    expect=fail    rc=2 OK {'prefixes_v4@': '10.20.0.0/16', 'prefixes_v6@': 'fc01:20::/64'}
xfail#3 remove idx 0           expect=fail    rc=2 OK {'prefixes_v4@': '', 'prefixes_v6@': ''}
xfail#4 remove idx 0           expect=fail    rc=2 OK {'prefixes_v4@': '', 'prefixes_v6@': ''}
tc1_replace                    expect=success rc=0 OK {'prefixes_v4@': '10.30.0.0/16', 'prefixes_v6@': 'fc01:30::/64'}
tc1_remove                     expect=success rc=0 OK {}
```

`tc1_replace` recovers only because sonic-net/sonic-buildimage#28248 made the read side tolerate
`['']`. Before that fix the corrupt entry could not be reloaded, and the rest of the suite failed,
which is the 202605 nightly failure tracked in sonic-net/sonic-mgmt#25549.

**sonic-utilities with #4731, suite unchanged** - two failures:

```
xfail#3 remove idx 0             expect=fail    rc=0  **TEST FAILS**   db={'NULL': 'NULL'}
tc1_replace                      expect=success rc=2  **TEST FAILS**   db={'NULL': 'NULL'}
```

`xfail#3` now succeeds and genuinely empties both leaf-lists, so `tc1_replace` has no
`prefixes_v4/0` left to replace.

**sonic-utilities with #4731, suite as changed by this PR** - every step behaves as asserted:

```
add_config                    expect=success rc=0 OK {'prefixes_v4@': '10.20.0.0/16', 'prefixes_v6@': 'fc01:20::/64'}
xfail#1 add invalid v4 idx0   expect=fail    rc=2 OK {'prefixes_v4@': '10.20.0.0/16', 'prefixes_v6@': 'fc01:20::/64'}
xfail#2 add invalid v6 idx0   expect=fail    rc=2 OK {'prefixes_v4@': '10.20.0.0/16', 'prefixes_v6@': 'fc01:20::/64'}
xfail#3 remove idx 1          expect=fail    rc=2 OK {'prefixes_v4@': '10.20.0.0/16', 'prefixes_v6@': 'fc01:20::/64'}
xfail#4 remove idx 1          expect=fail    rc=2 OK {'prefixes_v4@': '10.20.0.0/16', 'prefixes_v6@': 'fc01:20::/64'}
tc1_replace                   expect=success rc=0 OK {'prefixes_v4@': '10.30.0.0/16', 'prefixes_v6@': 'fc01:30::/64'}
NEW remove_last_prefix        expect=success rc=0 OK {'prefixes_v6@': 'fc01:30::/64'}
NEW readd_prefix              expect=success rc=0 OK {'prefixes_v6@': 'fc01:30::/64', 'prefixes_v4@': '10.30.0.0/16'}
tc1_remove                    expect=success rc=0 OK {}
```

The out of range remove reports, as intended:

```
Error: Validate json patch: [... 'path': '.../prefixes_v6/1' ...] failed due to:
       can't remove a non-existent object '1'
```

Additional checks:

- Generated patches captured for both `community` parametrisations (`empty` and `1010:1010`) by
  loading the module with stubbed helpers, confirming the paths and values are as intended.
- The changed and added step functions were executed directly against a live `docker-sonic-vs`
  (`bgpcfgd` and `bgpd` running, `bgp.allow_list.enabled: true`), so every assertion in them ran for
  real, including the CONFIG_DB reads and the FRR running config matches:

```
                               with #4731                                   before #4731
add_config                     PASS                                         PASS
xfail (4 negative cases)       PASS                                         PASS
tc1_replace                    PASS                                         PASS
NEW remove_last_prefix         PASS  {'prefixes_v6@': 'fc01:30::/64'}       FAIL  {'prefixes_v4@': '', 'prefixes_v6@': 'fc01:30::/64'}
NEW readd_prefix               PASS                                         PASS
tc1_remove                     PASS                                         PASS
                               0 failed                                     1 failed
```

  The right hand column is the regression check: against sonic-utilities before #4731 the new step
  fails on exactly the state sonic-net/sonic-buildimage#27818 reports. `remove_last_prefix` passing
  on the left also means `prefixes_v6` was still programmed in FRR after `prefixes_v4` was emptied,
  which is the collateral damage the issue describes.

- 16 scenario table run against the two new steps with a faked DUT, covering the correct behaviour,
  the leftover empty value, a bgpcfgd entry drop, v4 still programmed, v6 lost from CONFIG_DB, and
  the re-add failure modes. All 16 behave as expected.
- `flake8 --max-line-length=120` clean.

Not yet executed by pytest on a physical t1/t2 testbed. The conditional mark for this test skips it
on `asic_type in ['vs']`, so the kvm PR checks do not run it either; a nightly run on hardware is the
remaining validation.

### Approach

#### What is the motivation for this PR?

Restore `test_bgp_prefix_tc1_suite` on master, which is red now that
sonic-net/sonic-buildimage#28831 has pulled sonic-net/sonic-utilities#4731 into the submodule and
#26492 has removed the xfail, and close the coverage gap that let
sonic-net/sonic-buildimage#27818 be reported as a bug instead of caught as a test failure.

#### How did you do it?

Made the leaf-list index explicit in the `xfail_input` parametrisation so the "unexisting prefix"
cases use an out of range index, and added two steps to the tc1 suite that empty a leaf-list and then
repopulate it, asserting CONFIG_DB field state in addition to the FRR running config.

#### How did you verify/test it?

See **Test result** above.

#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

Unchanged: `t1`, `t2`, `lrh`, `urh`, as declared by the existing `pytestmark` in this module.

### Documentation

No, this is a test only change.



