### PR TITLE
[bgp] Avoid prefix_list no-op hosts in suppress tests

### DIFF
--- a/tests/bgp/test_prefix_list_suppress.py
+++ b/tests/bgp/test_prefix_list_suppress.py
@@ -96,6 +96,10 @@ def has_chassisdb_conf(duthost):
     return duthost.stat(path=CHASSISDB_CONF)["stat"]["exists"]
 
 
+def runs_prefix_list_cli(duthost):
+    return not duthost.is_supervisor_node() and not has_chassisdb_conf(duthost)
+
+
 def op_prefix_with_cmd(duthost, prefix_type, prefix, action, ignore_error=False):
     """Run ``sudo prefix_list <action> <type> <prefix>``."""
     pytest_assert(
@@ -442,34 +446,34 @@ def prefix_cleanup():
 
 @pytest.fixture(scope="module")
 def rand_one_uplink_duthost(duthosts):
-    """Pick one UpstreamLC / UpperSpineRouter duthost. Skip otherwise."""
+    """Pick one UpstreamLC / UpperSpineRouter duthost that runs prefix_list."""
     candidates = [
         dh for dh in duthosts
-        if not dh.is_supervisor_node() and is_upstream_spine(dh)
+        if runs_prefix_list_cli(dh) and is_upstream_spine(dh)
     ]
     if not candidates:
-        pytest.skip("No UpstreamLC / UpperSpineRouter duthost in this testbed")
+        pytest.skip("No UpstreamLC / UpperSpineRouter duthost that runs prefix_list in this testbed")
     return random.choice(candidates)
 
 
 @pytest.fixture(scope="module")
 def rand_one_non_spine_duthost(duthosts):
-    """Pick one non-spine, non-supervisor frontend duthost. Skip otherwise."""
+    """Pick one non-spine frontend duthost that runs prefix_list."""
     candidates = [
         dh for dh in duthosts
-        if not dh.is_supervisor_node() and not is_upstream_spine(dh)
+        if runs_prefix_list_cli(dh) and not is_upstream_spine(dh)
     ]
     if not candidates:
-        pytest.skip("No non-spine frontend duthost in this testbed")
+        pytest.skip("No non-spine frontend duthost that runs prefix_list in this testbed")
     return random.choice(candidates)
 
 
 @pytest.fixture(scope="module")
 def rand_one_frontend_duthost(duthosts):
-    """Pick any frontend (non-supervisor) duthost."""
-    candidates = [dh for dh in duthosts if not dh.is_supervisor_node()]
+    """Pick any frontend duthost that runs prefix_list."""
+    candidates = [dh for dh in duthosts if runs_prefix_list_cli(dh)]
     if not candidates:
-        pytest.skip("No frontend duthost in this testbed")
+        pytest.skip("No frontend duthost that runs prefix_list in this testbed")
     return random.choice(candidates)
 
 


### PR DESCRIPTION
### Description of PR
Fixes SONiC nightly PBI 39190250 where `bgp/test_prefix_list_suppress.py::TestSuppressPrefix::test_suppress_prefix_persists_through_reload` selected a SmartSwitch/chassisdb host. The `prefix_list` utility intentionally no-ops on hosts with `/etc/sonic/chassisdb.conf`, returning `Skipping Operation on chassis supervisor`, so the suppress-prefix tests could not program CONFIG_DB/FRR and failed after reload.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [x] 202605

### Approach
#### What is the motivation for this PR?
The suppress prefix tests need a DUT where `prefix_list` actually performs add/remove/status operations. Hosts with `chassisdb.conf` are covered separately by the supervisor skip test and should not be selected by the operation fixtures.

#### How did you do it?
Added a `runs_prefix_list_cli` helper and used it in the frontend/uplink/non-spine fixtures so operation tests only choose non-supervisor hosts that do not trigger the CLI's chassis-supervisor no-op path.

#### How did you verify/test it?
Ran `python -m py_compile tests/bgp/test_prefix_list_suppress.py`.

#### Any platform specific information?
Observed on Mellanox-SN4280-O28 T1 SmartSwitch nightly.

#### Supported testbed topology if it's a new test case?
T0/T1/T2 as already marked by the test module.

### Documentation
N/A.

## Broader applicability

ADO [39190250](https://msazure.visualstudio.com/One/_workitems/edit/39190250) was later closed by the Storm AI cleanup as `Recovered / monitor`, but the same chassis-supervisor no-op root cause recurred in telemetry through 2026-08-25. This fixture guard therefore remains applicable beyond that single ADO and also addresses the same failure family tracked by ADOs 39059740, 39059743, 39326137, 39373330, 39373332, and 39418026.
