### PR TITLE
Generic config updater

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1755,9 +1755,9 @@ ecmp/inner_hashing/test_inner_hashing.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox', 'vs']"
+      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
       - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_inner_hashing_lag.py:
@@ -1766,9 +1766,9 @@ ecmp/inner_hashing/test_inner_hashing_lag.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox', 'vs']"
+      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
       - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_wr_inner_hashing.py:
@@ -1777,9 +1777,9 @@ ecmp/inner_hashing/test_wr_inner_hashing.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox', 'vs']"
+      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
       - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
@@ -1788,10 +1788,52 @@ ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-wistron_6512_32r-r0', 'x86_64-marvell_d64p512t-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox', 'vs']"
+      - "asic_type not in ['mellanox', 'vs', 'marvell-teralynx']"
       - "'dualtor' in topo_name"
+
+ecmp/inner_hashing/test_inner_hashing.py::TestDynamicInnerHashing::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_inner_hashing.py::TestStaticInnerHashing::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_inner_hashing_lag.py::TestDynamicInnerHashingLag::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_wr_inner_hashing.py::TestWRDynamicInnerHashing::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_wr_inner_hashing.py::TestWRStaticInnerHashing::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
+
+ecmp/inner_hashing/test_wr_inner_hashing_lag.py::TestWRDynamicInnerHashingLag::test_inner_hashing[ipv6-ipv6]:
+  skip:
+    reason: "IPv6-IPv6 not supported on TL Platform"
+    condition:
+      - "topo_type in ['t0']"
+      - "asic_type in ['marvell-teralynx']"
 
 ecmp/test_ecmp_balance.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2893,6 +2893,24 @@ generic_config_updater/test_ntp.py::test_ntp_server_change_source_intf:
     conditions:
       - "'bmc' in topo_type"
 
+generic_config_updater/test_packet_trimming_config_asymmetric.py:
+    skip:
+        reason: "Packet trim is not supported in 202505 image"
+        conditions:
+        - "asic_type in ['vs','marvell-teralynx']"
+
+generic_config_updater/test_packet_trimming_config_symmetric:
+  skip:
+    reason: "Packet trim is not supported in 202505 image"
+    conditions:
+      - "asic_type in ['vs','marvell-teralynx']"
+
+generic_config_updater/test_srv6.py:
+  skip:
+    reason: "SRv6 feature support is not added for TL platforms so tests cannot be run and needs to be skipped"
+    conditions:
+      - "asic_type in ['vs','marvell-teralynx']"
+
 generic_config_updater/test_pfcwd_interval.py:
   skip:
     reason: "This test can only support mellanox platforms. This test is not run on this hwsku currently"


### PR DESCRIPTION
**Description of PR**
Skip Packet Trimming and SRv6 test cases on unsupported platforms. These tests are skipped until the required feature support is added.
The following test cases are impacted:
generic_config_updater/test_packet_trimming_config_asymmetric.py
generic_config_updater/test_packet_trimming_config_symmetric
generic_config_updater/test_srv6.py

**Summary:**
Fixes # (issue)

 **Type of change:**  Skipped for non-supported platforms

**Back port request:** 202511

 **Approach:**
 Added platform-specific skip conditions for Packet Trimming and SRv6 tests on Marvell Teralynx platforms where the required features are not supported.

How did you do it?
Run the testcase and confirmed with the Dev Team 

Any platform specific information?
N/A

Supported testbed topology if it's a new test case?
N/A