### PR TITLE
[dualtor]: Restore multivlan minigraph on setup failure

### DIFF
--- a/tests/dualtor/test_mux_port_iptables_entries.py
+++ b/tests/dualtor/test_mux_port_iptables_entries.py
@@ -18,9 +18,20 @@ pytestmark = [
         ]
 
 
+@pytest.fixture(scope="function")
+def backup_minigraph(duthost):
+    """Restore minigraph even if setup_multiple_vlans fails before yield."""
+    duthost.command("cp /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.bak")
+
+    yield
+
+    duthost.command("cp /etc/sonic/minigraph.xml.bak /etc/sonic/minigraph.xml")
+    config_reload(duthost, config_source="minigraph")
+
+
 # This is only supposed to be run on tor
 @pytest.fixture(scope="function")
-def setup_multiple_vlans(request, duthost, localhost, tbinfo):
+def setup_multiple_vlans(request, duthost, localhost, tbinfo, backup_minigraph):
     hostname = duthost.hostname
     # inventory = tbinfo["inv_name"]
     topo = tbinfo["topo"]["name"]
@@ -92,16 +103,12 @@ def setup_multiple_vlans(request, duthost, localhost, tbinfo):
     minigraph_xml = re.sub("[ \t]*<DeviceDataPlaneInfo>(.|\n)*</DeviceDataPlaneInfo>[ \t]*",
                            multivlan_mux_config_xml, minigraph_xml)
     minigraph_xml = minigraph_xml.replace("PLACEHOLDER", first_match)
-    duthost.command("cp /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.bak")
     duthost.copy(content=minigraph_xml, dest="/etc/sonic/minigraph.xml")
     config_reload(duthost, config_source='minigraph')
     config_facts = duthost.get_running_config_facts()
     pytest_assert(len(config_facts['VLAN_INTERFACE']) == 4, "Configuring multivlan is not successful")
 
     yield
-
-    duthost.command("cp /etc/sonic/minigraph.xml.bak /etc/sonic/minigraph.xml")
-    config_reload(duthost, config_source='minigraph')
 
 
 def verify_mux_port_iptables_entries(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix `dualtor/test_mux_port_iptables_entries.py::test_multivlan_mux_port_iptables_entries`
  cleanup on the 202605 branch.

  The test modifies `/etc/sonic/minigraph.xml` in the `setup_multiple_vlans`
  fixture and then runs `config_reload()`. If `config_reload()` fails before the
  fixture reaches `yield`, the old teardown code is skipped and the DUT can be
  left with the temporary `four_vlan_a` multivlan minigraph.

  Move minigraph backup and restore into a separate function-scoped fixture and
  make `setup_multiple_vlans` depend on it. Pytest will then run the restore
  fixture teardown even when `setup_multiple_vlans` fails during setup.

Summary:
Fixes #26924 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
- 202605:
**Issue  Before Fix :** 
**Primary Test** 
[test_mux_port_iptables_entries.log](https://github.com/user-attachments/files/30910342/test_mux_port_iptables_entries.log)
[test_mux_port_iptables_entries.xml](https://github.com/user-attachments/files/30910344/test_mux_port_iptables_entries.xml)
**Fallout of the Leak**
[test_orchagent_slb.log](https://github.com/user-attachments/files/30910345/test_orchagent_slb.log)
[test_orchagent_slb.xml](https://github.com/user-attachments/files/30910347/test_orchagent_slb.xml)

**After  Fix**
Tests pass and no fallout seen 

### Approach
#### What is the motivation for this PR?

 `test_multivlan_mux_port_iptables_entries` can leak temporary multivlan
  minigraph state if setup fails after overwriting `/etc/sonic/minigraph.xml` but
  before fixture teardown is reached. This can cause downstream dualtor tests to
  fail with VLAN/topology mismatch symptoms.

  This is a 202605-specific fix. In master, PR #24670 replaced this local
  minigraph rewrite path with `parametrize_vlan_config_from_topo`, so the same
  patch does not apply there.

#### How did you do it?
Added a function-scoped `backup_minigraph` fixture that backs up
  `/etc/sonic/minigraph.xml` before setup and restores it with `config_reload()`
  during fixture teardown.

  Made `setup_multiple_vlans` depend on `backup_minigraph`, then removed the old
  restore code from after `yield`.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

Validation temporarily injected pytest.fail() after multivlan config_reload() and before setup_multiple_vlans reached yield, recreating the RCA setup failure window.
The induced run failed as expected, but backup_minigraph teardown still restored minigraph, reran config_reload(config_source="minigraph"), and  passed post-restore YANG validation.

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A