### PR TITLE
Skip non-PFC-enabled ports in PFC counter test

### DIFF
--- a/tests/common/helpers/pfc_counters.py
+++ b/tests/common/helpers/pfc_counters.py
@@ -144,8 +144,14 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
     only_lossless_rx_counters = any(sku in asic.sonichost.facts["hwsku"] for sku in only_lossless_rx_counters_hwskus)
     no_xon_counters_hwskus = ["Cisco-8122", "Cisco-8223"]
     no_xon_counters = any(sku in asic.sonichost.facts["hwsku"] for sku in no_xon_counters_hwskus)
-    if only_lossless_rx_counters and asic_type != 'vs':
+    config_facts = None
+    if asic_type != 'vs':
         config_facts = asic.config_facts(host=asic.hostname, source='persistent')['ansible_facts']
+        # PFC Rx counters are only maintained on PFC-enabled ports, so skip ports without
+        # pfc_enable (e.g. lossy breakout ports) to avoid false counter-mismatch failures.
+        pfc_qos_map = config_facts.get("PORT_QOS_MAP", {})
+        active_phy_intfs = [intf for intf in active_phy_intfs
+                            if 'pfc_enable' in pfc_qos_map.get(intf, {})]
     if not check_continuous_pfc:
         if asic_type != 'vs':
             """ Generate PFC or FC packets for active physical interfaces """


### PR DESCRIPTION
### Description of PR

Summary:
`qos/test_pfc_counters.py` asserts that PFC Rx counters increment on **every** active physical interface. On platforms that have PFC-disabled ports — e.g. the lossy 10G breakout ports `etp25a`/`etp25b` (Ethernet512/513) on `Arista-7060X6-16PE-384C-B-O128S2` — those ports have no `pfc_enable` entry in `PORT_QOS_MAP` and never maintain PFC Rx counters. They always read `0`, producing spurious counter-mismatch failures (`test_pfc_pause`, `test_pfc_unpause`, `test_continous_pfc`) even though all PFC-enabled ports pass. The failure is intermittent because the breakout ports flap oper up/down, and only fail when they happen to be oper-up.

This PR restricts PFC verification (packet injection and counter checks, including the continuous-PFC path) to ports that actually have `pfc_enable` configured in `PORT_QOS_MAP`.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression (test-code gap exposed by PFC-disabled breakout ports on O128S2 topology)

### Tested branch
- [ ] master
- [x] 202511
- [ ] N/A

### Test result
- 202511: SONiC.20251110 (internal-202511 image) on `Arista-7060X6-16PE-384C-B-O128S2` — `qos/test_pfc_counters.py` **PASSED 5/0/0** on both testbeds.

| Testbed | Elastictest plan | test_pfc_counters.py |
|---------|------------------|----------------------|
| vms91-t0-7060x6-moby-512-3 | 6a7a7c507b2a1146b3a1f7b0 | PASS 5 / fail 0 / skip 0 |
| vms92-t0-7060x6-moby-512-2 | 6a7a7c547b2a1146b3a1f7b2 | PASS 5 / fail 0 / skip 0 |

### Approach
#### What is the motivation for this PR?
Eliminate false failures of `test_pfc_counters.py` on platforms/topologies that expose PFC-disabled ports (lossy breakout ports), which never maintain PFC Rx counters.

#### How did you do it?
In `tests/common/helpers/pfc_counters.py::run_test`, fetch `config_facts["PORT_QOS_MAP"]` for non-`vs` DUTs and narrow `active_phy_intfs` to only the ports whose `PORT_QOS_MAP` entry contains `pfc_enable`. All downstream PFC injection and counter-check loops then skip PFC-disabled ports. `vs` behavior is unchanged.

#### How did you verify/test it?
Root cause was confirmed on the live DUT `str5-7060x6-moby-512-3`: Ethernet512/513 (etp25a/b, 10G) have no `pfc_enable` in `PORT_QOS_MAP` and only a lossy `BUFFER_PG|...|0`, while all 400G ports have `pfc_enable: 3,4`.

Verified on the affected platform via Elastictest, branch `dev/xuliping/20260810_internal-202511_pfc-skip-non-pfc-ports`, `internal-202511` image, on **both** 7060X6-O128S2 testbeds:

| Testbed | Plan | pretest | test_pfc_counters.py | posttest |
|---------|------|---------|----------------------|----------|
| vms91-t0-7060x6-moby-512-3 | 6a7a7c507b2a1146b3a1f7b0 | PASS 12/0/3 | **PASS 5/0/0** | PASS 5/0/0 |
| vms92-t0-7060x6-moby-512-2 | 6a7a7c547b2a1146b3a1f7b2 | PASS 12/0/3 | **PASS 5/0/0** | PASS 5/0/0 |

All five cases (`test_pfc_pause`, `test_pfc_unpause`, `test_fc_pause`, `test_fc_unpause`, `test_continous_pfc`) pass — the previously-failing PFC-disabled breakout ports are now correctly excluded, while all PFC-enabled ports are still verified.

#### Any platform specific information?
Observed on `Arista-7060X6-16PE-384C-B-O128S2` (O128S2 breakout topology). The fix is platform-agnostic — it keys off `pfc_enable` in `PORT_QOS_MAP`, so any port without PFC configured is skipped.

#### Supported testbed topology if it's a new test case?
N/A (existing test).

### Documentation
N/A

