### PR TITLE
[bgp] Restore CONFIG_DB on failed setup in test_bgp_router_id

### DIFF
--- a/tests/bgp/test_bgp_router_id.py
+++ b/tests/bgp/test_bgp_router_id.py
@@ -208,7 +208,7 @@ def restart_bgp_tracked(duthost, enum_asic_index, tbinfo, bgp_restart_state, bes
     """
     try:
         restart_bgp(duthost, enum_asic_index, tbinfo)
-    except Exception as e:
+    except (Exception, pytest.fail.Exception) as e:
         bgp_restart_state["wedged"].add((duthost.hostname, enum_asic_index))
         if not best_effort:
             raise

--- a/tests/bgp/test_bgp_router_id.py
+++ b/tests/bgp/test_bgp_router_id.py
@@ -182,41 +182,93 @@ def restart_bgp(duthost, enum_asic_index, tbinfo):
     wait_bgp_sessions(duthost, asic_index=enum_asic_index)
 
 
+@pytest.fixture(scope="module")
+def bgp_restart_state():
+    """Remember which DUT and ASIC combinations failed a BGP restart in this module.
+
+    The sanity check is module scoped, so a DUT wedged by a failed restart is not recovered
+    until the whole module has finished. Without this the remaining cases each pay the full
+    restart budget and the module is killed by the test timeout before it reports anything.
+    """
+    return {"wedged": set()}
+
+
+def skip_if_bgp_wedged(duthost, enum_asic_index, bgp_restart_state):
+    if (duthost.hostname, enum_asic_index) in bgp_restart_state["wedged"]:
+        pytest.skip("A BGP restart already failed for this ASIC, it is not in a usable state")
+
+
+def restart_bgp_tracked(duthost, enum_asic_index, tbinfo, bgp_restart_state, best_effort=False):
+    """Restart BGP and record the failure so the rest of the module can bail out cheaply.
+
+    During teardown use best_effort: CONFIG_DB has already been restored at that point, so if
+    BGP still does not come back there is nothing more the fixture can usefully do. Recovery is
+    left to the module scoped sanity check, whose config reload now succeeds because the
+    config is correct again.
+    """
+    try:
+        restart_bgp(duthost, enum_asic_index, tbinfo)
+    except Exception as e:
+        bgp_restart_state["wedged"].add((duthost.hostname, enum_asic_index))
+        if not best_effort:
+            raise
+        logger.warning("BGP restart failed during teardown, leaving recovery to the sanity check: %s", e)
+
+
 @pytest.fixture()
-def router_id_setup_and_teardown(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, tbinfo):
+def router_id_setup_and_teardown(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, tbinfo,
+                                 bgp_restart_state):
     duthost = duthosts[enum_frontend_dut_hostname]
-    run_config_db_cmd(duthost, enum_frontend_asic_index,
-                      "hset \"DEVICE_METADATA|localhost\" \"bgp_router_id\" \"{}\""
-                      .format(CUSTOMIZED_BGP_ROUTER_ID))
-    restart_bgp(duthost, enum_frontend_asic_index, tbinfo)
+    skip_if_bgp_wedged(duthost, enum_frontend_asic_index, bgp_restart_state)
+    try:
+        run_config_db_cmd(duthost, enum_frontend_asic_index,
+                          "hset \"DEVICE_METADATA|localhost\" \"bgp_router_id\" \"{}\""
+                          .format(CUSTOMIZED_BGP_ROUTER_ID))
+        restart_bgp_tracked(duthost, enum_frontend_asic_index, tbinfo, bgp_restart_state)
 
-    yield
-
-    run_config_db_cmd(duthost, enum_frontend_asic_index,
-                      "hdel \"DEVICE_METADATA|localhost\" \"bgp_router_id\"")
-    restart_bgp(duthost, enum_frontend_asic_index, tbinfo)
+        yield
+    finally:
+        # Restore CONFIG_DB even when setup failed, otherwise the DUT is left with the
+        # customized router id and the next test or the sanity recovery has to deal with it.
+        run_config_db_cmd(duthost, enum_frontend_asic_index,
+                          "hdel \"DEVICE_METADATA|localhost\" \"bgp_router_id\"")
+        if (duthost.hostname, enum_frontend_asic_index) in bgp_restart_state["wedged"]:
+            logger.warning("Not restarting BGP during teardown, a restart already failed in this module. "
+                           "CONFIG_DB has been restored so the sanity check can recover the DUT.")
+        else:
+            restart_bgp_tracked(duthost, enum_frontend_asic_index, tbinfo, bgp_restart_state, best_effort=True)
 
 
 @pytest.fixture(scope="function")
 def router_id_loopback_setup_and_teardown(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, loopback_ip,
-                                          tbinfo):
+                                          tbinfo, bgp_restart_state):
     duthost = duthosts[enum_frontend_dut_hostname]
-    run_config_db_cmd(duthost, enum_frontend_asic_index,
-                      "hset \"DEVICE_METADATA|localhost\" \"bgp_router_id\" \"{}\""
-                      .format(CUSTOMIZED_BGP_ROUTER_ID))
-    run_config_db_cmd(duthost, enum_frontend_asic_index,
-                      "del \"LOOPBACK_INTERFACE|Loopback0|{}/32\"".format(loopback_ip),
-                      module_ignore_errors=False)
-    restart_bgp(duthost, enum_frontend_asic_index, tbinfo)
+    skip_if_bgp_wedged(duthost, enum_frontend_asic_index, bgp_restart_state)
+    try:
+        run_config_db_cmd(duthost, enum_frontend_asic_index,
+                          "hset \"DEVICE_METADATA|localhost\" \"bgp_router_id\" \"{}\""
+                          .format(CUSTOMIZED_BGP_ROUTER_ID))
+        run_config_db_cmd(duthost, enum_frontend_asic_index,
+                          "del \"LOOPBACK_INTERFACE|Loopback0|{}/32\"".format(loopback_ip),
+                          module_ignore_errors=False)
+        restart_bgp_tracked(duthost, enum_frontend_asic_index, tbinfo, bgp_restart_state)
 
-    yield
-
-    run_config_db_cmd(duthost, enum_frontend_asic_index,
-                      "hdel \"DEVICE_METADATA|localhost\" \"bgp_router_id\"")
-    run_config_db_cmd(duthost, enum_frontend_asic_index,
-                      "hset \"LOOPBACK_INTERFACE|Loopback0|{}/32\" \"NULL\" \"NULL\""
-                      .format(loopback_ip))
-    restart_bgp(duthost, enum_frontend_asic_index, tbinfo)
+        yield
+    finally:
+        # Loopback0 is removed as part of setup. If setup fails after that point the DUT is left
+        # without Loopback0 and is not recoverable by the sanity check, which wedges the module
+        # until the test timeout, so always put the config back. Loopback0 is restored first
+        # because it is the only one of the two whose absence blocks recovery.
+        run_config_db_cmd(duthost, enum_frontend_asic_index,
+                          "hset \"LOOPBACK_INTERFACE|Loopback0|{}/32\" \"NULL\" \"NULL\""
+                          .format(loopback_ip))
+        run_config_db_cmd(duthost, enum_frontend_asic_index,
+                          "hdel \"DEVICE_METADATA|localhost\" \"bgp_router_id\"")
+        if (duthost.hostname, enum_frontend_asic_index) in bgp_restart_state["wedged"]:
+            logger.warning("Not restarting BGP during teardown, a restart already failed in this module. "
+                           "CONFIG_DB has been restored so the sanity check can recover the DUT.")
+        else:
+            restart_bgp_tracked(duthost, enum_frontend_asic_index, tbinfo, bgp_restart_state, best_effort=True)
 
 
 def test_bgp_router_id_default(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, nbrhosts, request,

--- a/tests/bgp/test_bgp_router_id.py
+++ b/tests/bgp/test_bgp_router_id.py
@@ -180,41 +180,93 @@ def restart_bgp(duthost, tbinfo):
     wait_bgp_sessions(duthost)
 
 
+@pytest.fixture(scope="module")
+def bgp_restart_state():
+    """Remember whether a BGP restart has already failed in this module.
+
+    The sanity check is module scoped, so a DUT wedged by a failed restart is not recovered
+    until the whole module has finished. Without this the remaining cases each pay the full
+    restart budget and the module is killed by the test timeout before it reports anything.
+    """
+    return {"wedged": False}
+
+
+def skip_if_bgp_wedged(bgp_restart_state):
+    if bgp_restart_state["wedged"]:
+        pytest.skip("A BGP restart already failed in this module, the DUT is not in a usable state")
+
+
+def restart_bgp_tracked(duthost, tbinfo, bgp_restart_state, best_effort=False):
+    """Restart BGP and record the failure so the rest of the module can bail out cheaply.
+
+    During teardown use best_effort: CONFIG_DB has already been restored at that point, so if
+    BGP still does not come back there is nothing more the fixture can usefully do. Recovery is
+    left to the module scoped sanity check, whose config reload now succeeds because the
+    config is correct again.
+    """
+    try:
+        restart_bgp(duthost, tbinfo)
+    except Exception as e:
+        bgp_restart_state["wedged"] = True
+        if not best_effort:
+            raise
+        logger.warning("BGP restart failed during teardown, leaving recovery to the sanity check: %s", e)
+
+
 @pytest.fixture()
-def router_id_setup_and_teardown(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, tbinfo):
+def router_id_setup_and_teardown(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, tbinfo,
+                                 bgp_restart_state):
     duthost = duthosts[enum_frontend_dut_hostname]
-    run_config_db_cmd(duthost, enum_frontend_asic_index,
-                      "hset \"DEVICE_METADATA|localhost\" \"bgp_router_id\" \"{}\""
-                      .format(CUSTOMIZED_BGP_ROUTER_ID))
-    restart_bgp(duthost, tbinfo)
+    skip_if_bgp_wedged(bgp_restart_state)
+    try:
+        run_config_db_cmd(duthost, enum_frontend_asic_index,
+                          "hset \"DEVICE_METADATA|localhost\" \"bgp_router_id\" \"{}\""
+                          .format(CUSTOMIZED_BGP_ROUTER_ID))
+        restart_bgp_tracked(duthost, tbinfo, bgp_restart_state)
 
-    yield
-
-    run_config_db_cmd(duthost, enum_frontend_asic_index,
-                      "hdel \"DEVICE_METADATA|localhost\" \"bgp_router_id\"")
-    restart_bgp(duthost, tbinfo)
+        yield
+    finally:
+        # Restore CONFIG_DB even when setup failed, otherwise the DUT is left with the
+        # customized router id and the next test or the sanity recovery has to deal with it.
+        run_config_db_cmd(duthost, enum_frontend_asic_index,
+                          "hdel \"DEVICE_METADATA|localhost\" \"bgp_router_id\"")
+        if bgp_restart_state["wedged"]:
+            logger.warning("Not restarting BGP during teardown, a restart already failed in this module. "
+                           "CONFIG_DB has been restored so the sanity check can recover the DUT.")
+        else:
+            restart_bgp_tracked(duthost, tbinfo, bgp_restart_state, best_effort=True)
 
 
 @pytest.fixture(scope="function")
 def router_id_loopback_setup_and_teardown(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, loopback_ip,
-                                          tbinfo):
+                                          tbinfo, bgp_restart_state):
     duthost = duthosts[enum_frontend_dut_hostname]
-    run_config_db_cmd(duthost, enum_frontend_asic_index,
-                      "hset \"DEVICE_METADATA|localhost\" \"bgp_router_id\" \"{}\""
-                      .format(CUSTOMIZED_BGP_ROUTER_ID))
-    run_config_db_cmd(duthost, enum_frontend_asic_index,
-                      "del \"LOOPBACK_INTERFACE|Loopback0|{}/32\"".format(loopback_ip),
-                      module_ignore_errors=False)
-    restart_bgp(duthost, tbinfo)
+    skip_if_bgp_wedged(bgp_restart_state)
+    try:
+        run_config_db_cmd(duthost, enum_frontend_asic_index,
+                          "hset \"DEVICE_METADATA|localhost\" \"bgp_router_id\" \"{}\""
+                          .format(CUSTOMIZED_BGP_ROUTER_ID))
+        run_config_db_cmd(duthost, enum_frontend_asic_index,
+                          "del \"LOOPBACK_INTERFACE|Loopback0|{}/32\"".format(loopback_ip),
+                          module_ignore_errors=False)
+        restart_bgp_tracked(duthost, tbinfo, bgp_restart_state)
 
-    yield
-
-    run_config_db_cmd(duthost, enum_frontend_asic_index,
-                      "hdel \"DEVICE_METADATA|localhost\" \"bgp_router_id\"")
-    run_config_db_cmd(duthost, enum_frontend_asic_index,
-                      "hset \"LOOPBACK_INTERFACE|Loopback0|{}/32\" \"NULL\" \"NULL\""
-                      .format(loopback_ip))
-    restart_bgp(duthost, tbinfo)
+        yield
+    finally:
+        # Loopback0 is removed as part of setup. If setup fails after that point the DUT is left
+        # without Loopback0 and is not recoverable by the sanity check, which wedges the module
+        # until the test timeout, so always put the config back. Loopback0 is restored first
+        # because it is the only one of the two whose absence blocks recovery.
+        run_config_db_cmd(duthost, enum_frontend_asic_index,
+                          "hset \"LOOPBACK_INTERFACE|Loopback0|{}/32\" \"NULL\" \"NULL\""
+                          .format(loopback_ip))
+        run_config_db_cmd(duthost, enum_frontend_asic_index,
+                          "hdel \"DEVICE_METADATA|localhost\" \"bgp_router_id\"")
+        if bgp_restart_state["wedged"]:
+            logger.warning("Not restarting BGP during teardown, a restart already failed in this module. "
+                           "CONFIG_DB has been restored so the sanity check can recover the DUT.")
+        else:
+            restart_bgp_tracked(duthost, tbinfo, bgp_restart_state, best_effort=True)
 
 
 def test_bgp_router_id_default(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, nbrhosts, request,


### PR DESCRIPTION
### Descrption of PR

When `restart_bgp()` fails inside fixture **setup** in `bgp/test_bgp_router_id.py`, pytest never runs that fixture's teardown, so the DUT is left with `Loopback0` deleted. Nothing repairs that mid-module, so every remaining case then fails slowly for a reason that is not its own, and the module can exceed its timeout and be killed without producing any JUnit XML.

Summary:
**Fixes** the module-level hang / cascade in `bgp.test_bgp_router_id`

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request

None requested.

### Approach

#### What is the motivation for this PR?

Over the **last 14 days** this module failed on **54 distinct PR test plans** (66 case failures) on **14 of 14 consecutive days**.

| Signature | Fails | Plans |
|---|---|---|
| `bgp_facts` 120s timeout (*"caller should retry"*) | 21 | 21 |
| teardown: *"Got matched syslog in processes..."* | 11 | 9 |
| **`Test failed and no xml file created`** (module killed) | **10** | **10** |
| `BGP session not established for neighbor ...` | 9 | 9 |
| `show ip bgp summary` rc=1 / sanity recovery failed | 9 | 9 |
| loopback advertisement / default route / other | 6 | 6 |

Row 3 is what this PR targets: **10 plans produced no XML at all**, so the plan cannot even report which case was at fault (e.g. 
 https://elastictest.org/scheduler/testplan/6a7494e8101ed2146e80a4b7?leftSideViewMode=detail&testcase=bgp%2Ftest_bgp_router_id.py&type=console, https://elastictest.org/scheduler/testplan/6a71be3cb103fcbd8adfc49f?leftSideViewMode=detail&testcase=bgp%2Ftest_bgp_router_id.py&type=console).

 Case runtimes on failure ran 237s to 1262s: cases burning their full restart budget before failing.

#### How did you do it?

Three changes, all in `tests/bgp/test_bgp_router_id.py`.

**1. Crash-safe fixtures (`try/finally`).** `router_id_loopback_setup_and_teardown` deletes `Loopback0` and *then* calls `restart_bgp()`. Cleanup was written after `yield`, and pytest only runs post-`yield` code if the fixture actually reached `yield`, so a failure in `restart_bgp()` skipped cleanup entirely. `finally` closes that window. `Loopback0` is restored **first**, since its absence is what blocks the sanity check's config reload from recovering the DUT.

**2. Module-scoped circuit breaker.** `sanity_check` is `scope="module", autouse=True`, so recovery only happens at **module boundaries**, never between cases. `try/finally` alone still leaves every later case paying a full restart budget on a DUT that cannot converge. `bgp_restart_state` is a module-scoped dict shared by both fixtures; the first failed restart sets `wedged=True` and later cases skip immediately instead of spending another 300-1100s rediscovering the same breakage.

No timeout values are changed. **3.** Teardown restarts best-effort (logs instead of raising, since CONFIG_DB is already restored by then). The slow restart is the trigger; the missing cleanup is the bug.

#### How did you verify/test it?

Dev-VM `vlab-03` (SONiC-VS/KVM, `Force10-S6000`, single ASIC), testbed `vms-kvm-t1-lag`, ~30 cEOS neighbours.

**Method.** `restart_bgp()` restarts the bgp container, so `SIGSTOP` on `bgpd` does not survive it. Instead `/usr/bin/vtysh` in that container was replaced with a sleeping stub, which survives `docker restart` via the writable layer, reproducing the exact production signature (`'show ip bgp summary' did not succeed within 120s, rc=124; caller should retry`). The break is applied **transiently** (healthy at module entry, stalled T+180s to T+600s, then healed) to mirror a mid-module stall. An earlier *permanent* stub was discarded as invalid: it killed the DUT before the module opened, so pytest hung inside `sanity_check` and never reached the code under test.

**Result 1, transient break, full module, both runs from a verified-clean DUT:**

| | master | this PR |
|---|---|---|
| Wall time | 736s | 646s |
| Outcome | 2 passed, **2 errors** | 2 passed, **1 skipped**, 1 error |
| Case 4 | **ERROR** (inherited) | **SKIPPED** (breaker) |
| `config_db_check` | **FAILED** | **clean** |

**Result 2, the state corruption this fixes.** On master, conftest's config checker caught the leak after setup failed pre-`yield`: `LOOPBACK_INTERFACE` lost `Loopback0|10.1.0.32/32` and never got it back, and `DEVICE_METADATA` kept the leaked `bgp_router_id: 8.8.8.8`. With this PR `config_db_check` is clean on every path.

**Result 3, cascade cost, full module from a healthy DUT:**

| | master | this PR |
|---|---|---|
| Wall time | **1613s** (26:50) | **398s** (6:34) |
| Outcome | 1 passed, 3 errors | 3 passed, 1 failed |
| `config_db_check` | FAILED | clean |

All three master errors carried the *same* message, `Default route not ready`. Only the first was genuine; the other two inherited the broken DUT. 4.1x faster and more correct on identical hardware.


#### Any platform specific information?

No. Test fixture logic only, platform-independent.

### Documentation

None required.
