### PR TITLE
Reset BGP service restart counter before restarts

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -240,6 +240,7 @@ def remove_bgp_neighbors(duthost, asic_index):
     duthost.shell(cmd)
 
     # Restart BGP instance on that asic
+    duthost.asic_instance(asic_index).reset_service("bgp")
     duthost.restart_service_on_asic("bgp", asic_index)
     pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started_per_asic_or_host, "bgp"), "BGP not started.")
 
@@ -258,6 +259,7 @@ def restore_bgp_neighbors(duthost, asic_index, bgp_neighbors):
     duthost.shell("sudo sonic-cfggen {} -a '{}' --write-to-db".format(namespace_prefix, bgp_neigh_json))
 
     # Restart BGP instance on that asic
+    duthost.asic_instance(asic_index).reset_service("bgp")
     duthost.restart_service_on_asic("bgp", asic_index)
     pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started_per_asic_or_host, "bgp"), "BGP not started.")
 

--- a/tests/bgp/test_prefix_list_suppress.py
+++ b/tests/bgp/test_prefix_list_suppress.py
@@ -315,6 +315,10 @@ def restart_bgp_container(duthost):
     # 1. Restart all ASICs in parallel
     for service, _ in service_container_pairs:
         duthost.shell(
+            "sudo systemctl reset-failed {}".format(service),
+            module_ignore_errors=True,
+        )
+        duthost.shell(
             "sudo systemctl restart {}".format(service),
             module_ignore_errors=True,
         )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Running `test_prefix_list_suppress` before `test_TSA_B_C_with_no_neighbors` can exhaust BGP's 3 starts in 20-minute limit, configured by `StartLimitBurst=3` and `StartLimitIntervalSec=1200.`

Reset the counter before BGP restarts. `reset_service()` and `systemctl reset-failed` are equivalent here; one resolves the ASIC while the other uses its resolved service name.

Fixes #26940
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202605: bgp/test_prefix_list_suppress.py and bgp/test_traffic_shift.py passed when running together

### Approach
#### What is the motivation for this PR?
`bgp/test_traffic_shift.py::test_TSA_B_C_with_no_neighbors` failed after running new test case `bgp/test_prefix_list_suppress.py`

#### How did you do it?
Reset BGP service restart counter before bgp restarts

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Run `bgp/test_prefix_list_suppress.py` then `bgp/test_traffic_shift.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
