### PR TITLE
[dns]: Preserve management IP during dhclient static DNS test

### DIFF
--- a/tests/dns/static_dns/dhclient_restore.sh
+++ b/tests/dns/static_dns/dhclient_restore.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -u
+
+mgmt_port="$1"
+pid_file="$2"
+done_file="$3"
+
+ip_addrs=$(mktemp)
+routes=$(mktemp)
+
+cleanup() {
+    rm -f "$ip_addrs" "$routes"
+}
+trap cleanup EXIT
+
+# Save the full pre-test IPv4 state before dhclient can modify eth0.
+sudo ip -4 -o addr show dev "$mgmt_port" scope global | awk '{print $4}' > "$ip_addrs"
+sudo ip -4 route show default dev "$mgmt_port" > "$routes"
+
+# Run DHCP and stop the client started by this test.
+sudo dhclient -pf "$pid_file" "$mgmt_port"
+if [ -f "$pid_file" ]; then
+    sudo kill "$(cat "$pid_file")" || true
+fi
+rm -f "$pid_file"
+
+# Clear current global IPv4 addresses because dhclient may have added a lease address.
+sudo ip -4 addr flush dev "$mgmt_port" scope global
+
+# Add back exactly the IPv4 addresses captured before DHCP.
+while read -r addr; do
+    [ -n "$addr" ] || continue
+    sudo ip -4 addr add "$addr" dev "$mgmt_port"
+done < "$ip_addrs"
+
+# Remove current default routes because dhclient may have installed or changed one.
+while sudo ip -4 route del default dev "$mgmt_port" 2>/dev/null; do
+    true
+done
+
+# Restore the exact default routes captured before DHCP.
+while read -r route; do
+    [ -n "$route" ] || continue
+    # Keep $route unquoted so ip receives the saved route fields as separate arguments.
+    sudo ip -4 route add $route 2>/dev/null || sudo ip -4 route replace $route 2>/dev/null || true
+done < "$routes"
+
+touch "$done_file"

--- a/tests/dns/static_dns/dhclient_restore.sh
+++ b/tests/dns/static_dns/dhclient_restore.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -euo pipefail
 
 mgmt_port="$1"
 pid_file="$2"
@@ -8,22 +8,24 @@ done_file="$3"
 
 ip_addrs=$(mktemp)
 routes=$(mktemp)
+current_ip_addrs=$(mktemp)
+current_routes=$(mktemp)
 
 cleanup() {
-    rm -f "$ip_addrs" "$routes"
+    rm -f "$ip_addrs" "$routes" "$current_ip_addrs" "$current_routes"
 }
 trap cleanup EXIT
 
 # Save the full pre-test IPv4 state before dhclient can modify eth0.
-sudo ip -4 -o addr show dev "$mgmt_port" scope global | awk '{print $4}' > "$ip_addrs"
-sudo ip -4 route show default dev "$mgmt_port" > "$routes"
+sudo ip -4 -o addr show dev "$mgmt_port" scope global | awk '{print $4}' | sort > "$ip_addrs"
+sudo ip -4 route show default dev "$mgmt_port" | sort > "$routes"
 
 # Run DHCP and stop the client started by this test.
 sudo dhclient -pf "$pid_file" "$mgmt_port"
 if [ -f "$pid_file" ]; then
     sudo kill "$(cat "$pid_file")" || true
 fi
-rm -f "$pid_file"
+sudo rm -f "$pid_file"
 
 # Clear current global IPv4 addresses because dhclient may have added a lease address.
 sudo ip -4 addr flush dev "$mgmt_port" scope global
@@ -43,7 +45,14 @@ done
 while read -r route; do
     [ -n "$route" ] || continue
     # Keep $route unquoted so ip receives the saved route fields as separate arguments.
-    sudo ip -4 route add $route 2>/dev/null || sudo ip -4 route replace $route 2>/dev/null || true
+    # shellcheck disable=SC2086
+    sudo ip -4 route add $route 2>/dev/null || sudo ip -4 route replace $route
 done < "$routes"
+
+sudo ip -4 -o addr show dev "$mgmt_port" scope global | awk '{print $4}' | sort > "$current_ip_addrs"
+sudo ip -4 route show default dev "$mgmt_port" | sort > "$current_routes"
+
+diff -u "$ip_addrs" "$current_ip_addrs"
+diff -u "$routes" "$current_routes"
 
 touch "$done_file"

--- a/tests/dns/static_dns/test_static_dns.py
+++ b/tests/dns/static_dns/test_static_dns.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+import os
 import re
 
 from tests.common.reboot import reboot
@@ -41,21 +42,45 @@ UNCONFIGURED_IP_ERR = r"Error: DNS nameserver .* is not configured"
 EXCEED_MAX_ERR = r"Error: The maximum number \(3\) of nameservers exceeded"
 DUPLICATED_IP_ERR = r"Error: .* nameserver is already configured"
 
+DHCLIENT_RESTORE_SCRIPT = os.path.join(os.path.dirname(__file__), "dhclient_restore.sh")
+REMOTE_DHCLIENT_RESTORE_SCRIPT = "/tmp/dhclient-dns-test-restore.sh"
 MGMT_PORT = "eth0"
 DHCLIENT_PID_FILE = "/run/dhclient-dns-test.pid"
+DHCLIENT_DONE_FILE = "/tmp/dhclient-dns-test.done"
 
 
 def start_dhclient(duthost):
-    duthost.shell(f"sudo dhclient -pf {DHCLIENT_PID_FILE} {MGMT_PORT}")
+    """Run dhclient without leaving the Ansible management path broken.
+
+    Static-management testbeds can use eth0 as the Ansible SSH control
+    interface. Running dhclient on eth0 may replace the inventory IP before
+    Ansible receives the command result, so the restore has to run entirely
+    inside the DUT before the controller waits for completion.
+    """
+    # Run restore from the DUT so Ansible can reconnect even if dhclient
+    # briefly changes the management address used by the control connection.
+    duthost.copy(src=DHCLIENT_RESTORE_SCRIPT,
+                 dest=REMOTE_DHCLIENT_RESTORE_SCRIPT,
+                 mode="0755")
+    cmd = (
+        f"rm -f {DHCLIENT_DONE_FILE}\n"
+        f"nohup bash {REMOTE_DHCLIENT_RESTORE_SCRIPT} "
+        f"{MGMT_PORT} {DHCLIENT_PID_FILE} {DHCLIENT_DONE_FILE} "
+        "> /dev/null 2>&1 &"
+    )
+    duthost.shell(cmd)
+    try:
+        pytest_assert(wait_until(180, 5, 5, is_dhclient_restore_done, duthost),
+                      f"DHCP renew did not complete on {MGMT_PORT}")
+    finally:
+        duthost.shell(
+            f"sudo rm -f {DHCLIENT_DONE_FILE} {REMOTE_DHCLIENT_RESTORE_SCRIPT}",
+            module_ignore_errors=True)
 
 
-@pytest.fixture()
-def stop_dhclient(duthost):
-    yield
-
-    if duthost.shell(f'ls {DHCLIENT_PID_FILE}', module_ignore_errors=True)['rc'] == 0:
-        duthost.shell(f"sudo kill $(cat {DHCLIENT_PID_FILE})")
-        duthost.shell(f"rm -rf {DHCLIENT_PID_FILE}")
+def is_dhclient_restore_done(duthost):
+    return duthost.shell(f"test -f {DHCLIENT_DONE_FILE}",
+                         module_ignore_errors=True, verbose=False).get("rc") == 0
 
 
 @pytest.mark.disable_loganalyzer
@@ -119,7 +144,7 @@ def test_static_dns_basic(request, duthost, localhost, backup_and_restore_config
 
 @pytest.mark.usefixtures('static_mgmt_ip_configured')
 class TestStaticMgmtPortIP():
-    def test_dynamic_dns_not_working_when_static_ip_configured(self, duthost, stop_dhclient):
+    def test_dynamic_dns_not_working_when_static_ip_configured(self, duthost):
         """
         Test to verify Dynamic DNS not work when static ip address is configured on the mgmt port
         :param duthost: DUT host object
@@ -142,7 +167,7 @@ class TestStaticMgmtPortIP():
 
 @pytest.mark.usefixtures('static_mgmt_ip_not_configured')
 class TestDynamicMgmtPortIP():
-    def test_static_dns_is_not_changing_when_do_dhcp_renew(self, duthost, stop_dhclient):
+    def test_static_dns_is_not_changing_when_do_dhcp_renew(self, duthost):
         """
         Test case to verify Static DNS will not change when do dhcp renew for the mgmt port
         :param duthost: DUT host object
@@ -169,7 +194,7 @@ class TestDynamicMgmtPortIP():
                 del_dns_nameserver(duthost, nameserver)
 
     @pytest.mark.usefixtures('static_mgmt_ip_not_configured')
-    def test_dynamic_dns_working_when_no_static_ip_and_static_dns(self, duthost, stop_dhclient):
+    def test_dynamic_dns_working_when_no_static_ip_and_static_dns(self, duthost):
         """
         The test is to verify Dynamic DNS work as expected when no static ip configured on mgmt port and
         static DNS is configured.

--- a/tests/dns/static_dns/test_static_dns.py
+++ b/tests/dns/static_dns/test_static_dns.py
@@ -47,6 +47,7 @@ REMOTE_DHCLIENT_RESTORE_SCRIPT = "/tmp/dhclient-dns-test-restore.sh"
 MGMT_PORT = "eth0"
 DHCLIENT_PID_FILE = "/run/dhclient-dns-test.pid"
 DHCLIENT_DONE_FILE = "/tmp/dhclient-dns-test.done"
+DHCLIENT_LOG_FILE = "/tmp/dhclient-dns-test.log"
 
 
 def start_dhclient(duthost):
@@ -63,24 +64,29 @@ def start_dhclient(duthost):
                  dest=REMOTE_DHCLIENT_RESTORE_SCRIPT,
                  mode="0755")
     cmd = (
-        f"rm -f {DHCLIENT_DONE_FILE}\n"
+        f"rm -f {DHCLIENT_DONE_FILE} {DHCLIENT_LOG_FILE}\n"
         f"nohup bash {REMOTE_DHCLIENT_RESTORE_SCRIPT} "
         f"{MGMT_PORT} {DHCLIENT_PID_FILE} {DHCLIENT_DONE_FILE} "
-        "> /dev/null 2>&1 &"
+        f"> {DHCLIENT_LOG_FILE} 2>&1 &"
     )
     duthost.shell(cmd)
     try:
         pytest_assert(wait_until(180, 5, 5, is_dhclient_restore_done, duthost),
-                      f"DHCP renew did not complete on {MGMT_PORT}")
+                      f"DHCP renew did not complete on {MGMT_PORT}\n{get_dhclient_restore_output(duthost)}")
     finally:
         duthost.shell(
-            f"sudo rm -f {DHCLIENT_DONE_FILE} {REMOTE_DHCLIENT_RESTORE_SCRIPT}",
+            f"sudo rm -f {DHCLIENT_DONE_FILE} {DHCLIENT_LOG_FILE} {REMOTE_DHCLIENT_RESTORE_SCRIPT}",
             module_ignore_errors=True)
 
 
 def is_dhclient_restore_done(duthost):
     return duthost.shell(f"test -f {DHCLIENT_DONE_FILE}",
                          module_ignore_errors=True, verbose=False).get("rc") == 0
+
+
+def get_dhclient_restore_output(duthost):
+    return duthost.shell(f"test -f {DHCLIENT_LOG_FILE} && sudo cat {DHCLIENT_LOG_FILE} || true",
+                         module_ignore_errors=True, verbose=False).get("stdout", "")
 
 
 @pytest.mark.disable_loganalyzer


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
  `test_dynamic_dns_not_working_when_static_ip_configured` runs `dhclient` on
  `eth0`. On static-management testbeds, `eth0` can also be the Ansible SSH
  control interface. If DHCP changes the live management address before Ansible
  receives the command result, the DUT can become unreachable at the inventory IP
  and later commands can fail with transport errors.

  This PR runs the DHCP flow in a detached DUT-side helper, snapshots all
  pre-test global IPv4 addresses and default routes on `eth0`, restores any
  original address or route removed by DHCP, removes only addresses introduced
  by the test, and then reports completion with a done marker.

Summary:
Fixes #26918 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
**Tested on  202605:**
***Failure*** 
Image : branch.202605-ars.3213bfab-buildimage.63f17ae505b85275482fef3274201014c07fed91-nightly-2026.07.15.21.40

[fail_test_static_dns.log](https://github.com/user-attachments/files/30906023/fail_test_static_dns.log)
[fail_test_static_dns.xml](https://github.com/user-attachments/files/30906025/fail_test_static_dns.xml)

***Pass (after fix)***
Image :branch.202605-ars.75fa4b07-buildimage.c02e69d876b983e5923a6f501c56ac6940dba346-nightly-2026.09.03.14.40
[test_static_dns_multi_mgmt_ipv4_persistent.log](https://github.com/user-attachments/files/31885461/test_static_dns_multi_mgmt_ipv4_persistent.log)
[test_static_dns_multi_mgmt_ipv4_persistent.xml](https://github.com/user-attachments/files/31885460/test_static_dns_multi_mgmt_ipv4_persistent.xml)

### Approach
#### What is the motivation for this PR?
 The test validates that dynamic DNS does not override static management-port DNS
  configuration, but it starts `dhclient` directly on `eth0`. On testbeds where
  `eth0` is also the Ansible management path, DHCP can replace the inventory/static
  management IP and break the controller connection before cleanup runs.

#### How did you do it?
The test now copies a helper script to the DUT and starts it detached. The
 helper snapshots all global IPv4 addresses and default routes on `eth0`, runs
`dhclient`, stops the DHCP client, restores any original management IPv4
address or default route that was removed, deletes only IPv4 addresses
introduced by DHCP during the test, and touches a completion marker. Ansible
waits for that marker instead of depending on the original `dhclient` command
returning while the management path may be changing.



#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
 DUTs were configured with persistent secondary management IPv4 addresses:

  `ld599`:
  - `172.30.125.108/25`
  - `192.0.2.205/32`
  - `192.0.2.206/32`

  `ldp406`:
  - `172.30.125.110/25`
  - `192.0.2.215/32`
  - `192.0.2.216/32`

Then ran:  `dns/static_dns/test_static_dns.py::TestStaticMgmtPortIP::test_dynamic_dns_not_working_when_static_ip_configured`

Result: passed. 
Verified all pre-test management IPv4 addresses and default routes were still present after the test.

#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?
None 
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A

