### PR TITLE
[pfcwd] Use XGS PFC generator for NH-4210

### DIFF
--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -34,6 +34,7 @@ def get_chip_name_if_asic_pfc_storm_supported(fanout):
         "Arista-7260QX3": "Tomahawk2",
         "M2-W6940-64X1-FR4": "Tomahawk5",
         "Nokia-IXR7220": "Tomahawk6",
+        "NH-4210-F-O256": "Tomahawk6",
         }
 
     for sku, chip in hwSkuInfo.items():


### PR DESCRIPTION
### Description of PR

Summary:
Use the Broadcom XGS PFC generator for Nexthop NH-4210 SONiC fanouts by mapping the `NH-4210-F-O256` HWSKU to `Tomahawk6`.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: day-one issue

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

- Confirmed the generated fanout command uses `pfc_gen_brcm_xgs.py -c Tomahawk6` instead of the generic PFC generator.
- On `vms13-lt2-nh4210-1` (`lt2-u32d128`, `str4-nh4210-01`), the all-port PFC storm test detected storm on 142/160 ports, exceeding the 75% threshold.
- The IPv4 parameterization passed. The IPv6 parameterization also reached the storm threshold but later failed during watchdog restoration; that recovery failure is separate from generator selection.
- Python compilation, template-selection checks, and `git diff --check` passed.

### Approach
#### What is the motivation for this PR?

The Nexthop NH-4210 fanout uses a Broadcom Tomahawk6 ASIC. Without an HWSKU-to-chip mapping, the PFC storm helper does not recognize this fanout as XGS-capable and selects the generic generator path. On the NH-4210 LT2 testbed, that path did not generate enough PFC traffic for the DUT to detect a storm.

#### How did you do it?

Added `NH-4210-F-O256` to `get_chip_name_if_asic_pfc_storm_supported()` with the `Tomahawk6` chip name. The existing SONiC XGS path then deploys `pfc_gen_brcm_xgs.py` and renders the XGS-compatible start and stop templates with the correct chip argument.

#### How did you verify/test it?

Validated the all-port PFC watchdog storm test on `vms13-lt2-nh4210-1`. The fanout ran `pfc_gen_brcm_xgs.py -c Tomahawk6`, and storm detection reached 142/160 ports. The IPv4 test passed; IPv6 reached storm state but failed later during restore. Also verified Python syntax and the LT2 start/stop template selection locally.

#### Any platform specific information?

Nexthop NH-4210 HWSKU: `NH-4210-F-O256`; Broadcom ASIC: Tomahawk6.

#### Supported testbed topology if it's a new test case?

N/A; this updates generator selection for existing PFC watchdog tests on LT2.

### Documentation

N/A; no user-facing interface or new test case.