### PR TITLE
[action] [PR:23789] [copp] Pin ptf_nn_agent.py wget URLs to nnpy-compatible PTF commit (workaround)

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -20,6 +20,14 @@ _ADD_IP_SCRIPT = "scripts/add_ip.sh"
 _ADD_IP_BACKEND_SCRIPT = "scripts/add_ip_backend.sh"
 _UPDATE_COPP_SCRIPT = "copp/scripts/update_copp_config.py"
 
+_PTF_COMMIT = "9d41838d634c479fc24fac7a527ec5ee2d0ce8eb"
+_PTF_NN_AGENT_URL = (
+    "https://raw.githubusercontent.com/p4lang/ptf"
+    "/{}/ptf_nn/ptf_nn_agent.py".format(_PTF_COMMIT))
+_PTF_AFPACKET_URL = (
+    "https://raw.githubusercontent.com/p4lang/ptf"
+    "/{}/src/ptf/afpacket.py".format(_PTF_COMMIT))
+
 _BASE_COPP_CONFIG = "/tmp/base_copp_config.json"
 _APP_DB_COPP_CONFIG = ":/etc/swss/config.d/00-copp.config.json"
 _CONFIG_DB_COPP_CONFIG = "/etc/sonic/copp_cfg.json"
@@ -214,7 +222,7 @@ def _install_nano_bookworm(dut, creds, syncd_docker_name):
         http_proxy = creds.get('proxy_env', {}).get('http_proxy', '')
         https_proxy = creds.get('proxy_env', {}).get('https_proxy', '')
         # Change the permission of /tmp to 1777 to workaround issue sonic-net/sonic-buildimage#16034
-        cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+        cmd = '''docker exec -e http_proxy={0} -e https_proxy={1} {2} bash -c " \
                 mkdir -p /var/tmp_build \
                 && rm -rf /var/lib/apt/lists/* \
                 && apt-get update \
@@ -223,13 +231,12 @@ def _install_nano_bookworm(dut, creds, syncd_docker_name):
                 && TMPDIR=/var/tmp_build pip3 install --no-cache-dir cffi==1.16.0 \
                 && TMPDIR=/var/tmp_build pip3 install --no-cache-dir nnpy \
                 && rm -rf /var/tmp_build \
-                && mkdir -p /opt && cd /opt && wget \
-                https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                && mkdir ptf && cd ptf && wget \
-                https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
+                && mkdir -p /opt && cd /opt && wget {3} \
+                && mkdir ptf && cd ptf && wget {4} && touch __init__.py \
                 && apt-get -y purge build-essential libssl-dev libffi-dev python3-dev \
                 python3-setuptools wget \
-                " '''.format(http_proxy, https_proxy, syncd_docker_name)
+                " '''.format(http_proxy, https_proxy, syncd_docker_name,
+                             _PTF_NN_AGENT_URL, _PTF_AFPACKET_URL)
         dut.command(cmd)
 
 
@@ -260,7 +267,7 @@ def _install_nano(dut, creds,  syncd_docker_name):
         check_cmd = "docker exec -i {} bash -c 'cat /etc/os-release'".format(syncd_docker_name)
         # Change the permission of /tmp to 1777 to workaround issue sonic-net/sonic-buildimage#16034
         if "bullseye" in dut.shell(check_cmd)['stdout'].lower():
-            cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+            cmd = '''docker exec -e http_proxy={0} -e https_proxy={1} {2} bash -c " \
                     chmod 1777 /tmp \
                     && rm -rf /var/lib/apt/lists/* \
                     && apt-get update \
@@ -270,13 +277,12 @@ def _install_nano(dut, creds,  syncd_docker_name):
                     && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
                     && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
                     && rm -f 1.0.0.tar.gz && pip3 install cffi && pip3 install --upgrade cffi && pip3 install nnpy \
-                    && mkdir -p /opt && cd /opt && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                    && mkdir ptf && cd ptf && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
-                    " '''.format(http_proxy, https_proxy, syncd_docker_name)
+                    && mkdir -p /opt && cd /opt && wget {3} \
+                    && mkdir ptf && cd ptf && wget {4} && touch __init__.py \
+                    " '''.format(http_proxy, https_proxy, syncd_docker_name,
+                                 _PTF_NN_AGENT_URL, _PTF_AFPACKET_URL)
         else:
-            cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+            cmd = '''docker exec -e http_proxy={0} -e https_proxy={1} {2} bash -c " \
                     chmod 1777 /tmp \
                     && rm -rf /var/lib/apt/lists/* \
                     && apt-get update \
@@ -287,11 +293,10 @@ def _install_nano(dut, creds,  syncd_docker_name):
                     && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
                     && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade \
                     cffi==1.7.0 && pip2 install nnpy \
-                    && mkdir -p /opt && cd /opt && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                    && mkdir ptf && cd ptf && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
-                    " '''.format(http_proxy, https_proxy, syncd_docker_name)
+                    && mkdir -p /opt && cd /opt && wget {3} \
+                    && mkdir ptf && cd ptf && wget {4} && touch __init__.py \
+                    " '''.format(http_proxy, https_proxy, syncd_docker_name,
+                                 _PTF_NN_AGENT_URL, _PTF_AFPACKET_URL)
         dut.command(cmd)
 
 

--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -541,7 +541,7 @@ def is_trap_installed(duthost, trap_id):
     """
 
     output = parse_show_copp_configuration(duthost)
-    assert trap_id in output, f"Trap {trap_id} not found in the configuration"
+    assert trap_id in output, "Trap {} not found in the configuration".format(trap_id)
     assert "hw_status" in output[trap_id], f"hw_status not found for trap {trap_id}"
 
     return output[trap_id]["hw_status"] == "installed"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md
-->
### Description of PR

Summary:

Cherry-pick of #23789 to **202505**, plus one lint fix required to make the branch's pre-commit check pass.

**Commit 1 — `[copp] Pin ptf_nn_agent.py wget URLs to nnpy-compatible PTF commit (workaround) (#23789)`**

Clean cherry-pick of upstream commit `f9db8708fbeb2569be51996a7926bd9793ed2efa`.

On Apr 5 2026, p4lang/ptf PR #234 (commit `ebc00f94`) changed `ptf_nn_agent.py` to import `pynng` instead of `nnpy`. SONiC production PTF container images ship `nnpy` but **not** `pynng`. `copp_utils.py` downloads `ptf_nn_agent.py` from an unversioned `master` URL, so it now pulls the pynng-based version, which crashes on startup — port 10900 never opens and COPP tests time out after 600 s.

202505 still has all **6** unpinned `p4lang/ptf/master` URLs, so it is exposed to exactly this failure. This pins them to `9d41838d634c479fc24fac7a527ec5ee2d0ce8eb` (Apr 2 2026, last nnpy-compatible state) across the three code paths (`_install_nano_bookworm`, `_install_nano` bullseye, `_install_nano` buster/py2).

The proper long-term fix is for the PTF container image build to install `pynng`; this remains an explicit workaround, same as upstream.

**Commit 2 — `[ci] fix flake8 E713 false positive in copp_utils.py`**

Without this, the cherry-pick alone fails `Pre_test Static Analysis` on 202505:

```
tests/copp/copp_utils.py:544:48: E713 test for membership should be 'not in'
```

The flagged line is **not** a membership test — the `not ... in` text is inside an f-string message:

```python
assert trap_id in output, f"Trap {trap_id} not found in the configuration"
```

202505 pins **flake8 6.0.0 (pycodestyle 2.10.0)**, whose E713 check looks inside f-strings and mis-reads the literal text as code. master is on flake8 7.1.1 where this false positive is fixed, so the same line never trips there. Rather than bump flake8 on a release branch, this switches that one message to `.format()` — which is exactly how master already writes it.

The line itself is pre-existing (added by #18326 in 2025-08). It only surfaced now because #26885 moved the Pre_test jobs onto a hosted agent, so pre-commit actually runs on 202505 again for the first time.

Related, already merged to 202505:
- #26885 — `[action] [PR:25721]` move Pre_test jobs to hosted agents (unblocked CI on this branch)
- #26880 — `[action] [PR:22073]` fix nnpy install failure for test_copp (this PR builds directly on it)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Upstream PR #23789 (merged to master 2026-04-10, backported to 202511 via #23808). 202505 was skipped at the time and is still affected.
Failure type: **regression** — external change in p4lang/ptf (`ebc00f94`, Apr 5 2026) broke an unpinned dependency that 202505 still tracks.

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Test result

- 202505: static verification on this branch —
  - `p4lang/ptf/master` occurrences in `tests/copp/copp_utils.py`: **6 → 0**; `_PTF_COMMIT` now present and used by all three code paths.
  - `pycodestyle --max-line-length=120 tests/copp/copp_utils.py` with the **same flake8 6.0.0 / pycodestyle 2.10.0 that 202505 CI pins**: `E713` before → **exit 0, clean** after.
  - Cherry-pick of `f9db8708` applies cleanly on top of 202505 @ `9117b106` (no conflicts).

Upstream functional validation for the pinning change (from #23789, on 202511): COPP tests pass on T0 and T1, PTF container confirmed to have `nnpy` v0.10.0 and no `pynng`.
- https://elastictest.org/scheduler/testplan/69d824c02e61bab317c442d5
- https://elastictest.org/scheduler/testplan/69d824d559cbd7d94a4fe3b4

### Approach
#### What is the motivation for this PR?

202505 still downloads `ptf_nn_agent.py` from an unversioned `master` URL, so it picks up the pynng-based agent that SONiC PTF containers cannot run — COPP tests hang for 600 s and fail. 202511 got this fix in April via #23808; 202505 was never backported.

#### How did you do it?

Cherry-picked `f9db8708` (`-x`) onto 202505, then added the one-line `.format()` change needed to keep the branch's older flake8 from emitting a false-positive E713.

#### How did you verify/test it?

Verified the pinning is complete (6 → 0 unpinned URLs, `_PTF_COMMIT` referenced by all three install paths) and that pre-commit's flake8 stage is clean under the exact version 202505 pins. Functional evidence for the underlying change comes from upstream #23789 (T0/T1 test plans linked above); this cherry-pick makes no behavioural change beyond it.

#### Any platform specific information?

Not platform specific. The impact is on any testbed whose PTF container has `nnpy` but not `pynng`, which is the current SONiC production PTF image.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case.

### Documentation

N/A — no user-facing behaviour change.
