### PR TITLE
Fix SN4280 DPU reboot expectation after NPU crash

### DIFF
--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -35,12 +35,25 @@ DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION = 240
 MAX_COOL_OFF_TIME = 300
 EXTRA_DPU_ONLINE_TIMEOUT_FOR_WATCHDOG = 40
 MAX_DPU_DOWN_TIME_SPREAD_SECS = 20
+SN4280_HWSKU_PREFIX = "Mellanox-SN4280"
 
 
 @pytest.fixture(params=["gnoi_based", "cli_based"])
 def invocation_type(request):
     """Parametrize reboot tests to run with both gNOI and CLI reboot paths."""
     return request.param
+
+
+def expects_dpu_reboot_after_npu_crash(duthost):
+    """Return whether DPUs are expected to reboot after an NPU crash/recovery."""
+    hwsku = duthost.facts.get('hwsku', '')
+    if hwsku.startswith(SN4280_HWSKU_PREFIX):
+        logging.info(
+            "Skipping DPU uptime reboot validation: %s keeps DPUs up during NPU crash recovery",
+            hwsku
+        )
+        return False
+    return True
 
 
 @contextmanager
@@ -155,8 +168,10 @@ def test_dpu_status_post_switch_mem_exhaustion(duthosts, dpuhosts,
                                                  platform_api_conn,
                                                  num_dpu_modules)
 
-    logging.info("Recording DPU boot times before NPU memory exhaustion")
-    pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
+    pre_boot_times = None
+    if expects_dpu_reboot_after_npu_crash(duthost):
+        logging.info("Recording DPU boot times before NPU memory exhaustion")
+        pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
 
     logging.info("Starting memory exhaustion test on NPU by running \
                   a large process...")
@@ -203,8 +218,10 @@ def test_dpu_status_post_switch_kernel_panic(duthosts, dpuhosts,
                                                  platform_api_conn,
                                                  num_dpu_modules)
 
-    logging.info("Recording DPU boot times before NPU kernel panic")
-    pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
+    pre_boot_times = None
+    if expects_dpu_reboot_after_npu_crash(duthost):
+        logging.info("Recording DPU boot times before NPU kernel panic")
+        pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
 
     logging.info("Triggering kernel panic on NPU...")
     duthost.shell(kernel_panic_cmd, executable="/bin/bash")


### PR DESCRIPTION
### Description of PR
Fix SN4280 SmartSwitch NPU crash tests so they do not assert that DPUs reboot during NPU memory exhaustion/kernel panic recovery.

SN4280 keeps DPUs up when the NPU recovers from these crash scenarios. The tests should still verify DPU operational status and connectivity after recovery, but the optional uptime-based reboot validation is not valid for this platform.

Fixes sonic-net/sonic-mgmt#26455

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?
Nightly test `test_dpu_status_post_switch_kernel_panic` fails on SN4280 with `DPU DPU0 did not reboot: boot time is unchanged`. This is expected platform behavior for SN4280 NPU crash recovery, not a DPU recovery failure.

#### How did you do it?
Added a small platform expectation helper and used it to disable the optional DPU uptime reboot validation only for SN4280 in the NPU memory exhaustion and NPU kernel panic tests.

#### How did you verify/test it?
- Ran `python -m py_compile tests/smartswitch/platform_tests/test_reload_dpu.py`
- Ran `git diff --check`

#### Any platform specific information?
Mellanox-SN4280 keeps DPUs up during NPU memory exhaustion/kernel panic recovery.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
