### PR TITLE
Test_Passive_Peering - T2 Update

### DIFF
--- a/tests/bgp/test_passive_peering.py
+++ b/tests/bgp/test_passive_peering.py
@@ -1,6 +1,6 @@
 '''
 
-This script is to test BGP passive peering on SONiC.
+This script is to test BGP passive peering on SONiC
 
 '''
 

--- a/tests/bgp/test_passive_peering.py
+++ b/tests/bgp/test_passive_peering.py
@@ -5,9 +5,9 @@ This script is to test BGP passive peering on SONiC
 '''
 
 import logging
+import time
 import pytest
 from tests.common.config_reload import config_reload
-from tests.common.devices.eos import EosHost
 from tests.common.helpers.bgp import get_vtysh_cmd_for_asic
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import wait_until
@@ -24,7 +24,27 @@ BGP_WAIT_INTERVAL = 10
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Test placeholder password")]
 peer_password = "sonic.123"
 wrong_password = "wrong-password"
-EOS_BACKUP_CONFIG_FILE = "/tmp/eos_neighbor_test_passive_peering_backup_config_{}"
+
+
+def remove_password_on_neighbor(setup):
+    """Undo neighbor BGP passwords added by the tests (EOS or SONiC)."""
+    if setup['is_sonic']:
+        for dut_ip in (setup['dut_ip_v4'], setup['dut_ip_v6']):
+            cmd = get_vtysh_cmd_for_asic(
+                setup['neighhost'], setup['neigh_asic_index'],
+                'vtysh -c "config" -c "router bgp {}" -c "no neighbor {} password {}"'.format(
+                    setup['neigh_asn'], dut_ip, peer_password),
+            )
+            setup['neighhost'].shell(cmd, module_ignore_errors=True)
+    else:
+        for dut_ip in (setup['dut_ip_v4'], setup['dut_ip_v6']):
+            try:
+                setup['neighhost'].eos_config(
+                    lines=["no neighbor {} password 0 {}".format(dut_ip, peer_password)],
+                    parents=setup['neigh_eos_bgp_parents'],
+                )
+            except Exception as e:
+                logger.warning("Failed to remove BGP password for neighbor {}: {}".format(dut_ip, e))
 
 
 @pytest.fixture(scope='module')
@@ -112,30 +132,18 @@ def setup(tbinfo, nbrhosts, duthosts, rand_one_dut_front_end_hostname, request):
     }
 
     logger.debug('Setup_info: {}'.format(setup_info))
-    neighbor_dut = nbrhosts[neigh_name]["host"]
-
-    is_arista_neighbor = not is_sonic and isinstance(neighbor_dut, EosHost)
-
-    if is_arista_neighbor:
-        # Neighbor is running EOS, backup config
-        neighbor_dut.eos_config(
-            backup=True,
-            backup_options={
-                'filename': EOS_BACKUP_CONFIG_FILE.format(neighbor_dut.hostname)
-            }
-        )
 
     yield setup_info
 
-    # restore config to original state on both DUT and neighbor
-
-    if is_arista_neighbor:
-        # Neighbor is running EOS, backup config
-        neighbor_dut.load_configuration(EOS_BACKUP_CONFIG_FILE.format(neighbor_dut.hostname))
-    elif is_sonic:
+    # Undo only what the tests changed on the neighbor. Full EOS backup restore via
+    # load_configuration() can fail on VS (e.g. VLAN subnet overlap on Vl2004/Vlan1).
+    if is_sonic:
         config_reload(nbrhosts[neigh_name]["host"], is_dut=False)
+    else:
+        remove_password_on_neighbor(setup_info)
 
-    config_reload(duthost, safe_reload=True, wait_for_bgp=True)
+    time.sleep(10)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
 
 def check_bgp_neighbor_state(duthost, asic_index, neigh_ip, should_be_established=True):

--- a/tests/bgp/test_passive_peering.py
+++ b/tests/bgp/test_passive_peering.py
@@ -32,19 +32,16 @@ def remove_password_on_neighbor(setup):
         for dut_ip in (setup['dut_ip_v4'], setup['dut_ip_v6']):
             cmd = get_vtysh_cmd_for_asic(
                 setup['neighhost'], setup['neigh_asic_index'],
-                'vtysh -c "config" -c "router bgp {}" -c "no neighbor {} password {}"'.format(
-                    setup['neigh_asn'], dut_ip, peer_password),
+                'vtysh -c "config" -c "router bgp {}" -c "no neighbor {} password"'.format(
+                    setup['neigh_asn'], dut_ip),
             )
-            setup['neighhost'].shell(cmd, module_ignore_errors=True)
+            setup['neighhost'].shell(cmd)
     else:
-        for dut_ip in (setup['dut_ip_v4'], setup['dut_ip_v6']):
-            try:
-                setup['neighhost'].eos_config(
-                    lines=["no neighbor {} password 0 {}".format(dut_ip, peer_password)],
-                    parents=setup['neigh_eos_bgp_parents'],
-                )
-            except Exception as e:
-                logger.warning("Failed to remove BGP password for neighbor {}: {}".format(dut_ip, e))
+        cmd = [
+            "no neighbor {} password".format(setup['dut_ip_v4']),
+            "no neighbor {} password".format(setup['dut_ip_v6']),
+        ]
+        setup['neighhost'].eos_config(lines=cmd, parents=setup['neigh_eos_bgp_parents'])
 
 
 @pytest.fixture(scope='module')
@@ -77,6 +74,10 @@ def setup(tbinfo, nbrhosts, duthosts, rand_one_dut_front_end_hostname, request):
     skip_hosts = duthost.get_asic_namespace_list()
 
     bgp_facts = duthost.bgp_facts(instance_id=asic_index)['ansible_facts']
+    neigh_ip_v4 = None
+    neigh_ip_v6 = None
+    peer_group_v4 = None
+    peer_group_v6 = None
     neigh_asn = dict()
     for k, v in bgp_facts['bgp_neighbors'].items():
         if v['description'] not in skip_hosts:
@@ -90,6 +91,10 @@ def setup(tbinfo, nbrhosts, duthosts, rand_one_dut_front_end_hostname, request):
                     peer_group_v6 = v['peer group']
                     assert v['state'] == 'established'
             neigh_asn[v['description']] = v['remote AS']
+
+    if (neigh_ip_v4 is None or neigh_ip_v6 is None or peer_group_v4 is None or
+            peer_group_v6 is None):
+        pytest.skip("Failed to get neighbor info")
 
     neigh_bgp_config = tbinfo['topo']['properties']['configuration'][neigh_name]['bgp']
     peer_in_bgp_confed = neigh_bgp_config.get('peer_in_bgp_confed', False)

--- a/tests/bgp/test_passive_peering.py
+++ b/tests/bgp/test_passive_peering.py
@@ -8,6 +8,7 @@ import logging
 import pytest
 from tests.common.config_reload import config_reload
 from tests.common.devices.eos import EosHost
+from tests.common.helpers.bgp import get_vtysh_cmd_for_asic
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import wait_until
 from tests.bgp.bgp_helpers import eos_bgp_neighbor_config_parents
@@ -160,9 +161,11 @@ def check_bgp_neighbor_state(duthost, asic_index, neigh_ip, should_be_establishe
 
 def test_bgp_passive_peering_ipv4(setup):
     # configure passive EBGP peering session on DUT and ensure adjacency stays established (IPv4)
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} passive"'.format(setup['asic_index'],
-                                                                                       setup['dut_asn'],
-                                                                                       setup['peer_group_v4'])
+    cmd = get_vtysh_cmd_for_asic(
+        setup['duthost'], setup['asic_index'],
+        'vtysh -c "config" -c "router bgp {}" -c "neighbor {} passive"'.format(
+            setup['dut_asn'], setup['peer_group_v4']),
+    )
     setup['duthost'].shell(cmd, module_ignore_errors=True)
 
     assert wait_until(BGP_WAIT_TIMEOUT, BGP_WAIT_INTERVAL, 0,
@@ -171,10 +174,11 @@ def test_bgp_passive_peering_ipv4(setup):
         "BGP IPv4 session not established after configuring passive peering"
 
     # configure password on DUT and ensure the adjacency is not established (IPv4)
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} password {}"'.format(setup['asic_index'],
-                                                                                           setup['dut_asn'],
-                                                                                           setup['peer_group_v4'],
-                                                                                           peer_password)
+    cmd = get_vtysh_cmd_for_asic(
+        setup['duthost'], setup['asic_index'],
+        'vtysh -c "config" -c "router bgp {}" -c "neighbor {} password {}"'.format(
+            setup['dut_asn'], setup['peer_group_v4'], peer_password),
+    )
     setup['duthost'].shell(cmd, module_ignore_errors=True)
 
     assert wait_until(BGP_WAIT_TIMEOUT, BGP_WAIT_INTERVAL, 0,
@@ -186,11 +190,11 @@ def test_bgp_passive_peering_ipv4(setup):
 
     # configure password on Neighbor and ensure the adjacency is established (IPv4)
     if setup['is_sonic']:
-        cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} password {}"'.format(
-                                                                                        setup['neigh_asic_index'],
-                                                                                        setup['neigh_asn'],
-                                                                                        setup['dut_ip_v4'],
-                                                                                        peer_password)
+        cmd = get_vtysh_cmd_for_asic(
+            setup['neighhost'], setup['neigh_asic_index'],
+            'vtysh -c "config" -c "router bgp {}" -c "neighbor {} password {}"'.format(
+                setup['neigh_asn'], setup['dut_ip_v4'], peer_password),
+        )
         setup['neighhost'].shell(cmd, module_ignore_errors=True)
     else:
         cmd = ["neighbor {} password 0 {}".format(setup['dut_ip_v4'], peer_password)]
@@ -204,10 +208,11 @@ def test_bgp_passive_peering_ipv4(setup):
         "BGP IPv4 session not established after configuring matching password"
 
     # configure mismatch password on DUT and ensure the adjacency is not established (IPv4)
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} password {}"'.format(setup['asic_index'],
-                                                                                           setup['dut_asn'],
-                                                                                           setup['peer_group_v4'],
-                                                                                           wrong_password)
+    cmd = get_vtysh_cmd_for_asic(
+        setup['duthost'], setup['asic_index'],
+        'vtysh -c "config" -c "router bgp {}" -c "neighbor {} password {}"'.format(
+            setup['dut_asn'], setup['peer_group_v4'], wrong_password),
+    )
     setup['duthost'].shell(cmd, module_ignore_errors=True)
 
     assert wait_until(BGP_WAIT_TIMEOUT, BGP_WAIT_INTERVAL, 0,
@@ -218,9 +223,11 @@ def test_bgp_passive_peering_ipv4(setup):
 
 def test_bgp_passive_peering_ipv6(setup):
     # configure passive EBGP peering session on DUT and ensure adjacency stays established (IPv6)
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} passive"'.format(setup['asic_index'],
-                                                                                       setup['dut_asn'],
-                                                                                       setup['peer_group_v6'])
+    cmd = get_vtysh_cmd_for_asic(
+        setup['duthost'], setup['asic_index'],
+        'vtysh -c "config" -c "router bgp {}" -c "neighbor {} passive"'.format(
+            setup['dut_asn'], setup['peer_group_v6']),
+    )
     setup['duthost'].shell(cmd, module_ignore_errors=True)
 
     assert wait_until(BGP_WAIT_TIMEOUT, BGP_WAIT_INTERVAL, 0,
@@ -229,10 +236,11 @@ def test_bgp_passive_peering_ipv6(setup):
         "BGP IPv6 session not established after configuring passive peering"
 
     # configure password on DUT and ensure the adjacency is not established (IPv6)
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} password {}"'.format(setup['asic_index'],
-                                                                                           setup['dut_asn'],
-                                                                                           setup['peer_group_v6'],
-                                                                                           peer_password)
+    cmd = get_vtysh_cmd_for_asic(
+        setup['duthost'], setup['asic_index'],
+        'vtysh -c "config" -c "router bgp {}" -c "neighbor {} password {}"'.format(
+            setup['dut_asn'], setup['peer_group_v6'], peer_password),
+    )
     setup['duthost'].shell(cmd, module_ignore_errors=True)
 
     assert wait_until(BGP_WAIT_TIMEOUT, BGP_WAIT_INTERVAL, 0,
@@ -242,12 +250,11 @@ def test_bgp_passive_peering_ipv6(setup):
 
     # configure password on Neighbor and ensure the adjacency is established (IPv6)
     if setup['is_sonic']:
-        cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} password {}"'.\
-                                                                                    format(
-                                                                                        setup['neigh_asic_index'],
-                                                                                        setup['neigh_asn'],
-                                                                                        setup['dut_ip_v6'],
-                                                                                        peer_password)
+        cmd = get_vtysh_cmd_for_asic(
+            setup['neighhost'], setup['neigh_asic_index'],
+            'vtysh -c "config" -c "router bgp {}" -c "neighbor {} password {}"'.format(
+                setup['neigh_asn'], setup['dut_ip_v6'], peer_password),
+        )
         setup['neighhost'].shell(cmd, module_ignore_errors=True)
     else:
         cmd = ["neighbor {} password 0 {}".format(setup['dut_ip_v6'], peer_password)]
@@ -261,10 +268,11 @@ def test_bgp_passive_peering_ipv6(setup):
         "BGP IPv6 session not established after configuring matching password"
 
     # configure mismatch password on DUT and ensure the adjacency is not established (IPv6)
-    cmd = 'vtysh -n {} -c "config" -c "router bgp {}" -c "neighbor {} password {}"'.format(setup['asic_index'],
-                                                                                           setup['dut_asn'],
-                                                                                           setup['peer_group_v6'],
-                                                                                           wrong_password)
+    cmd = get_vtysh_cmd_for_asic(
+        setup['duthost'], setup['asic_index'],
+        'vtysh -c "config" -c "router bgp {}" -c "neighbor {} password {}"'.format(
+            setup['dut_asn'], setup['peer_group_v6'], wrong_password),
+    )
     setup['duthost'].shell(cmd, module_ignore_errors=True)
 
     assert wait_until(BGP_WAIT_TIMEOUT, BGP_WAIT_INTERVAL, 0,

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
@@ -88,11 +88,6 @@ bgp/test_ipv6_nlri_over_ipv4.py:
     conditions:
     - asic_type in ['vs'] and 't2' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
-bgp/test_passive_peering.py:
-  skip:
-    conditions:
-    - asic_type in ['vs'] and 't2' in topo_name
-    reason: This test case either cannot pass or should be skipped on virtual chassis
 bgp/test_prefix_list.py:
   skip:
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable `test_passive_peering` on T2 multi-ASIC by scoping BGP config commands to the correct ASIC namespace and removing the T2 skip.

The test validates BGP passive peering and password authentication on T2 linecards. It identifies which ASIC owns the LLDP neighbor and resolves the namespace, but all config commands used `-n {asic_index}` instead of the namespace name (`-n asic0`). Then, on multi-ASIC T2, config changes hit the wrong BGP instance, causing false failures. Session state checks via were already correct. 

**Changes:**
- Route DUT and sonic-neighbor commands through `get_vtysh_cmd_for_asic()` (similar to other multi-ASIC BGP tests).
- Remove the VS T2 conditional skip for this test.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
N/A 

<!--
- master: <image version> - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

On multi-ASIC topology, vtysh must target the ASIC namespace that owns the neighbor session. The test used numeric ASIC indices instead of namespace names, so passive/password config did not apply to the correct BGP instance.

#### How did you do it?

- Replaced `vtysh -n {asic_index} ...` commands with `get_vtysh_cmd_for_asic()` for all DUT config steps.
- Applied the same helper for sonic-neighbor password config.
- BGP neighbor state check functionality is unchanged as it already used ASIC index.
- Removed the T2 skip from `tests_mark_conditions_vs_t2.yaml`.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
- Code review for quality and functionality. 
- Code review for consistency with other BGP T2 tests. 
- Full validation for T2 (and all) topologies via GitHub checks / pipeline.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
Existing test, updated logic to support T2.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A.