### PR TITLE
Skip byte counter validation for SuperboltX

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1097,6 +1097,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                 if duthost.facts["platform"] in ["x86_64-8111_32eh_o-r0",
                                                  "x86_64-8122_64eh_o-r0",
                                                  "x86_64-8122_64ehf_o-r0",
+                                                 "x86_64-8122x_64ef_o-r0",
                                                  "x86_64-8223_64e_mo-r0",
                                                  "x86_64-8223_64ef_mo-r0"]:
                     skip_byte_accounting = True


### PR DESCRIPTION
### Description of PR

Add `x86_64-8122x_64ef_o-r0` (SuperboltX / Cisco-8122X-O128S2) to the
`skip_byte_accounting` platform list in the class-scoped `counters_sanity_check`
fixture in `tests/acl/test_acl.py`.

On SuperboltX, running `acl/test_acl.py` reports `384 passed, 16 errors` with
teardown message `Failed: ACL rule count mismatch: 0 should be greater than 0`.
All ACL traffic pass/drop tests pass; failures are fixture teardown errors when
validating ACL **byte** counters, which stay at 0 on G200-family platforms.

Sibling G200 platforms (8111, 8122, 8122F) already skip byte counter validation
in this fixture. SuperboltX was omitted when the platform was added.

Summary:
- Add `x86_64-8122x_64ef_o-r0` to `skip_byte_accounting` in `counters_sanity_check`
- Test-only fix; no product/SAI change
- Packet counters and PTF traffic validation remain unchanged

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- N/A unless backport requested -->

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: Verified on supx-t0 testbed (t0-64, DUT: supx-t0-dut)
  - Platform: `x86_64-8122x_64ef_o-r0`
  - HWSKU: `Cisco-8122X-O128S2`
  - ASIC: cisco-8000
  - Before: `384 passed, 616 skipped, 16 errors`
  - After: `384 passed, 616 skipped, 0 errors`
  - Smoke: `acl/test_acl.py::TestBasicAcl::test_dest_ip_match_dropped` — pass, no teardown error

### Approach

#### What is the motivation for this PR?

SuperboltX (8122X) does not report ACL byte counters in the SAI/SDK path (byte
counters remain 0; packet counters increment correctly). The existing
`counters_sanity_check` fixture validates byte counter growth at teardown unless
the platform is in the `skip_byte_accounting` allowlist. 8111/8122/8122F are
already listed; 8122X was missing, causing 16 teardown errors despite all ACL
functional tests passing.

#### How did you do it?

Added `x86_64-8122x_64ef_o-r0` to the existing platform allowlist in
`counters_sanity_check`, consistent with other G200-family entries in the same
fixture.

#### How did you verify/test it?

Ran full `acl/test_acl.py` on supx-t0 (SuperboltX). Confirmed:
- All ACL forward/drop traffic tests pass (unchanged)
- Teardown errors drop from 16 to 0
- Packet counters increment; byte counters remain 0 on platform (expected)

#### Supported testbed topology if it's a new test case?

N/A — test case improvement only; no new test case.

### Documentation

N/A