### PR TITLE
Wait for systemd to finish initializing before mgmt VRF teardown

### DIFF
--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -41,6 +41,16 @@ def restore_config_db(duthost):
     config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
 
+SYSTEMD_INIT_TIMEOUT_SECS = 600
+SYSTEMD_INIT_POLL_INTERVAL_SECS = 20
+
+
+def systemd_finished_initializing(duthost) -> bool:
+    state = duthost.shell("systemctl is-system-running",
+                          module_ignore_errors=True)["stdout"].strip()
+    return state not in ("initializing", "starting")
+
+
 @pytest.fixture(scope="module")
 def check_ntp_sync(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
@@ -127,6 +137,20 @@ def setup_mvrf(duthosts, rand_one_dut_hostname, localhost, check_ntp_sync,
     yield
 
     try:
+        # After this module's fast/warm-boot cases, systemd stays in
+        # 'starting' for several minutes (warmboot-finalizer gates
+        # multi-user.target) and hostcfgd defers acting on CONFIG_DB changes
+        # until systemd finishes initializing. A 'config vrf del mgmt' issued
+        # in that window is applied later, in the middle of
+        # restore_config_db()'s config reload, flapping eth0 and killing the
+        # SSH session carrying the reload command. Wait out the window so the
+        # VRF removal is applied here, where the connection loss is expected
+        # and handled.
+        if not wait_until(SYSTEMD_INIT_TIMEOUT_SECS, SYSTEMD_INIT_POLL_INTERVAL_SECS, 0,
+                          systemd_finished_initializing, duthost):
+            logger.warning("systemd did not finish initializing within {}s; "
+                           "proceeding with mgmt vrf teardown anyway".format(SYSTEMD_INIT_TIMEOUT_SECS))
+
         logger.info("Unconfigure  mgmt vrf")
         duthost.shell("sudo config vrf del mgmt", module_async=True)
         time.sleep(5)


### PR DESCRIPTION
### Description of PR

Summary:
Resolves #26927

`mvrf/test_mgmtvrf.py::TestReboot::test_fastboot`'s module teardown can error with `pytest_ansible.errors.AnsibleConnectionFailure: Host unreachable in the inventory` on platforms where systemd stays `starting` for several minutes after a fast-reboot.

Root cause: while systemd is still `starting`, hostcfgd defers acting on CONFIG_DB changes, so the teardown's `config vrf del mgmt` doesn't take effect immediately. The deferred VRF removal is instead applied later, in the middle of the teardown's subsequent `config_reload()`, which briefly flaps `eth0` and kills the SSH session carrying the reload command.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: N/A

### Approach
#### What is the motivation for this PR?

Any platform where systemd can still be `starting` at module-teardown time is exposed to this teardown failure.

#### How did you do it?

Wait for `systemctl is-system-running` to leave `initializing`/`starting` (600s timeout, 20s poll) at the start of the module teardown, before `config vrf del mgmt`, so the removal takes effect immediately instead of firing mid-reload.

#### How did you verify/test it?

Full `mvrf/test_mgmtvrf.py` on a physical NH-4010 testbed (202511.2 build 138961): 10 passed, 0 failed — the teardown waited ~2m43s for systemd and no connection loss occurred.

#### Any platform specific information?

Deterministic on platforms where fastboot support makes `test_fastboot` run last and systemd is still initializing at module-teardown time.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
