### PR TITLE
Fix AnsibleHostBase: set self.hostname first so real host-construction errors are not masked

### DIFF
--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -135,6 +135,12 @@ class AnsibleHostBase(object):
             return super().default(obj)
 
     def __init__(self, ansible_adhoc, hostname, *args, **kwargs):
+        # Set hostname first. Everything below can raise (missing inventory entry,
+        # unreachable host, ansible errors). If hostname were assigned last, a
+        # partially constructed host would lack it, and the @cached decorator's
+        # _get_default_zone() would then raise a misleading
+        # "Failed to get attribute 'hostname'" ValueError that masks the real error.
+        self.hostname = hostname
         if hostname == 'localhost':
             self.host = ansible_adhoc(connection='local', host_pattern=hostname)[hostname]
         else:
@@ -161,7 +167,6 @@ class AnsibleHostBase(object):
             else:
                 self.mgmt_ip = ansible_host
                 self.mgmt_ipv6 = ansible_hostv6
-        self.hostname = hostname
 
     def __getattr__(self, module_name):
         with _ansible_module_resolution_lock:


### PR DESCRIPTION
### Description of PR

Summary:
Fixes the misleading `ValueError: Failed to get attribute 'hostname' ...` that masks the
real reason a host object could not be built.

ADO: https://dev.azure.com/msazure/One/_workitems/edit/38753996

`self.hostname` was assigned as the **last** statement of `AnsibleHostBase.__init__`.
Every statement before it can raise:

* a host missing from the inventory makes
  `self.host.options["inventory_manager"].get_host(hostname)` return `None`, so `.vars`
  raises `AttributeError`;
* an unreachable/unresolvable host makes `ansible_adhoc(...)` fail.

In those cases the partially constructed host object never gets a `hostname` attribute.
Any later `@cached` fact call then reaches `_get_default_zone()` in
`tests/common/cache/facts_cache.py`:

```python
hostname = getattr(func_args[0], "hostname", None)
if not hostname or not isinstance(hostname, (str, unicode_type)):
    raise ValueError("Failed to get attribute 'hostname' of type string from instance of type %s."
                     % type(func_args[0]))
```

which raises:

```
ValueError: Failed to get attribute 'hostname' of type string from instance of type
<class 'tests.common.devices.sonic.SonicHost'>
```

That message **replaces** the original exception and gives no hint about the actual
cause, so triage of these runs starts from a dead end.

The fix is to assign `self.hostname` as the first statement of `__init__`, so a
partially constructed host still carries its name and the original exception surfaces
unchanged.

#### Observed impact

From Kusto `SonicTestData` (`V2TestCases` restricted to NIGHTLY `TestPlans`), last 30
days, module `test_pretest`:

* **807 reported case-failures** carry this `ValueError`.
* Those 807 rows come from only **6 distinct nightly test plans** — i.e. this is a
  small number of real incidents that each **cascade** into 72–375 reported failures,
  because once the host object is broken *every* `test_pretest` case (times every DUT
  in the plan) fails with the same masked message.

Per-plan breakdown:

| Test plan | Reported failures | Date | Image |
|---|---|---|---|
| `6a5b5cb079c65de50a7f3d0a` | 375 | 2026-07-18 | SONiC.20250510.38 |
| `6a6435879008c6708bb1d5d4` | 90 | 2026-07-25 | SONiC.20250510.38 |
| `6a5eef9744243293671bc0ce` | 90 | 2026-07-21 | SONiC.20250510.38 |
| `6a6acd0cc738d690ad9c1aca` | 90 | 2026-07-30 | SONiC.20250510.38 |
| `6a6d7031b103fcbd8adfbfc4` | 90 | 2026-08-01 | SONiC.20250510.38 |
| `6a682a04eb2c1b23503d2387` | 72 | 2026-07-28 | SONiC.20250510.38 |

Example (plan `6a6d7031b103fcbd8adfbfc4`, testbed `vms20-dual-t0-4700-7`): at
`2026-08-01T08:44:53` the same `ValueError` is reported simultaneously for
`test_conn_graph_valid`, `test_generate_running_golden_config`,
`test_disable_startup_tsa_tsb_service`, `test_update_buffer_template`,
`test_update_saithrift_ptf` and `test_backend_acl_load` — one broken host object, six
identical and equally uninformative failures.

So the value of this change is twofold: the underlying incident becomes diagnosable
instead of being hidden, and a single incident stops producing hundreds of
misattributed case-failures that distort nightly failure statistics.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: other (diagnostics/error-reporting defect, not a test regression)

<!-- No backport requested at this time. The change only improves error reporting;
     it can be cherry-picked later if the noisy ValueError is seen on a release branch. -->

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Static validation on `master`:

* `python -m py_compile tests/common/devices/base.py` — passes.
* `pre-commit run --files tests/common/devices/base.py` — all applicable hooks pass
  (trailing whitespace, end-of-file, python ast, flake8).
* Verified `self.hostname = hostname` now appears exactly once in the file and is the
  first statement of `__init__`.

Behavioural reasoning (no functional change on the success path): the assignment is
simply moved earlier within the same constructor. `hostname` is a plain parameter, the
assignment has no side effects and does not depend on anything created later in
`__init__`, so a successfully constructed host is byte-for-byte identical. The only
difference is on the failure path, where the original exception is no longer replaced
by the `ValueError`.

### Approach
#### What is the motivation for this PR?

When host construction fails, the resulting error message points at `hostname` instead
of the real cause (host not in inventory, host unreachable, ansible failure). This
sends triage down the wrong path, and because the broken object is reused for every
subsequent case in the module, one incident buries the real error under dozens or
hundreds of identical messages.

#### How did you do it?

Moved `self.hostname = hostname` from the last line of `AnsibleHostBase.__init__` to the
first line, and added a comment explaining why the ordering matters so it is not moved
back.

#### How did you verify/test it?

* `py_compile` and `pre-commit` (flake8 etc.) pass on the changed file.
* Confirmed by reading `_get_default_zone()` in `tests/common/cache/facts_cache.py`
  that `getattr(obj, "hostname", None)` is the only trigger for this `ValueError`, so
  guaranteeing the attribute exists removes the masking.
* No success-path behaviour change: the statement is a side-effect-free assignment of a
  constructor parameter, independent of everything else in `__init__`.

Note on scope: this PR does **not** attempt to fix whatever made host construction fail
in those runs (inventory/reachability). It only stops the real exception from being
swallowed, so the next occurrence can actually be diagnosed.

#### Any platform specific information?

None. `AnsibleHostBase` is the common base for all device host objects, so this affects
every platform and topology equally. The observed occurrences span
`Mellanox-SN4700-V64` (dualtor-aa-64-breakout) and `Nokia-M0-7215` (m0) testbeds.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case.

### Documentation

N/A — no user-facing behaviour or documented interface changes; the change only affects
which exception surfaces when host construction fails.
