### PR TITLE
[cacl] Contract: require FORWARD chain for multi-ASIC control-plane ACLs (follow-up to #26113)

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -527,19 +527,7 @@ def append_midplane_traffic_rules(duthost, iptables_rules):
         iptables_rules.append("-A INPUT -s {}/32 -d {}/32 -j ACCEPT".format(midplane_ip, midplane_ip))
 
 
-def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby,
-                            use_forward_chain_for_multiasic=False):
-    """
-    Args:
-        ...
-        use_forward_chain_for_multiasic: When True (and asic_index is not None), generate the newer
-            expected iptables rules that use the FORWARD chain (instead of INPUT) for control-plane
-            ACL rules on multi-asic platforms, matching caclmgrd's namespace-to-host forwarding
-            security patch. Kept as an opt-in flag (default False) so callers/tests can build both
-            the pre-patch and post-patch expected rule sets and tolerate either one on the DUT,
-            avoiding a hard dependency between this test change and the caclmgrd code change landing
-            in lock-step.
-    """
+def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby):
     iptables_rules = []
     ip6tables_rules = []
 
@@ -673,9 +661,8 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
     rules_applied_from_config = 0
 
     # On multi-asic platforms, caclmgrd forwards namespace-originated control-plane traffic
-    # for select services (e.g. SSH/SNMP) to the host via the FORWARD chain. Explicitly allow
-    # that forwarded traffic when the newer FORWARD-chain-based behavior is expected.
-    if asic_index is not None and use_forward_chain_for_multiasic:
+    # for select services (e.g. SSH/SNMP) to the host via the FORWARD chain.
+    if asic_index is not None:
         for acl_service, acl_service_info in ACL_SERVICES.items():
             if acl_service_info["multi_asic_ns_to_host_fwd"]:
                 for ip_protocol in acl_service_info["ip_protocols"]:
@@ -734,7 +721,7 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
                 # Apply the rule to the default protocol(s) for this ACL service
                 for ip_protocol in ip_protocols:
                     for dst_port in dst_ports:
-                        if asic_index is not None and use_forward_chain_for_multiasic:
+                        if asic_index is not None:
                             new_iptables_rule = "-A FORWARD"
                         else:
                             new_iptables_rule = "-A INPUT"
@@ -790,7 +777,7 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
         # Default drop rules
         iptables_rules.append("-A INPUT -j DROP")
         ip6tables_rules.append("-A INPUT -j DROP")
-        if asic_index is not None and use_forward_chain_for_multiasic:
+        if asic_index is not None:
             iptables_rules.append("-A FORWARD -j DROP")
             ip6tables_rules.append("-A FORWARD -j DROP")
 
@@ -1143,45 +1130,22 @@ def verify_cacl_show_acl_rule(duthost, acl_file):
 
 def verify_cacl(duthost, tbinfo, localhost, creds, docker_network,
                 expected_dhcp_rules_for_standby=None, asic_index=None):
-    # Build two variants of the expected rules: the "legacy" INPUT-chain based rules, and the
-    # newer FORWARD-chain based rules used by caclmgrd's multi-asic namespace-to-host forwarding
-    # security patch (restricting SSH/SNMP/etc. namespace->host forwarding to specific IP ranges).
-    # On single-asic platforms (asic_index is None) both variants are identical. Accepting either
-    # variant lets this test change merge independently of the caclmgrd code change landing,
-    # avoiding a cyclic cross-repo merge-order dependency between the two PRs.
-    expected_iptables_rules_legacy, expected_ip6tables_rules_legacy = \
-        generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby,
-                                use_forward_chain_for_multiasic=False)
-    expected_iptables_rules_fwd, expected_ip6tables_rules_fwd = \
-        generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby,
-                                use_forward_chain_for_multiasic=True)
+    expected_iptables_rules, expected_ip6tables_rules = \
+        generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby)
 
     stdout = duthost.get_asic_or_sonic_host(asic_index).command("iptables -S")["stdout"]
     actual_iptables_rules = stdout.strip().split("\n")
 
-    logger.info("Number of expected iptable rules (legacy/forward-chain):{}/{}, number of actual iptables rules:{}"
-                .format(len(set(expected_iptables_rules_legacy)), len(set(expected_iptables_rules_fwd)),
-                        len(set(actual_iptables_rules))))
+    logger.info("Number of expected iptable rules:{}, number of actual iptables rules:{}"
+                .format(len(set(expected_iptables_rules)), len(set(actual_iptables_rules))))
 
-    # Ensure the actual iptables rules match either the legacy or the FORWARD-chain expected rule set
-    missing_iptables_rules_legacy = set(expected_iptables_rules_legacy) - set(actual_iptables_rules)
-    unexpected_iptables_rules_legacy = set(actual_iptables_rules) - set(expected_iptables_rules_legacy)
-    missing_iptables_rules_fwd = set(expected_iptables_rules_fwd) - set(actual_iptables_rules)
-    unexpected_iptables_rules_fwd = set(actual_iptables_rules) - set(expected_iptables_rules_fwd)
+    missing_iptables_rules = set(expected_iptables_rules) - set(actual_iptables_rules)
+    pytest_assert(len(missing_iptables_rules) == 0, "Missing expected iptables rules: {}"
+                  .format(repr(missing_iptables_rules)))
 
-    iptables_rules_match_legacy = len(missing_iptables_rules_legacy) == 0 and \
-        len(unexpected_iptables_rules_legacy) == 0
-    iptables_rules_match_fwd = len(missing_iptables_rules_fwd) == 0 and len(unexpected_iptables_rules_fwd) == 0
-
-    pytest_assert(
-        iptables_rules_match_legacy or iptables_rules_match_fwd,
-        "iptables rules did not match either the legacy (pre multi-asic FORWARD-chain security patch) or "
-        "the newer (post-patch) expected rule set.\n"
-        "Legacy variant - missing: {}, unexpected: {}\n"
-        "FORWARD-chain variant - missing: {}, unexpected: {}"
-        .format(repr(missing_iptables_rules_legacy), repr(unexpected_iptables_rules_legacy),
-                repr(missing_iptables_rules_fwd), repr(unexpected_iptables_rules_fwd))
-    )
+    unexpected_iptables_rules = set(actual_iptables_rules) - set(expected_iptables_rules)
+    pytest_assert(len(unexpected_iptables_rules) == 0, "Unexpected iptables rules: {}"
+                  .format(repr(unexpected_iptables_rules)))
 
     # TODO: caclmgrd currently applies the "block_ip2me" rules in the order it gathers the interfaces and
     #       their IPs from Config DB, which is indeterminate. We first need to modify caclmgrd to sort
@@ -1194,29 +1158,16 @@ def verify_cacl(duthost, tbinfo, localhost, creds, docker_network,
     stdout = duthost.get_asic_or_sonic_host(asic_index).command("ip6tables -S")["stdout"]
     actual_ip6tables_rules = stdout.strip().split("\n")
 
-    logger.info("Number of expected ip6table rules (legacy/forward-chain):{}/{}, number of actual ip6tables rules:{}"
-                .format(len(set(expected_ip6tables_rules_legacy)), len(set(expected_ip6tables_rules_fwd)),
-                        len(set(actual_ip6tables_rules))))
+    logger.info("Number of expected ip6table rules:{}, number of actual ip6tables rules:{}"
+                .format(len(set(expected_ip6tables_rules)), len(set(actual_ip6tables_rules))))
 
-    # Ensure the actual ip6tables rules match either the legacy or the FORWARD-chain expected rule set
-    missing_ip6tables_rules_legacy = set(expected_ip6tables_rules_legacy) - set(actual_ip6tables_rules)
-    unexpected_ip6tables_rules_legacy = set(actual_ip6tables_rules) - set(expected_ip6tables_rules_legacy)
-    missing_ip6tables_rules_fwd = set(expected_ip6tables_rules_fwd) - set(actual_ip6tables_rules)
-    unexpected_ip6tables_rules_fwd = set(actual_ip6tables_rules) - set(expected_ip6tables_rules_fwd)
+    missing_ip6tables_rules = set(expected_ip6tables_rules) - set(actual_ip6tables_rules)
+    pytest_assert(len(missing_ip6tables_rules) == 0, "Missing expected ip6tables rules: {}"
+                  .format(repr(missing_ip6tables_rules)))
 
-    ip6tables_rules_match_legacy = len(missing_ip6tables_rules_legacy) == 0 and \
-        len(unexpected_ip6tables_rules_legacy) == 0
-    ip6tables_rules_match_fwd = len(missing_ip6tables_rules_fwd) == 0 and len(unexpected_ip6tables_rules_fwd) == 0
-
-    pytest_assert(
-        ip6tables_rules_match_legacy or ip6tables_rules_match_fwd,
-        "ip6tables rules did not match either the legacy (pre multi-asic FORWARD-chain security patch) or "
-        "the newer (post-patch) expected rule set.\n"
-        "Legacy variant - missing: {}, unexpected: {}\n"
-        "FORWARD-chain variant - missing: {}, unexpected: {}"
-        .format(repr(missing_ip6tables_rules_legacy), repr(unexpected_ip6tables_rules_legacy),
-                repr(missing_ip6tables_rules_fwd), repr(unexpected_ip6tables_rules_fwd))
-    )
+    unexpected_ip6tables_rules = set(actual_ip6tables_rules) - set(expected_ip6tables_rules)
+    pytest_assert(len(unexpected_ip6tables_rules) == 0, "Unexpected ip6tables rules: {}"
+                  .format(repr(unexpected_ip6tables_rules)))
 
     # TODO: caclmgrd currently applies the "block_ip2me" rules in the order it gathers the interfaces and
     #       their IPs from Config DB, which is indeterminate. We first need to modify caclmgrd to sort


### PR DESCRIPTION
## Description

Follow-up 'contract' to the expand-then-contract approach in #26113, now that **sonic-buildimage#28061** (which includes sonic-host-services#389) has merged to master.

caclmgrd now uses the **FORWARD chain exclusively** for namespace-originated control-plane ACL traffic (SSH, SNMP, etc.) on multi-ASIC platforms. The legacy INPUT-chain compatibility shim is no longer needed.

## What this PR does

**`tests/cacl/test_cacl_application.py`:**

### `generate_expected_rules()`
- Removes the `use_forward_chain_for_multiasic` opt-in flag (and its docstring)
- Always generates FORWARD-chain rules when `asic_index is not None` — 3 sites:
  1. FORWARD ACCEPT rules for SSH/SNMP src-IP-matched traffic
  2. Per-rule `-A FORWARD` instead of `-A INPUT` for ACL table rules
  3. `-A FORWARD -j DROP` catch-all

### `verify_cacl()`
- Removes the dual-variant legacy/forward-chain tolerance added in #26113
- Single call to `generate_expected_rules()` with clean `missing`/`unexpected` assertions for both `iptables` and `ip6tables`

## Relation to other PRs

| PR | What it does |
|----|-------------|
| #26113 (merged) | Expand: tolerate both INPUT and FORWARD chains |
| **This PR** | Contract: require FORWARD chain only |
| #26935 | Add expected FRR OUTPUT rules (ports 2601/2620) — independent |