### PR TITLE
[GCU] Preserve existing golden config during CACL reload

### DIFF
--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -8,8 +8,12 @@ from tests.common.gu_utils import apply_patch, expect_op_success, expect_res_suc
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import format_json_patch_for_multiasic
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
-from tests.common.utilities import wait_until
-from tests.common.config_reload import config_reload_minigraph_with_rendered_golden_config_override
+from tests.common.utilities import file_exists_on_dut, wait_until
+from tests.common.config_reload import (
+    DEFAULT_GOLDEN_CONFIG_PATH,
+    config_reload,
+    config_reload_minigraph_with_rendered_golden_config_override,
+)
 
 # Test on t0 topo to verify functionality and to choose predefined variable
 # admin@vlab-01:~$ show acl table
@@ -49,9 +53,30 @@ def get_iptable_rules(duthost, ip_netns_namespace_prefix):
 @pytest.fixture(scope="module", autouse=True)
 def restore_test_env(duthosts, rand_one_dut_front_end_hostname):
     duthost = duthosts[rand_one_dut_front_end_hostname]
-    config_reload_minigraph_with_rendered_golden_config_override(
-        duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
-    yield
+    golden_config_exists = file_exists_on_dut(duthost, DEFAULT_GOLDEN_CONFIG_PATH)
+    try:
+        if golden_config_exists:
+            config_reload(
+                duthost,
+                config_source="minigraph",
+                safe_reload=True,
+                check_intf_up_ports=True,
+                wait_for_bgp=True,
+                override_config=True,
+            )
+        else:
+            config_reload_minigraph_with_rendered_golden_config_override(
+                duthost,
+                safe_reload=True,
+                check_intf_up_ports=True,
+                wait_for_bgp=True,
+            )
+        yield
+    finally:
+        if not golden_config_exists and file_exists_on_dut(duthost, DEFAULT_GOLDEN_CONFIG_PATH):
+            duthost.command(
+                "mv {} {}_backup".format(DEFAULT_GOLDEN_CONFIG_PATH, DEFAULT_GOLDEN_CONFIG_PATH)
+            )
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix  generic_config_updater/test_cacl.py  so its module-level minigraph reload preserves an existing deployment-generated  /etc/sonic/golden_config_db.json .

When the file is absent, retain the fallback introduced by PR #25691. Preserve the existing interface and BGP readiness checks and clean up the fallback-generated file after the module.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
On the fully lossy Mellanox-SN5640-C512S2 SKU, deployment generates a
golden config containing:

"default_pfcwd_status": "disable"

PR #25691 changed the CACL setup to call
config_reload_minigraph_with_rendered_golden_config_override(). Its default
template contains only an empty JSON object, so rendering it overwrote the
deployment-generated golden config.

The subsequent minigraph reload therefore lost the SKU-specific
default_pfcwd_status setting and used the global init_cfg.json default,
which enabled PFC watchdog.

Because this SKU has no lossless traffic classes, orchagent repeatedly
logged:

createEntry: Failed to start PFC Watchdog on port EthernetN

This caused LogAnalyzer teardown failures across the CACL module even
though the test bodies passed.

#### How did you do it?
Change

- Check whether /etc/sonic/golden_config_db.json already exists.
- If present, use it with config_reload(..., override_config=True).
- If absent, use
  config_reload_minigraph_with_rendered_golden_config_override() as the
  fallback introduced by PR #25691.
- Preserve check_intf_up_ports=True and wait_for_bgp=True in both reload
  paths.
- Reuse file_exists_on_dut().
- Move the fallback-generated golden config out of the active path after
  the module so it cannot be mistaken for a deployment-generated file on
  a later run.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Manual test: https://elastictest.org/scheduler/testplan/6a7d1b9319239aa976852df9?testcase=generic_config_updater%2Ftest_cacl.py+&type=console
Run the CACL case that exercises module setup, minigraph reload,
the test body, rollback, and LogAnalyzer teardown. Test passed.
<img width="874" height="330" alt="Screenshot 2026-08-11 120645" src="https://github.com/user-attachments/assets/6260740b-7010-47d4-967e-ffc2569aa0b7" />


#### Any platform specific information?
fully lossy SN5640 SKUs

#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
