### PR TITLE
[snappi_tests]: fix PortChannel member lookup

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -390,13 +390,11 @@ def __portchannel_intf_config(config, port_config_list, duthost, snappi_ports):
 
         # Added fix to select member_port_id based on peer_port and peer_dut
         member_port_ids = [
-            int(sp['port_id'])
-            for sp in (snappi_ports)
-            for m in members
-            if ((sp['peer_port'] == m) and (sp['peer_device'] == duthost.hostname))]
-
-        member_port_ids = [int(sp['port_id']) for sp in (snappi_ports) for m in members if
-                           ((sp['peer_port'] == m) and (sp['peer_device'] == duthost.hostname))]
+            port_index
+            for port_index, sp in enumerate(snappi_ports)
+            for member in members
+            if ((sp['peer_port'] == member) and
+                (sp['peer_device'] == duthost.hostname))]
 
         if not member_port_ids:
             continue


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Use the position in `snappi_ports` instead of converting the physical IxNetwork port identifier to an integer. Also remove the duplicated `member_port_ids` assignment.

Fixes #26950 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #26950 
Failure type: regression

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- 202605: branch.202605-ars.0cb04ff1-buildimage.fe5ae5db34c88c8e8d331b3d16c01540cef906ca-nightly-2026.07.22.14.40 - Applicable Snappi tests passed.
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
PR #22435 added peer-DUT filtering to the Snappi PortChannel member
lookup, but changed the lookup to convert `sp['port_id']` to an integer.
Physical IxNetwork port identifiers can be strings such as `5.1`, causing
a `ValueError` during fixture setup.

PR #23914 corrected a later lookup in the same function. However, an
earlier duplicated `member_port_ids` lookup still performs the invalid
conversion before execution reaches the corrected code.

#### How did you do it?
Replaced the duplicated `int(sp['port_id'])` lookups with one
`enumerate(snappi_ports)` lookup. The existing peer-interface and peer-DUT
filters are retained.

#### How did you verify/test it?
Validated applicable Snappi tests on a 202605 image containing this change
as part of the downstream patch set. No test failures or errors were
observed. All applicable pre-commit checks passed.
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
Applicable to IxNetwork-based TGEN testbeds.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
