### PR TITLE
Fix dead connection-loss handler in config reload

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -11,12 +11,9 @@ from tests.common.utilities import wait_until
 from tests.common.configlet.utils import chk_for_pfc_wd
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs
-<<<<<<< HEAD
 from tests.common.vs_data import is_vs_device
-=======
 from ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.errors import AnsibleConnectionFailure as PytestAnsibleConnectionFailure
->>>>>>> 736703c96 (NOS-8757: fix dead connection-loss handler in config reload (#2479))
 
 logger = logging.getLogger(__name__)
 
@@ -282,10 +279,6 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
     :return:
     """
     def _config_reload_cmd_wrapper(cmd, executable):
-<<<<<<< HEAD
-        out = sonic_host.shell(cmd, executable=executable)
-        if out['rc'] == 0:
-=======
         try:
             out = sonic_host.shell(cmd, executable=executable, module_ignore_errors=True)
             if out['rc'] == 0:
@@ -294,9 +287,9 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
                 return False
         except (AnsibleConnectionFailure, PytestAnsibleConnectionFailure) as conn_err:
             logger.info("Connection lost during config reload: {}".format(str(conn_err)))
->>>>>>> 736703c96 (NOS-8757: fix dead connection-loss handler in config reload (#2479))
             return True
-        else:
+        except Exception as e:
+            logger.info("Config reload try failed with exception: {}".format(str(e)))
             return False
 
     if config_source not in config_sources:

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -11,7 +11,12 @@ from tests.common.utilities import wait_until
 from tests.common.configlet.utils import chk_for_pfc_wd
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs
+<<<<<<< HEAD
 from tests.common.vs_data import is_vs_device
+=======
+from ansible.errors import AnsibleConnectionFailure
+from pytest_ansible.errors import AnsibleConnectionFailure as PytestAnsibleConnectionFailure
+>>>>>>> 736703c96 (NOS-8757: fix dead connection-loss handler in config reload (#2479))
 
 logger = logging.getLogger(__name__)
 
@@ -277,8 +282,19 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
     :return:
     """
     def _config_reload_cmd_wrapper(cmd, executable):
+<<<<<<< HEAD
         out = sonic_host.shell(cmd, executable=executable)
         if out['rc'] == 0:
+=======
+        try:
+            out = sonic_host.shell(cmd, executable=executable, module_ignore_errors=True)
+            if out['rc'] == 0:
+                return True
+            else:
+                return False
+        except (AnsibleConnectionFailure, PytestAnsibleConnectionFailure) as conn_err:
+            logger.info("Connection lost during config reload: {}".format(str(conn_err)))
+>>>>>>> 736703c96 (NOS-8757: fix dead connection-loss handler in config reload (#2479))
             return True
         else:
             return False


### PR DESCRIPTION
### Description of PR

Summary:
Resolves #26927

`_config_reload_cmd_wrapper`'s connection-loss handler in `tests/common/config_reload.py` is dead code: pytest-ansible raises its own `AnsibleConnectionFailure`, which subclasses `AnsibleError`, not `ansible.errors.AnsibleConnectionFailure`, so the `except` never fires. A connection drop while issuing the wrapped `config reload -y` falls into the generic handler, returns False, and the wrapper retries and then force-reloads a device that is already reloading. Catch the pytest-ansible class as well.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: N/A

### Approach
#### What is the motivation for this PR?

The wrapper's intended tolerance — treat a mid-reload connection loss as reload-in-progress and let the safe_reload checks verify recovery — never engages. The main affected caller is the post-test config restore in `tests/conftest.py` (`wait_before_force_reload=300`), which nearly every module runs.

#### How did you do it?

Extended the `except` clause to also catch `pytest_ansible.errors.AnsibleConnectionFailure`.

#### How did you verify/test it?

**Why the existing `except` is dead code.** All host commands in this framework go through pytest-ansible (`sonic_host.shell()` -> `devices/base.py::_run` -> pytest-ansible's module dispatcher), and on a connection drop the dispatcher raises its *own* `AnsibleConnectionFailure`, which is not a subclass of the `ansible.errors` one the handler catches:

```
  File "/var/AzDevOps/sonic-mgmt/tests/common/devices/base.py", line 163, in _run_wrapper
    return self._run(module_name, *module_args, **kwargs)
  File "/var/AzDevOps/sonic-mgmt/tests/common/devices/base.py", line 214, in _run
    adhoc_res: AdHocResult = module(*module_args, **complex_args)
  File "/opt/venv/lib/python3.12/site-packages/pytest_ansible/module_dispatcher/v213.py", line 287, in _run
    raise AnsibleConnectionFailure(
pytest_ansible.errors.AnsibleConnectionFailure: Host unreachable in the inventory
```

```python
>>> import ansible.errors, pytest_ansible.errors
>>> pytest_ansible.errors.AnsibleConnectionFailure.__mro__
(<class 'pytest_ansible.errors.AnsibleConnectionFailure'>, <class 'ansible.errors.AnsibleError'>,
 <class 'Exception'>, <class 'BaseException'>, <class 'object'>)
>>> issubclass(pytest_ansible.errors.AnsibleConnectionFailure, ansible.errors.AnsibleConnectionFailure)
False
```

Inside `_config_reload_cmd_wrapper` this never surfaces as a traceback: the exception lands in the generic `except Exception` ("Config reload try failed with exception: Host unreachable in the inventory"), the wrapper returns False as if the reload command had simply failed, `wait_until` keeps re-issuing `config reload -y` against a device that is already reloading, and once `wait_before_force_reload` expires a `config reload -y -f` is forced on top of the in-flight reload.

**Repro.** A mid-reload connection drop through the wrapper path, reproduced on a physical NH-4010 testbed (202511.2) with a throwaway pytest test that calls the `config_reload` helper directly with `wait_before_force_reload` set (the same wrapper path the post-test config restore in `tests/conftest.py` takes):

1. Save a copy of the running config without mgmt VRF.
2. Enable mgmt VRF and persist it so it survives a reboot.
3. Fast-reboot. Afterwards systemd stays in `starting` for several minutes.
4. While systemd is still `starting`, delete the mgmt VRF — the kernel-side teardown is deferred.
5. Restore the saved config file and call `config_reload(duthost, config_source='config_db', wait_before_force_reload=600, safe_reload=True)`. For the first ~170s the wrapped `config reload -y` returns rc=1 ("System is not up. Retry later or use -f to avoid system checks") and the wrapper retries every 10s; once the system check passes the reload starts, the deferred VRF teardown flushes mid-reload (bouncing eth0), and the SSH session carrying `config reload -y` drops with `pytest_ansible.errors.AnsibleConnectionFailure: Host unreachable in the inventory`.

**Result with the fix:** the handler fires exactly at the drop and the wrapper treats the reload as in progress instead of failed — no further retries, no forced reload — and all safe_reload checks (critical processes/services) pass, 1/1 PASS:

```
DEBUG:tests.common.utilities:Time elapsed: 169.592547 seconds
DEBUG:...base.py::_run_wrapper#163: [gold111] AnsibleModule::shell, args=["sudo config reload -y"], ...
INFO:tests.common.config_reload:Connection lost during config reload: Host unreachable in the inventory
DEBUG:tests.common.utilities:_config_reload_cmd_wrapper is True, exit early with True
```

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
