### PR TITLE
[bgp] Fix prefix-list suppress supervisor filtering

### DIFF
--- a/tests/bgp/test_prefix_list_suppress.py
+++ b/tests/bgp/test_prefix_list_suppress.py
@@ -96,6 +96,10 @@ def has_chassisdb_conf(duthost):
     return duthost.stat(path=CHASSISDB_CONF)["stat"]["exists"]
 
 
+def is_chassis_supervisor_host(duthost):
+    return duthost.is_supervisor_node() or has_chassisdb_conf(duthost)
+
+
 def op_prefix_with_cmd(duthost, prefix_type, prefix, action, ignore_error=False):
     """Run ``sudo prefix_list <action> <type> <prefix>``."""
     pytest_assert(
@@ -445,7 +449,7 @@ def rand_one_uplink_duthost(duthosts):
     """Pick one UpstreamLC / UpperSpineRouter duthost. Skip otherwise."""
     candidates = [
         dh for dh in duthosts
-        if not dh.is_supervisor_node() and is_upstream_spine(dh)
+        if not is_chassis_supervisor_host(dh) and is_upstream_spine(dh)
     ]
     if not candidates:
         pytest.skip("No UpstreamLC / UpperSpineRouter duthost in this testbed")
@@ -457,7 +461,7 @@ def rand_one_non_spine_duthost(duthosts):
     """Pick one non-spine, non-supervisor frontend duthost. Skip otherwise."""
     candidates = [
         dh for dh in duthosts
-        if not dh.is_supervisor_node() and not is_upstream_spine(dh)
+        if not is_chassis_supervisor_host(dh) and not is_upstream_spine(dh)
     ]
     if not candidates:
         pytest.skip("No non-spine frontend duthost in this testbed")
@@ -467,7 +471,7 @@ def rand_one_non_spine_duthost(duthosts):
 @pytest.fixture(scope="module")
 def rand_one_frontend_duthost(duthosts):
     """Pick any frontend (non-supervisor) duthost."""
-    candidates = [dh for dh in duthosts if not dh.is_supervisor_node()]
+    candidates = [dh for dh in duthosts if not is_chassis_supervisor_host(dh)]
     if not candidates:
         pytest.skip("No frontend duthost in this testbed")
     return random.choice(candidates)
@@ -476,7 +480,7 @@ def rand_one_frontend_duthost(duthosts):
 @pytest.fixture(scope="module")
 def supervisor_duthost(duthosts):
     """Return the chassis supervisor duthost (skip on non-chassis testbeds)."""
-    candidates = [dh for dh in duthosts if dh.is_supervisor_node()]
+    candidates = [dh for dh in duthosts if is_chassis_supervisor_host(dh)]
     if not candidates:
         pytest.skip("Testbed has no chassis supervisor")
     return candidates[0]


### PR DESCRIPTION
### Description of PR
Fixes a false failure in `bgp/test_prefix_list_suppress.py` on chassis/smartswitch supervisors. The `prefix_list` utility intentionally exits successfully with `Skipping Operation on chassis supervisor` when `/etc/sonic/chassisdb.conf` exists, but the test fixtures only filtered hosts by `duthost.is_supervisor_node()`. On some smartswitch T1 runs that did not identify the selected host as a supervisor, the test attempted frontend checks on a supervisor and failed to find SUPPRESS_PREFIX entries in CONFIG_DB/FRR.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Approach
#### What is the motivation for this PR?
PBI 39190252: `[SONiC_Nightly][Failed_Case][bgp.test_prefix_list_suppress.TestSuppressPrefix][test_suppress_prefix_frr_rendering][20260510][T1]` failed on `Mellanox-SN4280-O28` / T1 smartswitch with `Did not see SUPPRESS_IPV4_PREFIX permit 192.168.100.0/24 in FRR`. Logs show `prefix_list add ...` returned rc=0 with `Skipping Operation on chassis supervisor`, so no CONFIG_DB/FRR entry was expected.

#### How did you do it?
Add a local helper that treats a DUT as a chassis supervisor when either `duthost.is_supervisor_node()` is true or `/etc/sonic/chassisdb.conf` exists, matching the `prefix_list` utility's own supervisor skip condition. Use that helper in the prefix-list suppress host-selection fixtures.

#### How did you verify/test it?
- `python -m py_compile tests\bgp\test_prefix_list_suppress.py`

#### Any platform specific information?
Observed on Mellanox-SN4280-O28 T1 smartswitch nightly.

#### Supported testbed topology if it's a new test case?
Existing test only; no new topology.

### Documentation
N/A