### PR TITLE
[BMC] Fix GCU test failures on SONiC BMC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2839,12 +2839,6 @@ generic_config_updater/test_multiasic_linkcrc.py:
       - "(is_multi_asic is False)"
       - "'bmc' in topo_type"
 
-generic_config_updater/test_ntp.py::test_ntp_server_change_source_intf:
-  skip:
-    reason: "Loopback0 is not present on BMC platforms (no routing data plane); sonic-ntp YANG validation rejects src_intf=Loopback0."
-    conditions:
-      - "'bmc' in topo_type"
-
 generic_config_updater/test_pfcwd_interval.py:
   skip:
     reason: "This test can only support mellanox platforms. This test is not run on this hwsku currently"

--- a/tests/generic_config_updater/test_apply_patch_perf.py
+++ b/tests/generic_config_updater/test_apply_patch_perf.py
@@ -95,7 +95,11 @@ def perf_ctx(duthosts, rand_one_dut_front_end_hostname):
     # (binding ACL tables to LAG member ports causes orchagent ERR logs
     # which trigger loganalyzer failures)
     output = duthost.shell("sonic-cfggen -d --var-json PORT")
-    ports = json.loads(output['stdout'])
+    # Devices with no PORT table at all (e.g. a BMC) return empty stdout, so fall
+    # through to the admin-up port check below rather than failing to parse.
+    ports = {}
+    if output['rc'] == 0 and output['stdout'].strip():
+        ports = json.loads(output['stdout'])
 
     pc_output = duthost.shell("sonic-db-cli CONFIG_DB keys 'PORTCHANNEL_MEMBER|*'",
                               module_ignore_errors=True)

--- a/tests/generic_config_updater/test_ntp.py
+++ b/tests/generic_config_updater/test_ntp.py
@@ -347,5 +347,7 @@ def test_ntp_server_change_source_intf(rand_selected_front_end_dut):
     """
     ntp_service = get_ntp_service_name(rand_selected_front_end_dut)
 
-    ntp_server_set_intf(rand_selected_front_end_dut, ntp_service, "Loopback0")
+    # A BMC has no Loopback0, so the src_intf leafref has nothing to resolve against.
+    if not rand_selected_front_end_dut.is_bmc():
+        ntp_server_set_intf(rand_selected_front_end_dut, ntp_service, "Loopback0")
     ntp_server_set_intf(rand_selected_front_end_dut, ntp_service, "eth0")


### PR DESCRIPTION
### Description of PR

Summary:
Two `generic_config_updater` tests fail on a SONiC BMC DUT because they assume a switch data plane that a BMC does not have. Neither is a product defect, the tests are simply not applicable as written.

This also narrows one of the skips added in #24617. That PR skipped `test_ntp_server_change_source_intf` entirely on BMC, but only the `Loopback0` leg is inapplicable: the `eth0` leg is valid on a BMC and exercises real behaviour, so skipping the whole test discarded working coverage. Here the guard is moved into the test so the `eth0` leg runs again, and the now-redundant `conditional_mark` entry is removed. cc @Gfrom2016 @Blueve, as the author and reviewer of #24617.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

No backport requested.

### Tested branch

- [x] master

### Test result

On a BMC DUT, topology `bmc-shared-mgmt`, platform `NH-4210-F-O256`:

```
tests/generic_config_updater/test_ntp.py               total 2, skipped 0, PASS
tests/generic_config_updater/test_apply_patch_perf.py  6 skipped, 0 errors, 0 failed
                                                       reason: "Need at least 2 admin-up ports, have 0"
```

`test_ntp.py` reporting `total 2, skipped 0` confirms both tests in the file pass, so the sibling `test_ntp_server_tc1_suite` is unaffected. The perf skip reason is the fixture's own message, which confirms it now reaches the intended check rather than crashing.

A full-suite run with both fixes applied went from 6 errors to 0 for `test_apply_patch_perf`, with no new failures introduced elsewhere.

### Approach

#### What is the motivation for this PR?

**`test_ntp_server_change_source_intf`** patches `/NTP/global/src_intf = Loopback0`. In `sonic-ntp.yang`, `src_intf` is a leaf-list of a five-member union, three of whose members are leafrefs to `PORT` / `PORTCHANNEL` / `LOOPBACK_INTERFACE`. A BMC has none of those tables, so the value cannot resolve.

A BMC has no `Loopback0` by design, guarded three independent ways by #23555: `minigraph_dpg.j2` emits `<LoopbackIPInterfaces i:nil="true"/>` for bmc topologies, `minigraph_template.j2` never sets `lp_ipv4`/`lp_ipv6`, and the bmc topology files declare no DUT interfaces at all. Confirmed on hardware: `LOOPBACK_INTERFACE` is empty on the BMC, while a switch in the same lab has `Loopback0` at a routable /32.

**`test_apply_patch_perf.py`** has a module-scoped `perf_ctx` fixture that runs `sonic-cfggen -d --var-json PORT`. On a BMC that returns rc=0 with **empty stdout**, because there is no `PORT` table, and `json.loads('')` then raises `JSONDecodeError`. Because the failure is in a shared module-scoped fixture, all six `test_perf_*` tests report ERROR at setup from one root cause.

#### How did you do it?

**NTP**: guard only the `Loopback0` call with `is_bmc()` and remove the now-redundant `conditional_mark` entry, so the `eth0` leg runs again. `is_bmc()` is already used this way twice in `test_cacl.py`, so no new helper or import is needed.

**perf**: initialise `ports = {}` and parse only when the command succeeded and stdout is non-empty. This lets the fixture fall through to its own pre-existing guard 20 lines later:

```python
if len(up_ports) < 2:
    pytest.skip("Need at least 2 admin-up ports, have {}".format(len(up_ports)))
```

The fixture was always written to skip on a device without enough ports, it just crashed before reaching that check. The new guard matches the idiom this same file already uses for the identical `json.loads` on `NTP_SERVER`, so the two paths are now consistent.

#### How did you verify/test it?

See the Test result section above. `pre-commit run --files <the three changed files>` is clean, including the `check conditional mark sort` hook.

#### Any platform specific information?

BMC only. No behaviour change on switches:

- `is_bmc()` returns false on a switch, so the `Loopback0` leg still runs there exactly as before.
- The perf guard is a no-op wherever `PORT` is populated, it only changes the empty-output path, which previously crashed.

#### Supported testbed topology if it's a new test case?

Not a new test case. Verified on `bmc-shared-mgmt`; the affected tests are marked `topology('any')` and are unchanged in that respect.

### Documentation

No documentation change needed, no new feature or test case, and the skip reasons are self-describing in the test output.
