### PR TITLE
[ha]: Fix disabled flag in DPU repairing test

### DIFF
--- a/tests/ha/test_ha_repairing_dpu.py
+++ b/tests/ha/test_ha_repairing_dpu.py
@@ -683,7 +683,7 @@ def test_ha_repairing_dpu(
             repair_vdpu_key,
             "dead",
             ha_owner,
-            disabled=True,
+            disabled=False,
         )
 
         pytest_assert(


### PR DESCRIPTION
### Description of PR

Summary:
Correct the planned shutdown step in the DPU re-pairing test so the HA scope remains enabled while transitioning to the dead state.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: SONiC.20260510.09 - `test_ha_repairing_dpu[primary]` and `test_ha_repairing_dpu[standby]` passed.

### Approach
#### What is the motivation for this PR?

The re-pairing test models a planned DPU shutdown. Setting `disabled=True` incorrectly disables the HA scope during this transition instead of keeping the scope enabled and requesting the dead state.

#### How did you do it?

Changed the planned shutdown call to use `disabled=False`.

#### How did you verify/test it?

Ran both primary and standby DPU re-pairing variants on a SmartSwitch HA testbed. Both variants completed the full shutdown, replacement, activation, final-state, traffic, and cleanup workflow successfully.

```text
ha/test_ha_repairing_dpu.py::test_ha_repairing_dpu[primary] PASSED
ha/test_ha_repairing_dpu.py::test_ha_repairing_dpu[standby] PASSED
================ 2 passed, 1357 warnings in 2062.65s (0:34:22) =================
```

#### Any platform specific information?

Validated on a Cisco 8102 SmartSwitch with Pensando DPUs.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
