### PR TITLE
conditional_mark: handle pytest 9 Everflow parameter order

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1898,16 +1898,6 @@ everflow/test_everflow_per_interface.py:
       - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
       - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-buildimage/issues/11776"
 
-everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-erspan:
-  skip:
-    reason: "Skip everflow packet integrity IPv6 test on unsupported platforms"
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['cisco-8000', 'marvell', 'mellanox', 'marvell-prestera'] or (asic_subtype in ['broadcom-dnx'] and https://github.com/sonic-net/sonic-swss/issues/2204)"
-      - "'dualtor' in topo_name"
-      - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
-      - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-buildimage/issues/11776"
-
 everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-m0_l3_scenario]:
   skip:
     reason: "Skip m0 everflow packet integrity IPv6 test on unsupported platforms"
@@ -1928,6 +1918,17 @@ everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-m0_vla
       - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
       - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-buildimage/issues/11776"
 
+everflow/test_everflow_per_interface.py::test_everflow_packet_format\[(?:ipv6-erspan_ipv[46]|erspan_ipv[46]-ipv6)(?:-|\]):
+  regex: true
+  skip:
+    reason: "Skip everflow packet integrity IPv6 test on unsupported platforms"
+    conditions_logical_operator: or
+    conditions:
+      - "asic_type in ['cisco-8000', 'marvell', 'mellanox', 'marvell-prestera'] or (asic_subtype in ['broadcom-dnx'] and https://github.com/sonic-net/sonic-swss/issues/2204)"
+      - "'dualtor' in topo_name"
+      - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
+      - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-buildimage/issues/11776"
+
 everflow/test_everflow_per_interface.py::test_everflow_packet_format\[.*ipv4:
   regex: true
   skip:
@@ -1940,16 +1941,6 @@ everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4-erspan
     reason: "xfail for scale topology, PTF is not stable at the scale testbed"
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/21571 and 't0-isolated-d256u256s2' in topo_name"
-
-everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-erspan:
-  skip:
-    reason: "Skip everflow per interface IPv6 test on unsupported platforms"
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['cisco-8000', 'marvell', 'mellanox', 'marvell-prestera'] or (asic_subtype in ['broadcom-dnx'] and https://github.com/sonic-net/sonic-swss/issues/2204)"
-      - "'dualtor' in topo_name"
-      - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
-      - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-buildimage/issues/11776"
 
 everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-erspan_ipv6-default]:
   skip:
@@ -1973,6 +1964,17 @@ everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-m0_vla
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['marvell', 'marvell-prestera']"
+      - "'dualtor' in topo_name"
+      - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
+      - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-buildimage/issues/11776"
+
+everflow/test_everflow_per_interface.py::test_everflow_per_interface\[(?:ipv6-erspan_ipv[46]|erspan_ipv[46]-ipv6)(?:-|\]):
+  regex: true
+  skip:
+    reason: "Skip everflow per interface IPv6 test on unsupported platforms"
+    conditions_logical_operator: or
+    conditions:
+      - "asic_type in ['cisco-8000', 'marvell', 'mellanox', 'marvell-prestera'] or (asic_subtype in ['broadcom-dnx'] and https://github.com/sonic-net/sonic-swss/issues/2204)"
       - "'dualtor' in topo_name"
       - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
       - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-buildimage/issues/11776"

--- a/tests/common/plugins/conditional_mark/unit_test/tests_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/unit_test/tests_conditions.yaml
@@ -123,3 +123,13 @@ test_conditional_mark.py::test_mark_9_2:
     reason: "Xfail test_conditional_mark.py::test_mark_9_2"
     conditions:
       - "asic_type in ['vs']"
+
+# Mirrors the shape of the production regex added for
+# https://github.com/sonic-net/sonic-mgmt/issues/26793 (conditional_mark rules
+# that must match regardless of which order pytest joins two independently
+# parametrized fixtures into the nodeid, e.g. pytest <=8 "ipv6-erspan_ipv4" vs
+# pytest 9 "erspan_ipv4-ipv6").
+test_everflow_reorder_mark.py::test_everflow_reorder_mark\[(?:ipv6-erspan_ipv[46]|erspan_ipv[46]-ipv6)(?:-|\]):
+  regex: true
+  skip:
+    reason: "Skip test_everflow_reorder_mark.py::test_everflow_reorder_mark"

--- a/tests/common/plugins/conditional_mark/unit_test/unittest_find_all_matches.py
+++ b/tests/common/plugins/conditional_mark/unit_test/unittest_find_all_matches.py
@@ -292,6 +292,95 @@ class TestFindAllMatches(unittest.TestCase):
         self.assertEqual(len(marks_found), 1)
         self.assertIn('xfail', marks_found)
 
+    # Regression coverage for https://github.com/sonic-net/sonic-mgmt/issues/26793:
+    # pytest 9 changed the join order of independently parametrized fixtures in
+    # generated node IDs (e.g. "ipv6-erspan_ipv4" under pytest <=8 becomes
+    # "erspan_ipv4-ipv6" under pytest 9). A plain nodeid.startswith() prefix rule
+    # written against one order silently stops matching under the other. These
+    # cases exercise a regex:true rule (mirroring the production fix in
+    # tests_mark_conditions.yaml) that matches both orders.
+    def test_reorder_regex_old_order_erspan_ipv4(self):
+        conditions, session_mock = load_test_conditions()
+        nodeid = "test_everflow_reorder_mark.py::test_everflow_reorder_mark[ipv6-erspan_ipv4-default]"
+
+        marks_found = []
+        matches = find_all_matches(nodeid, conditions, session_mock, DYNAMIC_UPDATE_SKIP_REASON, CUSTOM_BASIC_FACTS)
+
+        for match in matches:
+            for mark_name, mark_details in list(list(match.values())[0].items()):
+                marks_found.append(mark_name)
+
+                if mark_name == "skip":
+                    self.assertEqual(
+                        mark_details.get("reason"),
+                        "Skip test_everflow_reorder_mark.py::test_everflow_reorder_mark")
+
+        self.assertEqual(len(marks_found), 1)
+        self.assertIn('skip', marks_found)
+
+    def test_reorder_regex_old_order_erspan_ipv6(self):
+        conditions, session_mock = load_test_conditions()
+        nodeid = "test_everflow_reorder_mark.py::test_everflow_reorder_mark[ipv6-erspan_ipv6-default]"
+
+        marks_found = []
+        matches = find_all_matches(nodeid, conditions, session_mock, DYNAMIC_UPDATE_SKIP_REASON, CUSTOM_BASIC_FACTS)
+
+        for match in matches:
+            for mark_name, mark_details in list(list(match.values())[0].items()):
+                marks_found.append(mark_name)
+
+        self.assertEqual(len(marks_found), 1)
+        self.assertIn('skip', marks_found)
+
+    def test_reorder_regex_pytest9_order_erspan_ipv4(self):
+        conditions, session_mock = load_test_conditions()
+        nodeid = "test_everflow_reorder_mark.py::test_everflow_reorder_mark[erspan_ipv4-ipv6-default]"
+
+        marks_found = []
+        matches = find_all_matches(nodeid, conditions, session_mock, DYNAMIC_UPDATE_SKIP_REASON, CUSTOM_BASIC_FACTS)
+
+        for match in matches:
+            for mark_name, mark_details in list(list(match.values())[0].items()):
+                marks_found.append(mark_name)
+
+        self.assertEqual(len(marks_found), 1)
+        self.assertIn('skip', marks_found)
+
+    def test_reorder_regex_pytest9_order_erspan_ipv6(self):
+        conditions, session_mock = load_test_conditions()
+        nodeid = "test_everflow_reorder_mark.py::test_everflow_reorder_mark[erspan_ipv6-ipv6-default]"
+
+        marks_found = []
+        matches = find_all_matches(nodeid, conditions, session_mock, DYNAMIC_UPDATE_SKIP_REASON, CUSTOM_BASIC_FACTS)
+
+        for match in matches:
+            for mark_name, mark_details in list(list(match.values())[0].items()):
+                marks_found.append(mark_name)
+
+        self.assertEqual(len(marks_found), 1)
+        self.assertIn('skip', marks_found)
+
+    def test_reorder_regex_does_not_match_ipv4(self):
+        conditions, session_mock = load_test_conditions()
+
+        for nodeid in (
+            "test_everflow_reorder_mark.py::test_everflow_reorder_mark[ipv4-erspan_ipv4-default]",
+            "test_everflow_reorder_mark.py::test_everflow_reorder_mark[erspan_ipv4-ipv4-default]",
+        ):
+            matches = find_all_matches(nodeid, conditions, session_mock, DYNAMIC_UPDATE_SKIP_REASON,
+                                       CUSTOM_BASIC_FACTS)
+            self.assertFalse(matches, "unexpected match for {}".format(nodeid))
+
+    def test_reorder_regex_does_not_match_other_function(self):
+        conditions, session_mock = load_test_conditions()
+        # Same file, a function name that has test_everflow_reorder_mark as a
+        # prefix -- must not match, proving the rule is anchored to the exact
+        # test function rather than just searching for the tokens anywhere.
+        nodeid = "test_everflow_reorder_mark.py::test_everflow_reorder_mark_extra[ipv6-erspan_ipv4-default]"
+
+        matches = find_all_matches(nodeid, conditions, session_mock, DYNAMIC_UPDATE_SKIP_REASON, CUSTOM_BASIC_FACTS)
+        self.assertFalse(matches)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of PR

Summary:

Fixes #26793

Pytest 9 changed fixture-closure traversal from breadth-first to depth-first, which changes the order of independently parametrized fixture values in some Everflow test node IDs.

For example, node IDs that previously contained:

`[ipv6-erspan_ipv4-...]`

can now contain:

`[erspan_ipv4-ipv6-...]`

Two `conditional_mark` rules for `test_everflow_packet_format` and `test_everflow_per_interface` relied on the previous literal parameter order, so their skip conditions no longer matched under pytest 9.

This changes those two rules to narrowly scoped regex entries that accept either fixture ordering while preserving their existing skip conditions and reasons.

Focused unit coverage verifies both pytest <=8 and pytest 9 orderings and guards against matching IPv4 or a different test function.

### Type of change

* [x] Bug fix
* [ ] Testbed and Framework(new/improvement)
* [ ] New Test case

  * [ ] Skipped for non-supported platforms
* [ ] Test case improvement

### Back port request

* [ ] 202311
* [ ] 202405
* [ ] 202411
* [ ] 202505
* [ ] 202511
* [ ] 202512
* [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A

Failure type: regression

### Tested branch

* [x] master
* [ ] 202311
* [ ] 202405
* [ ] 202411
* [ ] 202505
* [ ] 202511
* [ ] 202512
* [ ] 202605
* [ ] N/A

### Test result

* `conditional_mark` unit tests: 24 passed
* Verified both pytest <=8 and pytest 9 Everflow parameter orderings
* Verified IPv4 and a different test function do not match the new rules
* Conditional-mark YAML sort check passed
* flake8 passed on the changed Python test
* YAML parsing passed for both changed YAML files
* `git diff --check` passed

### Approach

#### What is the motivation for this PR?

The conditional-mark plugin matches non-regex rules against pytest node IDs. Pytest 9 can reorder independently parametrized fixture values in those IDs, causing rules written against the previous ordering to silently stop matching.

#### How did you do it?

Converted only the two confirmed affected Everflow rules to explicit `regex: true` entries that recognize either:

* `ipv6-erspan_ipv4` / `ipv6-erspan_ipv6`, or
* `erspan_ipv4-ipv6` / `erspan_ipv6-ipv6`

The matching logic itself is unchanged, and other Everflow conditional-mark rules are not modified.

Added focused regression cases to the existing `conditional_mark` unit-test harness.

#### How did you verify/test it?

Reproduced the fixture-order change using pytest 7.4.4 and pytest 9.1.1, then verified the new rules against both node-ID orderings.

The existing conditional-mark unit suite passes with the added regression cases.

#### Any platform specific information?

None. This is test-framework matching behavior and is platform independent.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

No documentation change.
