### PR TITLE
[acl] Fix remove_dataacl_table teardown to check golden_config_db.jso…

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -204,14 +204,25 @@ def remove_dataacl_table(duthosts):
     with SafeThreadPoolExecutor(max_workers=8) as executor:
         # Recover DUT by reloading minigraph
         for duthost in duthosts:
-            executor.submit(
-                config_reload,
-                duthost,
-                config_source="minigraph",
-                safe_reload=True,
-                override_config=True,
-                check_intf_up_ports=True
-            )
+            executor.submit(reload_minigraph_with_optional_override, duthost)
+
+
+def reload_minigraph_with_optional_override(duthost):
+    """
+    Reload minigraph, applying golden config override only if the golden
+    config file actually exists on the DUT. Passing override_config=True
+    causes config_reload/load_minigraph to abort test with
+    "Cannot find 'golden_config_db.json'!".
+    """
+    golden_cfg = duthost.stat(path="/etc/sonic/golden_config_db.json")
+    override_config = golden_cfg.get("stat", {}).get("exists", False)
+    config_reload(
+        duthost,
+        config_source="minigraph",
+        safe_reload=True,
+        override_config=override_config,
+        check_intf_up_ports=True
+    )
 
 
 def remove_dataacl_table_single_dut(table_name, duthost):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The  remove_dataacl_table  teardown in  tests/acl/test_acl.py  was reloading the minigraph with  override_config=True  unconditionally. This causes  config_reload / load_minigraph  to abort with:
Cannot find 'golden_config_db.json'!
on any DUT/testbed where  /etc/sonic/golden_config_db.json  does not exist, failing test teardown even when the actual test passed.
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
The  remove_dataacl_table  teardown in  tests/acl/test_acl.py  was reloading the minigraph with  override_config=True  unconditionally. This causes  config_reload / load_minigraph  to abort with:
Cannot find 'golden_config_db.json'!
on any DUT/testbed where  /etc/sonic/golden_config_db.json  does not exist, failing test teardown even when the actual test passed.

#### How did you do it?
Added a new helper  reload_minigraph_with_optional_override()  that:
• Checks whether  /etc/sonic/golden_config_db.json  exists on the DUT
• Sets  override_config=True  only if the file exists; otherwise falls back to  override_config=False .
• Preserves the original reload behavior.


#### How did you verify/test it?
Verified the fix by running test_acl elastic test
https://elastictest.org/scheduler/testplan/6a7ad3006fff0a820f1b3335 
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
