### PR TITLE
Test_Prefix_List - T2 Update

### DIFF
--- a/tests/bgp/test_prefix_list.py
+++ b/tests/bgp/test_prefix_list.py
@@ -36,7 +36,7 @@ CONSTANTS_FILE = "/etc/sonic/constants.yml"
 
 
 def op_anchor_prefix_with_cmd(duthost, prefix_type, prefix, action, ignore_error=False):
-    # Add or remove prefix list
+    # Add or remove prefix list.
     pytest_assert(action in ["add", "remove"], "Invalid action specified. Must be 'add' or 'remove'.")
     cmd = "sudo prefix_list {} {} {}".format(action, prefix_type, prefix)
     duthost.shell(cmd, module_ignore_errors=ignore_error)

--- a/tests/bgp/test_prefix_list.py
+++ b/tests/bgp/test_prefix_list.py
@@ -5,6 +5,7 @@ import json
 import time
 import yaml
 from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.bgp import get_db_cli_prefix, get_vtysh_cmd_for_asic
 from tests.common.helpers.parallel import parallel_run
 
 pytestmark = [
@@ -60,8 +61,9 @@ def verify_prefix_list_in_db(duthost, prefix_type, prefix):
 def verify_prefix_in_bgp_table(duthost, ip_version, prefix):
     # Check whether prefix in BGP table
     for asic_index in duthost.get_frontend_asic_ids():
-        asic_ns = f"-n {asic_index}" if duthost.is_multi_asic else ""
-        cmd = f"vtysh {asic_ns} -c 'show bgp {ip_version} {prefix}'"
+        cmd = get_vtysh_cmd_for_asic(
+            duthost, asic_index, f"vtysh -c 'show bgp {ip_version} {prefix}'"
+        )
         outputs = duthost.shell(cmd)["stdout"]
         if "Network not in table" in outputs:
             logger.info("Expected prefix {} to be in the BGP table, but it was not found".format(prefix))
@@ -72,8 +74,8 @@ def verify_prefix_in_bgp_table(duthost, ip_version, prefix):
 def verify_prefix_in_fib_table(duthost, prefix):
     # Check whether prefix in FIB table
     for asic_index in duthost.get_frontend_asic_ids():
-        asic_ns = f"-n asic{asic_index}" if duthost.is_multi_asic else ""
-        cmd = f"sonic-db-cli {asic_ns} APPL_DB hgetall \"ROUTE_TABLE:{prefix}\""
+        db_cli = get_db_cli_prefix(duthost, asic_index)
+        cmd = f'{db_cli} APPL_DB hgetall "ROUTE_TABLE:{prefix}"'
         output = duthost.shell(cmd)["stdout"].strip().replace("'", "\"")
         route_info = json.loads(output) if output else {}
         if route_info == {} or ("blackhole" in route_info and route_info["blackhole"] == "true"):

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
@@ -93,11 +93,6 @@ bgp/test_passive_peering.py:
     conditions:
     - asic_type in ['vs'] and 't2' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
-bgp/test_prefix_list.py:
-  skip:
-    conditions:
-    - asic_type in ['vs'] and 't2' in topo_name
-    reason: This test case either cannot pass or should be skipped on virtual chassis
 bgp/test_seq_idf_isolation.py:
   skip:
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable `test_prefix_list` on T2 multi-ASIC by aligning per-ASIC BGP/FIB verification with shared helpers and removing the T2 skip.

`test_prefix_list.py` already loops over frontend ASICs, but the BGP/FIB checks used open-coded namespace flags. The test was also skipped on VS T2.

**Changes:**
- Use shared multi-ASIC helpers in BGP/FIB verification (same method as `test_prefix_list_suppress.py`).
- Remove the VS T2 conditional skip for this test.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
N/A

<!--
- master: <image version> - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

On multi-ASIC chassis, BGP/FIB verification needs to query each frontend ASIC. This test already loops frontend ASICs, but used open-coded namespace flags and was skipped on VS T2. Align with shared helpers and remove the skip so it runs on multi-ASIC T2.

#### How did you do it?

- Updated `verify_prefix_in_bgp_table()` to build vtysh commands by ASIC.
- Updated `verify_prefix_in_fib_table()` to use `get_db_cli_prefix()` for consistency with the other multi-ASIC BGP tests.
- Removed the T2 skip from `tests_mark_conditions_vs_t2.yaml`.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

- Code review to check functionality. 
- Code review for consistency with existing multi-ASIC tests/functionality, such as in `tests/common/helpers/bgp.py`. 
- Full validation of functionality on all topologies using GitHub checks / pipeline.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
Existing test, updated logic for T2. 

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A - simple test logic update for T2.