### PR TITLE
[dualtor] Recover mux.service from systemd start limit

### DIFF
--- a/tests/common/dualtor/tor_failure_utils.py
+++ b/tests/common/dualtor/tor_failure_utils.py
@@ -58,7 +58,25 @@ def shutdown_tor_heartbeat():
     yield shutdown_tor_heartbeat
 
     for duthost in torhost:
-        duthost.shell("systemctl start mux")
+        # `mux.service` has a strict systemd start rate-limit
+        # (StartLimitBurst=3 / StartLimitIntervalSec=1200). When multiple
+        # test cases in the same module run in sequence, the start budget
+        # can be exhausted and `systemctl start mux` fails with
+        # "start of the service was attempted too often". Detect that and
+        # recover with `systemctl reset-failed mux` followed by a retry.
+        try:
+            duthost.shell("systemctl start mux")
+        except Exception as e:
+            if "start of the service was attempted too often" in str(e):
+                logger.warning(
+                    "mux.service hit systemd start rate-limit on %s; "
+                    "running 'systemctl reset-failed mux' and retrying start",
+                    duthost.hostname,
+                )
+                duthost.shell("systemctl reset-failed mux")
+                duthost.shell("systemctl start mux")
+            else:
+                raise
         duthost.shell("systemctl enable mux")
 
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: 20260531.9 test_heartbeat_failure.py

```
dualtor_io/test_heartbeat_failure.py::test_active_tor_heartbeat_failure_downstream_active[active-standby] PASSED                                                                                                                                     [100%]

================================================================================================ 1 passed, 1 deselected, 132 warnings in 514.99s (0:08:34) =================================================================================================
```

### Approach
#### What is the motivation for this PR?

The `shutdown_tor_heartbeat` fixture stops and disables `mux.service` in setup, then re-starts and re-enables it in teardown. Running the six test cases in `dualtor_io/test_heartbeat_failure.py` back-to-back drives more than three `systemctl start mux` invocations inside the service's `StartLimitIntervalSec=1200` window. Once the `StartLimitBurst=3` budget is exhausted, systemd rejects the teardown's start command with:

```
    Job for mux.service failed because start of the service was
    attempted too often.
    ...
    To force a start use "systemctl reset-failed mux.service"
    followed by "systemctl start mux.service" again.
```

This left mux down, causing cascading failures (container_checker monit alerts, arp_update failures, all mux ports forced to standby) and marked subsequent tests as failed.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

Detect this specific error in the teardown, run
`systemctl reset-failed mux` to clear the systemd burst counter, and retry `systemctl start mux`. Any other error from the start is re-raised unchanged.

#### How did you verify/test it?

```
dualtor_io/test_heartbeat_failure.py::test_active_tor_heartbeat_failure_downstream_active[active-standby] PASSED                                                                                                                                     [100%]

================================================================================================ 1 passed, 1 deselected, 132 warnings in 514.99s (0:08:34) =================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
