### PR TITLE
[action] [PR:26517] [ipfwd] Fix NHOP group capacity assertion

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -446,26 +446,22 @@ def test_nhop_group_member_count(duthost, tbinfo, loganalyzer):
             "crm config polling interval {}".format(crm_before["polling"])
         )
 
-    # verify the test used up all the NHOP group resources
-    # skip this check on Mellanox as ASIC resources are shared
-    if is_cisco_device(duthost) or "7060X6" in duthost.sonichost.get_facts()['platform'].upper():
-        pytest_assert(
-            crm_after["available_nhop_grp"] + nhop_group_count == crm_before["available_nhop_grp"],
-            "Unused NHOP group resource:{}, used:{}, nhop_group_count:{}, Unused NHOP group resource before:{}".format(
-                crm_after["available_nhop_grp"], crm_after["used_nhop_grp"], nhop_group_count,
-                crm_before["available_nhop_grp"]
-
-            )
-        )
-    elif is_mellanox_device(duthost):
+    # verify the test used the expected NHOP group resources
+    if is_mellanox_device(duthost):
         logger.info("skip this check on Mellanox as ASIC resources are shared")
     elif is_vs_device(duthost):
         logger.info("skip this check on VS as no real ASIC")
     else:
+        expected_available_nhop_grp = max(
+            crm_before["available_nhop_grp"] - nhop_group_count, 0
+        )
         pytest_assert(
-            crm_after["available_nhop_grp"] == 0,
-            "Unused NHOP group resource:{}, used_nhop_grp:{}".format(
-                crm_after["available_nhop_grp"], crm_after["used_nhop_grp"]
+            crm_after["available_nhop_grp"] == expected_available_nhop_grp,
+            "Unexpected available NHOP group resources:{}, expected:{}, used:{}, "
+            "nhop_group_count:{}, available before:{}".format(
+                crm_after["available_nhop_grp"], expected_available_nhop_grp,
+                crm_after["used_nhop_grp"], nhop_group_count,
+                crm_before["available_nhop_grp"]
             )
         )
 


### PR DESCRIPTION
### Description of PR

Summary:
Manually cherry-pick #26517 to 202605 after the automated cherry-pick reported a conflict. The CRM assertion now derives the expected remaining next-hop group capacity from the pre-test availability and requested group count.

The conflict was contextual: 202605 retains the older Cisco/7060X6 assertion branch and does not contain #24524's `is_high_scale_platform()` change. The resolution applies only the generic capacity calculation and preserves the branch's existing timeout and programming logic.

Fixes https://github.com/aristanetworks/sonic-qual.msft/issues/1349

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: https://github.com/aristanetworks/sonic-qual.msft/issues/1349

Failure type: regression

Source PR: #26517

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

- `python -m py_compile tests/ipfwd/test_nhop_group.py` passed on the 202605 cherry-pick branch.
- Critical flake8 checks (`E9,F63,F7,F82`) passed on the modified file.
- `git diff --check upstream/202605...HEAD` passed.
- Existing physical Broadcom validation for the same capacity calculation is documented in #26212.
- Direct physical 202605 validation has not yet been run.

### Approach
#### What is the motivation for this PR?

#26517 fixes a CRM assertion that can fail when the test intentionally requests more next-hop groups than the ASIC can allocate. For the reported regression, CRM correctly reached zero available groups, but the assertion incorrectly required all requested groups to have consumed a resource.

The source PR is approved for 202605, but its automated cherry-pick conflicted because the release branch has older platform-selection context.

#### How did you do it?

For platforms with deterministic CRM accounting, calculate the expected available next-hop groups as:

```python
max(available_before - requested_group_count, 0)
```

Compare the post-programming CRM value directly with this result. Mellanox remains excluded because its ASIC resources are shared, and VS remains excluded because it has no real ASIC.

The manual resolution removes only the obsolete platform-specific assertion from 202605. It does not import #24524 or alter the branch's timeout selection.

#### How did you verify/test it?

Validated Python compilation, critical flake8 rules, whitespace, commit ancestry, DCO sign-off, and the exact one-file delta against current `upstream/202605`. Physical target-branch testing is pending.

#### Any platform specific information?

The observed regression is on Arista 7050CX3-32C-S128. The generic calculation also preserves deterministic CRM accounting for Cisco and 7060X6 platforms. Mellanox shared-resource platforms and VS continue to skip the strict assertion.

#### Supported testbed topology if it's a new test case?

N/A. This fixes an existing test.

### Documentation

N/A. No documentation changes are required.
