### PR TITLE
[dut_basic_facts]: Resolve detached HEAD images as master

### DIFF
--- a/ansible/module_utils/sonic_release_utils.py
+++ b/ansible/module_utils/sonic_release_utils.py
@@ -22,7 +22,8 @@ def guess_release_from_build_version(release, build_version):
 
     * a leading 6-digit ``YYYYMM`` token -> that release (e.g. '202605'), which
       also covers old date-stamped images ('20181130.31' -> '201811');
-    * a ``build_version`` containing 'master' -> 'master';
+    * a ``build_version`` containing 'master' or starting with ``HEAD.`` ->
+      'master';
     * anything else -> 'unknown'.
 
     Note: prior to this helper the fallback only recognized '201811', '201911'
@@ -41,7 +42,7 @@ def guess_release_from_build_version(release, build_version):
         return release
 
     build_version = build_version or ''
-    if 'master' in build_version:
+    if 'master' in build_version or build_version.startswith('HEAD.'):
         return 'master'
 
     match = _RELEASE_TOKEN_RE.match(build_version)

--- a/ansible/module_utils/test_sonic_release_utils.py
+++ b/ansible/module_utils/test_sonic_release_utils.py
@@ -64,6 +64,14 @@ class TestGuessReleaseFromBuildVersion:
 
     @pytest.mark.parametrize("empty_release", [None, "", "none"])
     @pytest.mark.parametrize("build_version", [
+        "HEAD.0-9567328141",
+        "HEAD.123-deadbeef",
+    ])
+    def test_detached_head_build_version(self, empty_release, build_version):
+        assert guess_release_from_build_version(empty_release, build_version) == "master"
+
+    @pytest.mark.parametrize("empty_release", [None, "", "none"])
+    @pytest.mark.parametrize("build_version", [
         "",
         None,
         "foobar",


### PR DESCRIPTION
### Description of PR

Resolve detached-HEAD SONiC image versions as `master` when the image does not contain a stamped `/etc/sonic/sonic_release`.

Internal PR images currently report:
branch: HEAD
build_version: HEAD.0-<commit>
release: unknown

This prevents  release == 'master'  conditional marks from applying. For example, the module-level skip added for  bgp/test_bgp_suppress_fib.py  does not activate, causing tests to execute and generate known failures.

Summary:
ADO: https://dev.azure.com/msazure/One/_workitems/edit/39166624
  
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach

#### What is the motivation for this PR?

PR images can be built from detached Git checkouts.  sonic_get_version()  then generates versions such as:

HEAD.0-9567328141

When  /etc/sonic/sonic_release  is absent,  guess_release_from_build_version()  attempts to derive the release from this value. It recognizes  master  and leading  YYYYMM  tokens, but previously returned  unknown  for  HEAD.* .

This caused master-gated conditional marks to silently remain inactive for these PR images.

#### How did you do it?

Updated  guess_release_from_build_version()  so build versions starting with  HEAD.  resolve to  master :

if 'master' in build_version or build_version.startswith('HEAD.'):
    return 'master'

Added parameterized tests for representative detached-HEAD versions while preserving precedence for explicitly stamped releases and existing  YYYYMM  parsing.

#### How did you verify/test it?

Ran the targeted unit-test suite:

68 passed

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A