### PR TITLE
Skipping this testcase on Marvell_teralynx

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5505,6 +5505,18 @@ system_health/test_system_health.py::test_service_checker_with_process_exit:
       - "branch in ['internal-202012']"
       - "build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 44"
 
+system_health/test_system_health.py::test_service_checker:
+  skip:
+    reason: "Skipping this testcase on Marvell_teralynx"
+    conditions:
+      - "asic_type in ['marvell-teralynx']"
+
+system_health/test_system_health.py::test_service_checker_with_process_exit:
+  skip:
+    reason: "Skipping this testcase on Marvell_teralynx"
+    conditions:
+      - "asic_type in ['marvell-teralynx']"
+
 system_health/test_watchdog.py::test_orchagent_watchdog:
   skip:
     reason: "orchagent watchdog test requires SWSS/orchagent; BMC SONiC image has no orchagent"


### PR DESCRIPTION
### Description of PR

Summary:
Skip the following System Health test cases on Marvell Teralynx platforms as they are currently unsupported.

Added skip conditions for:

system_health/test_system_health.py::test_service_checker
system_health/test_system_health.py::test_service_checker_with_process_exit

Fixes # NA

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A


### Approach
#### What is the motivation for this PR?
The test_service_checker and test_service_checker_with_process_exit test cases are not supported on Marvell Teralynx platforms. These tests consistently fail due to platform limitations, resulting in false failures in the test pipeline.

#### How did you do it?
Added platform-specific skip conditions in the skip condition YAML file

#### How did you verify/test it?
Verified that both test cases are skipped on Marvell Teralynx platforms.
Verified that the skip conditions do not affect execution on other ASIC platforms.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
NA

### Documentation
NA
