### PR TITLE
[snappi] Derive TGEN link_training from DUT instead of hardcoding it

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1222,8 +1222,8 @@ def snappi_dut_base_config(duthost_list,
                 if lt_val is not None:
                     lt_from_dut = str(lt_val).lower() in ['on', 'true', 'yes', '1']
                     break
-    except Exception:
-        pass
+    except Exception as err:
+        logger.warning("Failed to derive link training from DUT CONFIG_DB; using legacy default: %s", err)
 
     if lt_from_dut is not None:
         l1_config.auto_negotiation.link_training = lt_from_dut

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1208,7 +1208,26 @@ def snappi_dut_base_config(duthost_list,
     l1_config.speed = 'speed_{}_gbps'.format(speed_gbps)
     l1_config.ieee_media_defaults = False
     l1_config.auto_negotiate = False
-    if is_snappi_multidut(duthost_list):
+
+    # Derive link_training from DUT CONFIG_DB if available, otherwise use legacy defaults
+    lt_from_dut = None
+    try:
+        dut_for_lt = duthost_list[0] if duthost_list else None
+        if dut_for_lt:
+            run_facts = dut_for_lt.config_facts(host=dut_for_lt.hostname, source="running")['ansible_facts']
+            port_table = run_facts.get('PORT', {})
+            for sp in new_snappi_ports:
+                p = sp.get('peer_port')
+                lt_val = port_table.get(p, {}).get('link_training')
+                if lt_val is not None:
+                    lt_from_dut = str(lt_val).lower() in ['on', 'true', 'yes', '1']
+                    break
+    except Exception:
+        pass
+
+    if lt_from_dut is not None:
+        l1_config.auto_negotiation.link_training = lt_from_dut
+    elif is_snappi_multidut(duthost_list):
         l1_config.auto_negotiation.link_training = False
     else:
         l1_config.auto_negotiation.link_training = True


### PR DESCRIPTION
### Description of PR

`snappi_dut_base_config` hardcodes the traffic generator's `auto_negotiation.link_training = True` for single-DUT testbeds (introduced in #14361). On **optical 400G single-DUT** beds where the DUT runs `link_training: off` (e.g. Q3D), forcing link training **on** at the TGEN makes the DUT↔TGEN link fault (`mac_local_fault` / `mac_remote_fault`); the link never trains, so ARP never resolves and every snappi test on that bed fails.

This change derives `link_training` from the DUT's CONFIG_DB `PORT` table (per `peer_port`) and applies it to the TGEN, so the TGEN matches the DUT's actual link-training setting.

Summary:
- Read `link_training` from the DUT running-config `PORT[<peer_port>]`.
- Apply the derived value to the TGEN L1 `auto_negotiation.link_training`.
- Fall back to the previous behavior (`multidut → False`, single-DUT → `True`) when the DUT does not set `link_training`, so beds that don't configure it are **unchanged** (backward compatible).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework (new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request

- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512

### Approach

#### What is the motivation for this PR?

Single-DUT snappi testbeds with optical 400G links that run `link_training: off` (e.g. Q3D) cannot bring up the DUT↔TGEN link, because the TGEN is hardcoded to `link_training = True`, producing `mac_local_fault` / `mac_remote_fault`. The link never trains, ARP never resolves, and every snappi test on the bed fails.

#### How did you do it?

In `snappi_dut_base_config`, read `link_training` from the DUT CONFIG_DB `PORT` table for the test `peer_port`s and set the TGEN's `auto_negotiation.link_training` to that value. The previous hardcoded defaults are kept as a fallback for the case where the DUT does not set `link_training` (or the read fails), so existing behavior is preserved for those beds.

#### How did you verify/test it?

Ran `snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio` on Q3D platform(400G, `link_training: off`, RS-FEC) single-DUT snappi testbed:
- Before: `mac_local_fault` / `mac_remote_fault`, `ARP is not resolved in 60 seconds`, all tests fail.
- After: link trains, ARP resolves, **2 passed**.

#### Any platform specific information?

Affects single-DUT snappi testbeds whose DUT sets `link_training` (notably optical 400G platforms that require `link_training: off`). No behavior change for beds that don't set `link_training`.
