### PR TITLE
[test_ntp] Fix whole-key overwrite of NTP table

### DIFF
--- a/tests/generic_config_updater/test_ntp.py
+++ b/tests/generic_config_updater/test_ntp.py
@@ -305,12 +305,8 @@ def ntp_server_set_intf(duthost, ntp_service, src_intf):
     json_patch = [
         {
             "op": "add",
-            "path": "/NTP",
-            "value": {
-                "global": {
-                    "src_intf": src_intf
-                }
-            }
+            "path": "/NTP/global/src_intf",
+            "value": src_intf
         }
     ]
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fixes whole-key overwrite of NTP|global table in test_ntp_server_change_source_intf by targeting the leaf property path in the JSON patch payload.

Summary:
Fixes #26921
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
- 202605:
**Before Fix** 

Image Version: branch.202605-ars.d3ed3c17-buildimage.0fc772d2082790be95d4f09cc56470fc0243ac2c-nightly-2026.08.05.14.40

[test_ntp.log](https://github.com/user-attachments/files/30907747/test_ntp.log)
[test_ntp.xml](https://github.com/user-attachments/files/30907749/test_ntp.xml)

` grep inconsistent_config test_ntp.log`  will return
`08/08/2026 19:56:54 conftest.core_dump_and_config_check      L3410 WARNING| Core dump or config check failed for test_ntp.py, results: {"core_dump_check": {"failed": false, "new_core_dumps": {"ldp202": [], "ldp207": []}}, "config_db_check": {"failed": true, "pre_only_config": {"ldp202": {"null": {}}, "ldp207": {"null": {}}}, "cur_only_config": {"ldp202": {"null": {}}, "ldp207": {"null": {}}}, "inconsistent_config": {"ldp202": {"null": {"NTP": {"pre_value": {"global": {"admin_state": "enabled", "authentication": "disabled", "dhcp": "enabled", "server_role": "disabled", "src_intf": "eth0", "vrf": "default"}}, "cur_value": {"global": {"src_intf": "eth0"}}}}}, "ldp207": {"null": {}}}}}
`
**After Fix**

Image version: branch.202605-ars.d3ed3c17-buildimage.0fc772d2082790be95d4f09cc56470fc0243ac2c-nightly-2026.08.05.14.40

[test_ntp.log](https://github.com/user-attachments/files/30907931/test_ntp.log)
[test_ntp.xml](https://github.com/user-attachments/files/30907935/test_ntp.xml)

` grep inconsistent_config test_ntp.log ` will return nothing 


### Approach
#### What is the motivation for this PR?
In generic_config_updater/test_ntp.py, `test_ntp_server_change_source_intf `uses helper function `ntp_server_set_intf() ` which constructed a JSON patch targeting the top-level path `/NTP `instead of `/NTP/global/src_intf`.

Under Generic Config Updater (GCU) and RFC 6902 JSON patch rules, updating /NTP replaces the whole NTP object in Redis CONFIG_DB. As a result, other global keys like admin_state, vrf, authentication, dhcp, and server_role were wiped out during test execution 

#### How did you do it?
Updated `ntp_server_set_intf()` in `generic_config_updater/test_ntp.py` to target the specific leaf property `/NTP/global/src_intf` directly

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

1. Executed pytest generic_config_updater/test_ntp.py::test_ntp_server_change_source_intf on a standard testbed.
2. Verified CONFIG_DB during test execution to ensure standard NTP|global fields (admin_state, vrf, etc.) are preserved.
3. Verified test teardown health checks pass without reporting critical process failures.

#### Any platform specific information?
N/A 
#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A