### PR TITLE
Add gNMI audit and authorization tests

### DIFF
--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -585,13 +585,8 @@ def _restart_gnoi_server(duthost):
     if result['rc'] != 0:
         raise Exception(f"Failed to restart gnmi-native: {result['stderr']}")
 
-    # Wait for supervisor to report RUNNING. This is a fast guard against
-    # immediate crash loops; it does NOT prove that telemetry has actually
-    # bound its TLS listener (supervisor flips RUNNING after startsecs=1,
-    # but on slow armhf platforms the gnmi-native wrapper + Go telemetry
-    # startup can take longer than that to call listen()). The end-to-end
-    # readiness check lives in _verify_gnoi_tls_connectivity, which retries
-    # bounded grpcurl calls from PTF.
+    # Wait for supervisor to report RUNNING as a guard against immediate
+    # crash loops.
     def _supervisor_running():
         status = duthost.shell("docker exec gnmi supervisorctl status gnmi-native",
                                module_ignore_errors=True)
@@ -604,7 +599,37 @@ def _restart_gnoi_server(duthost):
             f"gnmi-native failed to reach RUNNING within 30s: {status.get('stdout', '')}"
         )
 
-    logger.info("gNOI server restart completed (supervisor reports RUNNING)")
+    # Supervisor can report RUNNING before telemetry binds its TLS listener,
+    # especially on slower platforms. Do not return until callers can safely
+    # start a client connection. Full TLS/RPC validation remains in
+    # _verify_gnoi_tls_connectivity.
+    def _tls_listener_ready():
+        status = duthost.shell(
+            "sudo ss -ltn | grep -q ':{} '".format(
+                grpc_config.DEFAULT_TLS_PORT
+            ),
+            module_ignore_errors=True,
+        )
+        return status.get('rc', 1) == 0
+
+    if not wait_until(60, 2, 0, _tls_listener_ready):
+        status = duthost.shell(
+            "sudo ss -ltn | grep ':{} '".format(
+                grpc_config.DEFAULT_TLS_PORT
+            ),
+            module_ignore_errors=True,
+        )
+        raise Exception(
+            "gNOI server failed to listen on port {} within 60s: {}".format(
+                grpc_config.DEFAULT_TLS_PORT,
+                status.get('stdout', ''),
+            )
+        )
+
+    logger.info(
+        "gNOI server restart completed (supervisor RUNNING, port %s listening)",
+        grpc_config.DEFAULT_TLS_PORT,
+    )
 
 
 def _verify_gnoi_tls_connectivity(duthost, ptfhost):

--- a/tests/common/helpers/gnmi_audit.py
+++ b/tests/common/helpers/gnmi_audit.py
@@ -1,0 +1,76 @@
+import json
+import shlex
+
+from scapy.all import Raw, UDP, rdpcap
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
+
+RPC_COMPLETION_PREFIX = "RPC_COMPLETION "
+
+
+def parse_audit_records(log_text, method, principal):
+    records = []
+    decoder = json.JSONDecoder()
+    for line in log_text.splitlines():
+        _, separator, payload = line.partition(RPC_COMPLETION_PREFIX)
+        if not separator:
+            continue
+        try:
+            record, _ = decoder.raw_decode(payload)
+        except json.JSONDecodeError:
+            continue
+        if (record.get("method") == method
+                and record.get("principal") == principal):
+            records.append(record)
+    return records
+
+
+def _audit_record_written(duthost, offset, method, principal):
+    new_log = duthost.shell(
+        "sudo tail -c +{} /var/log/gnmi.log".format(offset + 1),
+        module_ignore_errors=True,
+    )["stdout"]
+    return len(parse_audit_records(new_log, method, principal)) == 1
+
+
+def wait_for_audit_record(duthost, offset, method, principal):
+    pytest_assert(
+        wait_until(30, 1, 0, _audit_record_written,
+                   duthost, offset, method, principal),
+        "Missing {} completion record in /var/log/gnmi.log".format(method),
+    )
+    new_log = duthost.shell(
+        "sudo tail -c +{} /var/log/gnmi.log".format(offset + 1)
+    )["stdout"]
+    records = parse_audit_records(new_log, method, principal)
+    pytest_assert(
+        len(records) == 1,
+        "Expected exactly one {} completion record".format(method),
+    )
+    return records
+
+
+def read_forwarded_payloads(duthost, capture_result, capture_file):
+    pytest_assert(
+        wait_until(35, 1, 0, capture_result.ready),
+        "UDP/514 packet capture did not finish",
+    )
+    capture_status = capture_result.get()
+    pcap_status = duthost.shell(
+        "sudo test -s {}".format(shlex.quote(capture_file)),
+        module_ignore_errors=True,
+    )
+    pytest_assert(
+        pcap_status["rc"] == 0,
+        "UDP/514 capture file is empty or missing: {}".format(
+            capture_status
+        ),
+    )
+    duthost.fetch(src=capture_file, dest="/tmp/", flat=True)
+    return [
+        bytes(packet[Raw].load).decode("utf-8", errors="replace")
+        for packet in rdpcap(capture_file)
+        if UDP in packet and Raw in packet
+    ]

--- a/tests/common/helpers/gnmi_audit.py
+++ b/tests/common/helpers/gnmi_audit.py
@@ -10,7 +10,15 @@ from tests.common.utilities import wait_until
 RPC_COMPLETION_PREFIX = "RPC_COMPLETION "
 
 
-def parse_audit_records(log_text, method, principal):
+def get_audit_log_offset(duthost):
+    return int(
+        duthost.shell(
+            "sudo stat -c %s /var/log/gnmi.log"
+        )["stdout"].strip()
+    )
+
+
+def parse_audit_records(log_text, method, principal, code=None, path=None):
     records = []
     decoder = json.JSONDecoder()
     for line in log_text.splitlines():
@@ -21,35 +29,58 @@ def parse_audit_records(log_text, method, principal):
             record, _ = decoder.raw_decode(payload)
         except json.JSONDecodeError:
             continue
-        if (record.get("method") == method
-                and record.get("principal") == principal):
-            records.append(record)
+        if (record.get("method") != method
+                or record.get("principal") != principal):
+            continue
+        if code is not None and record.get("code") != code:
+            continue
+        if path is not None and path not in (record.get("path") or []):
+            continue
+        records.append(record)
     return records
 
 
-def _audit_record_written(duthost, offset, method, principal):
+def _audit_records_written(duthost, offset, method, principal,
+                           expected_count, code, path):
     new_log = duthost.shell(
         "sudo tail -c +{} /var/log/gnmi.log".format(offset + 1),
         module_ignore_errors=True,
     )["stdout"]
-    return len(parse_audit_records(new_log, method, principal)) == 1
+    records = parse_audit_records(
+        new_log, method, principal, code=code, path=path
+    )
+    return len(records) >= expected_count
 
 
-def wait_for_audit_record(duthost, offset, method, principal):
+def wait_for_audit_records(duthost, offset, method, principal,
+                           expected_count, code=None, path=None, timeout=30):
     pytest_assert(
-        wait_until(30, 1, 0, _audit_record_written,
-                   duthost, offset, method, principal),
-        "Missing {} completion record in /var/log/gnmi.log".format(method),
+        wait_until(timeout, 1, 0, _audit_records_written,
+                   duthost, offset, method, principal,
+                   expected_count, code, path),
+        "Expected {} {} completion records in /var/log/gnmi.log".format(
+            expected_count, method
+        ),
     )
     new_log = duthost.shell(
         "sudo tail -c +{} /var/log/gnmi.log".format(offset + 1)
     )["stdout"]
-    records = parse_audit_records(new_log, method, principal)
+    records = parse_audit_records(
+        new_log, method, principal, code=code, path=path
+    )
     pytest_assert(
-        len(records) == 1,
-        "Expected exactly one {} completion record".format(method),
+        len(records) == expected_count,
+        "Expected exactly {} {} completion records, got {}".format(
+            expected_count, method, len(records)
+        ),
     )
     return records
+
+
+def wait_for_audit_record(duthost, offset, method, principal):
+    return wait_for_audit_records(
+        duthost, offset, method, principal, expected_count=1
+    )
 
 
 def read_forwarded_payloads(duthost, capture_result, capture_file):

--- a/tests/common/helpers/gnmi_audit.py
+++ b/tests/common/helpers/gnmi_audit.py
@@ -1,7 +1,4 @@
 import json
-import shlex
-
-from scapy.all import Raw, UDP, rdpcap
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
@@ -81,27 +78,3 @@ def wait_for_audit_record(duthost, offset, method, principal):
     return wait_for_audit_records(
         duthost, offset, method, principal, expected_count=1
     )
-
-
-def read_forwarded_payloads(duthost, capture_result, capture_file):
-    pytest_assert(
-        wait_until(35, 1, 0, capture_result.ready),
-        "UDP/514 packet capture did not finish",
-    )
-    capture_status = capture_result.get()
-    pcap_status = duthost.shell(
-        "sudo test -s {}".format(shlex.quote(capture_file)),
-        module_ignore_errors=True,
-    )
-    pytest_assert(
-        pcap_status["rc"] == 0,
-        "UDP/514 capture file is empty or missing: {}".format(
-            capture_status
-        ),
-    )
-    duthost.fetch(src=capture_file, dest="/tmp/", flat=True)
-    return [
-        bytes(packet[Raw].load).decode("utf-8", errors="replace")
-        for packet in rdpcap(capture_file)
-        if UDP in packet and Raw in packet
-    ]

--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -258,7 +258,7 @@ def redis_hgetall(duthost, db, key):
 def redis_hset(duthost, db, key, **fields):
     """HSET one or more field=value pairs."""
     if not fields:
-        return
+        return None
     parts = ' '.join(
         "{key} {value}".format(
             key=shlex.quote(str(field_name)),
@@ -279,7 +279,7 @@ def redis_hset(duthost, db, key, **fields):
 def redis_hdel(duthost, db, key, *fields):
     """HDEL one or more fields from a hash."""
     if not fields:
-        return
+        return None
     return duthost.shell(
         "sonic-db-cli {db} -- HDEL {key} {fields}".format(
             db=db,

--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -265,6 +265,18 @@ def redis_hset(duthost, db, key, **fields):
     )
 
 
+def redis_hdel(duthost, db, key, *fields):
+    """HDEL one or more fields from a hash."""
+    if not fields:
+        return
+    duthost.shell(
+        "sonic-db-cli {db} HDEL '{key}' {fields}".format(
+            db=db, key=key, fields=' '.join(fields)
+        ),
+        module_ignore_errors=True
+    )
+
+
 def redis_del(duthost, db, *keys):
     """DEL one or more keys."""
     for k in keys:

--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -2,6 +2,7 @@ import logging
 import json
 import six
 import ast
+import shlex
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.devices.sonic_asic import SonicAsic
 
@@ -270,8 +271,10 @@ def redis_hdel(duthost, db, key, *fields):
     if not fields:
         return
     duthost.shell(
-        "sonic-db-cli {db} HDEL '{key}' {fields}".format(
-            db=db, key=key, fields=' '.join(fields)
+        "sonic-db-cli {db} -- HDEL {key} {fields}".format(
+            db=db,
+            key=shlex.quote(key),
+            fields=' '.join(shlex.quote(field) for field in fields),
         ),
         module_ignore_errors=True
     )

--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -259,9 +259,19 @@ def redis_hset(duthost, db, key, **fields):
     """HSET one or more field=value pairs."""
     if not fields:
         return
-    parts = ' '.join("{k} {v}".format(k=k, v=v) for k, v in fields.items())
-    duthost.shell(
-        "sonic-db-cli {db} -- HSET '{key}' {parts}".format(db=db, key=key, parts=parts),
+    parts = ' '.join(
+        "{key} {value}".format(
+            key=shlex.quote(str(field_name)),
+            value=shlex.quote(str(field_value)),
+        )
+        for field_name, field_value in fields.items()
+    )
+    return duthost.shell(
+        "sonic-db-cli {db} -- HSET {key} {parts}".format(
+            db=db,
+            key=shlex.quote(str(key)),
+            parts=parts,
+        ),
         module_ignore_errors=True
     )
 
@@ -270,11 +280,11 @@ def redis_hdel(duthost, db, key, *fields):
     """HDEL one or more fields from a hash."""
     if not fields:
         return
-    duthost.shell(
+    return duthost.shell(
         "sonic-db-cli {db} -- HDEL {key} {fields}".format(
             db=db,
-            key=shlex.quote(key),
-            fields=' '.join(shlex.quote(field) for field in fields),
+            key=shlex.quote(str(key)),
+            fields=' '.join(shlex.quote(str(field)) for field in fields),
         ),
         module_ignore_errors=True
     )
@@ -282,11 +292,18 @@ def redis_hdel(duthost, db, key, *fields):
 
 def redis_del(duthost, db, *keys):
     """DEL one or more keys."""
+    results = []
     for k in keys:
-        duthost.shell(
-            "sonic-db-cli {db} DEL '{k}'".format(db=db, k=k),
-            module_ignore_errors=True
+        results.append(
+            duthost.shell(
+                "sonic-db-cli {db} -- DEL {key}".format(
+                    db=db,
+                    key=shlex.quote(str(k)),
+                ),
+                module_ignore_errors=True,
+            )
         )
+    return results
 
 
 def redis_keys(duthost, db, pattern):

--- a/tests/common/helpers/syslog_helpers.py
+++ b/tests/common/helpers/syslog_helpers.py
@@ -1,8 +1,16 @@
-import os
+from contextlib import contextmanager
+
 import logging
-import pytest
+import os
+import shlex
 import time
-from scapy.all import rdpcap
+import uuid
+
+import pytest
+from scapy.all import Raw, UDP, rdpcap
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 
 DUT_PCAP_FILEPATH = "/tmp/test_syslog_tcpdump.pcap"
 DOCKER_TMP_PATH = "/tmp/"
@@ -27,6 +35,108 @@ def del_syslog_server(dut, syslog_server_ip, module_ignore_errors=False):
         "sudo config syslog del {}".format(syslog_server_ip),
         module_ignore_errors=module_ignore_errors,
     )
+
+
+@contextmanager
+def capture_remote_syslog(dut, destination, vrf=None):
+    capture_file = "/tmp/syslog-{}.pcap".format(uuid.uuid4().hex)
+    capture_pool = None
+    capture_result = None
+    server_added = False
+
+    try:
+        result = add_syslog_server(dut, destination, vrf=vrf)
+        pytest_assert(result["rc"] == 0, "Failed to add syslog server")
+        server_added = True
+
+        remote_action = 'Target="{}" Port="514"'.format(destination)
+
+        def remote_action_configured():
+            command = "grep -F {} /etc/rsyslog.conf".format(
+                shlex.quote(remote_action)
+            )
+            if vrf:
+                command += " | grep -Fq {}".format(
+                    shlex.quote('Device="{}"'.format(vrf))
+                )
+            else:
+                command += " >/dev/null"
+            return dut.shell(
+                command, module_ignore_errors=True
+            )["rc"] == 0
+
+        pytest_assert(
+            wait_until(30, 1, 0, remote_action_configured),
+            "Host rsyslog did not configure UDP/514 forwarding",
+        )
+
+        capture_command = (
+            "sudo timeout 30 tcpdump -i any -y LINUX_SLL -nn "
+            "-s0 -U -w {} {}"
+        ).format(
+            shlex.quote(capture_file),
+            shlex.quote(
+                "udp and dst host {} and dst port 514".format(destination)
+            ),
+        )
+        capture_pool, capture_result = dut.shell(
+            capture_command,
+            module_async=True,
+            module_ignore_errors=True,
+        )
+
+        def capture_started():
+            return dut.shell(
+                "sudo test $(stat -c %s {}) -ge 24".format(
+                    shlex.quote(capture_file)
+                ),
+                module_ignore_errors=True,
+            )["rc"] == 0
+
+        pytest_assert(
+            wait_until(10, 1, 0, capture_started),
+            "UDP/514 packet capture did not start",
+        )
+        yield capture_result, capture_file
+    finally:
+        if capture_pool is not None:
+            if capture_result.ready():
+                capture_pool.close()
+            else:
+                capture_pool.terminate()
+            capture_pool.join()
+        dut.shell(
+            "sudo rm -f {}".format(shlex.quote(capture_file)),
+            module_ignore_errors=True,
+        )
+        if os.path.exists(capture_file):
+            os.remove(capture_file)
+        if server_added:
+            del_syslog_server(dut, destination, module_ignore_errors=True)
+
+
+def read_syslog_payloads(dut, capture_result, capture_file):
+    pytest_assert(
+        wait_until(35, 1, 0, capture_result.ready),
+        "UDP/514 packet capture did not finish",
+    )
+    capture_status = capture_result.get()
+    pcap_status = dut.shell(
+        "sudo test -s {}".format(shlex.quote(capture_file)),
+        module_ignore_errors=True,
+    )
+    pytest_assert(
+        pcap_status["rc"] == 0,
+        "UDP/514 capture file is empty or missing: {}".format(
+            capture_status
+        ),
+    )
+    dut.fetch(src=capture_file, dest="/tmp/", flat=True)
+    return [
+        bytes(packet[Raw].load).decode("utf-8", errors="replace")
+        for packet in rdpcap(capture_file)
+        if UDP in packet and Raw in packet
+    ]
 
 
 # Before real test, check default route on DUT:

--- a/tests/common/helpers/syslog_helpers.py
+++ b/tests/common/helpers/syslog_helpers.py
@@ -10,6 +10,25 @@ DOCKER_TMP_PATH = "/tmp/"
 logger = logging.getLogger(__name__)
 
 
+def add_syslog_server(dut, syslog_server_ip, source=None, vrf=None, port=None):
+    command = "sudo config syslog add {}".format(syslog_server_ip)
+    if source:
+        command += " --source {}".format(source)
+    if vrf:
+        command += " --vrf {}".format(vrf)
+    if port:
+        command += " --port {}".format(port)
+    logger.debug("Add syslog server command: %s", command)
+    return dut.command(command, module_ignore_errors=True)
+
+
+def del_syslog_server(dut, syslog_server_ip, module_ignore_errors=False):
+    return dut.command(
+        "sudo config syslog del {}".format(syslog_server_ip),
+        module_ignore_errors=module_ignore_errors,
+    )
+
+
 # Before real test, check default route on DUT:
 #     If DUT has no IPv4 and IPv6 default route, skip syslog test. If DUT has at least one type default route,
 #     tell test_syslog function to do further check

--- a/tests/gnmi/test_gnmi.py
+++ b/tests/gnmi/test_gnmi.py
@@ -1,10 +1,7 @@
 import pytest
 import logging
 
-from tests.common.helpers.gnmi_utils import (
-    add_gnmi_client_common_name,
-    gnmi_capabilities,
-)
+from tests.common.helpers.gnmi_utils import gnmi_capabilities
 from .helper import gnmi_set, dump_gnmi_log, gnmi_subscribe_streaming_sample
 from tests.common.utilities import wait_until
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
@@ -41,81 +38,6 @@ def test_gnmi_capabilities(duthosts, rand_one_dut_hostname, localhost):
         "'JSON_IETF' not found in GNMI capabilities response message.\n"
         "- Actual message: {}"
     ).format(msg)
-
-
-def test_gnmi_capabilities_authenticate(duthosts, rand_one_dut_hostname, localhost):
-    '''
-    Verify GNMI capabilities with different roles
-    '''
-    duthost = duthosts[rand_one_dut_hostname]
-
-    with allure.step("Verify GNMI capabilities with noaccess role"):
-        role = "gnmi_noaccess"
-        add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
-        ret, msg = gnmi_capabilities(duthost, localhost)
-        assert ret != 0, (
-            "GNMI capabilities authenticate with noaccess role command unexpectedly succeeded "
-            "(zero return code) for a client with noaccess role.\n"
-            "- Error message: {}"
-        ).format(msg)
-
-        assert role in msg, (
-            "Expected role '{}' in GNMI capabilities authenticate with noaccess role response, but got: {}"
-        ).format(role, msg)
-
-    with allure.step("Verify GNMI capabilities with readonly role"):
-        role = "gnmi_readonly"
-        add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
-        ret, msg = gnmi_capabilities(duthost, localhost)
-        assert ret == 0, (
-            "GNMI capabilities authenticate readonly command failed (non-zero return code).\n"
-            "- Error message: {}"
-        ).format(msg)
-
-        assert "sonic-db" in msg, (
-            "Expected 'sonic-db' in GNMI capabilities authenticate with readonly role response, but got: {}"
-        ).format(msg)
-
-        assert "JSON_IETF" in msg, (
-            "Expected 'JSON_IETF' in GNMI capabilities authenticate with readonly role  response, but got: {}"
-        ).format(msg)
-
-    with allure.step("Verify GNMI capabilities with readwrite role"):
-        role = "gnmi_readwrite"
-        add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
-        ret, msg = gnmi_capabilities(duthost, localhost)
-        assert ret == 0, (
-            "GNMI capabilities authenticate readwrite role command failed (non-zero return code).\n"
-            "- Error message: {}"
-        ).format(msg)
-
-        assert "sonic-db" in msg, (
-            "Expected 'sonic-db' in GNMI capabilities with readwrite role response, but got: {}"
-        ).format(msg)
-
-        assert "JSON_IETF" in msg, (
-            "Expected 'JSON_IETF' in GNMI capabilities  with readwrite role response, but got: {}"
-        ).format(msg)
-
-    with allure.step("Verify GNMI capabilities with empty role"):
-        role = ""
-        add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
-        ret, msg = gnmi_capabilities(duthost, localhost)
-        assert ret == 0, (
-            "GNMI capabilities authenticate with empty role command failed (non-zero return code).\n"
-            "- Error message: {}"
-        ).format(msg)
-
-        assert "sonic-db" in msg, (
-            "Expected 'sonic-db' in GNMI capabilities with empty role response, but got: {}"
-        ).format(msg)
-
-        assert "JSON_IETF" in msg, (
-            "Expected 'JSON_IETF' in GNMI capabilities with empty role response, but got: {}"
-        ).format(msg)
-
-    # Restore default role
-    add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
 
 
 def gnmi_create_vnet(duthost, ptfhost, cert=None):

--- a/tests/gnmi/test_gnmi.py
+++ b/tests/gnmi/test_gnmi.py
@@ -1,8 +1,10 @@
 import pytest
 import logging
 
-from tests.common.helpers.gnmi_utils import gnmi_capabilities, add_gnmi_client_common_name, \
-                                            del_gnmi_client_common_name
+from tests.common.helpers.gnmi_utils import (
+    add_gnmi_client_common_name,
+    gnmi_capabilities,
+)
 from .helper import gnmi_set, dump_gnmi_log, gnmi_subscribe_streaming_sample
 from tests.common.utilities import wait_until
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
@@ -116,21 +118,6 @@ def test_gnmi_capabilities_authenticate(duthosts, rand_one_dut_hostname, localho
     add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
 
 
-@pytest.fixture(scope="function")
-def setup_invalid_client_cert_cname(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    del_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
-    add_gnmi_client_common_name(duthost, "invalid.cname")
-
-    keys = duthost.shell('sudo sonic-db-cli CONFIG_DB keys GNMI*')["stdout_lines"]
-    logger.debug("GNMI client cert keys: {}".format(keys))
-
-    yield
-
-    del_gnmi_client_common_name(duthost, "invalid.cname")
-    add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
-
-
 def gnmi_create_vnet(duthost, ptfhost, cert=None):
     file_name = "vnet.txt"
     text = "{\"Vnet1\": {\"vni\": \"1000\", \"guid\": \"559c6ce8-26ab-4193-b946-ccc6e8f930b2\"}}"
@@ -149,28 +136,6 @@ def gnmi_create_vnet(duthost, ptfhost, cert=None):
     gnmi_log = dump_gnmi_log(duthost)
 
     return msg, gnmi_log
-
-
-def test_gnmi_authorize_failed_with_invalid_cname(duthosts,
-                                                  rand_one_dut_hostname,
-                                                  ptfhost,
-                                                  setup_invalid_client_cert_cname):
-    '''
-    Verify GNMI native write, incremental config for configDB
-    GNMI set request with invalid path
-    '''
-    duthost = duthosts[rand_one_dut_hostname]
-    msg, gnmi_log = gnmi_create_vnet(duthost, ptfhost)
-
-    assert "Unauthenticated" in msg, (
-        "'Unauthenticated' error message not found in GNMI response. "
-        "- Actual message: '{}'"
-    ).format(msg)
-
-    assert "Failed to retrieve cert common name mapping" in gnmi_log, (
-        "'Failed to retrieve cert common name mapping' message not found in GNMI log. "
-        "- Actual GNMI log: '{}'"
-    ).format(gnmi_log)
 
 
 @pytest.fixture(scope="function")

--- a/tests/gnmi/test_gnmi_aaa.py
+++ b/tests/gnmi/test_gnmi_aaa.py
@@ -22,12 +22,15 @@ from tests.common.helpers.sonic_db import (
     CONFIG_DB,
     redis_del,
     redis_hdel,
+    redis_hget,
+    redis_hgetall,
     redis_hset,
     redis_keys,
 )
 from tests.common.helpers.syslog_helpers import (
     add_syslog_server,
     del_syslog_server,
+    is_mgmt_vrf_enabled,
 )
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from tests.common.pygnmi_client import PygnmiClientError
@@ -40,9 +43,17 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 allure.logger = logger
 CLIENT_PRINCIPAL = "test.client.gnmi.sonic"
-READWRITE_CLIENT_PRINCIPAL = "test.client.readwrite.gnmi.sonic"
-READONLY_ROLE = "gnmi_config_db_readonly"
-READWRITE_ROLE = "gnmi_config_db_readwrite"
+GENERIC_NOACCESS_ROLE = "gnmi_noaccess"
+GENERIC_READONLY_ROLE = "gnmi_readonly"
+GENERIC_READWRITE_ROLE = "gnmi_readwrite"
+CONFIG_DB_NOACCESS_ROLE = "gnmi_config_db_noaccess"
+CONFIG_DB_READONLY_ROLE = "gnmi_config_db_readonly"
+CONFIG_DB_READWRITE_ROLE = "gnmi_config_db_readwrite"
+NO_ACCESS_ERROR = "does not have access|gnmi.*noaccess"
+UNMAPPED_CN_ERROR = (
+    "Unauthenticated|unauthenticated|Invalid cert cname|"
+    "not a trusted|common name mapping"
+)
 
 
 def _set_configdb(client):
@@ -67,9 +78,98 @@ def _get_countersdb(client):
     )
 
 
+def _get_capabilities(client):
+    result = client.capabilities()
+    models = result.get("supported_models", [])
+    encodings = result.get("supported_encodings", [])
+    pytest_assert(
+        any(model.get("name") == "sonic-db" for model in models),
+        "sonic-db not found in gNMI capabilities: {}".format(models),
+    )
+    pytest_assert(
+        "json_ietf" in encodings,
+        "json_ietf not found in gNMI capabilities: {}".format(encodings),
+    )
+
+
 AUDIT_ACTIVITIES = [
     pytest.param(_get_countersdb, "/gnmi.gNMI/Get", id="get"),
     pytest.param(_set_configdb, "/gnmi.gNMI/Set", id="set"),
+]
+
+ROLE_ACCESS_CASES = [
+    pytest.param(
+        GENERIC_NOACCESS_ROLE,
+        _get_capabilities,
+        NO_ACCESS_ERROR,
+        id="generic-noaccess-capabilities",
+    ),
+    pytest.param(
+        GENERIC_READONLY_ROLE,
+        _get_capabilities,
+        None,
+        id="generic-readonly-capabilities",
+    ),
+    pytest.param(
+        GENERIC_READWRITE_ROLE,
+        _get_capabilities,
+        None,
+        id="generic-readwrite-capabilities",
+    ),
+    pytest.param(
+        "",
+        _get_capabilities,
+        None,
+        id="empty-role-capabilities",
+    ),
+    pytest.param(
+        CONFIG_DB_NOACCESS_ROLE,
+        _get_configdb,
+        NO_ACCESS_ERROR,
+        id="configdb-noaccess-get",
+    ),
+    pytest.param(
+        CONFIG_DB_NOACCESS_ROLE,
+        _set_configdb,
+        NO_ACCESS_ERROR,
+        id="configdb-noaccess-set",
+    ),
+    pytest.param(
+        CONFIG_DB_READONLY_ROLE,
+        _get_configdb,
+        None,
+        id="configdb-readonly-get",
+    ),
+    pytest.param(
+        CONFIG_DB_READONLY_ROLE,
+        _set_configdb,
+        CONFIG_DB_READONLY_ROLE,
+        id="configdb-readonly-set",
+    ),
+    pytest.param(
+        CONFIG_DB_READWRITE_ROLE,
+        _get_configdb,
+        None,
+        id="configdb-readwrite-get",
+    ),
+    pytest.param(
+        CONFIG_DB_READWRITE_ROLE,
+        _set_configdb,
+        None,
+        id="configdb-readwrite-set",
+    ),
+    pytest.param(
+        None,
+        _get_configdb,
+        UNMAPPED_CN_ERROR,
+        id="unmapped-get",
+    ),
+    pytest.param(
+        None,
+        _set_configdb,
+        UNMAPPED_CN_ERROR,
+        id="unmapped-set",
+    ),
 ]
 
 
@@ -77,6 +177,7 @@ AUDIT_ACTIVITIES = [
 def remote_syslog_capture(gnmi_tls, ptfhost):  # noqa: F811
     duthost = gnmi_tls.duthost
     ptf_ip = ptfhost.mgmt_ip
+    syslog_vrf = "mgmt" if is_mgmt_vrf_enabled(duthost) else None
     capture_file = "/tmp/gnmi-audit-{}.pcap".format(uuid.uuid4().hex)
     capture_pool = None
     capture_result = None
@@ -84,7 +185,7 @@ def remote_syslog_capture(gnmi_tls, ptfhost):  # noqa: F811
 
     try:
         logger.info("Adding temporary remote syslog server %s", ptf_ip)
-        add_result = add_syslog_server(duthost, ptf_ip)
+        add_result = add_syslog_server(duthost, ptf_ip, vrf=syslog_vrf)
         pytest_assert(
             add_result["rc"] == 0,
             "Failed to add temporary syslog server",
@@ -94,9 +195,15 @@ def remote_syslog_capture(gnmi_tls, ptfhost):  # noqa: F811
         remote_action = 'Target="{}" Port="514"'.format(ptf_ip)
 
         def remote_action_configured():
-            command = "grep -Fq {} /etc/rsyslog.conf".format(
+            command = "grep -F {} /etc/rsyslog.conf".format(
                 shlex.quote(remote_action)
             )
+            if syslog_vrf:
+                command += " | grep -Fq {}".format(
+                    shlex.quote('Device="{}"'.format(syslog_vrf))
+                )
+            else:
+                command += " >/dev/null"
             return duthost.shell(
                 command, module_ignore_errors=True
             )["rc"] == 0
@@ -211,7 +318,18 @@ def test_gnmi_audit_log_remote_forwarding(
 @pytest.mark.parametrize("operation,method", AUDIT_ACTIVITIES)
 def test_gnmi_default_cert_auth(gnmi_tls, operation, method):  # noqa: F811
     duthost = gnmi_tls.duthost
-    redis_hdel(duthost, CONFIG_DB, "GNMI|gnmi", "user_auth")
+    delete_result = redis_hdel(
+        duthost, CONFIG_DB, "GNMI|gnmi", "user_auth"
+    )
+    pytest_assert(
+        delete_result["rc"] == 0
+        and delete_result["stdout"].strip() == "1",
+        "Failed to delete GNMI|gnmi.user_auth: {}".format(delete_result),
+    )
+    pytest_assert(
+        not redis_hget(duthost, CONFIG_DB, "GNMI|gnmi", "user_auth"),
+        "GNMI|gnmi.user_auth is still configured after HDEL",
+    )
     _restart_gnoi_server(duthost)
 
     redis_del(
@@ -226,62 +344,42 @@ def test_gnmi_default_cert_auth(gnmi_tls, operation, method):  # noqa: F811
         operation(gnmi_tls.pygnmi_client)
 
 
-@pytest.mark.parametrize(
-    "cn_roles,error_pattern",
-    [
-        pytest.param(
-            {
-                CLIENT_PRINCIPAL: READONLY_ROLE,
-                READWRITE_CLIENT_PRINCIPAL: READWRITE_ROLE,
-            },
-            READONLY_ROLE,
-            id="readonly",
-        ),
-        pytest.param(
-            {READWRITE_CLIENT_PRINCIPAL: READWRITE_ROLE},
-            "Unauthenticated|Invalid cert cname|not a trusted",
-            id="unmapped",
-        ),
-    ],
-)
-def test_cn_insufficient_access(gnmi_tls, cn_roles, error_pattern):  # noqa: F811
+@pytest.mark.parametrize("role,operation,error_pattern", ROLE_ACCESS_CASES)
+def test_cn_role_access(gnmi_tls, role, operation, error_pattern):  # noqa: F811
+    """Verify generic and target-specific role authorization."""
     duthost = gnmi_tls.duthost
-    redis_del(
-        duthost,
-        CONFIG_DB,
-        *redis_keys(duthost, CONFIG_DB, "GNMI_CLIENT_CERT|*"),
-    )
-    for cname, role in cn_roles.items():
-        redis_hset(
+    role_key = "GNMI_CLIENT_CERT|{}".format(CLIENT_PRINCIPAL)
+
+    if role is None:
+        delete_results = redis_del(duthost, CONFIG_DB, role_key)
+        pytest_assert(
+            len(delete_results) == 1
+            and delete_results[0]["rc"] == 0
+            and delete_results[0]["stdout"].strip() == "1",
+            "Failed to remove client certificate mapping {}: {}".format(
+                role_key, delete_results
+            ),
+        )
+    else:
+        set_result = redis_hset(
             duthost,
             CONFIG_DB,
-            "GNMI_CLIENT_CERT|{}".format(cname),
+            role_key,
             **{"role@": role}
         )
+        pytest_assert(
+            set_result["rc"] == 0,
+            "Failed to set role {!r}: {}".format(role, set_result),
+        )
+        configured_fields = redis_hgetall(duthost, CONFIG_DB, role_key)
+        pytest_assert(
+            "role@" in configured_fields
+            and configured_fields["role@"] == role,
+            "Expected role {!r}, got {}".format(role, configured_fields),
+        )
 
-    with pytest.raises(
-        PygnmiClientError,
-        match=error_pattern,
-    ):
-        _set_configdb(gnmi_tls.pygnmi_client)
-
-
-@pytest.mark.parametrize(
-    "role,operation",
-    [
-        pytest.param(READONLY_ROLE, _get_configdb, id="readonly-get"),
-        pytest.param(READWRITE_ROLE, _get_configdb, id="readwrite-get"),
-        pytest.param(READWRITE_ROLE, _set_configdb, id="readwrite-set"),
-    ],
-)
-def test_cn_allowed_access(gnmi_tls, role, operation):  # noqa: F811
-    """Verify a mapped CN can perform the requested CONFIG_DB operation."""
-    duthost = gnmi_tls.duthost
-    redis_hset(
-        duthost,
-        CONFIG_DB,
-        "GNMI_CLIENT_CERT|{}".format(CLIENT_PRINCIPAL),
-        **{"role@": role}
-    )
-
-    operation(gnmi_tls.pygnmi_client)
+    if error_pattern:
+        with pytest.raises(PygnmiClientError, match=error_pattern):
+            operation(gnmi_tls.pygnmi_client)
+    else:
+        operation(gnmi_tls.pygnmi_client)

--- a/tests/gnmi/test_gnmi_aaa.py
+++ b/tests/gnmi/test_gnmi_aaa.py
@@ -104,13 +104,13 @@ def _get_countersdb(client):
 
 
 @pytest.mark.parametrize(
-    "request",
+    "operation",
     [
         pytest.param(_get_countersdb, id="get"),
         pytest.param(_set_configdb, id="set"),
     ],
 )
-def test_gnmi_default_cert_auth(gnmi_tls, request):  # noqa: F811
+def test_gnmi_default_cert_auth(gnmi_tls, operation):  # noqa: F811
     duthost = gnmi_tls.duthost
     redis_hdel(duthost, CONFIG_DB, "GNMI|gnmi", "user_auth")
     _restart_gnoi_server(duthost)
@@ -124,7 +124,7 @@ def test_gnmi_default_cert_auth(gnmi_tls, request):  # noqa: F811
         PygnmiClientError,
         match="Unauthenticated|unauthenticated|common name mapping",
     ):
-        request(gnmi_tls.pygnmi_client)
+        operation(gnmi_tls.pygnmi_client)
 
 
 @pytest.mark.parametrize(
@@ -168,14 +168,14 @@ def test_cn_insufficient_access(gnmi_tls, cn_roles, error_pattern):  # noqa: F81
 
 
 @pytest.mark.parametrize(
-    "role,request",
+    "role,operation",
     [
         pytest.param(READONLY_ROLE, _get_configdb, id="readonly-get"),
         pytest.param(READWRITE_ROLE, _get_configdb, id="readwrite-get"),
         pytest.param(READWRITE_ROLE, _set_configdb, id="readwrite-set"),
     ],
 )
-def test_cn_allowed_access(gnmi_tls, role, request):  # noqa: F811
+def test_cn_allowed_access(gnmi_tls, role, operation):  # noqa: F811
     """Verify a mapped CN can perform the requested CONFIG_DB operation."""
     duthost = gnmi_tls.duthost
     redis_hset(
@@ -185,4 +185,4 @@ def test_cn_allowed_access(gnmi_tls, role, request):  # noqa: F811
         **{"role@": role}
     )
 
-    request(gnmi_tls.pygnmi_client)
+    operation(gnmi_tls.pygnmi_client)

--- a/tests/gnmi/test_gnmi_aaa.py
+++ b/tests/gnmi/test_gnmi_aaa.py
@@ -85,7 +85,7 @@ def _set_configdb(client):
     client.set(
         update=[(
             "sonic-db:CONFIG_DB/localhost/DEVICE_METADATA/localhost/cloudtype",
-            "Public",
+            '"Public"',
         )],
     )
 

--- a/tests/gnmi/test_gnmi_aaa.py
+++ b/tests/gnmi/test_gnmi_aaa.py
@@ -13,7 +13,6 @@ from tests.common.helpers.sonic_db import (
     CONFIG_DB,
     redis_del,
     redis_hdel,
-    redis_hget,
     redis_hset,
     redis_keys,
 )
@@ -82,18 +81,39 @@ def test_gnmi_get_audit_log(gnmi_tls):  # noqa: F811
     )
 
 
-def test_gnmi_default_cert_auth(gnmi_tls):  # noqa: F811
+def _set_configdb(client):
+    client.set(
+        update=[(
+            "sonic-db:CONFIG_DB/localhost/GNMI/gnmi/log_level",
+            "1",
+        )],
+    )
+
+
+def _get_configdb(client):
+    client.get(
+        "sonic-db:CONFIG_DB/localhost/DEVICE_METADATA/localhost"
+    )
+
+
+def _get_countersdb(client):
+    client.get(
+        "COUNTERS_PORT_NAME_MAP",
+        target="COUNTERS_DB",
+    )
+
+
+@pytest.mark.parametrize(
+    "request",
+    [
+        pytest.param(_get_countersdb, id="get"),
+        pytest.param(_set_configdb, id="set"),
+    ],
+)
+def test_gnmi_default_cert_auth(gnmi_tls, request):  # noqa: F811
     duthost = gnmi_tls.duthost
     redis_hdel(duthost, CONFIG_DB, "GNMI|gnmi", "user_auth")
     _restart_gnoi_server(duthost)
-
-    user_auth = redis_hget(
-        duthost, CONFIG_DB, "GNMI|gnmi", "user_auth"
-    )
-    pytest_assert(
-        not user_auth,
-        "gNMI user_auth should be empty, got: {}".format(user_auth),
-    )
 
     redis_del(
         duthost,
@@ -104,10 +124,7 @@ def test_gnmi_default_cert_auth(gnmi_tls):  # noqa: F811
         PygnmiClientError,
         match="Unauthenticated|unauthenticated|common name mapping",
     ):
-        gnmi_tls.pygnmi_client.get(
-            "COUNTERS_PORT_NAME_MAP",
-            target="COUNTERS_DB",
-        )
+        request(gnmi_tls.pygnmi_client)
 
 
 @pytest.mark.parametrize(
@@ -147,9 +164,25 @@ def test_cn_insufficient_access(gnmi_tls, cn_roles, error_pattern):  # noqa: F81
         PygnmiClientError,
         match=error_pattern,
     ):
-        gnmi_tls.pygnmi_client.set(
-            update=[(
-                "sonic-db:CONFIG_DB/localhost/GNMI/gnmi/log_level",
-                "1",
-            )],
-        )
+        _set_configdb(gnmi_tls.pygnmi_client)
+
+
+@pytest.mark.parametrize(
+    "role,request",
+    [
+        pytest.param(READONLY_ROLE, _get_configdb, id="readonly-get"),
+        pytest.param(READWRITE_ROLE, _get_configdb, id="readwrite-get"),
+        pytest.param(READWRITE_ROLE, _set_configdb, id="readwrite-set"),
+    ],
+)
+def test_cn_allowed_access(gnmi_tls, role, request):  # noqa: F811
+    """Verify a mapped CN can perform the requested CONFIG_DB operation."""
+    duthost = gnmi_tls.duthost
+    redis_hset(
+        duthost,
+        CONFIG_DB,
+        "GNMI_CLIENT_CERT|{}".format(CLIENT_PRINCIPAL),
+        **{"role@": role}
+    )
+
+    request(gnmi_tls.pygnmi_client)

--- a/tests/gnmi/test_gnmi_aaa.py
+++ b/tests/gnmi/test_gnmi_aaa.py
@@ -1,6 +1,9 @@
 """gNMI audit, authentication, and authorization tests."""
 
-import json
+import logging
+import os
+import shlex
+import uuid
 
 import pytest
 
@@ -9,6 +12,12 @@ from tests.common.fixtures.grpc_fixtures import (  # noqa: F401
     gnmi_tls,
 )
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.gnmi_audit import (
+    RPC_COMPLETION_PREFIX,
+    parse_audit_records,
+    read_forwarded_payloads,
+    wait_for_audit_record,
+)
 from tests.common.helpers.sonic_db import (
     CONFIG_DB,
     redis_del,
@@ -16,6 +25,11 @@ from tests.common.helpers.sonic_db import (
     redis_hset,
     redis_keys,
 )
+from tests.common.helpers.syslog_helpers import (
+    add_syslog_server,
+    del_syslog_server,
+)
+from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from tests.common.pygnmi_client import PygnmiClientError
 from tests.common.utilities import wait_until
 
@@ -23,62 +37,12 @@ from tests.common.utilities import wait_until
 pytestmark = [
     pytest.mark.topology("any"),
 ]
-RPC_COMPLETION_PREFIX = "RPC_COMPLETION "
+logger = logging.getLogger(__name__)
+allure.logger = logger
 CLIENT_PRINCIPAL = "test.client.gnmi.sonic"
 READWRITE_CLIENT_PRINCIPAL = "test.client.readwrite.gnmi.sonic"
 READONLY_ROLE = "gnmi_config_db_readonly"
 READWRITE_ROLE = "gnmi_config_db_readwrite"
-
-
-def _get_completions(log_text):
-    records = []
-    decoder = json.JSONDecoder()
-    for line in log_text.splitlines():
-        _, separator, payload = line.partition(RPC_COMPLETION_PREFIX)
-        if not separator:
-            continue
-        try:
-            record, _ = decoder.raw_decode(payload)
-        except json.JSONDecodeError:
-            continue
-        if (record.get("method") == "/gnmi.gNMI/Get"
-                and record.get("path") == ["/COUNTERS_PORT_NAME_MAP"]
-                and record.get("principal") == CLIENT_PRINCIPAL):
-            records.append(record)
-    return records
-
-
-def test_gnmi_get_audit_log(gnmi_tls):  # noqa: F811
-    duthost = gnmi_tls.duthost
-    offset = int(
-        duthost.shell(
-            "sudo stat -c %s /var/log/gnmi.log"
-        )["stdout"].strip()
-    )
-
-    gnmi_tls.pygnmi_client.get(
-        "COUNTERS_PORT_NAME_MAP",
-        target="COUNTERS_DB",
-    )
-
-    def audit_record_written():
-        new_log = duthost.shell(
-            "sudo tail -c +{} /var/log/gnmi.log".format(offset + 1),
-            module_ignore_errors=True,
-        )["stdout"]
-        return bool(_get_completions(new_log))
-
-    pytest_assert(
-        wait_until(30, 1, 0, audit_record_written),
-        "No new Get completion record in /var/log/gnmi.log",
-    )
-    new_log = duthost.shell(
-        "sudo tail -c +{} /var/log/gnmi.log".format(offset + 1)
-    )["stdout"]
-    pytest_assert(
-        len(_get_completions(new_log)) == 1,
-        "Expected exactly one new Get completion record",
-    )
 
 
 def _set_configdb(client):
@@ -103,14 +67,149 @@ def _get_countersdb(client):
     )
 
 
-@pytest.mark.parametrize(
-    "operation",
-    [
-        pytest.param(_get_countersdb, id="get"),
-        pytest.param(_set_configdb, id="set"),
-    ],
-)
-def test_gnmi_default_cert_auth(gnmi_tls, operation):  # noqa: F811
+AUDIT_ACTIVITIES = [
+    pytest.param(_get_countersdb, "/gnmi.gNMI/Get", id="get"),
+    pytest.param(_set_configdb, "/gnmi.gNMI/Set", id="set"),
+]
+
+
+@pytest.fixture
+def remote_syslog_capture(gnmi_tls, ptfhost):  # noqa: F811
+    duthost = gnmi_tls.duthost
+    ptf_ip = ptfhost.mgmt_ip
+    capture_file = "/tmp/gnmi-audit-{}.pcap".format(uuid.uuid4().hex)
+    capture_pool = None
+    capture_result = None
+    syslog_server_added = False
+
+    try:
+        logger.info("Adding temporary remote syslog server %s", ptf_ip)
+        add_result = add_syslog_server(duthost, ptf_ip)
+        pytest_assert(
+            add_result["rc"] == 0,
+            "Failed to add temporary syslog server",
+        )
+        syslog_server_added = True
+
+        remote_action = 'Target="{}" Port="514"'.format(ptf_ip)
+
+        def remote_action_configured():
+            command = "grep -Fq {} /etc/rsyslog.conf".format(
+                shlex.quote(remote_action)
+            )
+            return duthost.shell(
+                command, module_ignore_errors=True
+            )["rc"] == 0
+
+        logger.info("Waiting for remote syslog configuration")
+        pytest_assert(
+            wait_until(30, 1, 0, remote_action_configured),
+            "Host rsyslog did not configure UDP/514 forwarding",
+        )
+
+        logger.info("Starting remote syslog packet capture")
+        capture_command = (
+            "sudo timeout 30 tcpdump -i any -y LINUX_SLL -nn "
+            "-s0 -U -w {} "
+            "'udp and dst host {} and dst port 514'"
+        ).format(shlex.quote(capture_file), ptf_ip)
+        capture_pool, capture_result = duthost.shell(
+            capture_command,
+            module_async=True,
+            module_ignore_errors=True,
+        )
+
+        def capture_started():
+            command = "sudo test $(stat -c %s {}) -ge 24".format(
+                shlex.quote(capture_file)
+            )
+            return duthost.shell(
+                command, module_ignore_errors=True
+            )["rc"] == 0
+
+        logger.info("Waiting for remote syslog packet capture")
+        pytest_assert(
+            wait_until(10, 1, 0, capture_started),
+            "UDP/514 packet capture did not start",
+        )
+
+        yield capture_result, capture_file
+    finally:
+        if capture_pool is not None:
+            if capture_result.ready():
+                capture_pool.close()
+            else:
+                capture_pool.terminate()
+            capture_pool.join()
+        duthost.shell(
+            "sudo rm -f {}".format(shlex.quote(capture_file)),
+            module_ignore_errors=True,
+        )
+        if os.path.exists(capture_file):
+            os.remove(capture_file)
+        if syslog_server_added:
+            del_syslog_server(duthost, ptf_ip, module_ignore_errors=True)
+
+
+@pytest.mark.parametrize("operation,method", AUDIT_ACTIVITIES)
+def test_gnmi_audit_log(gnmi_tls, operation, method):  # noqa: F811
+    duthost = gnmi_tls.duthost
+    offset = int(
+        duthost.shell(
+            "sudo stat -c %s /var/log/gnmi.log"
+        )["stdout"].strip()
+    )
+
+    operation(gnmi_tls.pygnmi_client)
+    wait_for_audit_record(duthost, offset, method, CLIENT_PRINCIPAL)
+
+
+@pytest.mark.parametrize("operation,method", AUDIT_ACTIVITIES)
+def test_gnmi_audit_log_remote_forwarding(
+    gnmi_tls, remote_syslog_capture, operation, method  # noqa: F811
+):
+    duthost = gnmi_tls.duthost
+    capture_result, capture_file = remote_syslog_capture
+    offset = int(
+        duthost.shell(
+            "sudo stat -c %s /var/log/gnmi.log"
+        )["stdout"].strip()
+    )
+
+    with allure.step("Generate a {} audit record".format(method)):
+        operation(gnmi_tls.pygnmi_client)
+
+    with allure.step("Verify the remotely forwarded audit record"):
+        local_records = wait_for_audit_record(
+            duthost, offset, method, CLIENT_PRINCIPAL
+        )
+        forwarded_payloads = read_forwarded_payloads(
+            duthost, capture_result, capture_file
+        )
+        pytest_assert(
+            any(RPC_COMPLETION_PREFIX in payload
+                for payload in forwarded_payloads),
+            "No RPC_COMPLETION marker found in forwarded UDP packets",
+        )
+        streamed_records = [
+            record
+            for payload in forwarded_payloads
+            for record in parse_audit_records(
+                payload, method, CLIENT_PRINCIPAL
+            )
+        ]
+        pytest_assert(
+            streamed_records == local_records,
+            "Streamed audit records differ from local gNMI records: "
+            "local={}, streamed={}".format(
+                local_records,
+                streamed_records,
+            ),
+        )
+
+
+@pytest.mark.parametrize("operation,method", AUDIT_ACTIVITIES)
+def test_gnmi_default_cert_auth(gnmi_tls, operation, method):  # noqa: F811
     duthost = gnmi_tls.duthost
     redis_hdel(duthost, CONFIG_DB, "GNMI|gnmi", "user_auth")
     _restart_gnoi_server(duthost)

--- a/tests/gnmi/test_gnmi_aaa.py
+++ b/tests/gnmi/test_gnmi_aaa.py
@@ -84,8 +84,8 @@ def test_gnmi_get_audit_log(gnmi_tls):  # noqa: F811
 def _set_configdb(client):
     client.set(
         update=[(
-            "sonic-db:CONFIG_DB/localhost/GNMI/gnmi/log_level",
-            "1",
+            "sonic-db:CONFIG_DB/localhost/DEVICE_METADATA/localhost/cloudtype",
+            "Public",
         )],
     )
 

--- a/tests/gnmi/test_gnmi_aaa.py
+++ b/tests/gnmi/test_gnmi_aaa.py
@@ -1,0 +1,155 @@
+"""gNMI audit, authentication, and authorization tests."""
+
+import json
+
+import pytest
+
+from tests.common.fixtures.grpc_fixtures import (  # noqa: F401
+    _restart_gnoi_server,
+    gnmi_tls,
+)
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.sonic_db import (
+    CONFIG_DB,
+    redis_del,
+    redis_hdel,
+    redis_hget,
+    redis_hset,
+    redis_keys,
+)
+from tests.common.pygnmi_client import PygnmiClientError
+from tests.common.utilities import wait_until
+
+
+pytestmark = [
+    pytest.mark.topology("any"),
+]
+RPC_COMPLETION_PREFIX = "RPC_COMPLETION "
+CLIENT_PRINCIPAL = "test.client.gnmi.sonic"
+READWRITE_CLIENT_PRINCIPAL = "test.client.readwrite.gnmi.sonic"
+READONLY_ROLE = "gnmi_config_db_readonly"
+READWRITE_ROLE = "gnmi_config_db_readwrite"
+
+
+def _get_completions(log_text):
+    records = []
+    decoder = json.JSONDecoder()
+    for line in log_text.splitlines():
+        _, separator, payload = line.partition(RPC_COMPLETION_PREFIX)
+        if not separator:
+            continue
+        try:
+            record, _ = decoder.raw_decode(payload)
+        except json.JSONDecodeError:
+            continue
+        if (record.get("method") == "/gnmi.gNMI/Get"
+                and record.get("path") == ["/COUNTERS_PORT_NAME_MAP"]
+                and record.get("principal") == CLIENT_PRINCIPAL):
+            records.append(record)
+    return records
+
+
+def test_gnmi_get_audit_log(gnmi_tls):  # noqa: F811
+    duthost = gnmi_tls.duthost
+    offset = int(
+        duthost.shell(
+            "sudo stat -c %s /var/log/gnmi.log"
+        )["stdout"].strip()
+    )
+
+    gnmi_tls.pygnmi_client.get(
+        "COUNTERS_PORT_NAME_MAP",
+        target="COUNTERS_DB",
+    )
+
+    def audit_record_written():
+        new_log = duthost.shell(
+            "sudo tail -c +{} /var/log/gnmi.log".format(offset + 1),
+            module_ignore_errors=True,
+        )["stdout"]
+        return bool(_get_completions(new_log))
+
+    pytest_assert(
+        wait_until(30, 1, 0, audit_record_written),
+        "No new Get completion record in /var/log/gnmi.log",
+    )
+    new_log = duthost.shell(
+        "sudo tail -c +{} /var/log/gnmi.log".format(offset + 1)
+    )["stdout"]
+    pytest_assert(
+        len(_get_completions(new_log)) == 1,
+        "Expected exactly one new Get completion record",
+    )
+
+
+def test_gnmi_default_cert_auth(gnmi_tls):  # noqa: F811
+    duthost = gnmi_tls.duthost
+    redis_hdel(duthost, CONFIG_DB, "GNMI|gnmi", "user_auth")
+    _restart_gnoi_server(duthost)
+
+    user_auth = redis_hget(
+        duthost, CONFIG_DB, "GNMI|gnmi", "user_auth"
+    )
+    pytest_assert(
+        not user_auth,
+        "gNMI user_auth should be empty, got: {}".format(user_auth),
+    )
+
+    redis_del(
+        duthost,
+        CONFIG_DB,
+        *redis_keys(duthost, CONFIG_DB, "GNMI_CLIENT_CERT|*"),
+    )
+    with pytest.raises(
+        PygnmiClientError,
+        match="Unauthenticated|unauthenticated|common name mapping",
+    ):
+        gnmi_tls.pygnmi_client.get(
+            "COUNTERS_PORT_NAME_MAP",
+            target="COUNTERS_DB",
+        )
+
+
+@pytest.mark.parametrize(
+    "cn_roles,error_pattern",
+    [
+        pytest.param(
+            {
+                CLIENT_PRINCIPAL: READONLY_ROLE,
+                READWRITE_CLIENT_PRINCIPAL: READWRITE_ROLE,
+            },
+            READONLY_ROLE,
+            id="readonly",
+        ),
+        pytest.param(
+            {READWRITE_CLIENT_PRINCIPAL: READWRITE_ROLE},
+            "Unauthenticated|Invalid cert cname|not a trusted",
+            id="unmapped",
+        ),
+    ],
+)
+def test_cn_insufficient_access(gnmi_tls, cn_roles, error_pattern):  # noqa: F811
+    duthost = gnmi_tls.duthost
+    redis_del(
+        duthost,
+        CONFIG_DB,
+        *redis_keys(duthost, CONFIG_DB, "GNMI_CLIENT_CERT|*"),
+    )
+    for cname, role in cn_roles.items():
+        redis_hset(
+            duthost,
+            CONFIG_DB,
+            "GNMI_CLIENT_CERT|{}".format(cname),
+            **{"role@": role}
+        )
+
+    with pytest.raises(
+        PygnmiClientError,
+        match=error_pattern,
+    ):
+        gnmi_tls.pygnmi_client.set(
+            update=[(
+                "sonic-db:CONFIG_DB/localhost/GNMI/gnmi/log_level",
+                "1",
+            )],
+        )

--- a/tests/gnmi/test_gnmi_aaa.py
+++ b/tests/gnmi/test_gnmi_aaa.py
@@ -1,10 +1,7 @@
 """gNMI audit, authentication, and authorization tests."""
 
 import logging
-import os
-import shlex
 import time
-import uuid
 
 import pytest
 from pygnmi.client import gNMIException
@@ -18,7 +15,6 @@ from tests.common.helpers.gnmi_audit import (
     RPC_COMPLETION_PREFIX,
     get_audit_log_offset,
     parse_audit_records,
-    read_forwarded_payloads,
     wait_for_audit_record,
     wait_for_audit_records,
 )
@@ -31,13 +27,12 @@ from tests.common.helpers.sonic_db import (
     redis_keys,
 )
 from tests.common.helpers.syslog_helpers import (
-    add_syslog_server,
-    del_syslog_server,
+    capture_remote_syslog,
     is_mgmt_vrf_enabled,
+    read_syslog_payloads,
 )
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from tests.common.pygnmi_client import GetDataType, PygnmiClientError
-from tests.common.utilities import wait_until
 
 
 pytestmark = [
@@ -130,166 +125,6 @@ AUDIT_ACTIVITIES = [
     pytest.param(_get_countersdb, GET_METHOD, id="get"),
     pytest.param(_set_configdb, SET_METHOD, id="set"),
 ]
-
-ROLE_ACCESS_CASES = [
-    pytest.param(
-        GENERIC_NOACCESS_ROLE,
-        _get_capabilities,
-        NO_ACCESS_ERROR,
-        id="generic-noaccess-capabilities",
-    ),
-    pytest.param(
-        GENERIC_READONLY_ROLE,
-        _get_capabilities,
-        None,
-        id="generic-readonly-capabilities",
-    ),
-    pytest.param(
-        GENERIC_READWRITE_ROLE,
-        _get_capabilities,
-        None,
-        id="generic-readwrite-capabilities",
-    ),
-    pytest.param(
-        "",
-        _get_capabilities,
-        None,
-        id="empty-role-capabilities",
-    ),
-    pytest.param(
-        CONFIG_DB_NOACCESS_ROLE,
-        _get_configdb,
-        NO_ACCESS_ERROR,
-        id="configdb-noaccess-get",
-    ),
-    pytest.param(
-        CONFIG_DB_NOACCESS_ROLE,
-        _set_configdb,
-        NO_ACCESS_ERROR,
-        id="configdb-noaccess-set",
-    ),
-    pytest.param(
-        CONFIG_DB_READONLY_ROLE,
-        _get_configdb,
-        None,
-        id="configdb-readonly-get",
-    ),
-    pytest.param(
-        CONFIG_DB_READONLY_ROLE,
-        _set_configdb,
-        CONFIG_DB_READONLY_ROLE,
-        id="configdb-readonly-set",
-    ),
-    pytest.param(
-        CONFIG_DB_READWRITE_ROLE,
-        _get_configdb,
-        None,
-        id="configdb-readwrite-get",
-    ),
-    pytest.param(
-        CONFIG_DB_READWRITE_ROLE,
-        _set_configdb,
-        None,
-        id="configdb-readwrite-set",
-    ),
-    pytest.param(
-        None,
-        _get_configdb,
-        UNMAPPED_CN_ERROR,
-        id="unmapped-get",
-    ),
-    pytest.param(
-        None,
-        _set_configdb,
-        UNMAPPED_CN_ERROR,
-        id="unmapped-set",
-    ),
-]
-
-
-@pytest.fixture
-def remote_syslog_capture(gnmi_tls, ptfhost):  # noqa: F811
-    duthost = gnmi_tls.duthost
-    ptf_ip = ptfhost.mgmt_ip
-    syslog_vrf = "mgmt" if is_mgmt_vrf_enabled(duthost) else None
-    capture_file = "/tmp/gnmi-audit-{}.pcap".format(uuid.uuid4().hex)
-    capture_pool = None
-    capture_result = None
-    syslog_server_added = False
-
-    try:
-        logger.info("Adding temporary remote syslog server %s", ptf_ip)
-        add_result = add_syslog_server(duthost, ptf_ip, vrf=syslog_vrf)
-        pytest_assert(
-            add_result["rc"] == 0,
-            "Failed to add temporary syslog server",
-        )
-        syslog_server_added = True
-
-        remote_action = 'Target="{}" Port="514"'.format(ptf_ip)
-
-        def remote_action_configured():
-            command = "grep -F {} /etc/rsyslog.conf".format(
-                shlex.quote(remote_action)
-            )
-            if syslog_vrf:
-                command += " | grep -Fq {}".format(
-                    shlex.quote('Device="{}"'.format(syslog_vrf))
-                )
-            else:
-                command += " >/dev/null"
-            return duthost.shell(
-                command, module_ignore_errors=True
-            )["rc"] == 0
-
-        logger.info("Waiting for remote syslog configuration")
-        pytest_assert(
-            wait_until(30, 1, 0, remote_action_configured),
-            "Host rsyslog did not configure UDP/514 forwarding",
-        )
-
-        logger.info("Starting remote syslog packet capture")
-        capture_command = (
-            "sudo timeout 30 tcpdump -i any -y LINUX_SLL -nn "
-            "-s0 -U -w {} "
-            "'udp and dst host {} and dst port 514'"
-        ).format(shlex.quote(capture_file), ptf_ip)
-        capture_pool, capture_result = duthost.shell(
-            capture_command,
-            module_async=True,
-            module_ignore_errors=True,
-        )
-
-        def capture_started():
-            command = "sudo test $(stat -c %s {}) -ge 24".format(
-                shlex.quote(capture_file)
-            )
-            return duthost.shell(
-                command, module_ignore_errors=True
-            )["rc"] == 0
-
-        logger.info("Waiting for remote syslog packet capture")
-        pytest_assert(
-            wait_until(10, 1, 0, capture_started),
-            "UDP/514 packet capture did not start",
-        )
-
-        yield capture_result, capture_file
-    finally:
-        if capture_pool is not None:
-            if capture_result.ready():
-                capture_pool.close()
-            else:
-                capture_pool.terminate()
-            capture_pool.join()
-        duthost.shell(
-            "sudo rm -f {}".format(shlex.quote(capture_file)),
-            module_ignore_errors=True,
-        )
-        if os.path.exists(capture_file):
-            os.remove(capture_file)
-        if syslog_server_added:
-            del_syslog_server(duthost, ptf_ip, module_ignore_errors=True)
 
 
 @pytest.mark.parametrize("operation,method", AUDIT_ACTIVITIES)
@@ -406,42 +241,45 @@ def test_gnmi_audit_rate_limit(gnmi_tls):  # noqa: F811
 
 @pytest.mark.parametrize("operation,method", AUDIT_ACTIVITIES)
 def test_gnmi_audit_log_remote_forwarding(
-    gnmi_tls, remote_syslog_capture, operation, method  # noqa: F811
+    gnmi_tls, ptfhost, operation, method  # noqa: F811
 ):
     duthost = gnmi_tls.duthost
-    capture_result, capture_file = remote_syslog_capture
-    offset = get_audit_log_offset(duthost)
+    syslog_vrf = "mgmt" if is_mgmt_vrf_enabled(duthost) else None
 
-    with allure.step("Generate a {} audit record".format(method)):
-        operation(gnmi_tls.pygnmi_client)
+    with capture_remote_syslog(
+        duthost, ptfhost.mgmt_ip, vrf=syslog_vrf
+    ) as (capture_result, capture_file):
+        offset = get_audit_log_offset(duthost)
+        with allure.step("Generate a {} audit record".format(method)):
+            operation(gnmi_tls.pygnmi_client)
 
-    with allure.step("Verify the remotely forwarded audit record"):
-        local_records = wait_for_audit_record(
-            duthost, offset, method, CLIENT_PRINCIPAL
-        )
-        forwarded_payloads = read_forwarded_payloads(
-            duthost, capture_result, capture_file
-        )
-        pytest_assert(
-            any(RPC_COMPLETION_PREFIX in payload
-                for payload in forwarded_payloads),
-            "No RPC_COMPLETION marker found in forwarded UDP packets",
-        )
-        streamed_records = [
-            record
-            for payload in forwarded_payloads
-            for record in parse_audit_records(
-                payload, method, CLIENT_PRINCIPAL
+        with allure.step("Verify the remotely forwarded audit record"):
+            local_records = wait_for_audit_record(
+                duthost, offset, method, CLIENT_PRINCIPAL
             )
-        ]
-        pytest_assert(
-            streamed_records == local_records,
-            "Streamed audit records differ from local gNMI records: "
-            "local={}, streamed={}".format(
-                local_records,
-                streamed_records,
-            ),
-        )
+            forwarded_payloads = read_syslog_payloads(
+                duthost, capture_result, capture_file
+            )
+            pytest_assert(
+                any(RPC_COMPLETION_PREFIX in payload
+                    for payload in forwarded_payloads),
+                "No RPC_COMPLETION marker found in forwarded UDP packets",
+            )
+            streamed_records = [
+                record
+                for payload in forwarded_payloads
+                for record in parse_audit_records(
+                    payload, method, CLIENT_PRINCIPAL
+                )
+            ]
+            pytest_assert(
+                streamed_records == local_records,
+                "Streamed audit records differ from local gNMI records: "
+                "local={}, streamed={}".format(
+                    local_records,
+                    streamed_records,
+                ),
+            )
 
 
 @pytest.mark.parametrize("operation,method", AUDIT_ACTIVITIES)
@@ -473,7 +311,92 @@ def test_gnmi_default_cert_auth(gnmi_tls, operation, method):  # noqa: F811
         operation(gnmi_tls.pygnmi_client)
 
 
-@pytest.mark.parametrize("role,operation,error_pattern", ROLE_ACCESS_CASES)
+CAPABILITIES_ROLE_CASES = [
+    pytest.param(
+        GENERIC_NOACCESS_ROLE,
+        _get_capabilities,
+        NO_ACCESS_ERROR,
+        id="generic-noaccess-capabilities",
+    ),
+    pytest.param(
+        GENERIC_READONLY_ROLE,
+        _get_capabilities,
+        None,
+        id="generic-readonly-capabilities",
+    ),
+    pytest.param(
+        GENERIC_READWRITE_ROLE,
+        _get_capabilities,
+        None,
+        id="generic-readwrite-capabilities",
+    ),
+    pytest.param(
+        "",
+        _get_capabilities,
+        None,
+        id="empty-role-capabilities",
+    ),
+]
+
+CONFIG_DB_ROLE_CASES = [
+    pytest.param(
+        CONFIG_DB_NOACCESS_ROLE,
+        _get_configdb,
+        NO_ACCESS_ERROR,
+        id="configdb-noaccess-get",
+    ),
+    pytest.param(
+        CONFIG_DB_NOACCESS_ROLE,
+        _set_configdb,
+        NO_ACCESS_ERROR,
+        id="configdb-noaccess-set",
+    ),
+    pytest.param(
+        CONFIG_DB_READONLY_ROLE,
+        _get_configdb,
+        None,
+        id="configdb-readonly-get",
+    ),
+    pytest.param(
+        CONFIG_DB_READONLY_ROLE,
+        _set_configdb,
+        CONFIG_DB_READONLY_ROLE,
+        id="configdb-readonly-set",
+    ),
+    pytest.param(
+        CONFIG_DB_READWRITE_ROLE,
+        _get_configdb,
+        None,
+        id="configdb-readwrite-get",
+    ),
+    pytest.param(
+        CONFIG_DB_READWRITE_ROLE,
+        _set_configdb,
+        None,
+        id="configdb-readwrite-set",
+    ),
+]
+
+UNMAPPED_CN_ROLE_CASES = [
+    pytest.param(
+        None,
+        _get_configdb,
+        UNMAPPED_CN_ERROR,
+        id="unmapped-get",
+    ),
+    pytest.param(
+        None,
+        _set_configdb,
+        UNMAPPED_CN_ERROR,
+        id="unmapped-set",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "role,operation,error_pattern",
+    CAPABILITIES_ROLE_CASES + CONFIG_DB_ROLE_CASES + UNMAPPED_CN_ROLE_CASES,
+)
 def test_cn_role_access(
     gnmi_tls, role, operation, error_pattern  # noqa: F811
 ):

--- a/tests/gnmi/test_gnmi_aaa.py
+++ b/tests/gnmi/test_gnmi_aaa.py
@@ -27,7 +27,6 @@ from tests.common.helpers.sonic_db import (
     redis_del,
     redis_hdel,
     redis_hget,
-    redis_hgetall,
     redis_hset,
     redis_keys,
 )
@@ -103,6 +102,27 @@ def _get_capabilities(client):
     pytest_assert(
         "json_ietf" in encodings,
         "json_ietf not found in gNMI capabilities: {}".format(encodings),
+    )
+
+
+def _set_client_cert_role(duthost, role):
+    role_key = "GNMI_CLIENT_CERT|{}".format(CLIENT_PRINCIPAL)
+    if role is None:
+        result = redis_del(duthost, CONFIG_DB, role_key)[0]
+        pytest_assert(
+            result["rc"] == 0 and result["stdout"].strip() == "1",
+            "Failed to remove client certificate mapping: {}".format(result),
+        )
+        return
+
+    result = redis_hset(duthost, CONFIG_DB, role_key, **{"role@": role})
+    pytest_assert(
+        result["rc"] == 0,
+        "Failed to set role {!r}: {}".format(role, result),
+    )
+    pytest_assert(
+        redis_hget(duthost, CONFIG_DB, role_key, "role@") == role,
+        "Client certificate role was not set to {!r}".format(role),
     )
 
 
@@ -336,38 +356,16 @@ def test_gnmi_audit_rate_limit(gnmi_tls):  # noqa: F811
         "Get/Unimplemented did not use an independent outcome bucket",
     )
 
-    role_key = "GNMI_CLIENT_CERT|{}".format(CLIENT_PRINCIPAL)
-    # Denied Sets exercise the unlimited policy without 61 config saves.
-    original_role = redis_hget(duthost, CONFIG_DB, role_key, "role@")
-    pytest_assert(original_role, "Client certificate role is not configured")
-    try:
-        set_result = redis_hset(
-            duthost,
-            CONFIG_DB,
-            role_key,
-            **{"role@": CONFIG_DB_READONLY_ROLE}
-        )
-        pytest_assert(
-            set_result["rc"] == 0,
-            "Failed to set read-only role: {}".format(set_result),
-        )
-        with gnmi_tls.pygnmi_client._build_client() as client:
-            for _ in range(RATE_LIMIT_BURST + 1):
-                with pytest.raises(
-                    gNMIException, match=CONFIG_DB_READONLY_ROLE
-                ):
-                    client.set(
-                        update=[(CONFIG_DB_SET_PATH, '"Public"')],
-                        encoding="json_ietf",
-                    )
-    finally:
-        restore_result = redis_hset(
-            duthost, CONFIG_DB, role_key, **{"role@": original_role}
-        )
-        pytest_assert(
-            restore_result["rc"] == 0,
-            "Failed to restore certificate role: {}".format(restore_result),
-        )
+    _set_client_cert_role(duthost, CONFIG_DB_READONLY_ROLE)
+    with gnmi_tls.pygnmi_client._build_client() as client:
+        for _ in range(RATE_LIMIT_BURST + 1):
+            with pytest.raises(
+                gNMIException, match=CONFIG_DB_READONLY_ROLE
+            ):
+                client.set(
+                    update=[(CONFIG_DB_SET_PATH, '"Public"')],
+                    encoding="json_ietf",
+                )
 
     set_records = wait_for_audit_records(
         duthost,
@@ -375,6 +373,7 @@ def test_gnmi_audit_rate_limit(gnmi_tls):  # noqa: F811
         SET_METHOD,
         CLIENT_PRINCIPAL,
         expected_count=RATE_LIMIT_BURST + 1,
+        code="Unknown",
         path=AUDIT_SET_PATH,
     )
     pytest_assert(
@@ -483,46 +482,12 @@ def test_cn_role_access(
     role_key = "GNMI_CLIENT_CERT|{}".format(CLIENT_PRINCIPAL)
     original_role = redis_hget(duthost, CONFIG_DB, role_key, "role@")
     pytest_assert(original_role, "Client certificate role is not configured")
-
     try:
-        if role is None:
-            delete_results = redis_del(duthost, CONFIG_DB, role_key)
-            pytest_assert(
-                len(delete_results) == 1
-                and delete_results[0]["rc"] == 0
-                and delete_results[0]["stdout"].strip() == "1",
-                "Failed to remove client certificate mapping {}: {}".format(
-                    role_key, delete_results
-                ),
-            )
-        else:
-            set_result = redis_hset(
-                duthost,
-                CONFIG_DB,
-                role_key,
-                **{"role@": role}
-            )
-            pytest_assert(
-                set_result["rc"] == 0,
-                "Failed to set role {!r}: {}".format(role, set_result),
-            )
-            configured_fields = redis_hgetall(duthost, CONFIG_DB, role_key)
-            pytest_assert(
-                "role@" in configured_fields
-                and configured_fields["role@"] == role,
-                "Expected role {!r}, got {}".format(role, configured_fields),
-            )
-
+        _set_client_cert_role(duthost, role)
         if error_pattern:
             with pytest.raises(PygnmiClientError, match=error_pattern):
                 operation(gnmi_tls.pygnmi_client)
         else:
             operation(gnmi_tls.pygnmi_client)
     finally:
-        restore_result = redis_hset(
-            duthost, CONFIG_DB, role_key, **{"role@": original_role}
-        )
-        pytest_assert(
-            restore_result["rc"] == 0,
-            "Failed to restore certificate role: {}".format(restore_result),
-        )
+        _set_client_cert_role(duthost, original_role)

--- a/tests/gnmi/test_gnmi_aaa.py
+++ b/tests/gnmi/test_gnmi_aaa.py
@@ -3,9 +3,11 @@
 import logging
 import os
 import shlex
+import time
 import uuid
 
 import pytest
+from pygnmi.client import gNMIException
 
 from tests.common.fixtures.grpc_fixtures import (  # noqa: F401
     _restart_gnoi_server,
@@ -14,9 +16,11 @@ from tests.common.fixtures.grpc_fixtures import (  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.gnmi_audit import (
     RPC_COMPLETION_PREFIX,
+    get_audit_log_offset,
     parse_audit_records,
     read_forwarded_payloads,
     wait_for_audit_record,
+    wait_for_audit_records,
 )
 from tests.common.helpers.sonic_db import (
     CONFIG_DB,
@@ -33,7 +37,7 @@ from tests.common.helpers.syslog_helpers import (
     is_mgmt_vrf_enabled,
 )
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from tests.common.pygnmi_client import PygnmiClientError
+from tests.common.pygnmi_client import GetDataType, PygnmiClientError
 from tests.common.utilities import wait_until
 
 
@@ -54,6 +58,16 @@ UNMAPPED_CN_ERROR = (
     "Unauthenticated|unauthenticated|Invalid cert cname|"
     "not a trusted|common name mapping"
 )
+GET_METHOD = "/gnmi.gNMI/Get"
+SET_METHOD = "/gnmi.gNMI/Set"
+RATE_LIMIT_BURST = 60
+RATE_LIMIT_REFILL_SECONDS = 60
+CONFIG_DB_GET_PATH = (
+    "sonic-db:CONFIG_DB/localhost/DEVICE_METADATA/localhost"
+)
+CONFIG_DB_SET_PATH = "{}/cloudtype".format(CONFIG_DB_GET_PATH)
+AUDIT_GET_PATH = "/CONFIG_DB/localhost/DEVICE_METADATA/localhost"
+AUDIT_SET_PATH = "{}/cloudtype".format(AUDIT_GET_PATH)
 
 
 def _set_configdb(client):
@@ -93,8 +107,8 @@ def _get_capabilities(client):
 
 
 AUDIT_ACTIVITIES = [
-    pytest.param(_get_countersdb, "/gnmi.gNMI/Get", id="get"),
-    pytest.param(_set_configdb, "/gnmi.gNMI/Set", id="set"),
+    pytest.param(_get_countersdb, GET_METHOD, id="get"),
+    pytest.param(_set_configdb, SET_METHOD, id="set"),
 ]
 
 ROLE_ACCESS_CASES = [
@@ -261,14 +275,134 @@ def remote_syslog_capture(gnmi_tls, ptfhost):  # noqa: F811
 @pytest.mark.parametrize("operation,method", AUDIT_ACTIVITIES)
 def test_gnmi_audit_log(gnmi_tls, operation, method):  # noqa: F811
     duthost = gnmi_tls.duthost
-    offset = int(
-        duthost.shell(
-            "sudo stat -c %s /var/log/gnmi.log"
-        )["stdout"].strip()
-    )
+    offset = get_audit_log_offset(duthost)
 
     operation(gnmi_tls.pygnmi_client)
     wait_for_audit_record(duthost, offset, method, CLIENT_PRINCIPAL)
+
+
+def test_gnmi_audit_rate_limit(gnmi_tls):  # noqa: F811
+    """Verify Get outcome buckets are limited and Set remains unlimited."""
+    duthost = gnmi_tls.duthost
+    offset = get_audit_log_offset(duthost)
+
+    burst_started = time.monotonic()
+    with gnmi_tls.pygnmi_client._build_client() as client:
+        for _ in range(RATE_LIMIT_BURST + 1):
+            client.get(
+                path=[CONFIG_DB_GET_PATH],
+                encoding="json_ietf",
+            )
+
+        get_burst_seconds = time.monotonic() - burst_started
+        pytest_assert(
+            get_burst_seconds < RATE_LIMIT_REFILL_SECONDS,
+            "Get burst took {:.1f}s; requests crossed the 60s refill "
+            "boundary".format(get_burst_seconds),
+        )
+
+        with pytest.raises(gNMIException, match="unsupported request type"):
+            client.get(
+                path=[CONFIG_DB_GET_PATH],
+                datatype=str(GetDataType.STATE),
+                encoding="json_ietf",
+            )
+
+    get_records = wait_for_audit_records(
+        duthost,
+        offset,
+        GET_METHOD,
+        CLIENT_PRINCIPAL,
+        expected_count=RATE_LIMIT_BURST,
+        code="OK",
+        path=AUDIT_GET_PATH,
+    )
+    pytest_assert(
+        all(record["suppressed"] == 0 for record in get_records),
+        "In-limit Get records unexpectedly reported suppression",
+    )
+
+    unimplemented_records = wait_for_audit_records(
+        duthost,
+        offset,
+        GET_METHOD,
+        CLIENT_PRINCIPAL,
+        expected_count=1,
+        code="Unimplemented",
+        path=AUDIT_GET_PATH,
+    )
+    pytest_assert(
+        unimplemented_records[0]["suppressed"] == 0,
+        "Get/Unimplemented did not use an independent outcome bucket",
+    )
+
+    role_key = "GNMI_CLIENT_CERT|{}".format(CLIENT_PRINCIPAL)
+    # Denied Sets exercise the unlimited policy without 61 config saves.
+    original_role = redis_hget(duthost, CONFIG_DB, role_key, "role@")
+    pytest_assert(original_role, "Client certificate role is not configured")
+    try:
+        set_result = redis_hset(
+            duthost,
+            CONFIG_DB,
+            role_key,
+            **{"role@": CONFIG_DB_READONLY_ROLE}
+        )
+        pytest_assert(
+            set_result["rc"] == 0,
+            "Failed to set read-only role: {}".format(set_result),
+        )
+        with gnmi_tls.pygnmi_client._build_client() as client:
+            for _ in range(RATE_LIMIT_BURST + 1):
+                with pytest.raises(
+                    gNMIException, match=CONFIG_DB_READONLY_ROLE
+                ):
+                    client.set(
+                        update=[(CONFIG_DB_SET_PATH, '"Public"')],
+                        encoding="json_ietf",
+                    )
+    finally:
+        restore_result = redis_hset(
+            duthost, CONFIG_DB, role_key, **{"role@": original_role}
+        )
+        pytest_assert(
+            restore_result["rc"] == 0,
+            "Failed to restore certificate role: {}".format(restore_result),
+        )
+
+    set_records = wait_for_audit_records(
+        duthost,
+        offset,
+        SET_METHOD,
+        CLIENT_PRINCIPAL,
+        expected_count=RATE_LIMIT_BURST + 1,
+        path=AUDIT_SET_PATH,
+    )
+    pytest_assert(
+        all(record["suppressed"] == 0 for record in set_records),
+        "Set records were unexpectedly rate-limited",
+    )
+
+    refill_wait = max(
+        0,
+        RATE_LIMIT_REFILL_SECONDS + 1 - (time.monotonic() - burst_started),
+    )
+    time.sleep(refill_wait)
+    gnmi_tls.pygnmi_client.get(CONFIG_DB_GET_PATH)
+
+    get_records = wait_for_audit_records(
+        duthost,
+        offset,
+        GET_METHOD,
+        CLIENT_PRINCIPAL,
+        expected_count=RATE_LIMIT_BURST + 1,
+        code="OK",
+        path=AUDIT_GET_PATH,
+    )
+    pytest_assert(
+        get_records[-1]["suppressed"] == 1,
+        "First refilled Get record did not report one suppressed request: {}"
+        .format(get_records[-1]),
+    )
 
 
 @pytest.mark.parametrize("operation,method", AUDIT_ACTIVITIES)
@@ -277,11 +411,7 @@ def test_gnmi_audit_log_remote_forwarding(
 ):
     duthost = gnmi_tls.duthost
     capture_result, capture_file = remote_syslog_capture
-    offset = int(
-        duthost.shell(
-            "sudo stat -c %s /var/log/gnmi.log"
-        )["stdout"].strip()
-    )
+    offset = get_audit_log_offset(duthost)
 
     with allure.step("Generate a {} audit record".format(method)):
         operation(gnmi_tls.pygnmi_client)
@@ -345,41 +475,54 @@ def test_gnmi_default_cert_auth(gnmi_tls, operation, method):  # noqa: F811
 
 
 @pytest.mark.parametrize("role,operation,error_pattern", ROLE_ACCESS_CASES)
-def test_cn_role_access(gnmi_tls, role, operation, error_pattern):  # noqa: F811
+def test_cn_role_access(
+    gnmi_tls, role, operation, error_pattern  # noqa: F811
+):
     """Verify generic and target-specific role authorization."""
     duthost = gnmi_tls.duthost
     role_key = "GNMI_CLIENT_CERT|{}".format(CLIENT_PRINCIPAL)
+    original_role = redis_hget(duthost, CONFIG_DB, role_key, "role@")
+    pytest_assert(original_role, "Client certificate role is not configured")
 
-    if role is None:
-        delete_results = redis_del(duthost, CONFIG_DB, role_key)
-        pytest_assert(
-            len(delete_results) == 1
-            and delete_results[0]["rc"] == 0
-            and delete_results[0]["stdout"].strip() == "1",
-            "Failed to remove client certificate mapping {}: {}".format(
-                role_key, delete_results
-            ),
-        )
-    else:
-        set_result = redis_hset(
-            duthost,
-            CONFIG_DB,
-            role_key,
-            **{"role@": role}
-        )
-        pytest_assert(
-            set_result["rc"] == 0,
-            "Failed to set role {!r}: {}".format(role, set_result),
-        )
-        configured_fields = redis_hgetall(duthost, CONFIG_DB, role_key)
-        pytest_assert(
-            "role@" in configured_fields
-            and configured_fields["role@"] == role,
-            "Expected role {!r}, got {}".format(role, configured_fields),
-        )
+    try:
+        if role is None:
+            delete_results = redis_del(duthost, CONFIG_DB, role_key)
+            pytest_assert(
+                len(delete_results) == 1
+                and delete_results[0]["rc"] == 0
+                and delete_results[0]["stdout"].strip() == "1",
+                "Failed to remove client certificate mapping {}: {}".format(
+                    role_key, delete_results
+                ),
+            )
+        else:
+            set_result = redis_hset(
+                duthost,
+                CONFIG_DB,
+                role_key,
+                **{"role@": role}
+            )
+            pytest_assert(
+                set_result["rc"] == 0,
+                "Failed to set role {!r}: {}".format(role, set_result),
+            )
+            configured_fields = redis_hgetall(duthost, CONFIG_DB, role_key)
+            pytest_assert(
+                "role@" in configured_fields
+                and configured_fields["role@"] == role,
+                "Expected role {!r}, got {}".format(role, configured_fields),
+            )
 
-    if error_pattern:
-        with pytest.raises(PygnmiClientError, match=error_pattern):
+        if error_pattern:
+            with pytest.raises(PygnmiClientError, match=error_pattern):
+                operation(gnmi_tls.pygnmi_client)
+        else:
             operation(gnmi_tls.pygnmi_client)
-    else:
-        operation(gnmi_tls.pygnmi_client)
+    finally:
+        restore_result = redis_hset(
+            duthost, CONFIG_DB, role_key, **{"role@": original_role}
+        )
+        pytest_assert(
+            restore_result["rc"] == 0,
+            "Failed to restore certificate role: {}".format(restore_result),
+        )

--- a/tests/gnmi/test_gnmi_audit.py
+++ b/tests/gnmi/test_gnmi_audit.py
@@ -18,7 +18,6 @@ from tests.common.gu_utils import (
 )
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from tests.common.pygnmi_client import PygnmiClientError
 from tests.common.utilities import wait_until
 from tests.syslog.syslog_utils import add_syslog_server
 
@@ -30,7 +29,6 @@ logger = logging.getLogger(__name__)
 allure.logger = logger
 RPC_COMPLETION_PREFIX = "RPC_COMPLETION "
 CLIENT_PRINCIPAL = "test.client.gnmi.sonic"
-INVALID_CN_CHECKPOINT = "invalid_cn_test"
 REMOTE_SYSLOG_CHECKPOINT = "gnmi_audit_remote_syslog"
 
 
@@ -50,24 +48,6 @@ def _config_db_checkpoint(duthost, checkpoint_name):
             ),
         )
         delete_checkpoint(duthost, checkpoint_name)
-
-
-def _clear_client_cn_mappings(duthost):
-    result = duthost.shell(
-        "sonic-db-cli CONFIG_DB keys 'GNMI_CLIENT_CERT|*'"
-    )
-    for key in result["stdout_lines"]:
-        duthost.shell(
-            "sonic-db-cli CONFIG_DB del {}".format(shlex.quote(key))
-        )
-
-    remaining = duthost.shell(
-        "sonic-db-cli CONFIG_DB keys 'GNMI_CLIENT_CERT|*'"
-    )["stdout_lines"]
-    pytest_assert(
-        not remaining,
-        "Failed to clear GNMI client CN mappings: {}".format(remaining),
-    )
 
 
 def _get_completions(log_text):
@@ -196,21 +176,6 @@ def test_gnmi_get_audit_log(gnmi_tls):  # noqa: F811
         len(_get_completions(new_log)) == 1,
         "Expected exactly one new Get completion record",
     )
-
-
-def test_gnmi_invalid_cn_name(gnmi_tls):  # noqa: F811
-    duthost = gnmi_tls.duthost
-
-    with _config_db_checkpoint(duthost, INVALID_CN_CHECKPOINT):
-        _clear_client_cn_mappings(duthost)
-        with pytest.raises(
-            PygnmiClientError,
-            match="Unauthenticated|unauthenticated|common name mapping",
-        ):
-            gnmi_tls.pygnmi_client.get(
-                "COUNTERS_PORT_NAME_MAP",
-                target="COUNTERS_DB",
-            )
 
 
 def test_gnmi_get_audit_log_remote_forwarding(

--- a/tests/gnmi/test_gnmi_audit.py
+++ b/tests/gnmi/test_gnmi_audit.py
@@ -18,6 +18,7 @@ from tests.common.gu_utils import (
 )
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
+from tests.common.pygnmi_client import PygnmiClientError
 from tests.common.utilities import wait_until
 from tests.syslog.syslog_utils import add_syslog_server
 
@@ -29,6 +30,7 @@ logger = logging.getLogger(__name__)
 allure.logger = logger
 RPC_COMPLETION_PREFIX = "RPC_COMPLETION "
 CLIENT_PRINCIPAL = "test.client.gnmi.sonic"
+INVALID_CN_CHECKPOINT = "invalid_cn_test"
 REMOTE_SYSLOG_CHECKPOINT = "gnmi_audit_remote_syslog"
 
 
@@ -50,6 +52,24 @@ def _config_db_checkpoint(duthost, checkpoint_name):
         delete_checkpoint(duthost, checkpoint_name)
 
 
+def _clear_client_cn_mappings(duthost):
+    result = duthost.shell(
+        "sonic-db-cli CONFIG_DB keys 'GNMI_CLIENT_CERT|*'"
+    )
+    for key in result["stdout_lines"]:
+        duthost.shell(
+            "sonic-db-cli CONFIG_DB del {}".format(shlex.quote(key))
+        )
+
+    remaining = duthost.shell(
+        "sonic-db-cli CONFIG_DB keys 'GNMI_CLIENT_CERT|*'"
+    )["stdout_lines"]
+    pytest_assert(
+        not remaining,
+        "Failed to clear GNMI client CN mappings: {}".format(remaining),
+    )
+
+
 def _get_completions(log_text):
     records = []
     decoder = json.JSONDecoder()
@@ -66,6 +86,28 @@ def _get_completions(log_text):
                 and record.get("principal") == CLIENT_PRINCIPAL):
             records.append(record)
     return records
+
+
+@pytest.fixture
+def gnmi_tls_with_cn_enforcement(
+    request,
+    duthosts,
+    rand_one_dut_hostname,
+):
+    duthost = duthosts[rand_one_dut_hostname]
+    process = duthost.shell(
+        "docker exec gnmi ps -eo args | grep '[t]elemetry'",
+        module_ignore_errors=True,
+    )
+    original_cn_enforcement = (
+        "--config_table_name GNMI_CLIENT_CERT" in process["stdout"]
+    )
+    if not original_cn_enforcement:
+        pytest.xfail(
+            "Original gNMI service does not enforce GNMI_CLIENT_CERT"
+        )
+
+    return request.getfixturevalue("gnmi_tls")
 
 
 @pytest.fixture
@@ -176,6 +218,21 @@ def test_gnmi_get_audit_log(gnmi_tls):  # noqa: F811
         len(_get_completions(new_log)) == 1,
         "Expected exactly one new Get completion record",
     )
+
+
+def test_gnmi_invalid_cn_name(gnmi_tls_with_cn_enforcement):
+    tls_fixture = gnmi_tls_with_cn_enforcement
+    duthost = tls_fixture.duthost
+    with _config_db_checkpoint(duthost, INVALID_CN_CHECKPOINT):
+        _clear_client_cn_mappings(duthost)
+        with pytest.raises(
+            PygnmiClientError,
+            match="Unauthenticated|unauthenticated|common name mapping",
+        ):
+            tls_fixture.pygnmi_client.get(
+                "COUNTERS_PORT_NAME_MAP",
+                target="COUNTERS_DB",
+            )
 
 
 def test_gnmi_get_audit_log_remote_forwarding(

--- a/tests/gnmi/test_gnmi_audit.py
+++ b/tests/gnmi/test_gnmi_audit.py
@@ -1,0 +1,257 @@
+"""gNMI audit tests."""
+
+import json
+import logging
+import os
+import shlex
+import uuid
+from contextlib import contextmanager
+
+import pytest
+from scapy.all import Raw, UDP, rdpcap
+
+from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
+from tests.common.gu_utils import (
+    create_checkpoint,
+    delete_checkpoint,
+    rollback,
+)
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
+from tests.common.pygnmi_client import PygnmiClientError
+from tests.common.utilities import wait_until
+from tests.syslog.syslog_utils import add_syslog_server
+
+
+pytestmark = [
+    pytest.mark.topology("any"),
+]
+logger = logging.getLogger(__name__)
+allure.logger = logger
+RPC_COMPLETION_PREFIX = "RPC_COMPLETION "
+CLIENT_PRINCIPAL = "test.client.gnmi.sonic"
+INVALID_CN_CHECKPOINT = "invalid_cn_test"
+REMOTE_SYSLOG_CHECKPOINT = "gnmi_audit_remote_syslog"
+
+
+@contextmanager
+def _config_db_checkpoint(duthost, checkpoint_name):
+    create_checkpoint(duthost, checkpoint_name)
+    try:
+        yield
+    finally:
+        rollback_result = rollback(duthost, checkpoint_name)
+        pytest_assert(
+            rollback_result["rc"] == 0
+            and "Config rolled back successfully"
+            in rollback_result["stdout"],
+            "Failed to restore CONFIG_DB checkpoint {}".format(
+                checkpoint_name
+            ),
+        )
+        delete_checkpoint(duthost, checkpoint_name)
+
+
+def _clear_client_cn_mappings(duthost):
+    result = duthost.shell(
+        "sonic-db-cli CONFIG_DB keys 'GNMI_CLIENT_CERT|*'"
+    )
+    for key in result["stdout_lines"]:
+        duthost.shell(
+            "sonic-db-cli CONFIG_DB del {}".format(shlex.quote(key))
+        )
+
+    remaining = duthost.shell(
+        "sonic-db-cli CONFIG_DB keys 'GNMI_CLIENT_CERT|*'"
+    )["stdout_lines"]
+    pytest_assert(
+        not remaining,
+        "Failed to clear GNMI client CN mappings: {}".format(remaining),
+    )
+
+
+def _get_completions(log_text):
+    records = []
+    decoder = json.JSONDecoder()
+    for line in log_text.splitlines():
+        _, separator, payload = line.partition(RPC_COMPLETION_PREFIX)
+        if not separator:
+            continue
+        try:
+            record, _ = decoder.raw_decode(payload)
+        except json.JSONDecodeError:
+            continue
+        if (record.get("method") == "/gnmi.gNMI/Get"
+                and record.get("path") == ["/COUNTERS_PORT_NAME_MAP"]
+                and record.get("principal") == CLIENT_PRINCIPAL):
+            records.append(record)
+    return records
+
+
+@pytest.fixture
+def remote_syslog_capture(gnmi_tls, ptfhost):  # noqa: F811
+    duthost = gnmi_tls.duthost
+    ptf_ip = ptfhost.mgmt_ip
+    capture_file = "/tmp/gnmi-audit-{}.pcap".format(uuid.uuid4().hex)
+    capture_pool = None
+
+    try:
+        with _config_db_checkpoint(
+            duthost,
+            REMOTE_SYSLOG_CHECKPOINT,
+        ):
+            with allure.step("Add remote syslog configuration"):
+                add_result = add_syslog_server(duthost, ptf_ip)
+                pytest_assert(
+                    add_result["rc"] == 0,
+                    "Failed to add temporary syslog server",
+                )
+
+            remote_action = 'Target="{}" Port="514"'.format(ptf_ip)
+
+            def remote_action_configured():
+                command = "grep -Fq {} /etc/rsyslog.conf".format(
+                    shlex.quote(remote_action)
+                )
+                return duthost.shell(
+                    command, module_ignore_errors=True
+                )["rc"] == 0
+
+            with allure.step("Verify remote syslog configuration"):
+                pytest_assert(
+                    wait_until(30, 1, 0, remote_action_configured),
+                    "Host rsyslog did not configure UDP/514 forwarding",
+                )
+
+            with allure.step("Start remote syslog packet capture"):
+                capture_command = (
+                    "sudo timeout 10 tcpdump -i any -y LINUX_SLL -nn "
+                    "-s0 -U -w {} "
+                    "'udp and dst host {} and dst port 514'"
+                ).format(shlex.quote(capture_file), ptf_ip)
+                capture_pool, capture_result = duthost.shell(
+                    capture_command,
+                    module_async=True,
+                    module_ignore_errors=True,
+                )
+
+            def capture_started():
+                command = "sudo test $(stat -c %s {}) -ge 24".format(
+                    shlex.quote(capture_file)
+                )
+                return duthost.shell(
+                    command, module_ignore_errors=True
+                )["rc"] == 0
+
+            with allure.step("Verify remote syslog packet capture is ready"):
+                pytest_assert(
+                    wait_until(10, 1, 0, capture_started),
+                    "UDP/514 packet capture did not start",
+                )
+
+            yield capture_result, capture_file
+    finally:
+        if capture_pool is not None:
+            if capture_result.ready():
+                capture_pool.close()
+            else:
+                capture_pool.terminate()
+            capture_pool.join()
+        duthost.shell(
+            "sudo rm -f {}".format(shlex.quote(capture_file)),
+            module_ignore_errors=True,
+        )
+        if os.path.exists(capture_file):
+            os.remove(capture_file)
+
+
+def test_gnmi_get_audit_log(gnmi_tls):  # noqa: F811
+    duthost = gnmi_tls.duthost
+    offset = int(
+        duthost.shell(
+            "sudo stat -c %s /var/log/gnmi.log"
+        )["stdout"].strip()
+    )
+
+    gnmi_tls.pygnmi_client.get(
+        "COUNTERS_PORT_NAME_MAP",
+        target="COUNTERS_DB",
+    )
+
+    def audit_record_written():
+        new_log = duthost.shell(
+            "sudo tail -c +{} /var/log/gnmi.log".format(offset + 1),
+            module_ignore_errors=True,
+        )["stdout"]
+        return bool(_get_completions(new_log))
+
+    pytest_assert(
+        wait_until(30, 1, 0, audit_record_written),
+        "No new Get completion record in /var/log/gnmi.log",
+    )
+    new_log = duthost.shell(
+        "sudo tail -c +{} /var/log/gnmi.log".format(offset + 1)
+    )["stdout"]
+    pytest_assert(
+        len(_get_completions(new_log)) == 1,
+        "Expected exactly one new Get completion record",
+    )
+
+
+def test_gnmi_invalid_cn_name(gnmi_tls):  # noqa: F811
+    duthost = gnmi_tls.duthost
+
+    with _config_db_checkpoint(duthost, INVALID_CN_CHECKPOINT):
+        _clear_client_cn_mappings(duthost)
+        with pytest.raises(
+            PygnmiClientError,
+            match="Unauthenticated|unauthenticated|common name mapping",
+        ):
+            gnmi_tls.pygnmi_client.get(
+                "COUNTERS_PORT_NAME_MAP",
+                target="COUNTERS_DB",
+            )
+
+
+def test_gnmi_get_audit_log_remote_forwarding(
+    gnmi_tls, remote_syslog_capture  # noqa: F811
+):
+    duthost = gnmi_tls.duthost
+    capture_result, capture_file = remote_syslog_capture
+
+    with allure.step("Generate a gNMI audit record"):
+        gnmi_tls.pygnmi_client.get(
+            "COUNTERS_PORT_NAME_MAP",
+            target="COUNTERS_DB",
+        )
+
+    with allure.step("Verify the remotely forwarded audit record"):
+        pytest_assert(
+            wait_until(15, 1, 0, capture_result.ready),
+            "UDP/514 packet capture did not finish",
+        )
+        capture_status = capture_result.get()
+        pcap_status = duthost.shell(
+            "sudo test -s {}".format(shlex.quote(capture_file)),
+            module_ignore_errors=True,
+        )
+        pytest_assert(
+            pcap_status["rc"] == 0,
+            "UDP/514 capture file is empty or missing: {}".format(
+                capture_status
+            ),
+        )
+        duthost.fetch(src=capture_file, dest="/tmp/", flat=True)
+        packets = rdpcap(capture_file)
+        matching_records = []
+        for packet in packets:
+            if UDP not in packet or Raw not in packet:
+                continue
+            payload = bytes(packet[Raw].load).decode(
+                "utf-8", errors="replace"
+            )
+            matching_records.extend(_get_completions(payload))
+        pytest_assert(
+            len(matching_records) == 1,
+            "Expected one forwarded UDP/514 Get audit record",
+        )

--- a/tests/syslog/syslog_utils.py
+++ b/tests/syslog/syslog_utils.py
@@ -15,40 +15,6 @@ class syslogUtilsConst:
     PACKETS_NUM = 2
 
 
-def add_syslog_server(dut, syslog_server_ip, source=None, vrf=None, port=None):
-    """
-    Add syslog server
-
-    Args:
-        dut (SonicHost): The target device
-        syslog_server_ip (str): Syslog server address
-        source (str): Source ip address
-        vrf (str): Vrf device (default,mgmt,Vrf-data)
-        port (str): Server udp port
-
-    """
-    cmd_add_syslog_server = 'sudo config syslog add {} '.format(syslog_server_ip)
-    if source:
-        cmd_add_syslog_server = "{} --source {} ".format(cmd_add_syslog_server, source)
-    if vrf:
-        cmd_add_syslog_server = "{} --vrf {} ".format(cmd_add_syslog_server, vrf)
-    if port:
-        cmd_add_syslog_server = "{} --port {} ".format(cmd_add_syslog_server, port)
-    logging.debug("add_syslog_server command is: %s", cmd_add_syslog_server)
-    return dut.command(cmd_add_syslog_server, module_ignore_errors=True)
-
-
-def del_syslog_server(dut, syslog_server_ip):
-    """
-    Del syslog server
-
-    Args:
-        dut (SonicHost): The target device
-        syslog_server_ip (str): Syslog server ip
-    """
-    dut.command('sudo config syslog del {} '.format(syslog_server_ip))
-
-
 def create_vrf(dut, vrf):
     """
     Create Vrf

--- a/tests/syslog/test_syslog_source_ip.py
+++ b/tests/syslog/test_syslog_source_ip.py
@@ -6,10 +6,10 @@ import allure
 import re
 import time
 from scapy.all import rdpcap
-from .syslog_utils import create_vrf, remove_vrf, add_syslog_server, del_syslog_server, capture_syslog_packets, \
+from .syslog_utils import create_vrf, remove_vrf, capture_syslog_packets, \
     replace_ip_neigh, bind_interface_to_vrf, check_vrf, syslogUtilsConst
 from tests.common.utilities import wait_until
-from tests.common.helpers.syslog_helpers import is_mgmt_vrf_enabled
+from tests.common.helpers.syslog_helpers import add_syslog_server, del_syslog_server, is_mgmt_vrf_enabled
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.reboot import reboot, SONIC_SSH_PORT, SONIC_SSH_REGEX
 from ipaddress import IPv4Address, IPv6Address, ip_address, ip_network, IPv6Network


### PR DESCRIPTION
## Summary
- validate local `RPC_COMPLETION` audit records for certificate-authenticated gNMI Get and Set operations
- validate Get's production rate policy: burst 60, one-minute refill, independent final-code buckets, and suppression carry-forward
- validate Set remains unlimited with 61 completion records from one rapid burst
- centralize certificate-role add/delete/readback checks in one local helper; parameterized role cases restore between cases, while the rate-limit test relies on `gnmi_tls` checkpoint rollback
- validate UDP/514 remote forwarding contains the `RPC_COMPLETION` marker and exactly matches the corresponding local audit record
- verify missing `GNMI|gnmi.user_auth` defaults to certificate authentication for both Get and Set
- cover generic gNMI roles, CONFIG_DB-specific roles, empty roles, no-access roles, and unmapped certificate CNs in one target-aware matrix
- consolidate AAA coverage in `tests/gnmi/test_gnmi_aaa.py`
- add reusable, shell-safe Redis mutation helpers with observable results
- make `_restart_gnoi_server()` wait for supervisor `RUNNING` and the TLS listener on port 50052
- move syslog server configuration and packet-capture lifecycle into `tests/common/helpers/syslog_helpers.py`
- route temporary syslog forwarding through the management VRF when it is enabled
- group role cases by Capabilities, CONFIG_DB, and unmapped-CN authorization targets

## Validation
- `python3 -m py_compile tests/common/fixtures/grpc_fixtures.py tests/common/helpers/gnmi_audit.py tests/common/helpers/sonic_db.py tests/common/helpers/syslog_helpers.py tests/gnmi/test_gnmi.py tests/gnmi/test_gnmi_aaa.py tests/syslog/syslog_utils.py tests/syslog/test_syslog_source_ip.py`
- `flake8 --max-line-length=120 tests/common/helpers/syslog_helpers.py tests/common/helpers/gnmi_audit.py tests/gnmi/test_gnmi_aaa.py`
- targeted dependency scans for `tests/gnmi` and `tests/syslog`
- focused collection: 19 `test_gnmi_aaa.py` cases
- `git diff --check`
- final head: `1c22ea54b`
- physical rate-limit E2E: 1 passed, 0 failed, 0 errors, 0 skipped in 150.295 seconds on `SONiC.20260510.10`
  - 61 rapid Get/OK calls completed inside one refill interval and produced exactly 60 records
  - Get/Unimplemented remained independently recordable after exhausting Get/OK
  - 61 rapid denied Sets produced 61 records with `suppressed=0`
  - the first refilled Get/OK record reported `suppressed=1`
  - post-test YANG, config, core-dump, process, and memory checks passed
- post-E2E structure refactors through `1c22ea54b`: compilation, Flake8, unchanged 19-case collection, and diff checks passed
- physical AAA validation at `c7cd68900`: 8 passed, 0 failed, 0 errors, 0 skipped
- targeted physical audit validation at `6c36e75d3`: 4 passed, 0 failed, 0 errors, 0 skipped
- final unified role matrix: 12 passed, 0 failed, 0 errors, 0 skipped on `SONiC.20260510.10`
  - generic `gnmi_noaccess`, `gnmi_readonly`, `gnmi_readwrite`, and empty role
  - CONFIG_DB noaccess/read-only/read-write Get and Set behavior
  - unmapped-CN Get and Set rejection
- final audit/default-auth validation: 6 passed, 0 failed, 0 errors, 0 skipped
  - local Get and Set audit records
  - forwarded Get and Set audit records
  - missing-`user_auth` Get and Set behavior
- temporary physical syslog-helper add/delete smoke validation: 1 passed, 0 failed, 0 errors, 0 skipped
- management-VRF forwarding selection and generated `Device="mgmt"` assertion are implemented; the available physical testbed had management VRF disabled
- the existing `test_config_syslog_non_existing_ip` reached its expected CLI error but failed an unrelated quote-style assertion on the DUT image
- physical audit validation temporarily overlaid an audit-enabled `sonic-gnmi` package because the available DUT image predated the required behavior; cleanup recreated the `gnmi` container, restored the clean-image binary hash, removed the SSH tunnel and temporary test state, verified service/Monit health, and released the testbed
- no public physical-test URL is available; sanitized JUnit evidence is retained locally

## Dependency
Uses the native `PygnmiClient` and `gnmi_tls` fixture merged in #26013.
