### PR TITLE
[cacl]: Mark CACL application tests as xfail

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -799,13 +799,14 @@ cacl/test_cacl_application.py::test_cacl_application_dualtor:
 
 cacl/test_cacl_application.py::test_cacl_application_nondualtor:
   skip:
-    reason: "test_cacl_application is only supported on non dualtor topology. Also temporarily
-      skipped while sonic-net/sonic-buildimage#28061 (adds new protected FRR BGP ports) is being
-      validated; test update to follow once that image is checked in."
-    conditions_logical_operator: or
+    reason: "test_cacl_application is only supported on non dualtor topology"
     conditions:
       - "'dualtor' in topo_name"
-      - "https://github.com/sonic-net/sonic-buildimage/issues/28061"
+  xfail:
+    reason: "sonic-net/sonic-buildimage#28061 adds new protected FRR BGP ports; test update to
+      follow once that image is checked in"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/26908"
 
 cacl/test_cacl_application.py::test_multiasic_cacl_application:
   skip:
@@ -815,7 +816,11 @@ cacl/test_cacl_application.py::test_multiasic_cacl_application:
     conditions_logical_operator: or
     conditions:
       - "not is_multi_asic"
-      - "https://github.com/sonic-net/sonic-buildimage/issues/28061"
+  xfail:
+    reason: "sonic-net/sonic-buildimage#28061 adds new protected FRR BGP ports; test update to
+      follow once that image is checked in"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/26908"
 
 cacl/test_cacl_function.py:
   xfail:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Mark the non-dual-ToR and multi-ASIC CACL application tests as expected failures while sonic-net/sonic-mgmt#26908 remains open. Unsupported topologies and platforms continue to be skipped.

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
N/A. This change only updates conditional pytest marks. The conditions file was successfully parsed as YAML, and the expected `skip` and `xfail` mark structure was verified.
### Approach
#### What is the motivation for this PR?
The CACL application tests are expected to fail while the protected FRR BGP port changes from sonic-buildimage#28061 are being integrated. Skipping these tests hides their results and prevents successful runs from being reported as XPASS.
#### How did you do it?
Separated the existing eligibility conditions from the temporary known-failure
condition:
- Unsupported topologies and platforms remain marked as `skip`.
- Applicable test runs are marked as `xfail` while sonic-mgmt#26908 remains open.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
