### PR TITLE
Add support for sai.profile.j2 in link local ip test

### DIFF
--- a/tests/ip/link_local/test_link_local_ip.py
+++ b/tests/ip/link_local/test_link_local_ip.py
@@ -61,7 +61,15 @@ class TestLinkLocalIPacket:
         hwsku = duthost.facts['hwsku']
         sai_settings = {}
         sai_profile = "/usr/share/sonic/device/{}/{}/sai.profile".format(platform, hwsku)
-        for line in duthost.command("cat %s" % sai_profile)["stdout_lines"]:
+        sai_profile_template = "{}.j2".format(sai_profile)
+        if duthost.stat(path=sai_profile)["stat"]["exists"]:
+            sai_profile_cmd = "cat {}".format(sai_profile)
+        elif duthost.stat(path=sai_profile_template)["stat"]["exists"]:
+            sai_profile_cmd = "sonic-cfggen -d -t {}".format(sai_profile_template)
+        else:
+            pytest.skip("Unable to determine link-local support: sai.profile or sai.profile.j2 is not present")
+            return
+        for line in duthost.command(sai_profile_cmd)["stdout_lines"]:
             if (not re.match("^[ \t]*#", line)) and re.search("=", line):
                 # line should not a comment, and must contain the "=".
                 key, value = line.split("=")


### PR DESCRIPTION
test_link_local_ip.py assumes every DUT has a sai.profile file at /usr/share/sonic/device/platform/hwsku/sai.profile.
Some platforms only provide sai.profile.j2, which must be rendered with sonic-cfggen before the test can read SAI_NOT_DROP_SIP_DIP_LINK_LOCAL.

When only the template exists, the test raises an exception trying to cat the missing file instead of correctly determining whether link local forwarding is supported.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Improve skip check for test_link_local_ip.py
Fixes #26863
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202605: 20260806.01 - test now correctly checks skip condition
Kusto ID: ad3ccad5-1cd4-48e9-8803-e74574c4d09d
### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
I ran the test on a testbed with a sai.profile.j2 template. Also, made sure it caused no regressions in hwsku with a sai.profile
#### Any platform specific information?
generic
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
