### PR TITLE
Make Ansible Dir Configurable

### DIFF
--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -17,9 +17,13 @@ steps:
     sudo apt-get -o DPkg::Lock::Timeout=600 update || true
     sudo apt-get -o DPkg::Lock::Timeout=600 -y install jq
 
-    echo "$TEST_SCRIPTS" > /tmp/ts.json
-    echo "TEST_SCRIPTS value from file:"
-    cat /tmp/ts.json
+    # TEST_SCRIPTS is shipped gzip+base64 encoded to stay under the agent's 40 KiB output line cap.
+    if ! printf '%s' "$TEST_SCRIPTS" | base64 -d 2>/dev/null | gunzip > /tmp/ts.json 2>/dev/null; then
+      echo "##vso[task.complete result=Failed;]Decode TEST_SCRIPTS fails."
+      exit 1
+    fi
+    echo "TEST_SCRIPTS script count per checker:"
+    jq -r 'to_entries[] | "  \(.key): \(.value | length)"' /tmp/ts.json
     TEST_SCRIPTS=$(jq -r -c '."${{ parameters.TOPOLOGY }}_checker"' /tmp/ts.json)
     rm /tmp/ts.json
     if [[ -z "$TEST_SCRIPTS" ]]; then

--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -14,6 +14,8 @@ steps:
       echo "Impact area info: $IMPACT_AREA_INFO"
       echo "Pre-defined test scripts: ${TEST_SCRIPTS}"
       echo "Pre-defined PR checkers: ${PR_CHECKERS}"
+      # The agent truncates any single output line at 40 KiB, which corrupts the JSON payload.
+      TEST_SCRIPTS=$(printf '%s' "${TEST_SCRIPTS}" | gzip -9 | base64 -w0)
       echo "##vso[task.setvariable variable=PR_CHECKERS;isOutput=true]${PR_CHECKERS}"
       echo "##vso[task.setvariable variable=TEST_SCRIPTS;isOutput=true]${TEST_SCRIPTS}"
     name: VerifyParams
@@ -57,8 +59,10 @@ steps:
     PR_CHECKERS='$(VerifyParams.PR_CHECKERS)'
     if [[ -n "$TEST_SCRIPTS" && -n "$PR_CHECKERS" ]]; then
       echo "Impact area was pre-defined, skip get impacted area step."
+      set +x
       echo "##vso[task.setvariable variable=PR_CHECKERS;isOutput=true]$PR_CHECKERS"
       echo "##vso[task.setvariable variable=TEST_SCRIPTS;isOutput=true]$TEST_SCRIPTS"
+      set -x
       exit 0
     fi
     sudo uv pip install --system PyYAML natsort
@@ -122,7 +126,8 @@ steps:
 
       # Validate TEST_SCRIPTS is valid JSON
       if echo "$TEST_SCRIPTS" | jq empty > /dev/null 2>&1; then
-        echo "TEST_SCRIPTS is valid JSON: $TEST_SCRIPTS"
+        echo "TEST_SCRIPTS is valid JSON, script count per checker:"
+        echo "$TEST_SCRIPTS" | jq -r 'to_entries[] | "  \(.key): \(.value | length)"'
 
         # Generate PR_CHECKERS
         PR_CHECKERS=$(echo "${TEST_SCRIPTS}" | jq -c 'keys')
@@ -135,7 +140,7 @@ steps:
           echo "PR_CHECKERS generation failed or invalid list: $PR_CHECKERS"
         fi
       else
-        echo "TEST_SCRIPTS is not valid JSON: $TEST_SCRIPTS"
+        echo "TEST_SCRIPTS is not valid JSON: $(echo "$TEST_SCRIPTS" | head -c 2000)"
       fi
 
       RETRY_COUNT=$((RETRY_COUNT + 1))
@@ -147,12 +152,17 @@ steps:
 
     # Final validation
     if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
-      echo "##vso[task.complete result=Failed;]Failed to generate valid JSON after $MAX_RETRIES attempts. Last TEST_SCRIPTS: $TEST_SCRIPTS"
+      echo "##vso[task.complete result=Failed;]Failed to generate valid JSON after $MAX_RETRIES attempts. Last TEST_SCRIPTS: $(echo "$TEST_SCRIPTS" | head -c 2000)"
       exit 1
     fi
 
+    # The agent truncates any single output line at 40 KiB, which corrupts the JSON payload.
+    TEST_SCRIPTS=$(printf '%s' "$TEST_SCRIPTS" | gzip -9 | base64 -w0)
+
+    set +x
     echo "##vso[task.setvariable variable=PR_CHECKERS;isOutput=true]$PR_CHECKERS"
     echo "##vso[task.setvariable variable=TEST_SCRIPTS;isOutput=true]$TEST_SCRIPTS"
+    set -x
   name: SetVariableTask
   continueOnError: false
   displayName: "Get impacted area"

--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -141,7 +141,7 @@ def restore_config_db(localhost, duthost):
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_vnet(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, localhost,
-              skip_test_module_over_backend_topologies):        # noqa F811
+              skip_test_module_over_backend_topologies, ansible_root):        # noqa F811
     duthost = duthosts[rand_one_dut_hostname]
 
     # backup config_db.json
@@ -202,7 +202,7 @@ def setup_vnet(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, localhost,
         duthost.shell("sonic-clear nd")
         duthost.shell("sonic-clear fdb all")
 
-        with open("../ansible/vars/topo_{}.yml".format(tbinfo['topo']['name']), 'r') as fh:
+        with open(ansible_root.joinpath("vars/topo_{}.yml".format(tbinfo['topo']['name'])), 'r') as fh:
             g_vars['topo_properties'] = yaml.safe_load(fh)
 
         g_vars['props'] = g_vars['topo_properties']['configuration_properties']['common']

--- a/tests/common/devices/aos.py
+++ b/tests/common/devices/aos.py
@@ -32,8 +32,8 @@ class AosHost(AnsibleHostBase):
 
     def _exec_jinja_template(self, task_name, jinja_template):
         inventory = 'lab'
-        ansible_root = pathlib.Path(os.getenv("ANSIBLE_CONFIG",
-                                              pathlib.Path(__file__).resolve().parent.joinpath("../../ansible")))
+        ansible_root = str(pathlib.Path(os.getenv(
+            "ANSIBLE_CONFIG", pathlib.Path(__file__).joinpath("../../../ansible"))).resolve()) + "/"
 
         playbook_name = 'accton_os_cmd_exec.yml'
         jinja_name = 'accton_os_cmd_exec.j2'

--- a/tests/common/devices/aos.py
+++ b/tests/common/devices/aos.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import pathlib
 
 from tests.common.devices.base import AnsibleHostBase
 import re
@@ -31,7 +32,9 @@ class AosHost(AnsibleHostBase):
 
     def _exec_jinja_template(self, task_name, jinja_template):
         inventory = 'lab'
-        ansible_root = '../ansible/'
+        ansible_root = pathlib.Path(os.getenv("ANSIBLE_CONFIG",
+                                              pathlib.Path(__file__).resolve().parent.joinpath("../../ansible")))
+
         playbook_name = 'accton_os_cmd_exec.yml'
         jinja_name = 'accton_os_cmd_exec.j2'
         playbook_text = '- hosts: {}\n'.format(self.hostname) + \

--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -3,6 +3,7 @@ import os
 import six
 import yaml
 import copy
+import pathlib
 
 
 @pytest.fixture(scope="module")
@@ -74,8 +75,9 @@ def get_graph_facts(duthost, localhost, hostnames):
     duthost - pytest fixture
     hostnames - can be either a single DUT or a list of multiple DUTs
     """
-    base_path = os.path.dirname(os.path.realpath(__file__))
-    lab_conn_graph_path = os.path.join(base_path, "../../../ansible/files/")
+    ansible_config_path = pathlib.Path(os.getenv("ANSIBLE_CONFIG",
+                                                 pathlib.Path(__file__).resolve().parent.joinpath("../../ansible")))
+    lab_conn_graph_path = os.path.join(ansible_config_path, "files/")
 
     inv_files = duthost.host.options["inventory_manager"]._sources
     graph_groups_file = os.path.join(lab_conn_graph_path, "graph_groups.yml")

--- a/tests/common/fixtures/pfc_asym.py
+++ b/tests/common/fixtures/pfc_asym.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import time
+import pathlib
 
 from netaddr import IPAddress
 from tests.common.helpers.generators import generate_ips
@@ -10,12 +11,13 @@ PFC_GEN_FILE = "pfc_gen.py"
 PFC_FRAMES_NUMBER = 50000000
 PFC_QUEUE_INDEX = 0xff
 
-ANSIBLE_ROOT = os.path.normpath((os.path.join(__file__, "../../../ansible")))
 RUN_PLAYBOOK = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../scripts/exec_template.yml"))
 
 OS_ROOT_DIR = "/root"
 TESTS_ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), "../.."))
-ANSIBLE_ROOT = os.path.realpath(os.path.join(TESTS_ROOT, "../ansible"))
+ANSIBLE_ROOT = pathlib.Path(os.getenv("ANSIBLE_CONFIG",
+                                      pathlib.Path(__file__).resolve().parent.joinpath("../../ansible")))
+
 
 ARP_RESPONDER = os.path.join(TESTS_ROOT, "scripts/arp_responder.py")
 ARP_RESPONDER_CONF = os.path.join(TESTS_ROOT, "templates/arp_responder.conf.j2")

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -1,4 +1,5 @@
 import logging
+import pathlib
 import allure
 import os
 import jinja2
@@ -30,7 +31,8 @@ NAT_ENABLE_KEY = "nat_enabled_on_{}"
 CONSOLE_RECONNECT_BACKOFF_SECS = 12
 
 # Ansible config files
-LAB_CONNECTION_GRAPH_PATH = os.path.normpath((os.path.join(os.path.dirname(__file__), "../../../ansible/files")))
+LAB_CONNECTION_GRAPH_PATH = pathlib.Path(
+    os.getenv("ANSIBLE_CONFIG", pathlib.Path(__file__).resolve().parent.joinpath("../../ansible"))).joinpath("files")
 
 BASI_PATH = os.path.dirname(os.path.abspath(__file__))
 

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 import re
 import json
 
@@ -8,7 +9,8 @@ from tests.common.errors import MissingInputError
 from tests.common.devices.sonic import SonicHost
 
 TEMPLATES_DIR = os.path.realpath((os.path.join(os.path.dirname(__file__), "../../common/templates")))
-ANSIBLE_ROOT = os.path.realpath((os.path.join(os.path.dirname(__file__), "../../../ansible")))
+ANSIBLE_ROOT = pathlib.Path(os.getenv("ANSIBLE_CONFIG",
+                                      pathlib.Path(__file__).resolve().parent.joinpath("../../ansible")))
 RUN_PLAYBOOK = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../scripts/exec_template.yml"))
 
 logger = logging.getLogger(__name__)

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -25,7 +25,8 @@ from tests.common.cisco_data import (
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONDITIONS_FILE = 'common/plugins/conditional_mark/tests_mark_conditions*.yaml'
-ANSIBLE_CONFIG_PATH = pathlib.Path(os.getenv('ANSIBLE_CONFIG', '../../../../ansible'))
+ANSIBLE_CONFIG_PATH = pathlib.Path(os.getenv("ANSIBLE_CONFIG",
+                                             pathlib.Path(__file__).resolve().parent.joinpath("../../../ansible")))
 ASIC_NAME_PATH = ANSIBLE_CONFIG_PATH.joinpath("group_vars/sonic/variables")
 ANSIBLE_LIBRARY_PATH = ANSIBLE_CONFIG_PATH.joinpath("library")
 MARK_CONDITIONS_CONSTANTS = {
@@ -135,9 +136,8 @@ def read_asic_name(hwsku):
         str or None: Return the asic generation name or None if something went wrong or nothing found in the file.
 
     '''
-    asic_name_file = ASIC_NAME_PATH
     try:
-        with open(asic_name_file) as f:
+        with open(ASIC_NAME_PATH) as f:
             asic_name = yaml.safe_load(f)
 
         for key, value in list(asic_name.copy().items()):
@@ -209,9 +209,7 @@ def get_basic_facts(session):
 
 
 def get_http_proxies(inv_name):
-    # INV_ENV_FILE = '../../../../ansible/group_vars/{}/env.yml'.format(inv_name)
     INV_ENV_FILE = ANSIBLE_CONFIG_PATH.joinpath("group_vars/{}/env.yml".format(inv_name))
-    # PUBLIC_ENV_FILE = '../../../../ansible/group_vars/all/env.yml'
     PUBLIC_ENV_FILE = ANSIBLE_CONFIG_PATH.joinpath("group_vars/all/env.yml")
     proxies = {}
 

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -6,6 +6,7 @@ marks, and conditions can be specified in a centralized file.
 import json
 import logging
 import os
+import pathlib
 import re
 import subprocess
 import yaml
@@ -24,8 +25,9 @@ from tests.common.cisco_data import (
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONDITIONS_FILE = 'common/plugins/conditional_mark/tests_mark_conditions*.yaml'
-ASIC_NAME_PATH = '/../../../../ansible/group_vars/sonic/variables'
-ANSIBLE_LIBRARY_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), '../../../../ansible/library'))
+ANSIBLE_CONFIG_PATH = pathlib.Path(os.getenv('ANSIBLE_CONFIG', '../../../../ansible'))
+ASIC_NAME_PATH = ANSIBLE_CONFIG_PATH.joinpath("group_vars/sonic/variables")
+ANSIBLE_LIBRARY_PATH = ANSIBLE_CONFIG_PATH.joinpath("library")
 MARK_CONDITIONS_CONSTANTS = {
     # Cisco platform prefixes for use in conditions like:
     #   platform.startswith(constants['CISCO_8122_PREFIX'])
@@ -133,7 +135,7 @@ def read_asic_name(hwsku):
         str or None: Return the asic generation name or None if something went wrong or nothing found in the file.
 
     '''
-    asic_name_file = os.path.dirname(__file__) + ASIC_NAME_PATH
+    asic_name_file = ASIC_NAME_PATH
     try:
         with open(asic_name_file) as f:
             asic_name = yaml.safe_load(f)
@@ -168,7 +170,7 @@ def load_dut_basic_facts(inv_name, dut_name):
     results = {}
     logger.info('Getting dut basic facts: {}'.format(dut_name))
     try:
-        inv_full_path = os.path.join(os.path.dirname(__file__), '../../../../ansible', inv_name)
+        inv_full_path = ANSIBLE_CONFIG_PATH.joinpath(inv_name)
         ansible_cmd = (
             'ansible -M {} -m dut_basic_facts -i {} {} -o'
             .format(ANSIBLE_LIBRARY_PATH, inv_full_path, dut_name))
@@ -207,16 +209,15 @@ def get_basic_facts(session):
 
 
 def get_http_proxies(inv_name):
-    INV_ENV_FILE = '../../../../ansible/group_vars/{}/env.yml'.format(inv_name)
-    PUBLIC_ENV_FILE = '../../../../ansible/group_vars/all/env.yml'
-    base_path = os.path.dirname(__file__)
-    inv_env_path = os.path.join(base_path, INV_ENV_FILE)
-    public_env_path = os.path.join(base_path, PUBLIC_ENV_FILE)
+    # INV_ENV_FILE = '../../../../ansible/group_vars/{}/env.yml'.format(inv_name)
+    INV_ENV_FILE = ANSIBLE_CONFIG_PATH.joinpath("group_vars/{}/env.yml".format(inv_name))
+    # PUBLIC_ENV_FILE = '../../../../ansible/group_vars/all/env.yml'
+    PUBLIC_ENV_FILE = ANSIBLE_CONFIG_PATH.joinpath("group_vars/all/env.yml")
     proxies = {}
 
-    if os.path.isfile(public_env_path):
+    if os.path.isfile(PUBLIC_ENV_FILE):
         try:
-            with open(public_env_path) as env_file:
+            with open(PUBLIC_ENV_FILE) as env_file:
                 proxy_env = yaml.safe_load(env_file)
                 if proxy_env is not None:
                     proxy = proxy_env.get("proxy_env", {})
@@ -225,19 +226,18 @@ def get_http_proxies(inv_name):
                 else:
                     proxies = {'http': '', 'https': ''}
         except Exception as e:
-            logger.error('Load proxy env from {} failed with error: {}'.format(public_env_path, repr(e)))
+            logger.error('Load proxy env from {} failed with error: {}'.format(PUBLIC_ENV_FILE, repr(e)))
 
-    if os.path.isfile(inv_env_path):
+    if os.path.isfile(INV_ENV_FILE):
         try:
-            with open(inv_env_path) as env_file:
+            with open(INV_ENV_FILE) as env_file:
                 proxy_env = yaml.safe_load(env_file)
                 if proxy_env is not None:
                     proxy = proxy_env.get("proxy_env", {})
                     http_proxy = proxy.get('http_proxy', '')
                     proxies = {'http': http_proxy, 'https': http_proxy}
         except Exception as e:
-            logger.error('Load proxy env from {} failed with error: {}'.format(inv_env_path, repr(e)))
-
+            logger.error('Load proxy env from {} failed with error: {}'.format(INV_ENV_FILE, repr(e)))
     return proxies
 
 

--- a/tests/common/sai_adhoc.py
+++ b/tests/common/sai_adhoc.py
@@ -9,6 +9,8 @@ import logging
 import argparse
 import yaml
 from yaml.loader import SafeLoader
+import os
+import pathlib
 
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()
@@ -22,7 +24,8 @@ def get_info_helper(conf_name):
         param:
             conf_name : configuration name in testbed.yaml
     """
-    with open('./ansible/testbed.yaml') as f:
+    ansible_config_path = pathlib.Path(os.getenv("ANSIBLE_CONFIG", pathlib.Path(__file__).resolve().parent.joinpath("../ansible")))
+    with open(ansible_config_path.joinpath("testbed.yaml")) as f:
         testbed_infos = yaml.load(f, Loader=SafeLoader)
         for testbed_info in testbed_infos:
             if testbed_info['conf-name'] == conf_name:

--- a/tests/common/sai_adhoc.py
+++ b/tests/common/sai_adhoc.py
@@ -24,7 +24,8 @@ def get_info_helper(conf_name):
         param:
             conf_name : configuration name in testbed.yaml
     """
-    ansible_config_path = pathlib.Path(os.getenv("ANSIBLE_CONFIG", pathlib.Path(__file__).resolve().parent.joinpath("../ansible")))
+    ansible_config_path = pathlib.Path(os.getenv("ANSIBLE_CONFIG",
+                                                 pathlib.Path(__file__).resolve().parent.joinpath("../ansible")))
     with open(ansible_config_path.joinpath("testbed.yaml")) as f:
         testbed_infos = yaml.load(f, Loader=SafeLoader)
         for testbed_info in testbed_infos:

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -25,8 +25,8 @@ class TestbedInfo(object):
     TESTBED_FIELDS_RECOMMENDED = ('conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf',
                                   'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut',
                                   'inv_name', 'auto_recover', 'is_smartswitch', 'comment')
-    TOPOLOGY_FILEPATH = "../../ansible/vars/"
-    NUT_TOPOLOGY_FILEPATH = "../../ansible/vars/nut_topos"
+    TOPOLOGY_FILEPATH = "../ansible/vars/"
+    NUT_TOPOLOGY_FILEPATH = "../ansible/vars/nut_topos"
 
     def __init__(self, testbed_file):
         if testbed_file.endswith(".csv"):
@@ -385,12 +385,12 @@ class TestbedInfo(object):
             tb["topo"]["type"] = self.get_testbed_type(topo)
 
             if topo.startswith("nut-"):
-                topo_dir = os.path.join(os.path.dirname(__file__), self.NUT_TOPOLOGY_FILEPATH)
+                topo_dir = os.path.join(os.path.dirname(self.testbed_filename), self.NUT_TOPOLOGY_FILEPATH)
                 topo_file = os.path.join(topo_dir, "{}.yml".format(topo))
                 with open(topo_file, 'r') as fh:
                     tb['topo']['properties'] = yaml.safe_load(fh)
             else:
-                topo_dir = os.path.join(os.path.dirname(__file__), self.TOPOLOGY_FILEPATH)
+                topo_dir = os.path.join(os.path.dirname(self.testbed_filename), self.TOPOLOGY_FILEPATH)
                 topo_file = os.path.join(topo_dir, "topo_{}.yml".format(topo))
                 with open(topo_file, 'r') as fh:
                     tb['topo']['properties'] = yaml.safe_load(fh)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4285,3 +4285,12 @@ def restore_counter_poll(rand_selected_dut):
         parsed_counterpoll_before,
         parsed_counterpoll_after
     )
+
+
+@pytest.fixture(scope="session")
+def ansible_root(request):
+    """
+    Returns the ansible directory.
+    """
+    tbfile = request.config.getoption("testbed_file")
+    return pathlib.Path(tbfile).parent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1051,7 +1051,7 @@ def ptfhosts(enhance_inventory, ansible_adhoc, tbinfo, duthost, request):
 
 
 @pytest.fixture(scope="module")
-def k8smasters(enhance_inventory, ansible_adhoc, request):
+def k8smasters(enhance_inventory, ansible_adhoc, request, ansible_root):
     """
     Shortcut fixture for getting Kubernetes master hosts
     """
@@ -1064,7 +1064,7 @@ def k8smasters(enhance_inventory, ansible_adhoc, request):
             k8s_inv_file = inv_file
     if not k8s_inv_file:
         pytest.skip("k8s inventory not found, skipping tests")
-    with open('../ansible/{}'.format(k8s_inv_file), 'r') as kinv:
+    with open(os.path.join(ansible_root, k8s_inv_file), 'r') as kinv:
         k8sinventory = yaml.safe_load(kinv)
         for hostname, attributes in list(k8sinventory[k8s_master_ansible_group]['hosts'].items()):
             if 'haproxy' in attributes:
@@ -1460,9 +1460,9 @@ def sonic():
 
 
 @pytest.fixture(scope='session')
-def pdu():
+def pdu(ansible_root):
     """ read and yield pdu configuration """
-    with open('../ansible/group_vars/pdu/pdu.yml') as stream:
+    with open(ansible_root.joinpath("group_vars/pdu/pdu.yml")) as stream:
         pdu = yaml.safe_load(stream)
         return pdu
 
@@ -1473,7 +1473,7 @@ def creds(duthost):
 
 
 @pytest.fixture(scope="session")
-def topo_bgp_routes(localhost, ptfhosts, tbinfo):
+def topo_bgp_routes(localhost, ptfhosts, tbinfo, ansible_root):
     bgp_routes = {}
     topo_name = tbinfo['topo']['name']
     servers_dut_interfaces = None
@@ -1490,7 +1490,7 @@ def topo_bgp_routes(localhost, ptfhosts, tbinfo):
             topo_name=topo_name,
             ptf_ip=ptf_ip,
             action='generate',
-            path="../ansible/",
+            path=str(ansible_root),
             log_path=log_path,
             dut_interfaces=servers_dut_interfaces.get(ptf_ip, '') if servers_dut_interfaces else '',
             verbose=False
@@ -4292,5 +4292,9 @@ def ansible_root(request):
     """
     Returns the ansible directory.
     """
-    tbfile = request.config.getoption("testbed_file")
-    return pathlib.Path(tbfile).parent
+    ansible_config_path = os.getenv("ANSIBLE_CONFIG", None)
+    if ansible_config_path:
+        return pathlib.Path(ansible_config_path)
+    else:
+        tbfile = request.config.getoption("testbed_file")
+        return pathlib.Path(tbfile).parent

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -33,6 +33,9 @@ function show_help_and_exit()
     echo "    -x             : print commands and their arguments as they are executed"
     echo "    -6             : IPv6-only management mode (use IPv6 for DUT mgmt connectivity)"
     echo "    -M             : run all 4 prober_type x neighbor_mode MUX_CABLE combos (dualtor/dualtor_io only)"
+    echo ""
+    echo "    environment variables:"
+    echo "    ANSIBLE_PARENT_DIR_OVERRIDE : root holding the 'ansible' directory (default: repo root)"
 
     exit $1
 }
@@ -103,6 +106,9 @@ function setup_environment()
     FULL_PATH=$(realpath ${SCRIPT})
     SCRIPT_PATH=$(dirname ${FULL_PATH})
     BASE_PATH=$(dirname ${SCRIPT_PATH})
+    # Root that holds the 'ansible' directory. Defaults to this repo checkout; set
+    # ANSIBLE_PARENT_DIR_OVERRIDE when the ansible tree lives somewhere else.
+    ANSIBLE_PARENT_DIR=${ANSIBLE_PARENT_DIR_OVERRIDE:-${BASE_PATH}}
     LOG_PATH="logs"
 
     AUTO_RECOVER="True"
@@ -112,13 +118,13 @@ function setup_environment()
     EXTRA_PARAMETERS=""
     FILE_LOG_LEVEL='debug'
     INCLUDE_FOLDERS=""
-    INVENTORY="${BASE_PATH}/ansible/lab,${BASE_PATH}/ansible/veos"
+    INVENTORY="${ANSIBLE_PARENT_DIR}/ansible/lab,${ANSIBLE_PARENT_DIR}/ansible/veos"
     KUBE_MASTER_ID="unset"
     OMIT_FILE_LOG="False"
     RETAIN_SUCCESS_LOG="False"
     SKIP_SCRIPTS=""
     SKIP_FOLDERS="ptftests acstests saitests scripts k8s sai_qualify"
-    TESTBED_FILE="${BASE_PATH}/ansible/testbed.yaml"
+    TESTBED_FILE="${ANSIBLE_PARENT_DIR}/ansible/testbed.yaml"
     TEST_CASES=""
     TEST_FILTER=""
     TEST_INPUT_ORDER="False"
@@ -129,11 +135,11 @@ function setup_environment()
     IPV6_ONLY_MGMT="False"
     MUX_COMBO_MODE="False"
 
-    export ANSIBLE_CONFIG=${BASE_PATH}/ansible
-    export ANSIBLE_LIBRARY=${BASE_PATH}/ansible/library/
-    export ANSIBLE_CONNECTION_PLUGINS=${BASE_PATH}/ansible/plugins/connection
-    export ANSIBLE_CLICONF_PLUGINS=${BASE_PATH}/ansible/cliconf_plugins
-    export ANSIBLE_TERMINAL_PLUGINS=${BASE_PATH}/ansible/terminal_plugins
+    export ANSIBLE_CONFIG=${ANSIBLE_PARENT_DIR}/ansible
+    export ANSIBLE_LIBRARY=${ANSIBLE_PARENT_DIR}/ansible/library/
+    export ANSIBLE_CONNECTION_PLUGINS=${ANSIBLE_PARENT_DIR}/ansible/plugins/connection
+    export ANSIBLE_CLICONF_PLUGINS=${ANSIBLE_PARENT_DIR}/ansible/cliconf_plugins
+    export ANSIBLE_TERMINAL_PLUGINS=${ANSIBLE_PARENT_DIR}/ansible/terminal_plugins
 
     # Kill pytest and ansible-playbook process
     pkill --signal 9 pytest
@@ -262,6 +268,7 @@ function run_debug_tests()
     echo "FULL_PATH:             ${FULL_PATH}"
     echo "SCRIPT_PATH:           ${SCRIPT_PATH}"
     echo "BASE_PATH:             ${BASE_PATH}"
+    echo "ANSIBLE_PARENT_DIR:    ${ANSIBLE_PARENT_DIR}"
 
     echo "ANSIBLE_CONFIG:        ${ANSIBLE_CONFIG}"
     echo "ANSIBLE_LIBRARY:       ${ANSIBLE_LIBRARY}"

--- a/tests/transceiver/attribute_parser/paths.py
+++ b/tests/transceiver/attribute_parser/paths.py
@@ -15,8 +15,8 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
-# Root directory (relative to repository root)
-REL_TRANSCEIVER_INV_DIR = os.path.join('ansible', 'files', 'transceiver', 'inventory')
+# Root directory (relative to ansible root)
+REL_TRANSCEIVER_INV_DIR = os.path.join('files', 'transceiver', 'inventory')
 
 # Subdirectories
 REL_ATTR_DIR = os.path.join(REL_TRANSCEIVER_INV_DIR, 'attributes')

--- a/tests/transceiver/cdb_firmware_upgrade/conftest.py
+++ b/tests/transceiver/cdb_firmware_upgrade/conftest.py
@@ -7,7 +7,6 @@ from tests.transceiver.attribute_parser.attribute_keys import (
     CDB_FIRMWARE_UPGRADE_ATTRIBUTES_KEY,
     EEPROM_ATTRIBUTES_KEY,
 )
-from tests.transceiver.attribute_parser.paths import get_repo_root
 from tests.transceiver.cdb_firmware_upgrade.parser import TransceiverFirmwareInfoParser
 from tests.transceiver.cdb_firmware_upgrade.utils.firmware_utils import (
     get_required_firmware_metadata_for_all_transceivers,
@@ -46,9 +45,8 @@ def _cdb_firmware_session_prerequisites(presence_verified, links_verified):
 
 
 @pytest.fixture(scope="session")
-def transceiver_firmware_info_parser():
-    repo_root = get_repo_root()
-    firmware_info_parser = TransceiverFirmwareInfoParser(repo_root)
+def transceiver_firmware_info_parser(ansible_root):
+    firmware_info_parser = TransceiverFirmwareInfoParser(ansible_root)
 
     if not firmware_info_parser.transceiver_firmware_info:
         pytest.skip("No transceiver firmware information found, skipping test.")

--- a/tests/transceiver/conftest.py
+++ b/tests/transceiver/conftest.py
@@ -153,7 +153,7 @@ def _load_platform_hwsku(duthost):
 
 
 @pytest.fixture(scope='session')
-def port_attributes_dict(request, duthost):
+def port_attributes_dict(request, ansible_root, duthost):
     """Session-scoped merged port attributes (BASE + category).
 
     Loads dut_info.json via DutInfoLoader and merges category attribute files via AttributeManager.
@@ -172,7 +172,7 @@ def port_attributes_dict(request, duthost):
         logger.warning("Platform/HWSKU not determined; platform/hwsku specific overrides may not apply")
 
     logger.info("Building transceiver base port attributes for DUT '%s'", dut_name)
-    loader = DutInfoLoader(REPO_ROOT)
+    loader = DutInfoLoader(ansible_root)
     try:
         base_dict = loader.build_base_port_attributes(dut_name)
     except DutInfoError as e:
@@ -181,12 +181,12 @@ def port_attributes_dict(request, duthost):
     if not base_dict:
         pytest.skip(f"No ports found for DUT '{dut_name}' in dut_info.json")
 
-    attr_dir = os.path.join(REPO_ROOT, REL_ATTR_DIR)
+    attr_dir = os.path.join(ansible_root, REL_ATTR_DIR)
     if not os.path.isdir(attr_dir):
         pytest.skip(f"Attributes directory {attr_dir} absent - returning base attributes only")
 
     logger.info("Merging category attributes from %s", attr_dir)
-    mgr = AttributeManager(REPO_ROOT, base_dict)
+    mgr = AttributeManager(ansible_root, base_dict)
     try:
         merged = mgr.build_port_attributes(dut_name, platform or '', hwsku or '')
     except AttributeMergeError as e:
@@ -195,10 +195,10 @@ def port_attributes_dict(request, duthost):
         pytest.skip(f"No merged attributes found for DUT '{dut_name}'")
 
     # Run compliance validation (validator handles detailed logging and raises on required misses)
-    templates_path = os.path.join(REPO_ROOT, REL_DEPLOYMENT_TEMPLATES_FILE)
+    templates_path = os.path.join(ansible_root, REL_DEPLOYMENT_TEMPLATES_FILE)
     if not request.config.getoption('--skip_transceiver_template_validation') and os.path.isfile(templates_path):
         logger.info("Validating transceiver attributes against templates in %s", templates_path)
-        validator = TemplateValidator(REPO_ROOT)
+        validator = TemplateValidator(ansible_root)
         try:
             # Validate merged attributes; raises on missing required attributes (partials only warn)
             compliance_dict = validator.validate(merged)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Makes the location of the `ansible` directory configurable instead of assuming it always lives at a fixed relative path (`../ansible`) from the `tests` directory in the repo checkout.

Test code across `tests/` hard-coded relative paths such as `../ansible/...`, `../../../ansible/files`, or `os.path.dirname(__file__) + '/../../../../ansible/...'`. This prevents running the test framework when the ansible inventory/config tree lives outside the `sonic-mgmt` checkout (e.g. a separate inventory repo or a packaged/installed layout).

This PR introduces a single source of truth for the ansible root:
- New session-scoped `ansible_root` pytest fixture in `tests/conftest.py`, resolved from the `ANSIBLE_CONFIG` environment variable, falling back to the directory of the `--testbed_file` option.
- Modules that cannot use a fixture (constants at import time) resolve the same way via `os.getenv("ANSIBLE_CONFIG", <path relative to __file__>)` using `pathlib`.
- `tests/run_tests.sh` now derives all ansible paths from `ANSIBLE_PARENT_DIR`, overridable with the new `ANSIBLE_PARENT_DIR_OVERRIDE` environment variable (defaults to the repo root, preserving current behavior).

Fixes # (issue)
It fixes the challenge of running the sonic-mgmt tests with an outside ansible directory.  
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
The `ansible` directory location was hard-coded as a relative path in many places under `tests/`, tying the test framework to the `sonic-mgmt` repo layout. Making it configurable allows the ansible inventory/config tree to live outside the checkout and removes fragile `../../../..`-style path arithmetic.

#### How did you do it?
- Added a session-scoped `ansible_root` fixture in `tests/conftest.py` (`ANSIBLE_CONFIG` env var, else the parent dir of the testbed file) and consumed it in `pdu`, `k8smasters`, `topo_bgp_routes`, `tests/bgp/test_bgp_vnet.py::setup_vnet`, `tests/transceiver/conftest.py::port_attributes_dict`, and `tests/transceiver/cdb_firmware_upgrade/conftest.py::transceiver_firmware_info_parser`.
- Replaced hard-coded relative ansible paths with `ANSIBLE_CONFIG`-based `pathlib` resolution in:
  - `tests/common/devices/aos.py`
  - `tests/common/fixtures/conn_graph_facts.py`
  - `tests/common/fixtures/pfc_asym.py`
  - `tests/common/helpers/dut_utils.py`
  - `tests/common/helpers/pfc_storm.py`
  - `tests/common/plugins/conditional_mark/__init__.py` (single `ANSIBLE_CONFIG_PATH` now derives `ASIC_NAME_PATH`, `ANSIBLE_LIBRARY_PATH`, inventory path, and proxy env files)
  - `tests/common/sai_adhoc.py`
- `tests/common/testbed.py` now resolves topology dirs relative to the testbed file location rather than `__file__`.
- `tests/transceiver/attribute_parser/paths.py` paths are now relative to the ansible root instead of the repo root.
- `tests/run_tests.sh`: added `ANSIBLE_PARENT_DIR` (overridable via `ANSIBLE_PARENT_DIR_OVERRIDE`), used for `INVENTORY`, `TESTBED_FILE`, and all exported `ANSIBLE_*` variables; documented in help and debug output.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran tests with and without `ANSIBLE_PARENT_DIR_OVERRIDE` env var. Tests are running as expected. Note that the testbed path should be from `ANSIBLE_PARENT_DIR_OVERRIDE` directory if you are using that env var.

#### Any platform specific information?
None. Changes are test-framework/path-resolution only; default behavior is unchanged when the env vars are not set.

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
The new `ANSIBLE_PARENT_DIR_OVERRIDE` variable is documented in `run_tests.sh -h` output.