### PR TITLE
Update Everlfow Policer to Skip Validations for Known Regressions

### DIFF
--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -854,12 +854,15 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                tolerance=everflow_tolerance)
 
             # Verify that packets dropped by policer do not increment TX_DROP counters
-            # We also skip for certain asics that have known regressions
             mirror_port = get_mirror_port(everflow_dut, "TEST_POLICER_SESSION")
-            if everflow_dut.get_asic_name() != "th2":
-                assert_no_tx_drops_on_mirror_port(everflow_dut, mirror_port)
-            if everflow_dut.get_asic_name() not in {"th2", "td3"}:
-                assert_no_tx_queue_drops_on_mirror_port(everflow_dut, mirror_port)
+            asic_name = everflow_dut.get_asic_name()
+            if asic_name == "th2":
+                pytest.xfail("TX drop counter validation is not supported on TH2")
+            assert_no_tx_drops_on_mirror_port(everflow_dut, mirror_port)
+
+            if asic_name == "td3":
+                pytest.xfail("TX queue drop counter validation is not supported on TD3")
+            assert_no_tx_queue_drops_on_mirror_port(everflow_dut, mirror_port)
         finally:
             # Clean up ACL rules and routes
             BaseEverflowTest.remove_acl_rule_config(everflow_dut, table_name, config_method)

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -98,7 +98,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     DEFAULT_SRC_IP = "20.0.0.1"
     DEFAULT_DST_IP = "30.0.0.1"
-    MIRROR_POLICER_UNSUPPORTED_ASIC_LIST = ["th5", "th4", "th3", "j2c+", "jr2"]
+    MIRROR_POLICER_UNSUPPORTED_ASIC_LIST = ["th5", "th4", "th3", "th2", "td3", "j2c+", "jr2"]
 
     @pytest.fixture(params=[DOWN_STREAM, UP_STREAM])
     def dest_port_type(self, setup_info, setup_mirror_session, tbinfo, request, erspan_ip_ver):        # noqa F811

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -856,9 +856,9 @@ class EverflowIPv4Tests(BaseEverflowTest):
             # Verify that packets dropped by policer do not increment TX_DROP counters
             # We also skip for certain asics that have known regressions
             mirror_port = get_mirror_port(everflow_dut, "TEST_POLICER_SESSION")
-            if duthost.get_asic_name() != "th2":
+            if everflow_dut.get_asic_name() != "th2":
                 assert_no_tx_drops_on_mirror_port(everflow_dut, mirror_port)
-            if duthost.get_asic_name() not in {"th2", "td3"}:
+            if everflow_dut.get_asic_name() not in {"th2", "td3"}:
                 assert_no_tx_queue_drops_on_mirror_port(everflow_dut, mirror_port)
         finally:
             # Clean up ACL rules and routes

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -98,7 +98,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     DEFAULT_SRC_IP = "20.0.0.1"
     DEFAULT_DST_IP = "30.0.0.1"
-    MIRROR_POLICER_UNSUPPORTED_ASIC_LIST = ["th5", "th4", "th3", "th2", "td3", "j2c+", "jr2"]
+    MIRROR_POLICER_UNSUPPORTED_ASIC_LIST = ["th5", "th4", "th3", "j2c+", "jr2"]
 
     @pytest.fixture(params=[DOWN_STREAM, UP_STREAM])
     def dest_port_type(self, setup_info, setup_mirror_session, tbinfo, request, erspan_ip_ver):        # noqa F811
@@ -854,9 +854,12 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                tolerance=everflow_tolerance)
 
             # Verify that packets dropped by policer do not increment TX_DROP counters
+            # We also skip for certain asics that have known regressions
             mirror_port = get_mirror_port(everflow_dut, "TEST_POLICER_SESSION")
-            assert_no_tx_drops_on_mirror_port(everflow_dut, mirror_port)
-            assert_no_tx_queue_drops_on_mirror_port(everflow_dut, mirror_port)
+            if duthost.get_asic_name() != "th2":
+                assert_no_tx_drops_on_mirror_port(everflow_dut, mirror_port)
+            if duthost.get_asic_name() not in {"th2", "td3"}:
+                assert_no_tx_queue_drops_on_mirror_port(everflow_dut, mirror_port)
         finally:
             # Clean up ACL rules and routes
             BaseEverflowTest.remove_acl_rule_config(everflow_dut, table_name, config_method)


### PR DESCRIPTION

### Description of PR
Skips policer test for TH3 and TD3 ASICs as they currently have issues regarding how they deal with policer-dropped packets in their packet and/or queue counters. These issues cause expected test failures, so we are xfailing the failing validations until we can reach a resolution

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

For 7260 xfails at initial interface counter check:
[sonic_test.log](https://github.com/user-attachments/files/31152456/sonic_test.log)



For 7050cx3 xfails at checking queue drops
[sonic_test.log](https://github.com/user-attachments/files/31154881/sonic_test.log)





### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
