### PR TITLE
Update iptables rules check to add IPv6 rules only when iptables-persistent is installed

### DIFF
--- a/tests/dualtor/test_mux_port_iptables_entries.py
+++ b/tests/dualtor/test_mux_port_iptables_entries.py
@@ -61,7 +61,11 @@ def generate_nat_expected_rules(duthost):
     ip6tables_natrules.append("-P POSTROUTING ACCEPT")
 
     debian_version = duthost.command("grep VERSION_CODENAME /etc/os-release")['stdout'].lower()
-    if "trixie" in debian_version:
+    # The iptables-persistent package causes iptables rules to persist across reboots, including rules that were
+    # added at build time, which is not the intention. This will be removed in later images.
+    iptables_rules_persist = "installed" in duthost.command("dpkg-query -W -f '${Status}\\n' iptables-persistent",
+                                                            module_ignore_errors=True)['stdout']
+    if "trixie" in debian_version and iptables_rules_persist:
         ip6tables_natrules.append("-N DOCKER")
         ip6tables_natrules.append("-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER")
         ip6tables_natrules.append("-A OUTPUT ! -d ::1/128 -m addrtype --dst-type LOCAL -j DOCKER")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Part of #26179
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

When the iptables-persistent package is installed, there is a chance that iptables rules that were added or present at build time may make their way into the image. Additionally, this may cause rules to persist across reboots, which likely is not the intention.

#### How did you do it?

Update test_mux_port_iptables_entries.py to expect the IPv6 rules only when the iptables-persistent package is present. This package will be removed from the SONiC image in sonic-net/sonic-buildimage#28596.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
