### PR TITLE
[sonic-mgmt]: Harden `test_subnet_decap` STATE_DB check and handle TD3 overlapping MP2MP constraint

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1105,12 +1105,13 @@ decap/test_decap.py:
 
 decap/test_subnet_decap.py::test_vip_packet_decap:
   skip:
-    reason: "Supported only on T0 topology with KVM or broadcom td3 asic or mellanox asic, and available for 202405 release and later"
+    reason: "Supported only on T0 topology with KVM or broadcom td3 asic or mellanox asic, and available for 202405 release and later. Broadcom TD3 rejects VIP subnet decap term when the VIP prefix overlaps an existing VLAN subnet decap term"
     conditions_logical_operator: or
     conditions:
       - "topo_type not in ['t0']"
       - "asic_type not in ['vs', 'mellanox'] and asic_gen not in ['td3']"
       - "release in ['202012', '202205', '202305', '202311']"
+      - "asic_type == 'broadcom' and asic_gen == 'td3' and https://github.com/sonic-net/sonic-mgmt/issues/26694"
 
 decap/test_subnet_decap.py::test_vip_packet_decap[IPv6]:
   xfail:

--- a/tests/decap/test_subnet_decap.py
+++ b/tests/decap/test_subnet_decap.py
@@ -4,6 +4,7 @@ import json
 import time
 import random
 import ipaddress
+import ast
 from collections import defaultdict
 
 import ptf.packet as packet
@@ -15,6 +16,7 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.config_reload import config_reload
 from tests.common.helpers.bgp import BGPNeighbor, NEIGHBOR_SAVE_DEST_TMPL, \
     BGP_SAVE_DEST_TMPL, _write_variable_from_j2_to_configdb, wait_tcp_connection
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +33,12 @@ SUBNET_DECAP_SRC_IP_V4 = "20.20.20.0/24"
 SUBNET_DECAP_SRC_IP_V6 = "fc01::/120"
 OUTER_DST_IP_V4 = "192.168.0.200"
 OUTER_DST_IP_V6 = "fc02:1000::200"
+VIP_ROUTE_V4 = "192.168.1.0/24"
+VIP_OUTER_DST_IP_V4 = "192.168.1.1"
+VIP_ROUTE_V6 = "fc02:2000::/120"
+VIP_OUTER_DST_IP_V6 = "fc02:2000::1"
+SUBNET_DECAP_TUNNEL_NAME_V4 = "IPINIP_SUBNET"
+SUBNET_DECAP_TUNNEL_NAME_V6 = "IPINIP_SUBNET_V6"
 
 
 @pytest.fixture(scope='module')
@@ -206,6 +214,32 @@ def verify_packet_with_expected(ptfadapter, stage, pkt, exp_pkt, send_port,
         testutils.verify_packet(ptfadapter, exp_pkt, recv_port, timeout=timeout)
 
 
+def get_vip_route(ip_version):
+    if ip_version == "IPv4":
+        return VIP_ROUTE_V4
+    return VIP_ROUTE_V6
+
+
+def get_subnet_decap_tunnel_name(ip_version):
+    if ip_version == "IPv4":
+        return SUBNET_DECAP_TUNNEL_NAME_V4
+    return SUBNET_DECAP_TUNNEL_NAME_V6
+
+
+def is_vip_decap_term_programmed(duthost, ip_version, vip_prefix):
+    tunnel_name = get_subnet_decap_tunnel_name(ip_version)
+    cmd = 'sonic-db-cli STATE_DB hgetall "TUNNEL_DECAP_TERM_TABLE|{}|{}"'.format(
+        tunnel_name, vip_prefix
+    )
+    output = duthost.command(cmd, module_ignore_errors=True)["stdout"].strip()
+    try:
+        decap_term = ast.literal_eval(output or "{}")
+    except (SyntaxError, ValueError):
+        logger.warning("Failed to parse VIP decap term output: %s", output)
+        return False
+    return decap_term.get("term_type") == "MP2MP" and decap_term.get("subnet_type") == "vip"
+
+
 @pytest.mark.parametrize("ip_version", ["IPv4", "IPv6"])
 @pytest.mark.parametrize("stage", ["positive", "negative"])
 def test_vlan_subnet_decap(request, rand_selected_dut, tbinfo, ptfhost, ptfadapter, ip_version, stage,
@@ -282,7 +316,7 @@ def setup_IPv4_SLB_connection(rand_selected_dut, ptfhost, prepare_vlan_subnet_te
 
     # announce the VIP route
     vip_route = {
-        "prefix": "192.168.1.0/24",
+        "prefix": VIP_ROUTE_V4,
         "nexthop": peer_addr,
         "aspath": "{}".format(slb_bgp.asn)
     }
@@ -414,7 +448,7 @@ def setup_IPv6_SLB_connection(rand_selected_dut, ptfhost, prepare_vlan_subnet_te
 
     # announce the VIP route
     vip_route = {
-        "prefix": "fc02:2000::/120",
+        "prefix": VIP_ROUTE_V6,
         "nexthop": peer_addr,
         "aspath": "{}".format(slb_bgp.asn)
     }
@@ -459,9 +493,14 @@ def test_vip_packet_decap(rand_selected_dut, ptfhost, ptfadapter, ip_version,
     else:
         neighbor_ip = request.getfixturevalue("setup_IPv6_SLB_connection")
 
-    # verify that STATE_DB gets programmed
-    decap_entries = duthost.command('sonic-db-cli STATE_DB keys "*TUNNEL_DECAP_TABLE*"')["stdout_lines"]
-    assert len(decap_entries) > 0, "No decap entries found in STATE_DB"
+    # Verify that the specific VIP decap term is programmed. A broad VLAN
+    # subnet term can decap overlapping traffic and hide VIP term failures.
+    vip_route = get_vip_route(ip_version)
+    subnet_decap_tunnel_name = get_subnet_decap_tunnel_name(ip_version)
+    assert wait_until(30, 2, 0, is_vip_decap_term_programmed, duthost, ip_version, vip_route), \
+        "VIP decap term TUNNEL_DECAP_TERM_TABLE|{}|{} is not programmed in STATE_DB".format(
+            subnet_decap_tunnel_name, vip_route
+        )
 
     # construct encapsulated packet and expected packet
     if ip_version == "IPv4":
@@ -475,7 +514,7 @@ def test_vip_packet_decap(rand_selected_dut, ptfhost, ptfadapter, ip_version,
             eth_dst=duthost.asic_instance().get_router_mac(),
             eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode(),
             ip_src="20.20.20.10",
-            ip_dst="192.168.1.1",
+            ip_dst=VIP_OUTER_DST_IP_V4,
             inner_frame=inner_packet[packet.IP]
         )
         expected_packet = inner_packet.copy()
@@ -495,7 +534,7 @@ def test_vip_packet_decap(rand_selected_dut, ptfhost, ptfadapter, ip_version,
             eth_dst=duthost.asic_instance().get_router_mac(),
             eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode(),
             ipv6_src="fc01::10",
-            ipv6_dst="fc02:2000::1",
+            ipv6_dst=VIP_OUTER_DST_IP_V6,
             inner_frame=inner_packet[packet.IPv6]
         )
         expected_packet = inner_packet.copy()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes false-passing dataplane assertions and handles Broadcom Trident3 (TD3) hardware limitations in `tests/decap/test_subnet_decap.py`.

`test_vip_packet_decap[IPv4]` previously reported a dataplane pass while failing during teardown via `loganalyzer`. The Broadcom TD3 SDK rejects overlapping `MP2MP` `IP-in-IP` tunnel terminators with `BCM_E_PARAM (SAI_STATUS_INVALID_PARAMETER)` when the `VIP` prefix (`192.168.1.0/24`) is a subnet of the broad VLAN subnet (`192.168.0.0/21`). Packets passed because the hardware matched the broader `/21` term, while `syncd` logged `SAI` failures when trying to program the narrower VIP entry.

This PR tightens the test assertion to explicitly check for the specific `VIP` term in `STATE_DB` before packet testing, and `handles/xfails` the IPv4 overlapping scenario on platforms enforcing non-overlapping MP2MP terminators.

Fixes #26694 

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: Test hardening / Day-one hardware constraint (Broadcom TD3 overlapping MP2MP IP-in-IP terminator rejection)

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- Test skips on td3 platforms.
- Correctly logs error when the vip term is not programmed correctly and the respective entry is not present in `STATE_DB`.
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

When `SUBNET_DECAP` is enabled, `ipinip.json.j2` installs an MP2MP decap term for the VLAN subnet (`192.168.0.0/21`). When the VIP route `192.168.1.0/24` arrives, `routeorch` attempts to add a second MP2MP term with the same outer source mask (`20.20.20.0/24`). Broadcom TD3 returns `BCM_E_PARAM` because `192.168.1.0/24` ⊂ `192.168.0.0/21`.

The current test validated `STATE_DB` using a generic key count (len(decap_entries) > 0). Because the VLAN subnet term existed, the assertion passed, and traffic sent to `192.168.1.1` was `decapped` by the /21 rule. The test then failed in teardown via `loganalyzer` due to syslog errors from `syncd/orchagent`.

#### How did you do it?
- Tightened Control-Plane Verification: Updated `test_subnet_decap.py `to query STATE_DB explicitly for `TUNNEL_DECAP_TERM_TABLE|IPINIP_SUBNET|<vip_prefix>` rather than checking for generic table existence. This ensures control-plane failure is flagged immediately.
- Platform Expectation Handling: Added `skip` markers for overlapping IPv4 VIP subnet decap on Broadcom TD3 platforms that enforce non-overlapping MP2MP IP-in-IP terminators.
#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
- Validated on `x86_64-arista_7050cx3_32s` (`dualtor` and `dualtor-aa`).
- Confirmed direct injection of non-overlapping terms (`10.10.10.0/24`) in `APP_DB` succeeds in hardware, isolating the issue specifically to prefix overlap.
- Confirmed that `STATE_DB` check correctly fails early when the VIP entry is missing due to SDK rejection.

#### Any platform specific information?
Affects Broadcom Trident3 (TD3) platforms (e.g., `Arista-7050CX3-32S`).
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
