### PR TITLE
Prevent warmboot state from polluting static route config reload test

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -588,6 +588,52 @@ def test_static_route_ecmp_ipv6(rand_selected_dut, rand_unselected_dut, ptfadapt
                           is_route_flow_counter_supported, ipv6=True, config_reload_test=True)
 
 
+# Keep non-reboot coverage ahead of warmboot tests. A failed warmboot can leave
+# SWSS/FIB unhealthy and cascade false wrong-egress failures into later cases.
+@pytest.mark.disable_loganalyzer
+def test_static_route_config_reload_with_traffic(rand_selected_dut, rand_unselected_dut, ptfadapter, ptfhost, tbinfo,
+                                                 setup_standby_ports_on_rand_unselected_tor, # noqa F811
+                                                 toggle_all_simulator_ports_to_rand_selected_tor_m, is_route_flow_counter_supported): # noqa F811
+    """
+    Test static route persistence through config reload with comprehensive traffic validation.
+    This test validates that:
+    1. Static routes are configured and traffic flows correctly
+    2. Routes persist through config reload
+    3. Traffic resumes correctly after config reload
+    4. BGP route advertisement is restored properly
+    """
+    duthost = rand_selected_dut
+    unselected_duthost = rand_unselected_dut
+    is_dual_tor = 'dualtor' in tbinfo['topo']['name'] and unselected_duthost is not None
+    prefix = "5.5.5.0/24"
+
+    with static_route_context(duthost, unselected_duthost, ptfadapter, ptfhost, tbinfo,
+                              prefix, nexthop_count=2,
+                              is_route_flow_counter_supported_flag=is_route_flow_counter_supported,
+                              ipv6=False):
+        # Perform config reload
+        duthost.shell('config save -y')
+        if duthost.facts["platform"] == "x86_64-cel_e1031-r0":
+            config_reload(duthost, wait=500)
+        else:
+            config_reload(duthost, wait=450)
+
+        # Handle potential mux state change on dualtor
+        if is_dual_tor:
+            duthost.shell("config mux mode active all")
+            unselected_duthost.shell("config mux mode standby all")
+            pytest_assert(wait_until(60, 5, 0, check_mux_status, duthost, 'active'),
+                          "Could not config ports to active")
+            pytest_assert(wait_until(60, 5, 0, check_mux_status, unselected_duthost, 'standby'),
+                          "Could not config ports to standby")
+
+        # Additional dualtor cleanup
+        if is_dual_tor:
+            duthost.shell('config mux mode auto all')
+            unselected_duthost.shell('config mux mode auto all')
+            unselected_duthost.shell('config save -y')
+
+
 @pytest.mark.disable_loganalyzer
 def test_static_route_warmboot(localhost, rand_selected_dut, rand_unselected_dut, ptfadapter, ptfhost, tbinfo,
                                setup_standby_ports_on_rand_unselected_tor, # noqa F811
@@ -662,50 +708,6 @@ def test_static_route_ipv6_warmboot(localhost, rand_selected_dut, rand_unselecte
         # Perform warmboot
         duthost.shell('config save -y')
         reboot(duthost, localhost, reboot_type='warm', wait_warmboot_finalizer=True, safe_reboot=True)
-
-
-@pytest.mark.disable_loganalyzer
-def test_static_route_config_reload_with_traffic(rand_selected_dut, rand_unselected_dut, ptfadapter, ptfhost, tbinfo,
-                                                 setup_standby_ports_on_rand_unselected_tor, # noqa F811
-                                                 toggle_all_simulator_ports_to_rand_selected_tor_m, is_route_flow_counter_supported): # noqa F811
-    """
-    Test static route persistence through config reload with comprehensive traffic validation.
-    This test validates that:
-    1. Static routes are configured and traffic flows correctly
-    2. Routes persist through config reload
-    3. Traffic resumes correctly after config reload
-    4. BGP route advertisement is restored properly
-    """
-    duthost = rand_selected_dut
-    unselected_duthost = rand_unselected_dut
-    is_dual_tor = 'dualtor' in tbinfo['topo']['name'] and unselected_duthost is not None
-    prefix = "5.5.5.0/24"
-
-    with static_route_context(duthost, unselected_duthost, ptfadapter, ptfhost, tbinfo,
-                              prefix, nexthop_count=2,
-                              is_route_flow_counter_supported_flag=is_route_flow_counter_supported,
-                              ipv6=False):
-        # Perform config reload
-        duthost.shell('config save -y')
-        if duthost.facts["platform"] == "x86_64-cel_e1031-r0":
-            config_reload(duthost, wait=500)
-        else:
-            config_reload(duthost, wait=450)
-
-        # Handle potential mux state change on dualtor
-        if is_dual_tor:
-            duthost.shell("config mux mode active all")
-            unselected_duthost.shell("config mux mode standby all")
-            pytest_assert(wait_until(60, 5, 0, check_mux_status, duthost, 'active'),
-                          "Could not config ports to active")
-            pytest_assert(wait_until(60, 5, 0, check_mux_status, unselected_duthost, 'standby'),
-                          "Could not config ports to standby")
-
-        # Additional dualtor cleanup
-        if is_dual_tor:
-            duthost.shell('config mux mode auto all')
-            unselected_duthost.shell('config mux mode auto all')
-            unselected_duthost.shell('config save -y')
 
 
 def check_static_route_removed(duthost, prefix, ipv6):

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -588,8 +588,8 @@ def test_static_route_ecmp_ipv6(rand_selected_dut, rand_unselected_dut, ptfadapt
                           is_route_flow_counter_supported, ipv6=True, config_reload_test=True)
 
 
-# Keep non-reboot coverage ahead of warmboot tests. A failed warmboot can leave
-# SWSS/FIB unhealthy and cascade false wrong-egress failures into later cases.
+# Keep this config-reload test ahead of warmboot tests. A failed warmboot can
+# leave SWSS/FIB unhealthy and make this case report a false wrong-egress failure.
 @pytest.mark.disable_loganalyzer
 def test_static_route_config_reload_with_traffic(rand_selected_dut, rand_unselected_dut, ptfadapter, ptfhost, tbinfo,
                                                  setup_standby_ports_on_rand_unselected_tor, # noqa F811


### PR DESCRIPTION
### Description of PR

Summary:
Move `test_static_route_config_reload_with_traffic` before the disruptive
warmboot cases in `test_static_route.py`.

A failed warmboot can leave orchagent/SWSS unhealthy while the module continues
running. The later config-reload case then programs its static route in software
but sends traffic through the M1 default route, producing a false wrong-egress
failure even though its expected server-port selection is correct.

The change preserves all test logic and only isolates the non-reboot coverage
from state left by failed warmboot tests.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38723051

Affected test:
- `route/test_static_route.py::test_static_route_config_reload_with_traffic`
- `internal-202605`, Arista-720DT-G48S4, M0 and MX
- 60/60 retry-deduplicated nightly plan failures across
  `SONiC.20260510.04` through `.09`

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
https://msazure.visualstudio.com/One/_workitems/edit/38723051

Failure type: day-one test-order issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: repository pre-commit suite passed for
  `tests/route/test_static_route.py`.
- 202605: `SONiC.20260510.09` (`ed7a797580`) on
  `testbed-bjw2-can-720dt-5` (Arista-720DT-G48S4, M0):
  - Recovered pretest: 11 passed, 3 skipped.
  - Target alone: passed.
  - Warmboot then target: reproduced warmboot critical-process failure,
    orchagent core, and target wrong egress (`51` instead of server ports).
  - Target then warmboot: target passed; warmboot failed independently.
  - Patched full module: target passed in its new position; only the three
    independent warmboot cases failed.
  - Patched target repetition: 5/5 passed in 3568.96 seconds.

### Approach
#### What is the motivation for this PR?

The 720DT M0/MX 202605 nightlies consistently attributed a wrong-egress
failure to the config-reload case. Hardware A/B testing proved that the case
passes on a healthy DUT and fails only when it follows the first warmboot test,
which creates an orchagent core and leaves the FIB unhealthy.

#### How did you do it?

Move the non-reboot config-reload test before all warmboot tests and add a
short comment documenting the ordering invariant.

#### How did you verify/test it?

Used the exact failing 202605 image and matching `internal-202605` test branch
on physical 720DT M0 hardware. The A/B order tests established causality, the
patched full module proved the new collection position, and five consecutive
target repetitions passed.

#### Any platform specific information?

Reproduced on Broadcom Arista-720DT-G48S4 M0. The nightly signature affects
both 720DT M0 and MX.

#### Supported testbed topology if it's a new test case?

Not a new test. Existing topology support is unchanged.

### Documentation

Not applicable.
