### PR TITLE
[process_monitoring]: Fix BGP recovery wait

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -71,8 +71,11 @@ def _filter_bmc_unsupported(duthost, container_name, critical_process_list):
 @pytest.fixture(autouse=True, scope='module')
 def config_reload_after_tests(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
+    up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
     yield
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=False)
+    if not postcheck_critical_processes_status(duthost, up_bgp_neighbors):
+        pytest.fail("Post-check failed after the module config reload!")
 
 
 @pytest.fixture(autouse=True, scope='module')
@@ -720,7 +723,7 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
     else:
         # Normal recovery for other containers
         logger.info("Executing the config reload...")
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=False)
         logger.info("Executing the config reload was done!")
 
         ensure_all_critical_processes_running(duthost, containers_in_namespaces)

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -33,6 +33,7 @@ CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_RESTART_THRESHOLD_SECS = 180
 POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 600
+# config_reload adds 120 seconds to these values for its BGP convergence check.
 CONFIG_RELOAD_WAIT_SECS = 120
 LT2_CONFIG_RELOAD_WAIT_SECS = 480
 
@@ -719,7 +720,8 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
                         % db_config_timeout)
 
         logger.info("Database config ready, performing config reload for clean recovery...")
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True,
+                      wait=get_config_reload_wait(tbinfo), wait_for_bgp=True)
 
         ensure_all_critical_processes_running(duthost, containers_in_namespaces)
 

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -33,6 +33,8 @@ CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_RESTART_THRESHOLD_SECS = 180
 POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 600
+CONFIG_RELOAD_WAIT_SECS = 120
+LT2_CONFIG_RELOAD_WAIT_SECS = 480
 
 # Delay (seconds) between issuing the SysRq kernel reboot and when it fires.
 # Used on multi-ASIC VS: the reboot is scheduled just before the global DB
@@ -68,11 +70,16 @@ def _filter_bmc_unsupported(duthost, container_name, critical_process_list):
     return filtered
 
 
+def get_config_reload_wait(tbinfo):
+    return LT2_CONFIG_RELOAD_WAIT_SECS if tbinfo["topo"]["type"] == "lt2" else CONFIG_RELOAD_WAIT_SECS
+
+
 @pytest.fixture(autouse=True, scope='module')
-def config_reload_after_tests(duthosts, rand_one_dut_hostname):
+def config_reload_after_tests(duthosts, rand_one_dut_hostname, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     yield
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait=480, wait_for_bgp=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True,
+                  wait=get_config_reload_wait(tbinfo), wait_for_bgp=True)
 
 
 @pytest.fixture(autouse=True, scope='module')
@@ -720,7 +727,8 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
     else:
         # Normal recovery for other containers
         logger.info("Executing the config reload...")
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait=480, wait_for_bgp=True)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True,
+                      wait=get_config_reload_wait(tbinfo), wait_for_bgp=True)
         logger.info("Executing the config reload was done!")
 
         ensure_all_critical_processes_running(duthost, containers_in_namespaces)

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -71,11 +71,8 @@ def _filter_bmc_unsupported(duthost, container_name, critical_process_list):
 @pytest.fixture(autouse=True, scope='module')
 def config_reload_after_tests(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
-    up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
     yield
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=False)
-    if not postcheck_critical_processes_status(duthost, up_bgp_neighbors):
-        pytest.fail("Post-check failed after the module config reload!")
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait=480, wait_for_bgp=True)
 
 
 @pytest.fixture(autouse=True, scope='module')
@@ -723,7 +720,7 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
     else:
         # Normal recovery for other containers
         logger.info("Executing the config reload...")
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=False)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait=480, wait_for_bgp=True)
         logger.info("Executing the config reload was done!")
 
         ensure_all_critical_processes_running(duthost, containers_in_namespaces)


### PR DESCRIPTION
### Description of PR

Summary:
Fix process-monitoring cleanup failures by allowing additional time for LT2 BGP neighbors to converge after configuration reload, without changing the timeout for other topologies.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: other

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] N/A

### Test result

- internal-202512, SONiC.20251210.10: `process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes` passed on `vms13-lt2-nh4210-1`: `1 passed, 1 deselected` in 14m35s.
- The database path was skipped because this physical testbed has no PDU recovery controller; the validation exercised normal recovery and module cleanup. The database recovery call uses the same topology-scoped helper.
- master: `python -m py_compile tests/process_monitoring/test_critical_process_monitoring.py`

### Approach
#### What is the motivation for this PR?

The process-monitoring test body passes, but cleanup can fail on LT2 testbeds because the default `config_reload` BGP convergence timeout expires before all neighbors recover. Applying the longer wait globally would unnecessarily change recovery behavior and runtime for other topologies.

#### How did you do it?

Added a helper that returns `wait=480` only when `tbinfo["topo"]["type"] == "lt2"` and preserves the existing `wait=120` elsewhere. Normal recovery, database recovery, and module cleanup use this helper.

`config_reload` adds 120 seconds to `wait` for its BGP check, so:

- LT2 receives up to 600 seconds for BGP recovery.
- Other topologies retain the existing 240-second recovery window.

#### How did you verify/test it?

Validated the affected test on `vms13-lt2-nh4210-1`. It passed with all IPv4 and IPv6 BGP sessions restored, and both config reload paths completed successfully. Also ran Python syntax validation and `git diff --check`.

#### Any platform specific information?

The failure was observed on the Nexthop NH-4210 LT2 testbed, where BGP convergence after config reload can exceed the generic timeout.

#### Supported testbed topology if it's a new test case?

Not applicable.

### Documentation

Not applicable.
