### PR TITLE
Ignore crash kernel message generated during warm-reboot with kdump config

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -505,6 +505,9 @@ r, ".*ERR swss#orchagent:.*SAI_API_QUEUE, status: SAI_STATUS_INVALID_PARAMETER.*
 # SAI cannot read LT registers while the port serdes is mid-transition
 r, ".* ERR swss\d*#orchagent:.*getPortLinkTrainingFailure: Failed to get LT failure status for .*"
 
+# Ignore crash kernel message generated with kdump config
+r, ".*crashkernel.*SONIC_BOOT_TYPE=warm"
+
 # Ignore RX signal detect and RX SNR feature unavailable errors on broadcom platforms
 # and the corresponding collectData failure from FlexCounter PORT_PHY_ATTR polling
 # https://github.com/sonic-net/sonic-mgmt/issues/24023

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5505,6 +5505,18 @@ system_health/test_system_health.py::test_service_checker_with_process_exit:
       - "branch in ['internal-202012']"
       - "build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 44"
 
+system_health/test_system_health.py::test_service_checker:
+  skip:
+    reason: "Skipping this testcase on Marvell_teralynx"
+    conditions:
+      - "asic_type in ['marvell-teralynx']"
+
+system_health/test_system_health.py::test_service_checker_with_process_exit:
+  skip:
+    reason: "Skipping this testcase on Marvell_teralynx"
+    conditions:
+      - "asic_type in ['marvell-teralynx']"
+
 system_health/test_watchdog.py::test_orchagent_watchdog:
   skip:
     reason: "orchagent watchdog test requires SWSS/orchagent; BMC SONiC image has no orchagent"


### PR DESCRIPTION

### Description of PR

Summary:
Update the common LogAnalyzer ignore list to suppress the expected crashkernel kernel message generated during warm boot when kdump is configured.

Added the following ignore pattern to loganalyzer_common_ignore.txt:

r, ".*crashkernel.*SONIC_BOOT_TYPE=warm"

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
NA

### Approach
#### What is the motivation for this PR?
When kdump is enabled, the kernel generates a crashkernel boot parameter message during warm boot. This is an expected informational message, but LogAnalyzer reports it as an unexpected log entry, leading to false test failures.

#### How did you do it?
Added a new regular expression to the common LogAnalyzer ignore list (loganalyzer_common_ignore.txt) to ignore the expected crashkernel message generated during warm boot:

r, ".*crashkernel.*SONIC_BOOT_TYPE=warm"

#### How did you verify/test it?
Verified that LogAnalyzer no longer flags the expected crashkernel warm boot message as an unexpected log.
Confirmed that log analysis continues to detect other unexpected log entries normally.

#### Any platform specific information?
he change is platform-independent and applies to systems where the crashkernel boot parameter is present during warm boot with kdump enabled.

#### Supported testbed topology if it's a new test case?
NA

### Documentation
