### PR TITLE
[smartswitch]: Skip admin-down DPUs during image upgrade

### DIFF
--- a/ansible/library/test_upgrade_dpu_sonic_image.py
+++ b/ansible/library/test_upgrade_dpu_sonic_image.py
@@ -1,0 +1,230 @@
+"""Unit tests for upgrade_dpu_sonic_image.py."""
+
+import importlib.util
+import os
+import sys
+import threading
+import types
+
+import pytest
+
+
+class ModuleExit(Exception):
+    """Represent Ansible module exit_json/fail_json calls in unit tests."""
+
+    def __init__(self, results):
+        super(ModuleExit, self).__init__(results.get("msg"))
+        self.results = results
+
+
+class FakeAnsibleModule(object):
+    def __init__(self, command_results=None):
+        self.command_results = list(command_results or [])
+        self.commands = []
+
+    def run_command(self, command, **kwargs):
+        self.commands.append(command)
+        return self.command_results.pop(0)
+
+    def fail_json(self, **kwargs):
+        raise ModuleExit(kwargs)
+
+    def exit_json(self, **kwargs):
+        raise ModuleExit(kwargs)
+
+
+def _load_upgrade_module():
+    ansible = types.ModuleType("ansible")
+    module_utils = types.ModuleType("ansible.module_utils")
+    basic = types.ModuleType("ansible.module_utils.basic")
+    basic.AnsibleModule = object
+    smartswitch_utils = types.ModuleType("ansible.module_utils.smartswitch_utils")
+    smartswitch_utils.smartswitch_hwsku_config = {}
+    debug_utils = types.ModuleType("ansible.module_utils.debug_utils")
+    debug_utils.config_module_logging = lambda _: None
+
+    saved_modules = {}
+    fake_modules = {
+        "ansible": ansible,
+        "ansible.module_utils": module_utils,
+        "ansible.module_utils.basic": basic,
+        "ansible.module_utils.smartswitch_utils": smartswitch_utils,
+        "ansible.module_utils.debug_utils": debug_utils,
+    }
+    for name, module in fake_modules.items():
+        saved_modules[name] = sys.modules.get(name)
+        sys.modules[name] = module
+
+    try:
+        module_path = os.path.join(os.path.dirname(__file__), "upgrade_dpu_sonic_image.py")
+        spec = importlib.util.spec_from_file_location("upgrade_dpu_sonic_image", module_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                del sys.modules[name]
+            else:
+                sys.modules[name] = module
+
+
+upgrade_module = _load_upgrade_module()
+
+
+def make_upgrade(command_results=None, dpu_num=3, target_dpu_index=-1):
+    upgrade = upgrade_module.UpgradeDpuSonicImageModule.__new__(
+        upgrade_module.UpgradeDpuSonicImageModule)
+    upgrade.module = FakeAnsibleModule(command_results)
+    upgrade.messages = []
+    upgrade._log_lock = threading.Lock()
+    upgrade._cli_lock = threading.Lock()
+    upgrade.dpu_num = dpu_num
+    upgrade.target_dpu_index = target_dpu_index
+    return upgrade
+
+
+def test_get_installed_images_normalizes_leading_slash():
+    """Image names should not retain the leading slash emitted by some installers."""
+    upgrade = make_upgrade([
+        (True, "Current: /SONiC-OS-20251110.34\nNext: SONiC-OS-20251110.34\n", ""),
+    ])
+    upgrade.execute_command = lambda *args, **kwargs: upgrade.module.command_results.pop(0)
+
+    assert upgrade.get_installed_images(object(), "169.254.200.1") == (
+        True, "SONiC-OS-20251110.34", "SONiC-OS-20251110.34")
+
+
+def test_prepare_image_for_reboot_maps_uboot_image_to_physical_slot():
+    """U-Boot selection must use the physical slot rather than the compact image list."""
+    upgrade = make_upgrade()
+    commands = []
+    results = iter([
+        (True, "NONE\nSONiC-OS-20260510.10\n", ""),
+        (True, "", ""),
+        (True, "", ""),
+        (True, "", ""),
+        (True, "run sonic_image_2\n", ""),
+    ])
+    upgrade.execute_command = lambda _, __, command: commands.append(command) or next(results)
+
+    assert upgrade.prepare_image_for_reboot(
+        object(), "169.254.200.1", "SONiC-OS-20260510.10") is True
+    assert commands[1:] == [
+        "sudo fw_setenv boot_next 'run sonic_image_2'",
+        "sudo fw_setenv boot_once 'run sonic_image_2'",
+        "sudo sync",
+        "fw_printenv -n boot_next",
+    ]
+
+
+@pytest.mark.parametrize("results", [
+    [(False, "", "slot read failed")],
+    [(True, "NONE\nSONiC-OS-20260510.10\n", ""), (False, "", "boot_next failed")],
+    [(True, "NONE\nSONiC-OS-20260510.10\n", ""), (True, "", ""), (False, "", "boot_once failed")],
+    [(True, "NONE\nSONiC-OS-20260510.10\n", ""), (True, "", ""), (True, "", ""),
+     (False, "", "sync failed")],
+])
+def test_prepare_image_for_reboot_rejects_command_failure(results):
+    """Any boot-selection command failure must prevent a reboot."""
+    upgrade = make_upgrade()
+    command_results = iter(results)
+    upgrade.execute_command = lambda *args: next(command_results)
+
+    assert upgrade.prepare_image_for_reboot(
+        object(), "169.254.200.1", "SONiC-OS-20260510.10") is False
+
+
+@pytest.mark.parametrize("slot_output", [
+    "NONE\nNONE\n",
+    "SONiC-OS-20260510.10\nSONiC-OS-20260510.10\n",
+])
+def test_prepare_image_for_reboot_rejects_missing_or_duplicate_uboot_slot(slot_output):
+    """An ambiguous U-Boot slot mapping must prevent the chassis power cycle."""
+    upgrade = make_upgrade()
+    upgrade.execute_command = lambda *args: (True, slot_output, "")
+
+    assert upgrade.prepare_image_for_reboot(
+        object(), "169.254.200.1", "SONiC-OS-20260510.10") is False
+
+
+def test_prepare_image_for_reboot_uses_installer_on_non_uboot_platform():
+    """Non-U-Boot platforms should retain the sonic-installer selection path."""
+    upgrade = make_upgrade()
+    commands = []
+    results = iter([
+        (True, "__NOT_UBOOT__\n", ""),
+        (True, "", ""),
+        (True, "", ""),
+        (True, "", ""),
+    ])
+    upgrade.execute_command = lambda _, __, command: commands.append(command) or next(results)
+    upgrade.get_installed_images = lambda *_: (
+        True, "SONiC-OS-20251110.34", "SONiC-OS-20260510.10")
+
+    assert upgrade.prepare_image_for_reboot(
+        object(), "169.254.200.1", "SONiC-OS-20260510.10") is True
+    assert commands[1:] == [
+        "sudo sonic-installer set-default SONiC-OS-20260510.10",
+        "sudo sonic-installer set-next-boot SONiC-OS-20260510.10",
+        "sudo sync",
+    ]
+
+
+def test_get_admin_up_dpu_indices_skips_admin_down_dpus():
+    """Only DPUs with admin_status=up should remain upgrade targets."""
+    upgrade = make_upgrade([
+        (0, "up\n", ""),
+        (0, "down\n", ""),
+        (0, "UP\n", ""),
+    ])
+
+    admin_up, skipped = upgrade.get_admin_up_dpu_indices([0, 1, 2])
+
+    assert admin_up == [0, 2]
+    assert skipped == [1]
+    assert upgrade.module.commands == [
+        'sonic-db-cli CONFIG_DB HGET "CHASSIS_MODULE|DPU0" admin_status',
+        'sonic-db-cli CONFIG_DB HGET "CHASSIS_MODULE|DPU1" admin_status',
+        'sonic-db-cli CONFIG_DB HGET "CHASSIS_MODULE|DPU2" admin_status',
+    ]
+
+
+@pytest.mark.parametrize("command_result, expected_message", [
+    ((1, "", "database unavailable"), "Failed to read admin status for DPU0"),
+    ((0, "", ""), "Invalid or missing admin status '' for DPU0"),
+])
+def test_get_admin_up_dpu_indices_rejects_unreadable_status(command_result, expected_message):
+    """Unreadable admin state should fail rather than accidentally upgrade a DPU."""
+    upgrade = make_upgrade([command_result], dpu_num=1)
+
+    with pytest.raises(ModuleExit, match=expected_message):
+        upgrade.get_admin_up_dpu_indices([0])
+
+
+def test_upgrade_dpus_does_not_download_when_all_targets_are_admin_down():
+    """An all-admin-down target set should complete without downloading an image."""
+    upgrade = make_upgrade([
+        (0, "down\n", ""),
+        (0, "down\n", ""),
+    ], dpu_num=2)
+    upgrade.download_image_on_npu = lambda: pytest.fail("image should not be downloaded")
+
+    assert upgrade.upgrade_dpus() == (0, 0, [0, 1])
+
+
+def test_run_reports_admin_down_target_as_unchanged():
+    """A specifically targeted admin-down DPU should be skipped without changes."""
+    upgrade = make_upgrade([(0, "down\n", "")], dpu_num=2, target_dpu_index=1)
+    upgrade.download_image_on_npu = lambda: pytest.fail("image should not be downloaded")
+
+    with pytest.raises(ModuleExit) as exc:
+        upgrade.run()
+
+    assert exc.value.results["changed"] is False
+    assert exc.value.results["success_count"] == 0
+    assert exc.value.results["failure_count"] == 0
+    assert exc.value.results["total_dpus"] == 0
+    assert exc.value.results["skipped_dpus"] == [1]
+    assert exc.value.results["msg"] == (
+        "No admin-up DPUs to upgrade (skipped 1 admin-down DPU(s))")

--- a/ansible/library/upgrade_dpu_sonic_image.py
+++ b/ansible/library/upgrade_dpu_sonic_image.py
@@ -361,7 +361,7 @@ class UpgradeDpuSonicImageModule(object):
 
     def prepare_image_for_reboot(self, ssh, dpu_ip, image):
         """Persist an image as both the default and one-time boot target, then verify it."""
-        # U-Boot is platform-specific; platforms without its tools use the sonic-installer path below.
+        # Pensando DPUs use U-Boot; platforms without its tools use the sonic-installer path below.
         uboot_slot_cmd = (
             "if command -v fw_printenv >/dev/null 2>&1 && command -v fw_setenv >/dev/null 2>&1; then "
             "printf '%s\\n' \"$(fw_printenv -n sonic_version_1 2>/dev/null || true)\" "

--- a/ansible/library/upgrade_dpu_sonic_image.py
+++ b/ansible/library/upgrade_dpu_sonic_image.py
@@ -21,6 +21,7 @@ short_description: Install a new SONiC image on one or all DPUs of a SmartSwitch
 description:
     - Downloads the image on the NPU (which has lab network access), then transfers
       it to each DPU via SCP over the midplane network (169.254.200.x).
+    - Skips DPUs whose CHASSIS_MODULE admin_status is down.
     - Cleans up old images, installs using sonic-installer, reboots the DPU.
     - Follows the same installation logic as reduce_and_add_sonic_images but executed
       remotely on DPUs via paramiko SSH (modeled after load_extra_dpu_config).
@@ -212,9 +213,9 @@ class UpgradeDpuSonicImageModule(object):
         curr = nxt = ""
         for line in out.split('\n'):
             if 'Current:' in line:
-                curr = line.split(':')[1].strip()
+                curr = line.split(':', 1)[1].strip().lstrip('/')
             elif 'Next:' in line:
-                nxt = line.split(':')[1].strip()
+                nxt = line.split(':', 1)[1].strip().lstrip('/')
         return ok, curr, nxt
 
     def get_host_avail_mb(self, ssh, dpu_ip):
@@ -238,22 +239,23 @@ class UpgradeDpuSonicImageModule(object):
             return None
 
     def reduce_installed_images(self, ssh, dpu_ip):
-        """Free disk space by cleaning up old DPU images, always attempting cleanup even if listing fails."""
+        """Free disk space without removing an image referenced by the bootloader."""
         self.log("[DPU {}] Step: Reducing installed images".format(dpu_ip))
 
         list_ok, curr_image, next_image = self.get_installed_images(ssh, dpu_ip)
-        if list_ok:
-            self.log("[DPU {}] Current image: '{}', Next image: '{}'".format(
-                dpu_ip, curr_image, next_image))
-            if curr_image and next_image and curr_image != next_image:
-                self.log("[DPU {}] Setting next-boot to current image".format(dpu_ip))
-                self.execute_command(ssh, dpu_ip,
-                                     "sudo sonic-installer set-next-boot {}".format(curr_image))
-        else:
+        if not (list_ok and curr_image and next_image):
             self.log("WARNING: [DPU {}] Could not list images after retries; "
-                     "attempting cleanup anyway".format(dpu_ip))
+                     "skipping cleanup to protect the boot image".format(dpu_ip))
+            return False
 
-        # Always attempt cleanup (safe: keeps Current and Next), retrying transient failures
+        self.log("[DPU {}] Current image: '{}', Next image: '{}'".format(
+            dpu_ip, curr_image, next_image))
+        if curr_image != next_image:
+            self.log("[DPU {}] Making current image the persistent and one-time boot target".format(dpu_ip))
+            if not self.prepare_image_for_reboot(ssh, dpu_ip, curr_image):
+                self.log("WARNING: [DPU {}] Could not protect current image before cleanup".format(dpu_ip))
+                return False
+
         cleaned = False
         for attempt in range(3):
             cleaned, _, err = self.execute_command(ssh, dpu_ip, "sudo sonic-installer cleanup -y")
@@ -265,7 +267,9 @@ class UpgradeDpuSonicImageModule(object):
 
         if not cleaned:
             self.log("WARNING: [DPU {}] sonic-installer cleanup did not succeed after 3 attempts".format(dpu_ip))
+            return False
         self.log("[DPU {}] Done reducing images".format(dpu_ip))
+        return True
 
     def free_up_disk_space(self, ssh, dpu_ip):
         """Remove old logs, core dumps, and other expendable files on the DPU."""
@@ -352,8 +356,82 @@ class UpgradeDpuSonicImageModule(object):
         if curr_image and curr_image != next_image:
             self.log("[DPU {}] Restoring default and next boot to current image '{}'".format(
                 dpu_ip, curr_image))
-            self.execute_command(ssh, dpu_ip, "sudo sonic-installer set-default {}".format(curr_image))
-            self.execute_command(ssh, dpu_ip, "sudo sonic-installer set-next-boot {}".format(curr_image))
+            if not self.prepare_image_for_reboot(ssh, dpu_ip, curr_image):
+                self.log("WARNING: [DPU {}] Failed to restore current image boot target".format(dpu_ip))
+
+    def prepare_image_for_reboot(self, ssh, dpu_ip, image):
+        """Persist an image as both the default and one-time boot target, then verify it."""
+        uboot_slot_cmd = (
+            "if command -v fw_printenv >/dev/null 2>&1 && command -v fw_setenv >/dev/null 2>&1; then "
+            "printf '%s\\n' \"$(fw_printenv -n sonic_version_1 2>/dev/null || true)\" "
+            "\"$(fw_printenv -n sonic_version_2 2>/dev/null || true)\"; "
+            "else echo __NOT_UBOOT__; fi"
+        )
+        slot_ok, slot_out, slot_err = self.execute_command(ssh, dpu_ip, uboot_slot_cmd)
+        if not slot_ok:
+            self.log("WARNING: [DPU {}] Failed to read boot slots for '{}': {}".format(
+                dpu_ip, image, slot_err.strip()))
+            return False
+
+        slots = slot_out.splitlines()
+        if slots != ["__NOT_UBOOT__"]:
+            matching_slots = [index for index, version in enumerate(slots[:2], 1) if version == image]
+            if len(matching_slots) != 1:
+                self.log("WARNING: [DPU {}] Image '{}' maps to {} U-Boot slots; refusing reboot".format(
+                    dpu_ip, image, len(matching_slots)))
+                return False
+
+            boot_target = "run sonic_image_{}".format(matching_slots[0])
+            quoted_target = shlex.quote(boot_target)
+            for variable in ("boot_next", "boot_once"):
+                ok, _, err = self.execute_command(
+                    ssh, dpu_ip, "sudo fw_setenv {} {}".format(variable, quoted_target))
+                if not ok:
+                    self.log("WARNING: [DPU {}] Failed to set {} to '{}': {}".format(
+                        dpu_ip, variable, boot_target, err.strip()))
+                    return False
+
+            sync_ok, _, sync_err = self.execute_command(ssh, dpu_ip, "sudo sync")
+            if not sync_ok:
+                self.log("WARNING: [DPU {}] Failed to persist U-Boot selection for '{}': {}".format(
+                    dpu_ip, image, sync_err.strip()))
+                return False
+
+            verify_cmd = "fw_printenv -n boot_next"
+            verify_ok, verify_out, verify_err = self.execute_command(ssh, dpu_ip, verify_cmd)
+            if not verify_ok or verify_out.strip() != boot_target:
+                self.log("WARNING: [DPU {}] U-Boot target verification failed for '{}': {}".format(
+                    dpu_ip, image, verify_err.strip() or verify_out.strip()))
+                return False
+            return True
+
+        quoted_image = shlex.quote(image)
+        default_ok, _, default_err = self.execute_command(
+            ssh, dpu_ip, "sudo sonic-installer set-default {}".format(quoted_image))
+        if not default_ok:
+            self.log("WARNING: [DPU {}] Failed to persist default image '{}': {}".format(
+                dpu_ip, image, default_err.strip()))
+            return False
+
+        next_ok, _, next_err = self.execute_command(
+            ssh, dpu_ip, "sudo sonic-installer set-next-boot {}".format(quoted_image))
+        if not next_ok:
+            self.log("WARNING: [DPU {}] Failed to set one-time boot image '{}': {}".format(
+                dpu_ip, image, next_err.strip()))
+            return False
+
+        sync_ok, _, sync_err = self.execute_command(ssh, dpu_ip, "sudo sync")
+        if not sync_ok:
+            self.log("WARNING: [DPU {}] Failed to persist boot selection for '{}': {}".format(
+                dpu_ip, image, sync_err.strip()))
+            return False
+
+        list_ok, _, next_image = self.get_installed_images(ssh, dpu_ip)
+        if not list_ok or next_image != image:
+            self.log("WARNING: [DPU {}] Persistent boot target is '{}' instead of '{}'".format(
+                dpu_ip, next_image, image))
+            return False
+        return True
 
     def install_image_on_dpu(self, ssh, dpu_ip):
         """Transfer the image from NPU to DPU via SCP and install it."""
@@ -409,17 +487,10 @@ class UpgradeDpuSonicImageModule(object):
             self.log("WARNING: [DPU {}] Image installation FAILED: {}".format(dpu_ip, err.strip()))
             return False
 
-        # Persist writes before verifying/rebooting; a failed sync means writes may not be durable
-        sync_ok, _, sync_err = self.execute_command(ssh, dpu_ip, "sudo sync")
         list_ok, curr_image, next_image = self.get_installed_images(ssh, dpu_ip)
         if not (list_ok and next_image):
             self.log("WARNING: [DPU {}] Could not read image list after install; "
                      "failing safe (not rebooting into an unverified image)".format(dpu_ip))
-            return False
-        if not sync_ok:
-            self.log("WARNING: [DPU {}] Post-install sync FAILED: {}; writes may not be persisted, "
-                     "not rebooting into a potentially corrupt image".format(dpu_ip, sync_err.strip()))
-            self.restore_boot_to_current(ssh, dpu_ip, curr_image, next_image)
             return False
         img_dir = "/host/image-{}".format(next_image.replace("SONiC-OS-", ""))
         _, initrd_out, _ = self.execute_command(
@@ -436,6 +507,11 @@ class UpgradeDpuSonicImageModule(object):
             return False
         self.log("[DPU {}] Post-install check OK for '{}': initrd {} bytes".format(
             dpu_ip, next_image, initrd_bytes))
+
+        if not self.prepare_image_for_reboot(ssh, dpu_ip, next_image):
+            self.log("WARNING: [DPU {}] Boot selection verification failed; not rebooting".format(dpu_ip))
+            self.restore_boot_to_current(ssh, dpu_ip, curr_image, next_image)
+            return False
 
         self.log("[DPU {}] Image installed successfully".format(dpu_ip))
         return True
@@ -618,7 +694,9 @@ class UpgradeDpuSonicImageModule(object):
             return False
 
         try:
-            self.reduce_installed_images(ssh, dpu_ip)
+            if not self.reduce_installed_images(ssh, dpu_ip):
+                self.log("WARNING: [DPU{}] FAILED: Could not safely clean installed images".format(dpu_index))
+                return False
             self.free_up_disk_space(ssh, dpu_ip)
 
             if not self.install_image_on_dpu(ssh, dpu_ip):
@@ -674,8 +752,37 @@ class UpgradeDpuSonicImageModule(object):
             return num_dpus
         return max(1, min(self.max_parallel_dpus, num_dpus))
 
+    def get_admin_up_dpu_indices(self, dpu_indices):
+        """Return targeted DPUs whose CONFIG_DB admin status is up."""
+        admin_up_dpus = []
+        skipped_dpus = []
+
+        for dpu_index in dpu_indices:
+            dpu_name = "DPU{}".format(dpu_index)
+            cmd = 'sonic-db-cli CONFIG_DB HGET "CHASSIS_MODULE|{}" admin_status'.format(dpu_name)
+            with self._cli_lock:
+                rc, out, err = self.module.run_command(cmd)
+
+            if rc != 0:
+                self.module.fail_json(
+                    msg="Failed to read admin status for {}: rc={}, err={}".format(
+                        dpu_name, rc, err.strip()))
+
+            admin_status = out.strip().lower()
+            if admin_status == "up":
+                admin_up_dpus.append(dpu_index)
+            elif admin_status == "down":
+                skipped_dpus.append(dpu_index)
+                self.log("[DPU{}] Skipping upgrade because admin_status is down".format(dpu_index))
+            else:
+                self.module.fail_json(
+                    msg="Invalid or missing admin status '{}' for {}".format(
+                        admin_status, dpu_name))
+
+        return admin_up_dpus, skipped_dpus
+
     def upgrade_dpus(self):
-        """Upgrade all targeted DPUs and return (success_count, failure_count)."""
+        """Upgrade admin-up targeted DPUs and return success, failure, and skipped counts."""
         if self.target_dpu_index >= 0:
             if self.target_dpu_index >= self.dpu_num:
                 self.module.fail_json(
@@ -685,7 +792,13 @@ class UpgradeDpuSonicImageModule(object):
         else:
             dpu_indices = list(range(self.dpu_num))
 
+        dpu_indices, skipped_dpus = self.get_admin_up_dpu_indices(dpu_indices)
         total = len(dpu_indices)
+        if total == 0:
+            self.log("No admin-up DPUs targeted for upgrade; skipped {} admin-down DPU(s)".format(
+                len(skipped_dpus)))
+            return 0, 0, skipped_dpus
+
         required = max(1, int(total * SUCCESS_THRESHOLD))
         success_count = 0
         failure_count = 0
@@ -736,26 +849,33 @@ class UpgradeDpuSonicImageModule(object):
                 success_count=success_count,
                 failure_count=failure_count,
                 total_dpus=total,
+                skipped_dpus=skipped_dpus,
                 messages=self.messages)
 
-        return success_count, failure_count
+        return success_count, failure_count, skipped_dpus
 
     def run(self):
-        success_count, failure_count = self.upgrade_dpus()
+        success_count, failure_count, skipped_dpus = self.upgrade_dpus()
         total = success_count + failure_count
 
-        if failure_count == 0:
+        if total == 0:
+            msg = "No admin-up DPUs to upgrade (skipped {} admin-down DPU(s))".format(
+                len(skipped_dpus))
+        elif failure_count == 0:
             msg = "Successfully upgraded all {} DPU(s)".format(success_count)
         else:
             msg = ("Upgraded {} of {} DPU(s) ({} failures, "
                    "met success threshold)").format(success_count, total, failure_count)
+        if total > 0 and skipped_dpus:
+            msg += "; skipped {} admin-down DPU(s)".format(len(skipped_dpus))
 
         self.module.exit_json(
-            changed=True,
+            changed=success_count > 0,
             msg=msg,
             success_count=success_count,
             failure_count=failure_count,
             total_dpus=total,
+            skipped_dpus=skipped_dpus,
             messages=self.messages)
 
 

--- a/ansible/library/upgrade_dpu_sonic_image.py
+++ b/ansible/library/upgrade_dpu_sonic_image.py
@@ -361,6 +361,7 @@ class UpgradeDpuSonicImageModule(object):
 
     def prepare_image_for_reboot(self, ssh, dpu_ip, image):
         """Persist an image as both the default and one-time boot target, then verify it."""
+        # U-Boot is platform-specific; platforms without its tools use the sonic-installer path below.
         uboot_slot_cmd = (
             "if command -v fw_printenv >/dev/null 2>&1 && command -v fw_setenv >/dev/null 2>&1; then "
             "printf '%s\\n' \"$(fw_printenv -n sonic_version_1 2>/dev/null || true)\" "


### PR DESCRIPTION
### Description of PR

Summary:
Skip administratively down DPUs during SONiC image upgrades and verify the physical U-Boot slot before rebooting.

Fixes # N/A

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: day-one issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: 14 focused unit tests passed.
- Live SmartSwitch validation with a tagged 202605 DPU image: admin-down DPUs were skipped, the enabled DPU booted the selected image, and the persistent U-Boot selector survived reboot.

### Approach
#### What is the motivation for this PR?

The upgrade module derives its targets from the HWSKU DPU count and therefore attempts to upgrade DPUs configured with `CHASSIS_MODULE.admin_status=down`. On U-Boot platforms, `sonic-installer` can also map a compact installed-image list to the wrong physical slot after cleanup, leaving the DPU at the bootloader prompt.

#### How did you do it?

Read each targeted DPU's `CHASSIS_MODULE` admin status from `CONFIG_DB` and exclude admin-down DPUs before downloading the image. Before cleanup or reboot, map the selected image against `sonic_version_1` and `sonic_version_2`, write `boot_next` and `boot_once` to the exact physical slot, sync, and verify the persistent selector. Non-U-Boot platforms retain the existing `sonic-installer` path.

#### How did you verify/test it?

Added focused unit coverage for mixed admin states, all-down and specifically targeted down DPUs, invalid admin state, U-Boot physical-slot mapping and failures, non-U-Boot fallback, and image-name normalization. Also validated admin-down skipping and persistent slot selection on physical SmartSwitch hardware.

#### Any platform specific information?

The physical-slot guard applies when `fw_printenv` and `fw_setenv` are available. Other bootloaders continue using `sonic-installer set-default` and `set-next-boot`.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

No user-facing documentation change is required. The Ansible module documentation now states that admin-down DPUs are skipped.
