### PR TITLE
Exclude recirc ports in `test_lldp.py`

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -353,7 +353,9 @@ def verify_lldp_table(duthost, intf_status_output, test_name=""):
     # Filter intf_status_output: exclude PortChannel interfaces and admin down interfaces
     intf_status_filtered_for_lldp = {
         intf['interface'] for intf in intf_status_output
-        if not intf['interface'].startswith('PortChannel') and intf['admin'].lower() == 'up'
+        if not intf['interface'].startswith('PortChannel') and
+        not intf['alias'].startswith('Recirc') and
+        intf['admin'].lower() == 'up'
     }
 
     missing_in_lldp_table = intf_status_filtered_for_lldp - lldp_table_interfaces_no_eth0
@@ -436,12 +438,15 @@ def verify_lldpcli_interfaces(duthost, asic, intf_status_output, test_name=""):
             asic.asic_index, len(asic_ports)))
         intf_status_filtered_for_lldpcli = {
             intf['interface'] for intf in intf_status_output
-            if not intf['interface'].startswith('PortChannel') and intf['interface'] in asic_ports
+            if not intf['interface'].startswith('PortChannel') and
+            not intf['alias'].startswith('Recirc') and
+            intf['interface'] in asic_ports
         }
     else:
         intf_status_filtered_for_lldpcli = {
             intf['interface'] for intf in intf_status_output
-            if not intf['interface'].startswith('PortChannel')
+            if not intf['interface'].startswith('PortChannel') and
+            not intf['alias'].startswith('Recirc')
         }
 
     missing_in_lldpcli = intf_status_filtered_for_lldpcli - lldpcli_interfaces_no_eth0
@@ -507,7 +512,9 @@ def verify_lldpctl_facts(duthost, enum_frontend_asic_index, intf_status_output, 
     # Compare intf_status_output with lldpctl_facts interfaces (exclude PortChannels and admin down from intf_status)
     intf_status_filtered_for_lldpctl = {
         intf['interface'] for intf in intf_status_output
-        if not intf['interface'].startswith('PortChannel') and intf['admin'].lower() == 'up'
+        if not intf['interface'].startswith('PortChannel') and
+        not intf['alias'].startswith('Recirc') and
+        intf['admin'].lower() == 'up'
     }
 
     missing_in_lldpctl_facts = intf_status_filtered_for_lldpctl - lldpctl_facts_interfaces


### PR DESCRIPTION
### Description of PR
Two new tests added in https://github.com/sonic-net/sonic-mgmt/pull/22420 `test_lldp_interfaces` and `test_lldp_interfaces_config_reload` didn't exclude recirc ports from the `show interface status` output when comparing with lldp output causing failures

Details in - https://github.com/sonic-net/sonic-mgmt/issues/26864

Summary:
Fixes #26864 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- 202605: latest image

### Approach
#### What is the motivation for this PR?
Recirc ports won't have LLDP output so we shouldn't try to match them to the LLDP command output.

#### How did you do it?
Exclude any port with an alias that starts with `Recirc`

#### How did you verify/test it?
Ran the test on 202605 with a dut that has `Recirc` ports that was previously failing, now passing.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
