### PR TITLE
[ptfhost_utils] Refresh only responder neighbors

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -168,10 +168,13 @@ def remove_ip_addresses(ptfhost):
 def setup_ptf_ip_responder(duthost, ptfhost, responder_conf_path, ip_intf_pairs, route=False):
     # Use route=True when the responder IP is not in the DUT interface subnet/VLAN
     # and needs an explicit host route through that interface.
+    ip_intf_pairs = list(ip_intf_pairs)
     arp_responder_conf = {}
     ping_commands = []
     for ip, dut_intf, ptf_index in ip_intf_pairs:
-        ip_addr = ip_interface(str(ip)).ip
+        ip_addr = ip_interface(ip).ip
+        duthost.shell(
+            "ip -{} neigh flush to {} dev {}".format(ip_addr.version, ip_addr, dut_intf))
         arp_responder_conf.setdefault("eth{}".format(ptf_index), []).append(str(ip_addr))
         ping = "ping6" if ip_addr.version == 6 else "ping"
         ping_commands.append("{} -c 1 -w 1 -I {} {}".format(ping, dut_intf, ip_addr))
@@ -185,16 +188,23 @@ def setup_ptf_ip_responder(duthost, ptfhost, responder_conf_path, ip_intf_pairs,
     if route:
         for ip, dut_intf, _ in ip_intf_pairs:
             duthost.shell(_ptf_ip_route_cmd("replace", ip, dut_intf))
-    duthost.command("sonic-clear fdb all")
-    duthost.command("sonic-clear arp")
-    duthost.command("sonic-clear ndp")
+    # Wait for Scapy/libpcap initialization before probing the PTF responder.
     time.sleep(20)
     for cmd in ping_commands:
         duthost.shell(cmd, module_ignore_errors=True)
 
 
 def teardown_ptf_ip_responder(duthost, ptfhost, responder_conf_path, ip_intf_pairs=None, route=False):
+    if ip_intf_pairs is not None:
+        ip_intf_pairs = list(ip_intf_pairs)
+
     ptfhost.shell("supervisorctl stop arp_responder", module_ignore_errors=True)
+    if ip_intf_pairs:
+        for ip, dut_intf, _ in ip_intf_pairs:
+            ip_addr = ip_interface(ip).ip
+            duthost.shell(
+                "ip -{} neigh flush to {} dev {}".format(ip_addr.version, ip_addr, dut_intf))
+
     ptfhost.file(path=responder_conf_path, state="absent")
     ptfhost.file(path="/etc/supervisor/conf.d/arp_responder.conf", state="absent")
     ptfhost.shell("supervisorctl reread && supervisorctl update", module_ignore_errors=True)
@@ -202,9 +212,6 @@ def teardown_ptf_ip_responder(duthost, ptfhost, responder_conf_path, ip_intf_pai
         assert ip_intf_pairs, "ip_intf_pairs is required when route=True to clean up host routes"
         for ip, dut_intf, _ in ip_intf_pairs:
             duthost.shell(_ptf_ip_route_cmd("del", ip, dut_intf), module_ignore_errors=True)
-    duthost.command("sonic-clear fdb all")
-    duthost.command("sonic-clear arp")
-    duthost.command("sonic-clear ndp")
 
 
 def _ptf_ip_route_cmd(action, ip, dut_intf):

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -171,7 +171,10 @@ def setup_ptf_ip_responder(duthost, ptfhost, responder_conf_path, ip_intf_pairs,
     arp_responder_conf = {}
     ping_commands = []
     for ip, dut_intf, ptf_index in ip_intf_pairs:
-        ip_addr = ip_interface(str(ip)).ip
+        ip_addr = ip_interface(ip).ip
+        duthost.shell(
+            "ip -{} neigh del {} dev {}".format(ip_addr.version, ip_addr, dut_intf),
+            module_ignore_errors=True)
         arp_responder_conf.setdefault("eth{}".format(ptf_index), []).append(str(ip_addr))
         ping = "ping6" if ip_addr.version == 6 else "ping"
         ping_commands.append("{} -c 1 -w 1 -I {} {}".format(ping, dut_intf, ip_addr))
@@ -185,9 +188,7 @@ def setup_ptf_ip_responder(duthost, ptfhost, responder_conf_path, ip_intf_pairs,
     if route:
         for ip, dut_intf, _ in ip_intf_pairs:
             duthost.shell(_ptf_ip_route_cmd("replace", ip, dut_intf))
-    duthost.command("sonic-clear fdb all")
-    duthost.command("sonic-clear arp")
-    duthost.command("sonic-clear ndp")
+    # Wait for Scapy/libpcap initialization before probing the PTF responder.
     time.sleep(20)
     for cmd in ping_commands:
         duthost.shell(cmd, module_ignore_errors=True)
@@ -202,9 +203,6 @@ def teardown_ptf_ip_responder(duthost, ptfhost, responder_conf_path, ip_intf_pai
         assert ip_intf_pairs, "ip_intf_pairs is required when route=True to clean up host routes"
         for ip, dut_intf, _ in ip_intf_pairs:
             duthost.shell(_ptf_ip_route_cmd("del", ip, dut_intf), module_ignore_errors=True)
-    duthost.command("sonic-clear fdb all")
-    duthost.command("sonic-clear arp")
-    duthost.command("sonic-clear ndp")
 
 
 def _ptf_ip_route_cmd(action, ip, dut_intf):

--- a/tests/wol/conftest.py
+++ b/tests/wol/conftest.py
@@ -74,11 +74,13 @@ def setup_ip_on_ptf(duthost, ptfhost, ip, intf_pairs):
     ptfhost.remove_ip_addresses()
     setup_ptf_ip_responder(
         duthost, ptfhost, ARP_RESPONDER_PATH,
-        [(ip, dut_intf, ptf_index) for dut_intf, ptf_index in intf_pairs])
+        ((ip, dut_intf, ptf_index) for dut_intf, ptf_index in intf_pairs))
 
 
-def remove_ip_on_ptf(duthost, ptfhost):
-    teardown_ptf_ip_responder(duthost, ptfhost, ARP_RESPONDER_PATH)
+def remove_ip_on_ptf(duthost, ptfhost, ip, intf_pairs):
+    teardown_ptf_ip_responder(
+        duthost, ptfhost, ARP_RESPONDER_PATH,
+        ((ip, dut_intf, ptf_index) for dut_intf, ptf_index in intf_pairs))
 
 
 @pytest.fixture(scope="class")
@@ -94,7 +96,7 @@ def dst_ip_intf(request, duthost, ptfhost, vlan_brief, random_vlan, random_intf_
     yield ip
 
     if ip and isinstance(ipaddress.ip_address(ip), ipaddress.IPv6Address):
-        remove_ip_on_ptf(duthost, ptfhost)
+        remove_ip_on_ptf(duthost, ptfhost, ip, [random_intf_pair_to_remove_under_vlan])
         duthost.shell("config interface ip remove {} {}".format(random_intf_pair_to_remove_under_vlan[0], vlan_intf))
 
 
@@ -117,7 +119,8 @@ def dst_ip_vlan(request, duthost, ptfhost, get_connected_dut_intf_to_ptf_index, 
     yield ip
 
     if ip and isinstance(ipaddress.ip_address(ip), ipaddress.IPv6Address):
-        remove_ip_on_ptf(duthost, ptfhost)
+        remove_ip_on_ptf(duthost, ptfhost, ip,
+                         filter(lambda item: item[0] in vlan_members, get_connected_dut_intf_to_ptf_index))
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
### Description of PR

Summary:
Replace global DUT FDB, ARP, and NDP cache flushes in the shared PTF IP-responder helper with refresh of only the responder-owned neighbor entries.

This is the narrow cache-invalidation fix uncovered while validating #23432.

#### History and scope

Current review version: `v3.0`, exact head `c1ac463c72f461c3e73ce33b55e296015d7219e0`. This version only normalizes three setup/teardown line-wrapping inconsistencies approved after the completed behavioral review.

1. #20113 disabled IPv6 router-advertisement acceptance on PTF interfaces. As documented in #20760, the DHCPv6 multi-VLAN test then began missing `verify_relayed_advertise()` because forwarding the Advertise back to PTF could take about two seconds.
2. #20760 recorded that regression and the affected case retained a conditional expected-fail mark.
3. #26008 later extracted the WoL PTF responder setup into a shared helper for reuse by #23432. As a behavior-preserving refactor, it retained the existing WoL `sonic-clear fdb all`, `sonic-clear arp`, and `sonic-clear ndp` operations.
4. When #23432 used that helper for a simulated downstream DHCPv6 relay, the global NDP clear also deleted the unrelated, already-resolved PTF client neighbor. Physical reproduction showed that this forced the cold-neighbor path reported in #20760 immediately before DHCPv6 Advertise forwarding.
5. Removing every clear was not sufficient: the simulated relay reuses one IP across randomly selected PTF ports, so its own neighbor entry can retain the MAC of a previously selected port. This PR therefore refreshes only each explicit responder IP's neighbor entry before setup and after teardown.

This PR does not revert #20113 or claim to close the underlying timing issue in #20760. It stops the shared responder helper from unnecessarily triggering that known failure while still refreshing the state the helper owns.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: exact current head `c1ac463c72f461c3e73ce33b55e296015d7219e0`; [Azure build 1194850](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1194850) passed every required check. Its initial t2 attempt hit the known-active `test_basic_fib[True-True-1514]` `KeyError: '3.3.3.2'` flake; the targeted t2 retry passed.
- 202605: current head `c1ac463c72f461c3e73ce33b55e296015d7219e0` differs from the physically validated final behavioral head `35e0136c6d2e32cee961fa1d16a96ca295e10f75` only by three line-wrapping normalizations. The behavioral tree (reviewed head `af074461561ba191a3fa05fdfa3e2a3a0520dce8`, patch-identical squash `35e0136c6d2e32cee961fa1d16a96ca295e10f75`) was validated on `SONiC.20260510.07` (`1df5b92630`), physical [`testbed-bjw-can-720dt-3`](https://elastictest.org/testbed?searchKeyword=testbed-bjw-can-720dt-3), m0:
  - Readiness: 11 passed, 3 skipped.
  - IPv6 WoL interface and VLAN responder coverage: 8 passed.
  - Combined only in the validation stack with merged independent PR #23432 at `cd76cc3fe8036343f05a62b6219570871f5f8262`: DHCPv6 multi-VLAN default passed 5 consecutive full setup/teardown iterations with the stale #20760 conditional mark disabled.

### Approach
#### What is the motivation for this PR?

The helper owns only the explicit temporary responder IPs passed by its caller. Flushing every FDB, ARP, and NDP entry on the DUT is broader than that ownership and can disturb unrelated traffic.

For DHCPv6, the global NDP clear removes the existing PTF client neighbor and forces the known #20760 cold-neighbor timing path immediately before the Relay-Reply must be forwarded as an Advertise.

The responder's own neighbor still needs to be refreshed. The simulated downstream relay reuses the same IP with different randomly selected PTF ports, so a stale neighbor can otherwise direct traffic to the MAC of a previous port.

#### How did you do it?

- Removed the global `sonic-clear fdb all`, `sonic-clear arp`, and `sonic-clear ndp` calls from responder setup and teardown.
- Reused the existing parsed responder IP to flush only that IP's neighbor entry on its DUT interface before setup and after teardown.
- Used targeted `ip neigh flush to` so a missing entry is idempotent while an invalid interface or namespace still fails visibly.
- Materialized responder pair iterables inside the shared helpers and passed the owned pairs through WoL teardown.
- Kept responder configuration, optional route setup/teardown, the 20-second Scapy/libpcap initialization wait, and reachability pings unchanged.

#### How did you verify/test it?

Validated the exact final tree on physical 202605 m0:

- Readiness passed: 11 passed, 3 skipped.
- 8 IPv6 WoL interface/VLAN variants passed.
- Merged independent PR #23432 combined only in the validation stack passed the DHCPv6 multi-VLAN case 5 consecutive times with full setup and teardown.
- Current formatting-only head `c1ac463c72f461c3e73ce33b55e296015d7219e0`: `py_compile` and `git diff --check` pass; Azure build 1194850 is fully green after the known-active t2 flake passed on targeted retry; current-head Copilot reviewed 2/2 files with no comments.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.

##### Work item tracking

- Microsoft ADO (number only): 39170960
- Underlying #20760 follow-up Task: [39171019](https://msazure.visualstudio.com/One/_workitems/edit/39171019).
