### PR TITLE
Test BGP 4 byte as trans - T2 Update

### DIFF
--- a/tests/bgp/test_bgp_4-byte_as_trans.py
+++ b/tests/bgp/test_bgp_4-byte_as_trans.py
@@ -70,9 +70,14 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand_one_
             neigh_asn[v['description']] = v['remote AS']
             neighbors[v['description']] = nbrhosts[v['description']]["host"]
     if neighbors[neigh1].is_multi_asic:
-        neigh_cli_options = " -n " + neigh1.get_namespace_from_asic_id(asic_index)
+        neigh_cli_options = " -n " + neighbors[neigh1].get_namespace_from_asic_id(asic_index)
     else:
         neigh_cli_options = ''
+
+    if neighbors[neigh2].is_multi_asic:
+        neigh2_cli_options = " -n " + neighbors[neigh2].get_namespace_from_asic_id(asic_index)
+    else:
+        neigh2_cli_options = ''
 
     dut_ip_v4 = tbinfo['topo']['properties']['configuration'][neigh1]['bgp']['peers'][dut_asn][0]
     dut_ip_v6 = tbinfo['topo']['properties']['configuration'][neigh1]['bgp']['peers'][dut_asn][1]
@@ -104,6 +109,7 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand_one_
         'neighbors': neighbors,
         'cli_options': cli_options,
         'neigh_cli_options': neigh_cli_options,
+        'neigh2_cli_options': neigh2_cli_options,
         'dut_ip_v4': dut_ip_v4,
         'dut_ip_v6': dut_ip_v6,
         'neigh_ip_v4': neigh_ip_v4,
@@ -292,5 +298,6 @@ def test_4_byte_asn_translation(setup):
             logger.debug(v['description'])
             assert v['state'] == 'established'
 
-    cmd = 'vtysh -c "show bgp ipv4 all neighbors {}" received-routes'.format(setup['neigh_ipv4_network'])
+    cmd = 'vtysh{} -c "show bgp ipv4 all neighbors {}" received-routes'.format(
+        setup['neigh2_cli_options'], setup['neigh_ipv4_network'])
     logger.debug(setup['neigh2host'].shell(cmd, module_ignore_errors=True))

--- a/tests/bgp/test_bgp_4-byte_as_trans.py
+++ b/tests/bgp/test_bgp_4-byte_as_trans.py
@@ -31,7 +31,7 @@ pytestmark = [
 
 @pytest.fixture(scope='module')
 def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_index, request):
-    # verify neighbors are type sonic
+    # verify neighbors are type sonic.
     if request.config.getoption("neighbor_type") != "sonic":
         pytest.skip("Neighbor type must be sonic")
     duthost = duthosts[enum_frontend_dut_hostname]

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
@@ -38,11 +38,6 @@ bgp/test_4-byte_asn_community.py:
     conditions:
     - asic_type in ['vs'] and 't2' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
-bgp/test_bgp_4-byte_as_trans.py:
-  skip:
-    conditions:
-    - asic_type in ['vs'] and 't2' in topo_name
-    reason: This test case either cannot pass or should be skipped on virtual chassis
 bgp/test_bgp_azng_migration.py:
   skip:
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable `test_bgp_4-byte_as_trans` on T2 multi-ASIC by fixing namespace-scoped vtysh on neighbor devices. 

DUT vtysh commands already used per-ASIC logic, but two neighbor-side issues broke multi-ASIC runs. `neigh_cli_options` used the neighbor hostname string instead of the neighbor host object, and the final received-routes check on neigh2 used global `vtysh` with no namespace. 

**Changes:**
- Fix `neigh_cli_options` to use ASIC index to get namespace.
- Added and used separate cli options for neigh2 and for final received-routes command.
- Remove the T2 conditional skip for this test.

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
N/A

<!--
- master: <image version> - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

On multi-ASIC T2, neighbor vtysh commands should target the correct ASIC namespace. The setup had a bug resolving neigh1’s namespace, and the final route verification on neigh2 fully omitted namespace scoping.

#### How did you do it?
- Fixed `neigh_cli_options` to call get namespace on host object rather than host string.
- Updated the final received routes command on neigh2 to use the added `neigh2_cli_options`.
- Removed the T2 skip for this test.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
- Code review for quality and functionality. 
- Code review for consistency with other similar T2 updates / tests. 
- GitHub PR checks / pipeline for full validation.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
Existing test, logic updated for T2. 

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A.