### PR TITLE
[202511][HFT] Avoid disruptive SWSS recovery in tests

### DIFF
--- a/tests/high_frequency_telemetry/conftest.py
+++ b/tests/high_frequency_telemetry/conftest.py
@@ -44,58 +44,33 @@ def ensure_swss_ready(duthosts, enum_rand_one_per_hwsku_hostname):
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
+    if not duthost.is_service_fully_started("swss"):
+        pytest.fail("swss container is not running")
+
     def get_swss_uptime_seconds():
-        """Get swss container uptime in seconds from docker ps"""
+        """Get swss container uptime in seconds via docker inspect."""
         try:
-            # Use docker ps to get status info - avoid template conflicts
+            # Step 1: Get container start time from docker inspect JSON
             result = duthost.shell(
-                'docker ps --filter "name=swss"',
+                "docker inspect swss | grep StartedAt | head -1 | cut -d'\"' -f4",
                 module_ignore_errors=True
             )
-            if result['rc'] != 0:
+            if result['rc'] != 0 or not result['stdout'].strip():
+                return 0
+            started_at = result['stdout'].strip()
+
+            # Step 2: Calculate uptime on DUT to avoid clock differences
+            result = duthost.shell(
+                f'started=$(date -ud "{started_at}" +%s) && '
+                'echo $(($(date -u +%s) - started))',
+                module_ignore_errors=True
+            )
+            if result['rc'] != 0 or not result['stdout'].strip():
                 return 0
 
-            stdout_lines = result['stdout_lines']
-            if len(stdout_lines) < 2:  # No container found (only header)
-                return 0
-
-            # Find the swss container line and extract status
-            for line in stdout_lines[1:]:  # Skip header
-                if 'swss' in line:
-                    # Line format: CONTAINER_ID IMAGE COMMAND
-                    # CREATED STATUS PORTS NAMES
-                    # Example: d0a33fe4d37f docker-orchagent:latest
-                    # "/usr/bin/docker-ini…" 8 days ago Up 18 minutes swss
-                    parts = line.split()
-
-                    # Find "Up" and get the next parts for time
-                    try:
-                        up_index = parts.index('Up')
-                        if up_index + 2 < len(parts):
-                            time_value = parts[up_index + 1]
-                            time_unit = parts[up_index + 2]
-
-                            logger.debug(f"swss container status: "
-                                         f"Up {time_value} {time_unit}")
-
-                            # Convert to seconds
-                            time_num = int(time_value)
-                            if 'second' in time_unit:
-                                return time_num
-                            elif 'minute' in time_unit:
-                                return time_num * 60
-                            elif 'hour' in time_unit:
-                                return time_num * 3600
-                            elif 'day' in time_unit:
-                                return time_num * 86400
-                            else:
-                                return 20  # Unknown format, assume long enough
-                    except (ValueError, IndexError):
-                        logger.warning(f"Failed to parse status line: {line}")
-                        return 0
-
-            return 0  # No swss container found
-
+            uptime = int(result['stdout'].strip())
+            logger.debug(f"swss container uptime: {uptime}s")
+            return uptime
         except Exception as e:
             logger.warning(f"Failed to get swss uptime: {e}")
             return 0
@@ -107,28 +82,7 @@ def ensure_swss_ready(duthosts, enum_rand_one_per_hwsku_hostname):
     min_uptime = 10  # Require at least 10 seconds uptime
 
     if uptime == 0:
-        logger.warning("swss container is not running, attempting to start...")
-
-        # Try to restart swss service
-        duthost.shell('sudo systemctl restart swss',
-                      module_ignore_errors=True)
-
-        # Wait for container to start and stabilize
-        max_wait = 40  # Total wait time
-        logger.info(f"Waiting up to {max_wait} seconds for swss container "
-                    f"to start and stabilize...")
-
-        for i in range(max_wait):
-            time.sleep(1)
-            current_uptime = get_swss_uptime_seconds()
-            if current_uptime >= min_uptime:
-                logger.info(f"swss container is stable "
-                            f"(uptime: {current_uptime}s)")
-                break
-        else:
-            raise RuntimeError(f"swss container failed to stabilize "
-                               f"after {max_wait} seconds")
-
+        pytest.fail("Failed to determine swss container uptime")
     elif uptime < min_uptime:
         wait_time = min_uptime - uptime + 1  # +1 for safety margin
         logger.info(f"swss container uptime is {uptime}s, "

--- a/tests/high_frequency_telemetry/test_high_frequency_telemetry.py
+++ b/tests/high_frequency_telemetry/test_high_frequency_telemetry.py
@@ -33,7 +33,7 @@ pytestmark = [
 
 
 def test_hft_port_counters(duthosts, enum_rand_one_per_hwsku_hostname,
-                           disable_flex_counters, tbinfo):
+                           cleanup_high_frequency_telemetry, tbinfo):
     """Test high frequency telemetry for port counters.
 
     This test:
@@ -104,7 +104,7 @@ def test_hft_port_counters(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_hft_full_queue_counters(duthosts, enum_rand_one_per_hwsku_hostname,
-                                 disable_flex_counters):
+                                 cleanup_high_frequency_telemetry):
     """
     Test high frequency telemetry for every configured queue.
 
@@ -165,7 +165,7 @@ def test_hft_full_queue_counters(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_hft_full_ingress_priority_group_counters(duthosts, enum_rand_one_per_hwsku_hostname,
-                                                  disable_flex_counters):
+                                                  cleanup_high_frequency_telemetry):
     """Test high frequency telemetry for all configured buffer queues (ingress priority groups)."""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     profile_name = "ingress_pg_profile"
@@ -209,7 +209,7 @@ def test_hft_full_ingress_priority_group_counters(duthosts, enum_rand_one_per_hw
 
 
 def test_hft_full_buffer_pool_counters(duthosts, enum_rand_one_per_hwsku_hostname,
-                                       disable_flex_counters):
+                                       cleanup_high_frequency_telemetry):
     """Test high frequency telemetry for all configured buffer pools."""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     profile_name = "buffer_pool_profile"
@@ -254,7 +254,7 @@ def test_hft_full_buffer_pool_counters(duthosts, enum_rand_one_per_hwsku_hostnam
 
 @pytest.mark.skip(reason="Full counters HFT isn't supported")
 def test_hft_full_counters(duthosts, enum_rand_one_per_hwsku_hostname,
-                           disable_flex_counters, tbinfo):
+                           cleanup_high_frequency_telemetry, tbinfo):
     """Test high frequency telemetry for all supported object types in one profile."""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     profile_name = "full_hft_profile"
@@ -313,7 +313,7 @@ def test_hft_full_counters(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_hft_full_port_counters(duthosts, enum_rand_one_per_hwsku_hostname,
-                                disable_flex_counters, tbinfo):
+                                cleanup_high_frequency_telemetry, tbinfo):
     """
     Test high frequency telemetry with all available ports and all
     available counter types.
@@ -423,7 +423,7 @@ def test_hft_full_port_counters(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_hft_disabled_stream(duthosts, enum_rand_one_per_hwsku_hostname,
-                             disable_flex_counters, tbinfo):
+                             cleanup_high_frequency_telemetry, tbinfo):
     """
     Test high frequency telemetry with disabled stream state transitions.
 
@@ -534,7 +534,7 @@ def test_hft_disabled_stream(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_hft_config_deletion_stream(duthosts, enum_rand_one_per_hwsku_hostname,
-                                    disable_flex_counters, tbinfo):
+                                    cleanup_high_frequency_telemetry, tbinfo):
     """
     Test high frequency telemetry with configuration deletion transitions.
 
@@ -638,7 +638,7 @@ def test_hft_config_deletion_stream(duthosts, enum_rand_one_per_hwsku_hostname,
 ])
 @pytest.mark.skip(reason="Some intervals may not be supported")
 def test_hft_poll_interval_validation(duthosts, enum_rand_one_per_hwsku_hostname,
-                                      disable_flex_counters, tbinfo,
+                                      cleanup_high_frequency_telemetry, tbinfo,
                                       poll_interval_us, expected_msg_per_sec):
     """Test high frequency telemetry with different poll intervals.
 
@@ -782,7 +782,7 @@ def test_hft_poll_interval_validation(duthosts, enum_rand_one_per_hwsku_hostname
 
 
 def test_hft_port_shutdown_stream(duthosts, enum_rand_one_per_hwsku_hostname,
-                                  disable_flex_counters, tbinfo, ptfadapter):
+                                  cleanup_high_frequency_telemetry, tbinfo, ptfadapter):
     """
     Test high frequency telemetry with port shutdown/startup transitions during continuous traffic.
 


### PR DESCRIPTION
### Description of PR

Backport of #26151 to `202511`.

The automatic backport conflicted because the release branch has a different HFT test set and does not contain `test_hft_end_to_end.py`. This backport keeps that file absent and applies the fix only to the two HFT files present on `202511`.

Fixes #26149.

### What changed

- Require `swss` to be fully started before checking uptime.
- Calculate container uptime on the DUT from `docker inspect`.
- Fail setup when SWSS state or uptime cannot be verified instead of restarting SWSS.
- Stop current HFT tests from changing global flex-counter state.
- Keep the existing `disable_flex_counters` fixture implementation available.

### Verification

Static/local:

- `pre-commit run --files tests/high_frequency_telemetry/conftest.py tests/high_frequency_telemetry/test_high_frequency_telemetry.py`
- `python3 -m compileall -q tests/high_frequency_telemetry`
- `python3 -m flake8 --select=F,E999 tests/high_frequency_telemetry/conftest.py tests/high_frequency_telemetry/test_high_frequency_telemetry.py`
- Focused fixture behavior test: `4 passed`; verified stopped SWSS, inspect failure, and uptime parse failure never issue `restart swss`.
- `git diff --check`

Physical DUT:

- Testbed: `vms95-t0-sn5640-3`
- DUT: `str5-sn5640-5` / Mellanox-SN5640-C512S2 / Nvidia SPC5
- Image: `SONiC.20251110.43`
- Manually applied sonic-buildimage #28408 to `/etc/sonic/otel_config.yml`; validated with the image's `otelcol-contrib validate` before restarting only the OTEL collector process.
- Full `high_frequency_telemetry/test_high_frequency_telemetry.py`: **7 passed, 7 skipped in 1:15:04**.
- Passed cases cover port counters, all queues, ingress priority groups, all ports, stream enable/disable transitions, configuration delete/recreate transitions, and port up/down transitions with PTF traffic.
- Skips are existing platform/test markers: unsupported buffer-pool counters, unsupported full-counters test, and five unsupported poll-interval parameters.
- LogAnalyzer, YANG validation, and post-test sanity passed.
- SWSS container remained the same instance throughout the run.
- FLEX_COUNTER state hash was unchanged before/after; no HFT CONFIG_DB keys or core files remained.
- Final state: 66 ports up, all 32 T1 and 2 PT0 IPv4 BGP neighbors established, OTEL collector running with no log amplification.

Signed-off-by: Ze Gan <zegan@microsoft.com>