### PR TITLE
[platform_tests]: Xfail SFP error description test on SN5640 isolated…

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -649,10 +649,11 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_error_description:
       - "asic_type in ['nvidia-bluefield', 'vs']"
       - "is_multi_asic==True and release in ['201911']"
   xfail:
-    reason: "Platform API 'get_error_description' not implemented. Or test case has issue on the t0-isolated-d256u256s2 topo."
+    reason: "Platform API 'get_error_description' not implemented. Or test case has issue on SN5640 isolated topologies."
     conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-cel_e1031-r0'] and https://github.com/sonic-net/sonic-buildimage/issues/18229"
+      - "'t0-isolated-d32u32s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_get_model:


### PR DESCRIPTION
[platform_tests]: Xfail SFP error description test on SN5640 isolated topology

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Conditionally xfail  TestSfpApi::test_get_error_description  on NVIDIA SN5640 devices using the  t0-isolated-d32u32s2  topology.

The test may report a transceiver error such as  ConfigUndefined  instead of the expected  OK  because  cmis.get_error_description()  evaluates all lanes of a split module rather than only the relevant sub-port lanes. This behavior is tracked by sonic-buildimage issue [#21878.](https://github.com/sonic-net/sonic-buildimage/issues/21878)

This change only marks the known platform/topology-specific failure as expected; it does not fix the underlying platform API behavior.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
platform_tests/api/test_sfp.py::TestSfpApi::test_get_error_description  consistently fails on the NVIDIA SN5640  t0-isolated-d32u32s2  testbed because the API returns  ConfigUndefined  for a transceiver where the test expects  OK .

For split transceiver modules,  cmis.get_error_description()  checks all module lanes. Admin-down lanes can therefore affect the status returned for an admin-up sub-port. The underlying behavior is documented in sonic-buildimage#21878.

The failure should be treated as expected until the platform API correctly handles lane-specific status for split ports.

#### How did you do it?
Added an xfail condition for  TestSfpApi::test_get_error_description  when:

• The topology is  t0-isolated-d32u32s2 .
• The platform is  x86_64-nvidia_sn5640-r0 .

The existing xfail conditions for other affected platforms and SN5640 isolated topologies remain unchanged.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran the test on 202511, it skipped it as expected.
<img width="884" height="436" alt="image" src="https://github.com/user-attachments/assets/2bbe8795-e9a8-4987-b2d1-9edadefd6cd3" />



#### Any platform specific information?
The xfail is restricted to:

Platform: x86_64-nvidia_sn5640-r0
HwSku: Mellanox-SN5640-C512S2
Topology: t0-isolated-d32u32s2

Related platform issue: sonic-buildimage#21878.

#### Supported testbed topology if it's a new test case?
Not applicable. This PR does not introduce a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
