### PR TITLE
[snappi] get_queue_scheduler_weight_dict: support VOQ compound QUEUE keys

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1574,7 +1574,37 @@ def get_queue_scheduler_weight_dict(host_ans, asic_value=None, port=None,
                                              source="running",
                                              namespace=asic_value)["ansible_facts"]
 
-    queue_cfg_all = config_facts.get("QUEUE") or {}
+    def _iter_queue_entries(node, tokens):
+        """Yield ``(tokens, cfg)`` for every leaf queue-config dict in ``node``,
+        accumulating the ``|``-split tokens of every key along the path.
+
+        This copes with any ``QUEUE`` layout config_facts produces:
+        classic ``{port: {queue: cfg}}``, fully nested VOQ
+        ``{host: {asic: {port: {queue: cfg}}}}``, and the multi-asic
+        compound-key form ``{host: {'<asic>|<port>|<queue>': cfg}}`` where
+        only the host prefix is split off and the rest stays a single key.
+        A leaf is a dict whose values are all scalars (the queue's fields,
+        e.g. ``scheduler`` / ``wred_profile``)."""
+        if not isinstance(node, dict) or not node:
+            return
+        if all(not isinstance(v, dict) for v in node.values()):
+            yield tokens, node
+            return
+        for key, val in node.items():
+            yield from _iter_queue_entries(val, tokens + tuple(str(key).split("|")))
+
+    # Normalize QUEUE to {port: {queue: cfg}} from whatever nesting/key format
+    # the platform uses. The port is the interface-looking token; the queue is
+    # the trailing token of the flattened key path.
+    queue_cfg_all = {}
+    for tokens, cfg in _iter_queue_entries(config_facts.get("QUEUE") or {}, ()):
+        if len(tokens) < 2:
+            continue
+        queue_id = tokens[-1]
+        port_tok = next((t for t in reversed(tokens[:-1])
+                         if t.startswith("Ethernet")), tokens[-2])
+        queue_cfg_all.setdefault(port_tok, {})[queue_id] = cfg
+
     scheduler_cfg = config_facts.get("SCHEDULER") or {}
 
     dscp_to_tc = config_facts.get("DSCP_TO_TC_MAP") or {}

--- a/tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py
+++ b/tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py
@@ -94,6 +94,45 @@ def test_get_queue_scheduler_weight_dict():
     assert _load("get_queue_scheduler_weight_dict")(host) == EXPECTED
 
 
+def test_get_queue_scheduler_weight_dict_voq_key_format():
+    """VOQ / multi-ASIC platforms may key ``QUEUE`` as
+    ``QUEUE|<host>|<asic>|<port>|<queue>``, so config_facts may nest it as
+    ``{host: {asic: {port: {queue: cfg}}}}``. The port lookup must still work."""
+    voq_facts = {k: v for k, v in CONFIG_FACTS.items() if k != "QUEUE"}
+    voq_facts["QUEUE"] = {
+        "sonic_dut": {
+            "Asic0": CONFIG_FACTS["QUEUE"],
+        },
+    }
+    host = MagicMock()
+    host.hostname = "sonic_dut"
+    host.config_facts.return_value = {"ansible_facts": voq_facts}
+
+    assert _load("get_queue_scheduler_weight_dict")(
+        host, port="Ethernet100") == EXPECTED
+
+
+def test_get_queue_scheduler_weight_dict_compound_key_format():
+    """VOQ / multi-ASIC hosts can return ``QUEUE`` from
+    config_facts as ``{host: {'<asic>|<port>|<queue>': cfg}}`` -- only the host
+    prefix is split off and the ``asic|port|queue`` remainder stays a single
+    compound key with a scalar-leaf cfg. The port/queue must be parsed out of
+    that compound key."""
+    compound_facts = {k: v for k, v in CONFIG_FACTS.items() if k != "QUEUE"}
+    compound_facts["QUEUE"] = {
+        "sonic_dut": {
+            "Asic0|Ethernet100|{}".format(q): cfg
+            for q, cfg in CONFIG_FACTS["QUEUE"]["Ethernet100"].items()
+        },
+    }
+    host = MagicMock()
+    host.hostname = "sonic_dut"
+    host.config_facts.return_value = {"ansible_facts": compound_facts}
+
+    assert _load("get_queue_scheduler_weight_dict")(
+        host, port="Ethernet100") == EXPECTED
+
+
 def test_get_queue_scheduler_weight_dict_defaults_when_unconfigured():
     """When QUEUE/SCHEDULER are absent, fall back to 8 queues w/ equal weights."""
     host = MagicMock()


### PR DESCRIPTION
#### Why I did it
`get_queue_scheduler_weight_dict` (used by `snappi_tests/pfc/test_m2o_fluctuating_lossless`) assumed `config_facts["QUEUE"]` is keyed directly by port, i.e. `{port: {queue: cfg}}`.

On VOQ / multi-ASIC platforms, `config_facts` can instead return `QUEUE` keyed by **hostname** with a **compound** remainder:

```
{'<host>': {'<asic>|<port>|<queue>': {...}, ...}}
```

so the per-port lookup raised:

```
KeyError: "Port <port> not found in QUEUE config (available: ['<host>'])"
```

failing `test_m2o_fluctuating_lossless` on such DUTs.

#### How I did it
Normalize `QUEUE` to `{port: {queue: cfg}}` with a small recursive token walk that splits every key on `|` along the path and derives the **port** (interface-looking token) and **queue** (trailing token) for each leaf cfg. Handles all three layouts:
- classic `{port: {queue: cfg}}`
- fully-nested `{host: {asic: {port: {queue: cfg}}}}`
- compound-key `{host: {'<asic>|<port>|<queue>': cfg}}`

#### How to verify it
- Existing classic unit test is unchanged and still passes (byte-identical output on non-VOQ platforms) — the change only rescues the previously-crashing VOQ path.
- Added `test_get_queue_scheduler_weight_dict_voq_key_format` and `test_get_queue_scheduler_weight_dict_compound_key_format`.
- `py_compile` + `flake8` clean.
- Verified on hardware: `test_m2o_fluctuating_lossless` now **passes** on a single-ASIC VOQ DUT (previously `KeyError`).

Single consumer of the function (`m2o_fluctuating_lossless_helper.py`), backward compatible.
