### PR TITLE
[mvrf] Enable test_mgmtvrf.py on vs testbeds: PTF NTP fallback for post-reboot check

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3811,10 +3811,10 @@ mvrf:
 
 mvrf/test_mgmtvrf.py:
   skip:
-    reason: "mvrf is not supported in x86_64-nokia_ixr7250e_36x400g-r0 platform, M* topo, mellanox and nvidia asic"
+    reason: "mvrf is not supported in x86_64-nokia_ixr7250e_36x400g-r0 platform, M* topo, mellanox, nvidia and broadcom asic from 202411 and later"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'nvidia']"
+      - "asic_type in ['mellanox', 'nvidia', 'broadcom']"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3811,20 +3811,12 @@ mvrf:
 
 mvrf/test_mgmtvrf.py:
   skip:
-<<<<<<< HEAD
-    reason: "mvrf is not supported in x86_64-nokia_ixr7250e_36x400g-r0 platform, M* topo, kvm testbed, mellanox, nvidia and broadcom asic from 202411 and later and  test skipped due to github issue #3589"
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vs', 'mellanox', 'nvidia', 'broadcom']"
-=======
     reason: "mvrf is not supported in x86_64-nokia_ixr7250e_36x400g-r0 platform, M* topo, mellanox and nvidia asic"
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['mellanox', 'nvidia']"
->>>>>>> 339e23779 (NOS-13590: enable mvrf/test_mgmtvrf.py on vs — PTF NTP for post-reboot check (#2508))
       - "topo_type in ['m0', 'mx', 'm1']"
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/3589"
 
 mvrf/test_mgmtvrf.py::TestReboot::test_fastboot:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3811,10 +3811,17 @@ mvrf:
 
 mvrf/test_mgmtvrf.py:
   skip:
+<<<<<<< HEAD
     reason: "mvrf is not supported in x86_64-nokia_ixr7250e_36x400g-r0 platform, M* topo, kvm testbed, mellanox, nvidia and broadcom asic from 202411 and later and  test skipped due to github issue #3589"
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vs', 'mellanox', 'nvidia', 'broadcom']"
+=======
+    reason: "mvrf is not supported in x86_64-nokia_ixr7250e_36x400g-r0 platform, M* topo, mellanox and nvidia asic"
+    conditions_logical_operator: or
+    conditions:
+      - "asic_type in ['mellanox', 'nvidia']"
+>>>>>>> 339e23779 (NOS-13590: enable mvrf/test_mgmtvrf.py on vs — PTF NTP for post-reboot check (#2508))
       - "topo_type in ['m0', 'mx', 'm1']"
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
       - "https://github.com/sonic-net/sonic-mgmt/issues/3589"

--- a/tests/mvrf/temp_http_server.py
+++ b/tests/mvrf/temp_http_server.py
@@ -12,7 +12,7 @@ class TempHttpServer(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "text/plain")
         self.end_headers()
 
-        self.wfile.write(bytes(MAGIC_STRING))
+        self.wfile.write(bytes(MAGIC_STRING, 'utf-8'))
 
 
 if __name__ == "__main__":

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -10,6 +10,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.ntp_helper import NtpDaemon, ntp_daemon_in_use, setup_ntp_context   # noqa: F401
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 from tests.common.devices.ptf import PTFHost
+from tests.common.gu_utils import apply_patch, generate_tmpfile, delete_tmpfile, format_json_patch_for_multiasic
 from tests.common.fixtures.duthost_utils import duthosts_ipv4_mgmt_only    # noqa: F401
 
 pytestmark = [
@@ -156,6 +157,26 @@ def ntp_servers(duthosts, rand_one_dut_hostname):
     return ntp_servers
 
 
+def ntp_vrf_config_update(duthost, vrf="default"):
+    """
+    Apply NTP configuration with specified VRF as json patch
+    """
+    json_patch = [
+        {
+            "op": "replace",
+            "path": "/NTP/global/vrf",
+            "value": vrf
+        }
+    ]
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    tmpfile = generate_tmpfile(duthost)
+    try:
+        output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+        logger.info(f"Apply patch result: {output}")
+    finally:
+        delete_tmpfile(duthost, tmpfile)
+
+
 @pytest.fixture()
 def ntp_teardown(ptfhost, duthosts, rand_one_dut_hostname, ntp_servers):
     yield
@@ -189,6 +210,48 @@ def check_ntp_status(host, ntp_daemon_in_use):  # noqa: F811
     else:
         res = execute_dut_command(host, ntpstat_cmd, mvrf=True, ignore_errors=True)
     return res['rc'] == 0
+
+
+def check_ntp_reachability(duthost, ntp_daemon_in_use):  # noqa: F811
+    """
+    Check if at least one NTP server is reachable.
+
+    For Chrony, parses output of 'chronyc sources -v':
+        Example line: ^* ntp1.example.com    2   6   377    64   +123us[ +140us] +/-   10ms
+        The reach column (index 4) is in octal: 377 = all 8 polls successful, 0 = none
+
+    For NTP/NTPSEC, parses output of 'ntpq -p':
+        Example line: *ntp1.example.com .GPS.  1 u  64  64  377  1.234  0.123  0.045
+        The reach column (index 7) is in octal: 377 = all 8 polls successful, 0 = none
+    """
+    if ntp_daemon_in_use == NtpDaemon.CHRONY:
+        sources = execute_dut_command(duthost, "chronyc sources -v", mvrf=True, ignore_errors=True)
+        if sources["rc"] == 0:
+            for line in sources["stdout"].split('\n'):
+                # Lines starting with ^ are server entries (^*, ^+, ^-, etc.)
+                # Skip the header line which contains "Reach"
+                if line.startswith('^') and 'Reach' not in line:
+                    parts = line.split()
+                    CHRONY_REACH_INDEX = 4
+                    if len(parts) >= CHRONY_REACH_INDEX + 1:
+                        reach_value = parts[CHRONY_REACH_INDEX]
+                        if reach_value != '0':
+                            logger.info(f"Found reachable NTP server: {line.strip()}")
+                            return True
+    else:
+        peers = execute_dut_command(duthost, "ntpq -p", mvrf=True, ignore_errors=True)
+        if peers["rc"] == 0:
+            for line in peers["stdout"].split('\n'):
+                # Lines starting with *, +, or - are active peer entries
+                if line.startswith('*') or line.startswith('+') or line.startswith('-'):
+                    parts = line.split()
+                    NTPQ_REACH_INDEX = 6
+                    if len(parts) >= NTPQ_REACH_INDEX + 1:
+                        reach_value = parts[NTPQ_REACH_INDEX]
+                        if reach_value != '0':
+                            logger.info(f"Found reachable NTP peer: {line.strip()}")
+                            return True
+    return False
 
 
 def verify_show_command(duthost, mvrf=True):
@@ -305,15 +368,11 @@ class TestServices():
 
 
 class TestReboot():
-<<<<<<< HEAD
-    def basic_check_after_reboot(self, duthost, localhost, ptfhost, creds):
-=======
     def basic_check_after_reboot(self, duthost, localhost, ptfhost, creds, ntp_daemon_in_use,  # noqa: F811
                                  check_ntp_sync):
         """
         Perform basic checks after reboot to verify mgmt VRF functionality.
         """
->>>>>>> 339e23779 (NOS-13590: enable mvrf/test_mgmtvrf.py on vs — PTF NTP for post-reboot check (#2508))
         verify_show_command(duthost)
         inbound_test = TestMvrfInbound()
         outbound_test = TestMvrfOutbound()
@@ -321,10 +380,6 @@ class TestReboot():
         inbound_test.test_ping(duthost=duthost)
         inbound_test.test_snmp_fact(localhost=localhost, duthost=duthost, creds=creds)
 
-<<<<<<< HEAD
-    @pytest.mark.disable_loganalyzer
-    def test_warmboot(self, duthosts, rand_one_dut_hostname, localhost, ptfhost, creds, change_critical_services):
-=======
         # Verify NTP is reachable after reboot when configured in mgmt VRF.
         # If the configured NTP servers were not reachable before the test
         # (e.g. vs testbeds have no route to the lab NTP servers), verify
@@ -344,11 +399,13 @@ class TestReboot():
     @pytest.mark.disable_loganalyzer
     def test_warmboot(self, duthosts, rand_one_dut_hostname, localhost, ptfhost, creds,
                       change_critical_services, ntp_daemon_in_use, check_ntp_sync):  # noqa: F811
->>>>>>> 339e23779 (NOS-13590: enable mvrf/test_mgmtvrf.py on vs — PTF NTP for post-reboot check (#2508))
         duthost = duthosts[rand_one_dut_hostname]
+
+        ntp_vrf_config_update(duthost, vrf="mgmt")
+
         duthost.command("sudo config save -y")  # This will override config_db.json with mgmt vrf config
         reboot(duthost, localhost, reboot_type="warm")
-        pytest_assert(wait_until(120, 20, 0, duthost.critical_services_fully_started),
+        pytest_assert(wait_until(240, 20, 0, duthost.critical_services_fully_started),
                       "Not all critical services are fully started")
 
         # Change default critical services to check services that starts with bootOn timer
@@ -365,44 +422,32 @@ class TestReboot():
             critical_services.append('telemetry')
         duthost.reset_critical_services_tracking_list(critical_services)
 
-        pytest_assert(wait_until(180, 20, 0, duthost.critical_services_fully_started),
+        pytest_assert(wait_until(360, 20, 0, duthost.critical_services_fully_started),
                       "Not all services which start with bootOn timer are fully started")
-<<<<<<< HEAD
-        self.basic_check_after_reboot(duthost, localhost, ptfhost, creds)
-
-    @pytest.mark.disable_loganalyzer
-    def test_reboot(self, duthosts, rand_one_dut_hostname, localhost, ptfhost, creds):
-=======
         self.basic_check_after_reboot(duthost, localhost, ptfhost, creds, ntp_daemon_in_use, check_ntp_sync)
 
     @pytest.mark.disable_loganalyzer
     def test_reboot(self, duthosts, rand_one_dut_hostname, localhost, ptfhost, creds,
                     ntp_daemon_in_use, check_ntp_sync):  # noqa: F811
->>>>>>> 339e23779 (NOS-13590: enable mvrf/test_mgmtvrf.py on vs — PTF NTP for post-reboot check (#2508))
         duthost = duthosts[rand_one_dut_hostname]
+
+        ntp_vrf_config_update(duthost, vrf="mgmt")
+
         duthost.command("sudo config save -y")  # This will override config_db.json with mgmt vrf config
         reboot(duthost, localhost)
-        pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
+        pytest_assert(wait_until(600, 20, 0, duthost.critical_services_fully_started),
                       "Not all critical services are fully started")
-<<<<<<< HEAD
-        self.basic_check_after_reboot(duthost, localhost, ptfhost, creds)
-
-    @pytest.mark.disable_loganalyzer
-    def test_fastboot(self, duthosts, rand_one_dut_hostname, localhost, ptfhost, creds):
-=======
         self.basic_check_after_reboot(duthost, localhost, ptfhost, creds, ntp_daemon_in_use, check_ntp_sync)
 
     @pytest.mark.disable_loganalyzer
     def test_fastboot(self, duthosts, rand_one_dut_hostname, localhost, ptfhost, creds,
                       ntp_daemon_in_use, check_ntp_sync):  # noqa: F811
->>>>>>> 339e23779 (NOS-13590: enable mvrf/test_mgmtvrf.py on vs — PTF NTP for post-reboot check (#2508))
         duthost = duthosts[rand_one_dut_hostname]
+
+        ntp_vrf_config_update(duthost, vrf="mgmt")
+
         duthost.command("sudo config save -y")  # This will override config_db.json with mgmt vrf config
         reboot(duthost, localhost, reboot_type="fast")
-        pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
+        pytest_assert(wait_until(600, 20, 0, duthost.critical_services_fully_started),
                       "Not all critical services are fully started")
-<<<<<<< HEAD
-        self.basic_check_after_reboot(duthost, localhost, ptfhost, creds)
-=======
         self.basic_check_after_reboot(duthost, localhost, ptfhost, creds, ntp_daemon_in_use, check_ntp_sync)
->>>>>>> 339e23779 (NOS-13590: enable mvrf/test_mgmtvrf.py on vs — PTF NTP for post-reboot check (#2508))

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -7,7 +7,8 @@ from tests.common import reboot
 from tests.common.utilities import wait_until
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.ntp_helper import NtpDaemon, ntp_daemon_in_use, setup_ntp_context   # noqa: F401
+from tests.common.helpers.ntp_helper import (NtpDaemon, ntp_daemon_in_use, setup_ntp_context,  # noqa: F401
+                                             get_ntp_daemon_in_use)
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 from tests.common.devices.ptf import PTFHost
 from tests.common.gu_utils import apply_patch, generate_tmpfile, delete_tmpfile, format_json_patch_for_multiasic
@@ -182,8 +183,16 @@ def ntp_teardown(ptfhost, duthosts, rand_one_dut_hostname, ntp_servers):
     yield
 
     duthost = duthosts[rand_one_dut_hostname]
+    # Determine the NTP service in use
+    ntp_daemon_type = get_ntp_daemon_in_use(ptfhost)
+    if ntp_daemon_type == NtpDaemon.NTPSEC:
+        ntp_service_name = 'ntpsec'
+    elif ntp_daemon_type == NtpDaemon.CHRONY:
+        ntp_service_name = 'chrony'
+    else:
+        ntp_service_name = 'ntp'
     # stop ntp server
-    ptfhost.service(name="ntp", state="stopped")
+    ptfhost.service(name=ntp_service_name, state="stopped")
     # reset ntp client configuration
     duthost.command("config ntp del %s" % ptfhost.mgmt_ip, module_ignore_errors=True)
     for ntp_server in ntp_servers:

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -305,7 +305,15 @@ class TestServices():
 
 
 class TestReboot():
+<<<<<<< HEAD
     def basic_check_after_reboot(self, duthost, localhost, ptfhost, creds):
+=======
+    def basic_check_after_reboot(self, duthost, localhost, ptfhost, creds, ntp_daemon_in_use,  # noqa: F811
+                                 check_ntp_sync):
+        """
+        Perform basic checks after reboot to verify mgmt VRF functionality.
+        """
+>>>>>>> 339e23779 (NOS-13590: enable mvrf/test_mgmtvrf.py on vs — PTF NTP for post-reboot check (#2508))
         verify_show_command(duthost)
         inbound_test = TestMvrfInbound()
         outbound_test = TestMvrfOutbound()
@@ -313,8 +321,30 @@ class TestReboot():
         inbound_test.test_ping(duthost=duthost)
         inbound_test.test_snmp_fact(localhost=localhost, duthost=duthost, creds=creds)
 
+<<<<<<< HEAD
     @pytest.mark.disable_loganalyzer
     def test_warmboot(self, duthosts, rand_one_dut_hostname, localhost, ptfhost, creds, change_critical_services):
+=======
+        # Verify NTP is reachable after reboot when configured in mgmt VRF.
+        # If the configured NTP servers were not reachable before the test
+        # (e.g. vs testbeds have no route to the lab NTP servers), verify
+        # through a PTF-hosted server instead, as TestServices::test_ntp does.
+        if check_ntp_sync:
+            with setup_ntp_context(ptfhost, duthost, False):
+                pytest_assert(
+                    wait_until(120, 10, 0, check_ntp_reachability, duthost, ntp_daemon_in_use),
+                    "NTP servers should be reachable after reboot when NTP is configured in mgmt VRF. "
+                )
+        else:
+            pytest_assert(
+                wait_until(120, 10, 0, check_ntp_reachability, duthost, ntp_daemon_in_use),
+                "NTP servers should be reachable after reboot when NTP is configured in mgmt VRF. "
+            )
+
+    @pytest.mark.disable_loganalyzer
+    def test_warmboot(self, duthosts, rand_one_dut_hostname, localhost, ptfhost, creds,
+                      change_critical_services, ntp_daemon_in_use, check_ntp_sync):  # noqa: F811
+>>>>>>> 339e23779 (NOS-13590: enable mvrf/test_mgmtvrf.py on vs — PTF NTP for post-reboot check (#2508))
         duthost = duthosts[rand_one_dut_hostname]
         duthost.command("sudo config save -y")  # This will override config_db.json with mgmt vrf config
         reboot(duthost, localhost, reboot_type="warm")
@@ -337,22 +367,42 @@ class TestReboot():
 
         pytest_assert(wait_until(180, 20, 0, duthost.critical_services_fully_started),
                       "Not all services which start with bootOn timer are fully started")
+<<<<<<< HEAD
         self.basic_check_after_reboot(duthost, localhost, ptfhost, creds)
 
     @pytest.mark.disable_loganalyzer
     def test_reboot(self, duthosts, rand_one_dut_hostname, localhost, ptfhost, creds):
+=======
+        self.basic_check_after_reboot(duthost, localhost, ptfhost, creds, ntp_daemon_in_use, check_ntp_sync)
+
+    @pytest.mark.disable_loganalyzer
+    def test_reboot(self, duthosts, rand_one_dut_hostname, localhost, ptfhost, creds,
+                    ntp_daemon_in_use, check_ntp_sync):  # noqa: F811
+>>>>>>> 339e23779 (NOS-13590: enable mvrf/test_mgmtvrf.py on vs — PTF NTP for post-reboot check (#2508))
         duthost = duthosts[rand_one_dut_hostname]
         duthost.command("sudo config save -y")  # This will override config_db.json with mgmt vrf config
         reboot(duthost, localhost)
         pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
                       "Not all critical services are fully started")
+<<<<<<< HEAD
         self.basic_check_after_reboot(duthost, localhost, ptfhost, creds)
 
     @pytest.mark.disable_loganalyzer
     def test_fastboot(self, duthosts, rand_one_dut_hostname, localhost, ptfhost, creds):
+=======
+        self.basic_check_after_reboot(duthost, localhost, ptfhost, creds, ntp_daemon_in_use, check_ntp_sync)
+
+    @pytest.mark.disable_loganalyzer
+    def test_fastboot(self, duthosts, rand_one_dut_hostname, localhost, ptfhost, creds,
+                      ntp_daemon_in_use, check_ntp_sync):  # noqa: F811
+>>>>>>> 339e23779 (NOS-13590: enable mvrf/test_mgmtvrf.py on vs — PTF NTP for post-reboot check (#2508))
         duthost = duthosts[rand_one_dut_hostname]
         duthost.command("sudo config save -y")  # This will override config_db.json with mgmt vrf config
         reboot(duthost, localhost, reboot_type="fast")
         pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
                       "Not all critical services are fully started")
+<<<<<<< HEAD
         self.basic_check_after_reboot(duthost, localhost, ptfhost, creds)
+=======
+        self.basic_check_after_reboot(duthost, localhost, ptfhost, creds, ntp_daemon_in_use, check_ntp_sync)
+>>>>>>> 339e23779 (NOS-13590: enable mvrf/test_mgmtvrf.py on vs — PTF NTP for post-reboot check (#2508))


### PR DESCRIPTION
### Description of PR

Summary:
Resolves #26886

Re-enables `mvrf/test_mgmtvrf.py` (skipped module-wide by a conditional_mark condition on issue #3589, open since 2021) and adds post-reboot NTP verification to `TestReboot`, with a PTF-hosted NTP fallback for testbeds that cannot reach the statically configured NTP servers (e.g. vs).

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: N/A

### Approach
#### What is the motivation for this PR?

The module never runs anywhere: the conditional_mark entry carries an or'd bare-URL condition on open issue #3589, so every platform skips it. And the reboot cases verify ping/SNMP after reboot but never NTP, so a regression that breaks NTP's mgmt-VRF binding across warm/cold/fast reboot goes unnoticed (`TestServices::test_ntp` covers steady state only).

#### How did you do it?

- Configure NTP into the mgmt VRF (GCU patch of `/NTP/global/vrf`) in the warm/cold/fast reboot cases, and verify NTP server reachability after reboot by parsing the reach column of `chronyc sources -v` / `ntpq -p`.
- When the configured NTP servers were not reachable before the test either (`check_ntp_sync`), verify through a PTF-hosted NTP server (`setup_ntp_context`) instead — the pattern `TestServices::test_ntp` already uses. This is what makes the check work on vs testbeds, which have no route to lab NTP servers.
- Bump the post-reboot critical-service timeouts (120→240, 180→360, 300→600); kvm needs the headroom.
- Drop the issue #3589 conditional_mark gate and remove `vs` from the asic skip list. The module remains skipped for mellanox/nvidia/broadcom asics, M* topos, and the Nokia IXR7250E platform, as before — the broadcom skip (#21056) is a separate, deliberate decision this PR doesn't touch.
- Fix two failures the re-enabled module hits on current kvm testbeds (root-caused by reproducing the kvmtest-t0 CI failure on a local `vms-kvm-t0` testbed with a master `sonic-vs` image):
  - `temp_http_server.py` wrote `bytes(MAGIC_STRING)` without an encoding — a `TypeError` on Python 3 after the headers are sent, so curl gets a 200 with an empty body and `test_curl` fails.
  - `ntp_teardown` hardcodes the `ntp` service name; current docker-ptf images run ntpsec or chrony, so teardown errored with "Could not find the requested service ntp". Detect the daemon in use, the same way `setup_ntp_context` already does.

#### How did you verify/test it?

kvm `vms-kvm-t0` (master `sonic-vs` image, cEOS neighbors, docker-ptf:latest): 9/9 pass, 35m05s — this reproduces the environment of the failed kvmtest-t0 check; before the last two fixes the same run showed exactly its failures (`test_curl` failed, `test_ntp` teardown error), and all three `TestReboot` cases took the PTF NTP fallback path and passed.

Internal equivalents of the TestReboot changes: kvm t0 10/10 (~39 min); physical Broadcom t0 10/10 — NTP is in sync with the lab NTP servers there, so the post-reboot check takes the direct (non-PTF) path.

#### Any platform specific information?

N/A.

#### Supported testbed topology if it's a new test case?

Existing tests, t0.

### Documentation

N/A.


