### PR TITLE
[drop_packets] Poll ACL drop counter instead of single fixed-interval read

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -225,16 +225,27 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
         if not tx_dut_ports:
             pytest.fail("No L3 interface specified")
 
-        time.sleep(ACL_COUNTERS_UPDATE_INTERVAL)
-        acl_drops = 0
-        for duthost in duthosts.frontend_nodes:
-            for sonic_host_or_asic_inst in duthost.get_sonic_host_and_frontend_asic_instance():
-                namespace = sonic_host_or_asic_inst.namespace if hasattr(sonic_host_or_asic_inst,
-                                                                         'namespace') else DEFAULT_NAMESPACE
-                if duthost.sonichost.is_multi_asic and namespace == DEFAULT_NAMESPACE:
-                    continue
-                acl_drops += duthost.acl_facts(namespace=namespace)["ansible_facts"]["ansible_acl_facts"][
-                    drop_information if drop_information else "DATAACL"]["rules"]["RULE_1"]["packets_count"]
+        def get_acl_drops():
+            acl_drops = 0
+            for duthost in duthosts.frontend_nodes:
+                for sonic_host_or_asic_inst in duthost.get_sonic_host_and_frontend_asic_instance():
+                    namespace = sonic_host_or_asic_inst.namespace if hasattr(sonic_host_or_asic_inst,
+                                                                             'namespace') else DEFAULT_NAMESPACE
+                    if duthost.sonichost.is_multi_asic and namespace == DEFAULT_NAMESPACE:
+                        continue
+                    acl_drops += duthost.acl_facts(namespace=namespace)["ansible_facts"]["ansible_acl_facts"][
+                        drop_information if drop_information else "DATAACL"]["rules"]["RULE_1"]["packets_count"]
+            return acl_drops
+
+        # A freshly-added ACL rule's flex counter is created immediately but reports no value until its
+        # first flex-counter poll, which lands one full POLL_INTERVAL (~10s) after creation. Until then
+        # `aclshow` shows "N/A", which acl_facts coerces to 0. Reading once after a fixed
+        # ACL_COUNTERS_UPDATE_INTERVAL sleep leaves zero margin against that poll interval, so under heavy
+        # control-plane load (e.g. route churn on the min-nexthop topo, which keeps syncd busy and delays
+        # the counter poll) the read can land before the first poll and fail spuriously. Poll instead.
+        wait_until(ACL_COUNTERS_UPDATE_INTERVAL * 6, ACL_COUNTERS_UPDATE_INTERVAL, ACL_COUNTERS_UPDATE_INTERVAL,
+                   lambda: get_acl_drops() == pkt_number)
+        acl_drops = get_acl_drops()
         if acl_drops != pkt_number:
             fail_msg = "ACL drop counter was not incremented on iface {}. DUT ACL counter == {}; Sent pkts == {}"\
                 .format(tx_dut_ports[ports_info["dut_iface"]], acl_drops, pkt_number)

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import time
 import pytest
 import yaml
 import re
@@ -243,10 +242,12 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
         # ACL_COUNTERS_UPDATE_INTERVAL sleep leaves zero margin against that poll interval, so under heavy
         # control-plane load (e.g. route churn on the min-nexthop topo, which keeps syncd busy and delays
         # the counter poll) the read can land before the first poll and fail spuriously. Poll instead.
-        wait_until(ACL_COUNTERS_UPDATE_INTERVAL * 6, ACL_COUNTERS_UPDATE_INTERVAL, ACL_COUNTERS_UPDATE_INTERVAL,
-                   lambda: get_acl_drops() == pkt_number)
-        acl_drops = get_acl_drops()
-        if acl_drops != pkt_number:
+        acl_counter_updated = wait_until(
+            ACL_COUNTERS_UPDATE_INTERVAL * 6, ACL_COUNTERS_UPDATE_INTERVAL, ACL_COUNTERS_UPDATE_INTERVAL,
+            lambda: get_acl_drops() == pkt_number
+        )
+        if not acl_counter_updated:
+            acl_drops = get_acl_drops()
             fail_msg = "ACL drop counter was not incremented on iface {}. DUT ACL counter == {}; Sent pkts == {}"\
                 .format(tx_dut_ports[ports_info["dut_iface"]], acl_drops, pkt_number)
             pytest.fail(fail_msg)


### PR DESCRIPTION
### Description of PR

**Summary:** `drop_packets/test_drop_counters.py::test_acl_drop` reads the ACL drop counter once after a fixed sleep, which races the flex-counter poll and fails spuriously under control-plane load. Replace the single read with a poll.

**Fixes:** flaky/failing `test_acl_drop` on the q3d ASIC min-topo nightly.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework (new/improved test & fixtures)
- [ ] New Test case
- [ ] Test case enhancement

### Approach

#### What is the motivation for this PR?

`test_acl_drop` programs `DATAACL/RULE_1` (drop), sends `PKT_NUMBER` packets, then reads `RULE_1["packets_count"]` **once** after a fixed `time.sleep(ACL_COUNTERS_UPDATE_INTERVAL)` (10 s).

That 10 s equals the ACL flex-counter `POLL_INTERVAL`, so there is **zero margin**: a freshly-added ACL rule's counter is created immediately but reports no value until its first poll tick. Until then `aclshow` shows `N/A`, which `acl_facts` coerces to `0`. When the read lands before that first poll, the test sees `0` and fails with *"ACL drop counter was not incremented … counter == 0"*.

This is load/topology-sensitive rather than an ASIC/image defect:
- On the **min-q3d-topo** topology the DUT's `syncd` is saturated by continuous BGP route churn (RIB ~102k vs ~800 programmed, `syncd` >60% CPU). `syncd` also services flex-counter polling, so the counter's first value is delayed past the 10 s read → **fails**.
- On the **max (stable) topology** `syncd` is idle, the counter polls on time → **passes**.

Measured on a q3d DUT: the ACL counter object is created in ~6 ms; its first value appears at ~10.4 s (the poll boundary) — confirming the read simply has no margin against the poll interval.

#### How did you do it?

Factored the per-DUT/per-asic counter summation into a `get_acl_drops()` helper and replaced the single `sleep(10)` + read with `wait_until(ACL_COUNTERS_UPDATE_INTERVAL * 6, ACL_COUNTERS_UPDATE_INTERVAL, ACL_COUNTERS_UPDATE_INTERVAL, lambda: get_acl_drops() == PKT_NUMBER)`, then the same final assertion. The initial 10 s delay is preserved, so behavior is unchanged where the counter is already up-to-date within 10 s; slower/loaded platforms simply wait a few more poll cycles (up to 60 s). Test-only change.

#### How did you verify/test it?

Ran `test_acl_drop` on a q3d min-topo testbed. `test_acl_drop[port_channel_members]` — the case that fails on nightly — now **passes** with the fix. (`test_acl_drop[rif_members]` failed for an unrelated reason on that run: its tx interface was oper-down, so no traffic could flow.)

### Any platform specific information?

Surfaces on the q3d ASIC under min-topo route churn, but the fix is platform-agnostic and behavior-preserving on platforms where the 10 s read already worked.

### Documentation

- [ ] N/A — no doc change.

