### PR TITLE
[qos]: Enable QoS SAI tests on t1-d96u4 topology

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -37,7 +37,7 @@ MARK_CONDITIONS_CONSTANTS = {
                      'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout',
                      't0-backend', 't0-d18u8s4', 't0-isolated-d96u32s2',
                      't1-lag', 't1-28-lag', 't1-48-lag', 't1-64-lag', 't1-56-lag',
-                     't1-backend', 't1-isolated-d128', 't1-isolated-d32',
+                     't1-backend', 't1-d96u4', 't1-isolated-d128', 't1-isolated-d32',
                      't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic',
                      'lt2-p32o64', 'lt2-o128', 'ft2-64', 'ft2-16', 't2_one_hwsku_min', 't2_one_hwsku_max',
                      't2-single-node-min', 't2_single_node_min', 't2_single_node_max',

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -55,7 +55,7 @@ class QosBase:
         "t0-88-o8c80", "t0-f2-d40u8", "t0-f2-d40u8-po2vlan"
     ]
     SUPPORTED_T1_TOPOS = ["t1", "t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend", "t1-28-lag", "t1-32-lag", "t1-48-lag",
-                          "t1-f2-d10u8", "t1-isolated-d32u1s2",
+                          "t1-f2-d10u8", "t1-isolated-d32u1s2", "t1-d96u4",
                           "t1-isolated-d28u1", "t1-isolated-v6-d28u1", "t1-isolated-d56u2", "t1-isolated-v6-d56u2",
                           "t1-isolated-d56u1-lag", "t1-isolated-v6-d56u1-lag", "t1-isolated-d128", "t1-isolated-d32",
                           "t1-isolated-d448u15-lag", "t1-isolated-v6-d448u15-lag"]
@@ -1058,6 +1058,17 @@ class QosSaiBase(QosBase):
         dst_dut_idx = get_src_dst_asic_and_duts['dst_dut_index']
         src_asic_idx = get_src_dst_asic_and_duts['src_asic_index']
         dst_asic_idx = get_src_dst_asic_and_duts['dst_asic_index']
+
+        # Unsupported or misconfigured topologies leave testPortIds empty. Fail with a
+        # clear assertion instead of StopIteration (RuntimeError under PEP 479 in
+        # generator fixtures), which previously masked the root cause on new topos
+        # such as t1-d96u4 before it was added to SUPPORTED_T1_TOPOS.
+        pytest_assert(
+            testPortIds,
+            "No QoS SAI test ports were selected. Ensure the topology is listed in "
+            "SUPPORTED_T0_TOPOS/SUPPORTED_T1_TOPOS (or is a supported T2 topology) "
+            "and that active L3 interfaces are available on the DUT."
+        )
 
         if src_dut_idx not in testPortIds:
             src_dut_idx = next(iter(testPortIds))


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #26876

On t1-d96u4, all single_asic QoS SAI tests failed in fixture setup with
`RuntimeError: generator raised StopIteration` because the topology was
not listed in `SUPPORTED_T1_TOPOS`, so `dutConfig` never populated
`testPortIds` and `__buildTestPorts` called `next(iter({}))`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
N/A — targeting master only for now. Backports can be requested later with lab evidence.
Failure type: N/A

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
- No physical/lab run of `qos/test_qos_sai.py` on t1-d96u4 yet
- PR CI (`Azure.sonic-mgmt` build 1187791) passed pre-checks and impacted-area KVM jobs; that does not validate this fix on t1-d96u4 hardware

### Approach
#### What is the motivation for this PR?
t1-d96u4 QoS SAI tests ERROR during fixture setup because the topology is
missing from the QoS T1 allowlist, leaving test port maps empty.

#### How did you do it?
- Add `t1-d96u4` to `SUPPORTED_T1_TOPOS` in `tests/qos/qos_sai_base.py`
- Add `t1-d96u4` to `QOS_SAI_TOPO` in conditional-mark constants
- Replace the empty-dict `next(iter(...))` failure mode with an explicit
  `pytest_assert` message for unsupported/misconfigured topologies

#### How did you verify/test it?
- Root-cause analysis of `dutConfig` / `__buildTestPorts` on unsupported topo names
- Diff limited to allowlist + clearer assertion; no intended behavior change for already-supported topologies
- PR CI passed, but t1-d96u4 QoS SAI lab validation is still pending

#### Any platform specific information?
Reported on Mellanox SN4280 (`Mellanox-SN4280-O4X96`) with t1-d96u4.
Fix is topology allowlist based and applies to any platform using t1-d96u4.

#### Supported testbed topology if it's a new test case?
N/A (enables existing QoS SAI cases on t1-d96u4)

### Documentation
N/A