### PR TITLE
[conftest] Exclude recirculation/inband ports from port enumeration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2025,6 +2025,13 @@ def generate_port_lists(request, port_scope, with_completeness_level=False):
         if 'intf_status' not in val:
             continue
         for intf, status in list(val['intf_status'].items()):
+            # Skip internal ports (recirculation / inband). They match the
+            # 'Ethernet' scope (e.g. 'Ethernet-Rec0', 'Ethernet-IB0') and can
+            # be oper/admin up, but they are not front-panel test ports and
+            # have no fanout/TGEN mapping, so tests that pick one (e.g. via
+            # rand_one_dut_portname_oper_up) fail to resolve a port id.
+            if intf.startswith(("Ethernet-Rec", "Ethernet-IB")):
+                continue
             if scope in intf and (not state or status[state] == 'up'):
                 dut_port_pairs.append(encode_dut_port_name(dut, intf))
         dut_port_map[dut] = dut_port_pairs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2025,12 +2025,13 @@ def generate_port_lists(request, port_scope, with_completeness_level=False):
         if 'intf_status' not in val:
             continue
         for intf, status in list(val['intf_status'].items()):
-            # Skip internal ports (recirculation / inband). They match the
-            # 'Ethernet' scope (e.g. 'Ethernet-Rec0', 'Ethernet-IB0') and can
-            # be oper/admin up, but they are not front-panel test ports and
-            # have no fanout/TGEN mapping, so tests that pick one (e.g. via
-            # rand_one_dut_portname_oper_up) fail to resolve a port id.
-            if intf.startswith(("Ethernet-Rec", "Ethernet-IB")):
+            # Skip internal ports (recirculation / inband / backplane). They
+            # match the 'Ethernet' scope (e.g. 'Ethernet-Rec0', 'Ethernet-IB0',
+            # 'Ethernet-BP0') and can be oper/admin up, but they are not
+            # front-panel test ports and have no fanout/TGEN mapping, so tests
+            # that pick one (e.g. via rand_one_dut_portname_oper_up) fail to
+            # resolve a port id.
+            if intf.startswith(("Ethernet-Rec", "Ethernet-IB", "Ethernet-BP")):
                 continue
             if scope in intf and (not state or status[state] == 'up'):
                 dut_port_pairs.append(encode_dut_port_name(dut, intf))


### PR DESCRIPTION
#### Why I did it
`generate_port_lists` (which backs `rand_one_dut_portname_oper_up`, `enum_dut_portname_oper_up`, `enum_dut_portname_admin_up`, etc.) selects interfaces with `scope in intf` where `scope == "Ethernet"`. That substring match also matches internal **recirculation** (`Ethernet-Rec*`) and **inband** (`Ethernet-IB*`) ports, which on VOQ/DNX platforms are oper/admin up but are **not** front-panel test ports and have no fanout/TGEN mapping.

When a test happens to draw one of these (e.g. `snappi_tests/pfc/test_pfc_pause_unset_bit_enable_vector` via `rand_one_dut_portname_oper_up`), `get_dut_port_id()` returns `None`, and the traffic setup then fails with:

```
ValueError: Fail to find configuration for RX port
```

Because the random pick is fixed per session, this manifests as an intermittent, all-or-nothing failure on VOQ/DNX DUTs.

#### How I did it
Skip interfaces whose name starts with `Ethernet-Rec` or `Ethernet-IB` in `generate_port_lists`, so these fixtures only enumerate real front-panel / PortChannel ports.

#### How to verify it
- The prefix is precise: SONiC recirculation/inband ports are named `Ethernet-Rec*` / `Ethernet-IB*`, while front-panel ports are `Ethernet<digits>`, so no real port is ever excluded.
- No test relies on recirc/inband ports coming from these enumeration fixtures (everflow's recircle-port tests obtain the port through their own helper, not these fixtures).
- `py_compile` + `flake8` clean.
