### PR TITLE
test_intf_fec: Add support for platform x86_64-nokia_ixr7220_h6_128-r0

### DIFF
--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -19,7 +19,8 @@ SUPPORTED_PLATFORMS = [
     "x86_64-nvidia",
     "x86_64-88_lc0_36fh_m-r0",
     "nexthop",
-    "marvell"
+    "marvell",
+    "nokia_ixr7220"
 ]
 
 SUPPORTED_SPEEDS = [


### PR DESCRIPTION
### Description of PR
Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`tests/platform_tests/test_intf_fec.py` skips FEC tests for platforms not listed in `SUPPORTED_PLATFORMS`. The new platform `x86_64-nokia_ixr7220_h6_128-r0` is not in this list, so the test is skipped for this platform.

#### How did you do it?
Added `nokia_ixr7220` to `SUPPORTED_PLATFORMS` so it matches the `x86_64-nokia_ixr7220_h6_128-r0` platform name (substring match), consistent with how other platform entries in this list work.

#### How did you verify/test it?
Reviewed the matching logic (`any(platform in duthost.facts['platform'] for platform in SUPPORTED_PLATFORMS)`) and confirmed `nokia_ixr7220` is a substring of `x86_64-nokia_ixr7220_h6_128-r0`.

#### Any platform specific information?
Enables FEC tests for Nokia IXR7220 H6 (x86_64-nokia_ixr7220_h6_128-r0) platform.

#### Supported testbed topology if it's a new test case?
N/A - existing test case, topology `any`.

### Documentation
N/A
