### PR TITLE
[cacl] Tolerate FRR loopback rule rollout

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -794,6 +794,12 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
             iptables_rules.append("-A FORWARD -j DROP")
             ip6tables_rules.append("-A FORWARD -j DROP")
 
+    # caclmgrd restricts FRR loopback ports in every managed namespace.
+    iptables_rules.append("-A OUTPUT -o lo -p tcp -m tcp --dport 2620 -m owner --uid-owner 300 -j ACCEPT")
+    iptables_rules.append("-A OUTPUT -o lo -p tcp -m tcp --dport 2601 -m owner --uid-owner 300 -j ACCEPT")
+    iptables_rules.append("-A OUTPUT -o lo -p tcp -m tcp --dport 2620 -j DROP")
+    iptables_rules.append("-A OUTPUT -o lo -p tcp -m tcp --dport 2601 -j DROP")
+
     # IP Table rule to allow eth1-midplane traffic for chassis
     if asic_index is None:
         append_midplane_traffic_rules(duthost, iptables_rules)

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -355,6 +355,13 @@ ACL_SERVICES = {
 # Template json file used to test scale rules
 SCALE_ACL_FILE = "/tmp/scale_cacl.json"
 
+FRR_LOOPBACK_RULES = [
+    "-A OUTPUT -o lo -p tcp -m tcp --dport 2620 -m owner --uid-owner 300 -j ACCEPT",
+    "-A OUTPUT -o lo -p tcp -m tcp --dport 2601 -m owner --uid-owner 300 -j ACCEPT",
+    "-A OUTPUT -o lo -p tcp -m tcp --dport 2620 -j DROP",
+    "-A OUTPUT -o lo -p tcp -m tcp --dport 2601 -j DROP",
+]
+
 
 def parse_int_to_tcp_flags(hex_value):
     tcp_flags_str = ""
@@ -794,12 +801,6 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
             iptables_rules.append("-A FORWARD -j DROP")
             ip6tables_rules.append("-A FORWARD -j DROP")
 
-    # caclmgrd restricts FRR loopback ports in every managed namespace.
-    iptables_rules.append("-A OUTPUT -o lo -p tcp -m tcp --dport 2620 -m owner --uid-owner 300 -j ACCEPT")
-    iptables_rules.append("-A OUTPUT -o lo -p tcp -m tcp --dport 2601 -m owner --uid-owner 300 -j ACCEPT")
-    iptables_rules.append("-A OUTPUT -o lo -p tcp -m tcp --dport 2620 -j DROP")
-    iptables_rules.append("-A OUTPUT -o lo -p tcp -m tcp --dport 2601 -j DROP")
-
     # IP Table rule to allow eth1-midplane traffic for chassis
     if asic_index is None:
         append_midplane_traffic_rules(duthost, iptables_rules)
@@ -1164,6 +1165,17 @@ def verify_cacl(duthost, tbinfo, localhost, creds, docker_network,
 
     stdout = duthost.get_asic_or_sonic_host(asic_index).command("iptables -S")["stdout"]
     actual_iptables_rules = stdout.strip().split("\n")
+
+    # Accept images from either side of the caclmgrd rollout, but reject a
+    # partially installed rule set.
+    actual_frr_loopback_rules = set(actual_iptables_rules) & set(FRR_LOOPBACK_RULES)
+    pytest_assert(
+        actual_frr_loopback_rules in (set(), set(FRR_LOOPBACK_RULES)),
+        "Incomplete FRR loopback rule set: {}".format(repr(actual_frr_loopback_rules))
+    )
+    if actual_frr_loopback_rules:
+        expected_iptables_rules_legacy.extend(FRR_LOOPBACK_RULES)
+        expected_iptables_rules_fwd.extend(FRR_LOOPBACK_RULES)
 
     logger.info("Number of expected iptable rules (legacy/forward-chain):{}/{}, number of actual iptables rules:{}"
                 .format(len(set(expected_iptables_rules_legacy)), len(set(expected_iptables_rules_fwd)),


### PR DESCRIPTION
## Why

Newer `caclmgrd` images install four IPv4 OUTPUT rules per managed namespace for FRR loopback ports `2601` and `2620`; older images do not. The CACL test must support both sides of that cross-repository rollout without accepting a partial rule set.

Supersedes #26305. Scope: one CACL test file; no test-skip changes.

Internal tracking: Azure DevOps work item 39199811.

## What

- Treat the two uid-owner `ACCEPT` rules and two catch-all `DROP` rules as one atomic optional set.
- Accept images with either all four rules or none; reject partial installation.
- Apply the check in every managed namespace, including multi-ASIC namespaces.

## Validation

- Passed: `python3 -m py_compile tests/cacl/test_cacl_application.py`.
- Passed: `flake8 --max-line-length=120 tests/cacl/test_cacl_application.py`.
- Passed: `git diff --check`.
- Rollout evidence: t0, t1-lag, and t2 in buildimage runs [1188566](https://dev.azure.com/mssonic/build/_build/results?buildId=1188566) and [1188567](https://dev.azure.com/mssonic/build/_build/results?buildId=1188567) observed the complete four-rule set.
- The CI baseline observed none of the four rules.
- KVM: rerunning on the rollout-compatible implementation.

## Scope Boundary

- Only `tests/cacl/test_cacl_application.py` changes.
- No test skip is added.
- Device/KVM validation is delegated to required PR CI.
