### PR TITLE
[action] [PR:25463] [ha]: Update FNIC steady-state flow checks

### DIFF
--- a/tests/ha/test_ha_steady_state_fnic.py
+++ b/tests/ha/test_ha_steady_state_fnic.py
@@ -12,7 +12,7 @@ from gnmi_utils import apply_messages
 from packets import inbound_pl_packets, outbound_pl_packets
 from tests.common.config_reload import config_reload
 from tests.common.dash_utils import verify_tunnel_packets
-from ha_dash_flow_utils import compare_flow_tables_pdsctl
+from ha_dash_flow_utils import compare_flow_tables
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +147,7 @@ def test_fnic_basic_transform(
 
     pytest_assert(sum(tunnel_endpoint_counts.values()) == NUM_PACKETS, "Expected active return-path packets")
 
-    flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
 
     # traffic to standby DPU (forwarded through active for processing)
@@ -167,5 +167,5 @@ def test_fnic_basic_transform(
 
     pytest_assert(sum(tunnel_endpoint_counts.values()) == NUM_PACKETS, "Expected standby return-path packets")
 
-    flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
+    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
     pytest_assert(flow_op, "Expected identical flow tables on primary and standby")


### PR DESCRIPTION
### Description of PR

Summary:
Manual backport of https://github.com/sonic-net/sonic-mgmt/pull/25463 to the 202605 branch. Updates the FNIC steady-state HA test to use the generic DASH flow-table comparison helper.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

Backport the FNIC steady-state flow-check update from PR #25463 to 202605 after the automatic backport could not be applied cleanly.

#### How did you do it?

Cherry-picked commit `eaf53ccf09246ab65dcd78094e0da50837a77b89` and manually resolved the import conflict. The resolution preserves the 202605-specific explicit pipeline setup and cleanup while applying the source intent: both active and standby checks now call `compare_flow_tables`, which selects the appropriate flow-dump implementation for the DPU platform.

#### How did you verify/test it?

- `python -m py_compile tests/ha/test_ha_steady_state_fnic.py tests/ha/ha_dash_flow_utils.py` — passed.
- `git diff --check upstream/202605...HEAD` — passed.
- Reviewed the final diff: one import and two call sites changed; 202605 setup/cleanup remains unchanged.
- Local flake8 reported only pre-existing E501 line-length findings, none introduced by this backport.

#### Any platform specific information?

SmartSwitch HA / FNIC test coverage; the generic helper dispatches by DPU ASIC type.

#### Supported testbed topology if it's a new test case?

N/A (existing `t1-smartswitch-ha` test).

### Documentation

N/A