### PR TITLE
fix(macsec): recover stale state between VS retries

### DIFF
--- a/tests/common/macsec/macsec_config_helper.py
+++ b/tests/common/macsec/macsec_config_helper.py
@@ -6,6 +6,7 @@ from passlib.hash import cisco_type7
 from tests.common.macsec.macsec_helper import get_mka_session, getns_prefix, wait_all_complete, \
      submit_async_task
 from tests.common.macsec.macsec_platform_helper import global_cmd, find_portchannel_from_member, get_portchannel
+from tests.common.config_reload import config_reload
 from tests.common.devices.eos import EosHost
 from tests.common.utilities import wait_until
 
@@ -214,6 +215,48 @@ def disable_macsec_feature(duthost, macsec_nbrhosts):
     global_cmd(duthost, macsec_nbrhosts, "sudo config feature state macsec disabled")
 
 
+def _wait_for_macsec_cleanup_with_vs_recovery(host, interfaces, is_dut):
+    if wait_for_macsec_cleanup(host, interfaces):
+        return False
+
+    if host.facts["asic_type"] != "vs":
+        return False
+
+    logger.warning(
+        "MACsec cleanup timed out on %s; reloading config to clear "
+        "stale VS state",
+        host.hostname,
+    )
+    if is_dut:
+        config_reload(
+            host,
+            config_source="config_db",
+            safe_reload=True,
+            yang_validate=False,
+        )
+    else:
+        host.shell("sudo config reload -y -f", executable="/bin/bash")
+        assert wait_until(
+            200, 10, 0, host.is_service_fully_started, "database"), \
+            "Database did not recover on {}".format(host.hostname)
+        assert wait_until(
+            420, 10, 0, host.critical_processes_running, "swss"), \
+            "Swss did not recover on {}".format(host.hostname)
+
+    assert wait_for_macsec_cleanup(host, interfaces), \
+        "MACsec entries remain on {} after config reload".format(host.hostname)
+    return True
+
+
+def _restore_macsec_feature_after_cleanup_recovery(
+        duthost, ctrl_links, recovered):
+    if not recovered:
+        return
+
+    nbrhosts = {nbr["name"]: nbr for nbr in ctrl_links.values()}
+    enable_macsec_feature(duthost, nbrhosts)
+
+
 def cleanup_macsec_configuration(duthost, ctrl_links, profile_name):
     devices = set()
     if duthost.facts["asic_type"] == "vs":
@@ -242,12 +285,18 @@ def cleanup_macsec_configuration(duthost, ctrl_links, profile_name):
     # Extract DUT interface names from ctrl_links and wait for automatic
     # MACsec cleanup on the DUT side.
     interfaces = list(ctrl_links.keys())
-    wait_for_macsec_cleanup(duthost, interfaces)
+    recovered = _wait_for_macsec_cleanup_with_vs_recovery(
+        duthost, interfaces, is_dut=True)
 
     # Also wait for neighbor devices to complete automatic cleanup for their
     # corresponding ports.
     for dut_port, nbr in list(ctrl_links.items()):
-        wait_for_macsec_cleanup(nbr["host"], [nbr["port"]])
+        neighbor_recovered = _wait_for_macsec_cleanup_with_vs_recovery(
+            nbr["host"], [nbr["port"]], is_dut=False)
+        recovered = neighbor_recovered or recovered
+
+    _restore_macsec_feature_after_cleanup_recovery(
+        duthost, ctrl_links, recovered)
 
     logger.info("Cleanup macsec configuration finished")
 
@@ -448,10 +497,16 @@ def cleanup_macsec_multi_profile_configuration(duthost, ctrl_links, port_profile
     logger.info("Multi-profile cleanup step 3: wait for automatic cleanup")
 
     interfaces = list(ctrl_links.keys())
-    wait_for_macsec_cleanup(duthost, interfaces)
+    recovered = _wait_for_macsec_cleanup_with_vs_recovery(
+        duthost, interfaces, is_dut=True)
 
     for dut_port, nbr in list(ctrl_links.items()):
-        wait_for_macsec_cleanup(nbr["host"], [nbr["port"]])
+        neighbor_recovered = _wait_for_macsec_cleanup_with_vs_recovery(
+            nbr["host"], [nbr["port"]], is_dut=False)
+        recovered = neighbor_recovered or recovered
+
+    _restore_macsec_feature_after_cleanup_recovery(
+        duthost, ctrl_links, recovered)
 
     logger.info("Multi-profile cleanup finished")
 

--- a/tests/common/macsec/macsec_config_helper.py
+++ b/tests/common/macsec/macsec_config_helper.py
@@ -249,10 +249,7 @@ def _wait_for_macsec_cleanup_with_vs_recovery(host, interfaces, is_dut):
 
 
 def _restore_macsec_feature_after_cleanup_recovery(
-        duthost, ctrl_links, recovered):
-    if not recovered:
-        return
-
+        duthost, ctrl_links):
     nbrhosts = {nbr["name"]: nbr for nbr in ctrl_links.values()}
     enable_macsec_feature(duthost, nbrhosts)
 
@@ -295,8 +292,9 @@ def cleanup_macsec_configuration(duthost, ctrl_links, profile_name):
             nbr["host"], [nbr["port"]], is_dut=False)
         recovered = neighbor_recovered or recovered
 
-    _restore_macsec_feature_after_cleanup_recovery(
-        duthost, ctrl_links, recovered)
+    if recovered:
+        _restore_macsec_feature_after_cleanup_recovery(
+            duthost, ctrl_links)
 
     logger.info("Cleanup macsec configuration finished")
 
@@ -505,8 +503,9 @@ def cleanup_macsec_multi_profile_configuration(duthost, ctrl_links, port_profile
             nbr["host"], [nbr["port"]], is_dut=False)
         recovered = neighbor_recovered or recovered
 
-    _restore_macsec_feature_after_cleanup_recovery(
-        duthost, ctrl_links, recovered)
+    if recovered:
+        _restore_macsec_feature_after_cleanup_recovery(
+            duthost, ctrl_links)
 
     logger.info("Multi-profile cleanup finished")
 

--- a/tests/macsec/test_macsec_recovery.py
+++ b/tests/macsec/test_macsec_recovery.py
@@ -29,6 +29,8 @@ def macsec_loganalyzer_ignore(loganalyzer, macsec_duthost):
       deletes a stale SA; the DNX platform logs this transiently.
     - 'KaY: The key server is not in my live peers list': wpa_supplicant logs
       this while MKA re-negotiates after the macsec container is killed.
+    - 'KaY: Reject distributed SAK since I'm a key server': the forced DUT key
+      server rejects a peer's transient SAK distribution during re-election.
     - 'e1000 ... Reset adapter': KVM virtual NIC resets when the macsec
       container is SIGKILL'd; this is a VTB environment artifact.
     """
@@ -36,6 +38,8 @@ def macsec_loganalyzer_ignore(loganalyzer, macsec_duthost):
         loganalyzer[macsec_duthost.hostname].ignore_regex.extend([
             r".*SAI_API_MACSEC:brcm_sai_dnx_get_macsec_sa_attribute.*Invalid object ID.*",
             r".*macsec\d*#wpa_supplicant.*KaY: The key server is not in my live peers list.*",
+            r".*macsec\d*#wpa_supplicant.*KaY: "
+            r"Reject distributed SAK since I'm a key server.*",
             r".*kernel:.*e1000.*Reset adapter.*",
         ])
 


### PR DESCRIPTION
### Description of PR

Summary:
Keep the real MACsec stale-SAK failure visible while preventing it from cascading into misleading VS retry failures. If automatic cleanup times out on a VS DUT or vSONIC neighbor, recover the host, verify cleanup, and restore the MACsec feature before configuring the next profile. Also ignore the expected MKA key-server rejection message during dirty-restart recovery.

Sample failures:
- [Test plan 6a7871157b2a1146b3a1f553](https://elastictest.org/scheduler/testplan/6a7871157b2a1146b3a1f553?searchTestCase=test_macsec&testcase=macsec%2Ftest_macsec_recovery.py%7C%7C%7C1&type=console)
- [Test plan 6a78bda332974924d6a7e716](https://elastictest.org/scheduler/testplan/6a78bda332974924d6a7e716?searchTestCase=test_macsec&testcase=macsec%2Ftest_macsec_recovery.py&type=console)

Root cause:
1. **Real image-side failure:** after a dirty MACsec container kill, `wpa_supplicant` writes a fresh SAK to APPL_DB while surviving orchagent/SAI state can keep the previous SAK in hardware. The test correctly reports this as an `APPL_DB->ASIC_DB SAK mismatch`. The product fix belongs in `sonic-swss`; [sonic-swss PR #4583](https://github.com/sonic-net/sonic-swss/pull/4583) is the corresponding image-side change.
2. **Retry isolation failure:** teardown can time out with MACsec Redis entries still present. The caller previously ignored the failed cleanup and started the next profile. This allowed a failed `256_XPN_SCI` attempt to contaminate the next `128_SCI` retry. The 128-bit retry reporting a 64-hex-character SAK is direct evidence of that cross-profile leak.
3. **Expected recovery log treated as failure:** while MKA re-elects roles after restart, the forced DUT key server can correctly reject a peer's transient distributed SAK. Loganalyzer treated that expected message as a teardown error even when the test body passed.

This sonic-mgmt PR fixes items 2 and 3. It does not replace the SWSS fix, or suppress or weaken the real stale-SAK assertion in item 1.

Fixes # (issue): N/A

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `SONiC.master-27370.1188200-7de89e764`
  - Reproduced the `APPL_DB->ASIC_DB SAK mismatch` on `vms-kvm-t0-64-32`.
  - Reproduced `[128_SCI]` contamination on the immediate retry after stale 256-bit state remained.
  - Passed `[128_SCI]` after forcing the cleanup-timeout recovery path with a stale STATE_DB sentinel.
  - Verified Python compilation, targeted lint, and DUT/vSONIC recovery branch behavior.

### Approach
#### What is the motivation for this PR?

The dirty-restart test can leave MACsec APPL_DB or STATE_DB entries behind when asynchronous cleanup exceeds its timeout. The cleanup caller previously ignored that timeout, allowing the next profile or retry to start with stale key state. This can make `[128_SCI]` validate a SAK left by `[256_XPN_SCI]`. Separately, MKA can legitimately log that the forced DUT key server rejected a peer's transient distributed SAK, which loganalyzer treated as a test error.

#### How did you do it?

Added VS-only recovery after a MACsec cleanup timeout. DUTs use the existing safe config reload path. Plain vSONIC neighbors use a forced config reload and wait for database and swss readiness. Cleanup is verified after recovery, and the MACsec feature is restored across the DUT and controlled neighbors before profile setup continues. Added the expected key-server rejection message to the test's loganalyzer ignore list.

#### How did you verify/test it?

Reproduced the original failure and retry contamination on the exact failing VS image. Exercised the new timeout branch with a stale STATE_DB sentinel and confirmed cleanup recovery, MACsec feature restoration, successful profile setup, a passing dirty-restart test, and clean teardown.

#### Any platform specific information?

The recovery fallback is restricted to VS platforms. Physical testbed cleanup behavior is unchanged.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
