### PR TITLE
IPv6_Not supported

### DIFF
--- a/0001-skip_ecmp_ipv6-ipv6_no-support.patch
+++ b/0001-skip_ecmp_ipv6-ipv6_no-support.patch
@@ -1,0 +1,152 @@
+From 8981065ed7e59fd2643de926c5ba6cdc311ae5b9 Mon Sep 17 00:00:00 2001
+From: Preethi Rangian <prangian@marvell.com>
+Date: Tue, 28 Apr 2026 13:26:05 +0530
+Subject: [PATCH] skip_ecmp_ipv6-ipv6_no supported on TL Platform
+
+---
+ .../tests_mark_conditions.yaml                | 58 ++++++++++++++++---
+ tests/ecmp/inner_hashing/conftest.py          | 30 +++++-----
+ 2 files changed, 65 insertions(+), 23 deletions(-)
+
+diff --git a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+index 83051d68c..6d89d506f 100644
+--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
++++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+@@ -1390,9 +1390,9 @@ ecmp/inner_hashing/test_inner_hashing.py:
+     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
+     conditions:
+       - "branch in ['201811', '201911', '202012', '202106']"
+-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
++      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
+       - "topo_type not in ['t0']"
+-      - "asic_type not in ['mellanox', 'vs']"
++      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
+       - "'dualtor' in topo_name"
+ 
+ ecmp/inner_hashing/test_inner_hashing_lag.py:
+@@ -1401,9 +1401,9 @@ ecmp/inner_hashing/test_inner_hashing_lag.py:
+     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
+     conditions:
+       - "branch in ['201811', '201911', '202012', '202106']"
+-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
++      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
+       - "topo_type not in ['t0']"
+-      - "asic_type not in ['mellanox', 'vs']"
++      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
+       - "'dualtor' in topo_name"
+ 
+ ecmp/inner_hashing/test_wr_inner_hashing.py:
+@@ -1412,9 +1412,9 @@ ecmp/inner_hashing/test_wr_inner_hashing.py:
+     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
+     conditions:
+       - "branch in ['201811', '201911', '202012', '202106']"
+-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
++      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
+       - "topo_type not in ['t0']"
+-      - "asic_type not in ['mellanox', 'vs']"
++      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
+       - "'dualtor' in topo_name"
+ 
+ ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
+@@ -1423,11 +1423,53 @@ ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
+     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
+     conditions:
+       - "branch in ['201811', '201911', '202012', '202106']"
+-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
++      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0','x86_64-marvell_d64p512t-r0']"
+       - "topo_type not in ['t0']"
+-      - "asic_type not in ['mellanox', 'vs']"
++      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
+       - "'dualtor' in topo_name"
+ 
++ecmp/inner_hashing/test_inner_hashing.py::TestDynamicInnerHashing::test_inner_hashing[ipv6-ipv6]:
++  skip:
++    reason: "IPv6-IPv6 not supported on TL Platform"
++    condition:
++      - "topo_type in ['t0']"
++      - "asic_type in ['marvell-teralynx']"
++
++ecmp/inner_hashing/test_inner_hashing.py::TestStaticInnerHashing::test_inner_hashing[ipv6-ipv6]:
++  skip:
++    reason: "IPv6-IPv6 not supported on TL Platform"
++    condition:
++      - "topo_type in ['t0']"
++      - "asic_type in ['marvell-teralynx']"
++
++ecmp/inner_hashing/test_inner_hashing_lag.py::TestDynamicInnerHashingLag::test_inner_hashing[ipv6-ipv6]:
++  skip:
++    reason: "IPv6-IPv6 not supported on TL Platform"
++    condition:
++      - "topo_type in ['t0']"
++      - "asic_type in ['marvell-teralynx']"
++
++ecmp/inner_hashing/test_wr_inner_hashing.py::TestWRDynamicInnerHashing::test_inner_hashing[ipv6-ipv6]:
++  skip:
++    reason: "IPv6-IPv6 not supported on TL Platform"
++    condition:
++      - "topo_type in ['t0']"
++      - "asic_type in ['marvell-teralynx']"
++
++ecmp/inner_hashing/test_wr_inner_hashing.py::TestWRStaticInnerHashing::test_inner_hashing[ipv6-ipv6]:
++  skip:
++    reason: "IPv6-IPv6 not supported on TL Platform"
++    condition:
++      - "topo_type in ['t0']"
++      - "asic_type in ['marvell-teralynx']"
++
++ecmp/inner_hashing/test_wr_inner_hashing_lag.py::TestWRDynamicInnerHashingLag::test_inner_hashing[ipv6-ipv6]:
++  skip:
++    reason: "IPv6-IPv6 not supported on TL Platform"
++    condition:
++      - "topo_type in ['t0']"
++      - "asic_type in ['marvell-teralynx']"
++
+ ecmp/test_ecmp_balance.py:
+   skip:
+     reason: "Only support Broadcom T1/T0 topology for now"
+diff --git a/tests/ecmp/inner_hashing/conftest.py b/tests/ecmp/inner_hashing/conftest.py
+index f37e38a2e..55985a0af 100644
+--- a/tests/ecmp/inner_hashing/conftest.py
++++ b/tests/ecmp/inner_hashing/conftest.py
+@@ -77,24 +77,24 @@ HASH_FIELD_CONFIG = {
+ 
+ 
+ def pytest_addoption(parser):
+-    parser.addoption('--static_config', action='store_true', default=False,
++    parser.addoption('--static_config', action='store_true', default=True,
+                      help="Test configurations done before the test - static config")
+ 
+ 
+-def pytest_collection_modifyitems(config, items):
+-    if config.getoption("--static_config"):
+-        # --static_config given in cli: skip test with dynamic config
+-        skip_dynamic_config = pytest.mark.skip(reason="need to remove '--static_config'"
+-                                                      " option to run the dynamic config tests")
+-        for item in items:
+-            if "dynamic_config" in item.keywords:
+-                item.add_marker(skip_dynamic_config)
+-    else:
+-        skip_static_config = pytest.mark.skip(reason="need '--static_config'"
+-                                                     " option to run the static config tests")
+-        for item in items:
+-            if "static_config" in item.keywords:
+-                item.add_marker(skip_static_config)
++# def pytest_collection_modifyitems(config, items):
++#     if config.getoption("--static_config"):
++#         # --static_config given in cli: skip test with dynamic config
++#         skip_dynamic_config = pytest.mark.skip(reason="need to remove '--static_config'"
++#                                                       " option to run the dynamic config tests")
++#         for item in items:
++#             if "dynamic_config" in item.keywords:
++#                 item.add_marker(skip_dynamic_config)
++#     else:
++#         skip_static_config = pytest.mark.skip(reason="need '--static_config'"
++#                                                      " option to run the static config tests")
++#         for item in items:
++#             if "static_config" in item.keywords:
++#                 item.add_marker(skip_static_config)
+ 
+ 
+ @pytest.fixture(scope='module')
+-- 
+2.50.1 (Apple Git-155)

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1755,9 +1755,9 @@ ecmp/inner_hashing/test_inner_hashing.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox', 'vs']"
+      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
       - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_inner_hashing_lag.py:
@@ -1766,9 +1766,9 @@ ecmp/inner_hashing/test_inner_hashing_lag.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox', 'vs']"
+      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
       - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_wr_inner_hashing.py:
@@ -1777,9 +1777,9 @@ ecmp/inner_hashing/test_wr_inner_hashing.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox', 'vs']"
+      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
       - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
@@ -1788,10 +1788,52 @@ ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0','x86_64-marvell_d64p512t-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox', 'vs']"
+      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
       - "'dualtor' in topo_name"
+
+ecmp/inner_hashing/test_inner_hashing.py::TestDynamicInnerHashing::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_inner_hashing.py::TestStaticInnerHashing::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_inner_hashing_lag.py::TestDynamicInnerHashingLag::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_wr_inner_hashing.py::TestWRDynamicInnerHashing::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_wr_inner_hashing.py::TestWRStaticInnerHashing::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_wr_inner_hashing_lag.py::TestWRDynamicInnerHashingLag::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
 
 ecmp/test_ecmp_balance.py:
   skip:

--- a/tests/ecmp/inner_hashing/conftest.py
+++ b/tests/ecmp/inner_hashing/conftest.py
@@ -77,24 +77,24 @@ HASH_FIELD_CONFIG = {
 
 
 def pytest_addoption(parser):
-    parser.addoption('--static_config', action='store_true', default=False,
+    parser.addoption('--static_config', action='store_true', default=True,
                      help="Test configurations done before the test - static config")
 
 
-def pytest_collection_modifyitems(config, items):
-    if config.getoption("--static_config"):
-        # --static_config given in cli: skip test with dynamic config
-        skip_dynamic_config = pytest.mark.skip(reason="need to remove '--static_config'"
-                                                      " option to run the dynamic config tests")
-        for item in items:
-            if "dynamic_config" in item.keywords:
-                item.add_marker(skip_dynamic_config)
-    else:
-        skip_static_config = pytest.mark.skip(reason="need '--static_config'"
-                                                     " option to run the static config tests")
-        for item in items:
-            if "static_config" in item.keywords:
-                item.add_marker(skip_static_config)
+# def pytest_collection_modifyitems(config, items):
+#     if config.getoption("--static_config"):
+#         # --static_config given in cli: skip test with dynamic config
+#         skip_dynamic_config = pytest.mark.skip(reason="need to remove '--static_config'"
+#                                                       " option to run the dynamic config tests")
+#         for item in items:
+#             if "dynamic_config" in item.keywords:
+#                 item.add_marker(skip_dynamic_config)
+#     else:
+#         skip_static_config = pytest.mark.skip(reason="need '--static_config'"
+#                                                      " option to run the static config tests")
+#         for item in items:
+#             if "static_config" in item.keywords:
+#                 item.add_marker(skip_static_config)
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
 **Description of PR**
The ECMP IPv6-IPv6 inner hashing test case is being skipped on the Marvell Teralynx (TL) platform because the required IPv6-IPv6 ECMP functionality is currently not supported. Therefore, the ECMP IPv6-IPv6 test case is marked as skipped on the TL platform until the required IPv6-Ipv6 ECMP support is available. Additionally, the test does not support DualToR topology. 
The following test cases are impacted:

ecmp/inner_hashing/test_inner_hashing.py
ecmp/inner_hashing/test_inner_hashing_lag.py
ecmp/inner_hashing/test_wr_inner_hashing.py
ecmp/inner_hashing/test_wr_inner_hashing_lag.py
ecmp/inner_hashing/test_inner_hashing.py::TestDynamicInnerHashing::test_inner_hashing[ipv6-ipv6]
ecmp/inner_hashing/test_inner_hashing.py::TestStaticInnerHashing::test_inner_hashing[ipv6-ipv6]
ecmp/inner_hashing/test_inner_hashing_lag.py::TestDynamicInnerHashingLag::test_inner_hashing[ipv6-ipv6]
ecmp/inner_hashing/test_wr_inner_hashing.py::TestWRDynamicInnerHashing::test_inner_hashing[ipv6-ipv6]
ecmp/inner_hashing/test_wr_inner_hashing.py::TestWRStaticInnerHashing::test_inner_hashing[ipv6-ipv6]
ecmp/inner_hashing/test_wr_inner_hashing_lag.py::TestWRDynamicInnerHashingLag::test_inner_hashing[ipv6-ipv6]

**Summary:**
Fixes # (issue)

**Type of change**
New Test case-Skipped for non-supported platforms


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A


Approach
Skip the ECMP IPv6-IPv6 inner hashing test cases on the TL platform and DualToR topology, as the required functionality is not supported.

 How did you verify/test it?
Run the testcase and confirmed with Dev 

Any platform specific information? 
N/A

Supported testbed topology if it's a new test case?
N/A

