### PR TITLE
[test] Skip process_monitoring tests on BMC topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4242,6 +4242,12 @@ portstat/test_portstat.py:
 #######################################
 #####     process_monitoring      #####
 #######################################
+process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes:
+  skip:
+    reason: "BMC platforms have no swss/orchagent/syncd containers. This test kills critical processes and relies on auto-restart to recover, which fails on BMC due to reduced container set and lack of PDU controller."
+    conditions:
+      - "'bmc' in topo_type"
+
 process_monitoring/test_critical_process_monitoring.py::test_orchagent_heartbeat:
   skip:
     reason: "This test is intended for Orchagent freeze scenario during warm-reboot. It is not required for T1 devices, and not supported on 202412 release. Also not applicable on BMC platforms which have no orchagent."


### PR DESCRIPTION
### Description of PR

Summary:
Skip `test_monitoring_critical_processes` on BMC topology via `conditional_mark` in `tests_mark_conditions.yaml`.

BMC platforms do not have swss/orchagent/syncd containers. This test kills critical processes and relies on container auto-restart to recover. On BMC:

1. Most containers tested (bgp, syncd, swss, etc.) do not exist
2. The test kills the database container as part of its sweep
3. Without a PDU controller, the board cannot recover from database container death (supervisord exhausts restart retries)
4. This leads to Redis being unreachable, cascading failures, and often an unrecoverable SPL boot loop requiring physical power cycle

`test_orchagent_heartbeat` already has a BMC skip condition. This adds the same for `test_monitoring_critical_processes`.

Fixes #26983

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: day-one issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: SONiC.20260810.05 (internal-202608 aspeed-arm64 build) — full 44-module test suite run on Komodo BMC board (`bmc-test-local` branch with this fix cherry-picked). `process_monitoring` module completed with all tests properly SKIPPED due to the conditional_mark. No container kills, no Redis failures. Board survived the entire run (11+ hours).

### Approach
#### What is the motivation for this PR?

Running `test_monitoring_critical_processes` on BMC boards crashes the DUT. The test sweeps through all critical processes and kills them expecting auto-restart. On BMC:
- `set_owner: kube` without Kubernetes means no auto-restart mechanism
- supervisord inside the database container exhausts 3 restart retries for Redis
- The container stays "Up" but is hollow (Redis dead)
- This cascades into high load, unreachable DUT, and SPL boot loops

This has caused multiple unrecoverable boot loops in our testbed (Jul 28, Aug 10) requiring physical power cycles.

#### How did you do it?

Added a skip condition in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`:

```yaml
process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes:
  skip:
    reason: "BMC platforms lack swss/orchagent/syncd; test kills database container causing unrecoverable state"
    conditions:
      - "'bmc' in topo_type"
```

This matches the existing pattern used by `test_orchagent_heartbeat`.

#### How did you verify/test it?

Full test suite run (44 modules, 11+ hours) on Komodo BMC board (SONiC.20260810.05):
- `process_monitoring` module: all tests SKIPPED with correct reason message
- No container kills, no Redis failures
- DUT remained healthy throughout the run (109 passed, 12 failed, 589 skipped)

#### Any platform specific information?

BMC platforms only: `arm64-nexthop_b27-r0` (Komodo), `arm64-aspeed_ast2700_evb-r0` (DVT)

#### Supported testbed topology if it's a new test case?

N/A (existing test, adding skip condition)

### Documentation

N/A