### PR TITLE
[loganalyzer] Ignore syncd port_serdes_rid lane count information error

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -521,5 +521,8 @@ r, ".* ERR auditd.*: auditd queue full reporting limit reached - ending dropped 
 r, ".* ERR ctrmgrd\.py: Refer file .* for troubleshooting tips.*"
 r, ".* ERR ctrmgrd\.py:.*\[WARNING SystemVerification\]:.*Docker version is not on the list of validated versions.*"
 
+# syncd port serdes lane count info not available
+r, ".* ERR syncd\d*#syncd: :- initAttrData: PORT_PHY_SERDES_ATTR: port_serdes_rid:0x\w+ has no lane count information.*"
+
 # Ignore loganalyzer add marker logs in case the test name matches an error pattern
 r, ".*INFO.*ansible.*loganalyzer.py.*--action add.*marker.*"

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -521,7 +521,8 @@ r, ".* ERR auditd.*: auditd queue full reporting limit reached - ending dropped 
 r, ".* ERR ctrmgrd\.py: Refer file .* for troubleshooting tips.*"
 r, ".* ERR ctrmgrd\.py:.*\[WARNING SystemVerification\]:.*Docker version is not on the list of validated versions.*"
 
-# syncd port serdes lane count info not available
+# syncd port serdes lane count info not available (fixed in https://github.com/sonic-net/sonic-sairedis/pull/1945)
+# tracked by https://github.com/sonic-net/sonic-sairedis/issues/1946
 r, ".* ERR syncd\d*#syncd: :- initAttrData: PORT_PHY_SERDES_ATTR: port_serdes_rid:0x\w+ has no lane count information.*"
 
 # Ignore loganalyzer add marker logs in case the test name matches an error pattern


### PR DESCRIPTION
### Description of PR

Summary: Add `syncd` port serdes lane count error to the loganalyzer global ignore list. This error (`port_serdes_rid has no lane count information`) is a benign informational message from syncd that does not indicate a real failure, but causes unrelated tests to fail when loganalyzer detects it.

The root cause fix is tracked by [sonic-net/sonic-sairedis#1946](https://github.com/sonic-net/sonic-sairedis/issues/1946) and addressed in [sonic-net/sonic-sairedis#1945](https://github.com/sonic-net/sonic-sairedis/pull/1945). This ignore entry can be removed once that fix is merged and deployed.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: Verified loganalyzer no longer flags `port_serdes_rid ... has no lane count information` errors during test runs on 7060x6-512 platform.

### Approach
#### What is the motivation for this PR?

Tests on platforms reporting `PORT_PHY_SERDES_ATTR: port_serdes_rid:0x... has no lane count information` fail due to loganalyzer catching this as an unexpected ERR syslog. The message is harmless and unrelated to test functionality. The underlying issue is tracked in [sonic-net/sonic-sairedis#1946](https://github.com/sonic-net/sonic-sairedis/issues/1946) with a fix in [sonic-net/sonic-sairedis#1945](https://github.com/sonic-net/sonic-sairedis/pull/1945).

#### How did you do it?

Added a regex entry to `ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt` to suppress this message globally.

#### How did you verify/test it?

Ran tests that previously failed due to this error and confirmed loganalyzer no longer raises false failures.

#### Any platform specific information?

Observed on Arista 7060X6 but the ignore is generic enough to cover any platform emitting this syncd message.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A