### PR TITLE
Skip ECMP IPv6-IPv6 inner hashing on unsupported platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1755,9 +1755,9 @@ ecmp/inner_hashing/test_inner_hashing.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox', 'vs']"
+      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
       - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_inner_hashing_lag.py:
@@ -1766,9 +1766,9 @@ ecmp/inner_hashing/test_inner_hashing_lag.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox', 'vs']"
+      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
       - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_wr_inner_hashing.py:
@@ -1777,9 +1777,9 @@ ecmp/inner_hashing/test_wr_inner_hashing.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox', 'vs']"
+      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
       - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
@@ -1788,10 +1788,52 @@ ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox', 'vs']"
+      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
       - "'dualtor' in topo_name"
+
+ecmp/inner_hashing/test_inner_hashing.py::TestDynamicInnerHashing::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_inner_hashing.py::TestStaticInnerHashing::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_inner_hashing_lag.py::TestDynamicInnerHashingLag::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_wr_inner_hashing.py::TestWRDynamicInnerHashing::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_wr_inner_hashing.py::TestWRStaticInnerHashing::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_wr_inner_hashing_lag.py::TestWRDynamicInnerHashingLag::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
 
 ecmp/test_ecmp_balance.py:
   skip:


### PR DESCRIPTION
**Description of PR**
The ECMP IPv6-IPv6 inner hashing test case is being skipped on the Marvell Teralynx (TL) platform because the required IPv6-IPv6 ECMP functionality is currently not supported.
Therefore, the ECMP IPv6-IPv6 test case is marked as skipped on the TL platform until the required IPv6-IPv6 ECMP support becomes available. Additionally, this test case does not support the DualToR topology.
The following test cases are impacted:
ecmp/inner_hashing/test_inner_hashing.py
ecmp/inner_hashing/test_inner_hashing_lag.py
ecmp/inner_hashing/test_wr_inner_hashing.py
ecmp/inner_hashing/test_wr_inner_hashing_lag.py
ecmp/inner_hashing/test_inner_hashing.py::TestDynamicInnerHashing::test_inner_hashing[ipv6-ipv6]
ecmp/inner_hashing/test_inner_hashing.py::TestStaticInnerHashing::test_inner_hashing[ipv6-ipv6]
ecmp/inner_hashing/test_inner_hashing_lag.py::TestDynamicInnerHashingLag::test_inner_hashing[ipv6-ipv6]
ecmp/inner_hashing/test_wr_inner_hashing.py::TestWRDynamicInnerHashing::test_inner_hashing[ipv6-ipv6]
ecmp/inner_hashing/test_wr_inner_hashing.py::TestWRStaticInnerHashing::test_inner_hashing[ipv6-ipv6]
ecmp/inner_hashing/test_wr_inner_hashing_lag.py::TestWRDynamicInnerHashingLag::test_inner_hashing[ipv6-ipv6]

Summary:
Fixes # (issue)

Type of change: Skipped for non-supported platforms

Back port request: 202511

Approach: Skip the ECMP IPv6-IPv6 inner hashing test cases on the TL platform and DualToR topology, as the required functionality is not supported.

How did you verify/test it?
Run the testcase  and confirmed with the Dev Team

Any platform specific information?
N/A

Supported testbed topology if it's a new test case?
N/A
 
