### PR TITLE
[202605][Backport #23914] Fix Snappi PortChannel mapping

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -384,15 +384,14 @@ def __portchannel_intf_config(config, port_config_list, duthost, snappi_ports):
             continue
         last_byte = _next_system_id & 0xFF
         lag = config.lags.lag(name='Lag {}'.format(pc))[-1]
-        lag.protocol.lacp.actor_system_id = f"00:00:00:00:00:{last_byte:02x}"
+        lag.protocol.lacp.actor_system_id = f"00:00:00:00:00:{last_byte:02x}"  # noqa: E231
         lag.protocol.lacp.actor_system_priority = 1
         lag.protocol.lacp.actor_key = 1
 
         for phy in members:
             # Added fix to select snappi_ports based on peer-device and peer-hostname.
             port_ids = [
-                int(sp['port_id'])
-                for sp in (snappi_ports)
+                i for i, sp in enumerate(snappi_ports)
                 if ((sp['peer_port'] == phy) and (sp['peer_device'] == duthost.hostname))]
 
             if len(port_ids) != 1:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Backport #23914 to the 202605 branch.

The change fixes the Snappi PortChannel member lookup by using the
zero-based position in `snappi_ports` instead of treating the physical
IxNetwork port number as an index into `config.ports`.

Related to #23913 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #23913 
Failure type: regression

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- 202605: branch.202605-ars.0cb04ff1-buildimage.fe5ae5db34c88c8e8d331b3d16c01540cef906ca-nightly-2026.07.22.14.40 - Applicable Snappi tests passed

<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
PR #22435 introduced PortChannel member lookup code that used the
physical IxNetwork port number as an index into `config.ports`.

However, `config.ports` contains only the traffic-generator ports selected
for the test and is indexed from zero. A physical IxNetwork port number
therefore does not necessarily match its position in `config.ports`. This
can cause an `IndexError` during Snappi fixture setup.

PR #23914 fixed this issue on master and was previously backported to
202511. This PR applies the same fix to the 202605 branch.

#### How did you do it?
Cherry-picked the merged commit from PR #23914:
`65f14abd4cbc6d41cf725bd65343c3e09cb94dba`

The change uses `enumerate(snappi_ports)` to obtain the port's zero-based
position, while retaining the existing peer-interface and peer-DUT matching.

#### How did you verify/test it?
Validated applicable Snappi tests on a 202605 image containing this change
as part of the downstream patch set. No test failures or errors were observed.
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
Applicable to IxNetwork-based TGEN testbeds.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
No documentation changes required.
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
