### PR TITLE
[action] [PR:26733] [dualtor][active-active] Support config mux mode all

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1700,6 +1700,8 @@ def check_active_active_port_status(duthost, ports, status):
     logging.debug("Check mux status for ports {} is {}".format(ports, status))
     show_mux_status_ret = show_muxcable_status(duthost)
     logging.debug("show_mux_status_ret: {}".format(json.dumps(show_mux_status_ret, indent=4)))
+    if ports == "all":
+        ports = list(show_mux_status_ret.keys())
     for port in ports:
         if port not in show_mux_status_ret:
             return False
@@ -1710,7 +1712,7 @@ def check_active_active_port_status(duthost, ports, status):
 
 @pytest.fixture
 def validate_active_active_dualtor_setup(
-        duthosts, active_active_ports, ptfhost, tbinfo, restart_nic_simulator):  # noqa: F811
+        duthosts, active_active_ports, active_standby_ports, ptfhost, tbinfo, restart_nic_simulator):  # noqa: F811
     """Validate that both ToRs are active for active-active mux ports."""
     if not ('dualtor' in tbinfo['topo']['name'] and active_active_ports):
         return
@@ -1725,17 +1727,30 @@ def validate_active_active_dualtor_setup(
     icmp_responder_status = ptfhost.shell("supervisorctl status icmp_responder", module_ignore_errors=True)["stdout"]
     pt_assert("RUNNING" in icmp_responder_status, "icmp_responder not running in ptf")
 
-    for port in active_active_ports:
+    if active_standby_ports:
+        # The topology is a dualtor-mixed and has active-standby ports, let's
+        # config the mux mode one by one
+        for port in active_active_ports:
+            for duthost in duthosts:
+                cmd = "config mux mode active {}".format(port)
+                pt_assert(
+                    wait_until(
+                        90, 10, 0, run_mux_config_command, duthost, cmd,
+                        expected_output=["OK"],
+                        forbidden_output=["this is not a valid port present on mux_cable"]
+                    ),
+                    "Port was not present on mux cable after 90 seconds - '{}' failed".format(cmd)
+                )
+    else:
+        # All mux ports are active-active, let's config the
+        # mux mode all at once
+        cmd = "config mux mode active all"
         for duthost in duthosts:
-            cmd = "config mux mode active {}".format(port)
             pt_assert(
-                wait_until(
-                    90, 10, 0, run_mux_config_command, duthost, cmd,
-                    expected_output=["OK"],
-                    forbidden_output=["this is not a valid port present on mux_cable"]
-                ),
-                "Port was not present on mux cable after 90 seconds - '{}' failed".format(cmd)
+                wait_until(90, 10, 0, run_mux_config_command, duthost, cmd, expected_output=["OK"]),
+                "config mux mode active all failed on device {}".format(duthost.hostname)
             )
+
     duthosts.shell("systemctl restart mux.service")
     # verify both ToRs are active
     for duthost in duthosts:
@@ -1753,9 +1768,14 @@ def config_active_active_dualtor(active_tor, standby_tor, ports, unconditionally
     logging.info("Configuring {} as active".format(active_tor.hostname))
     logging.info("Configuring {} as standby".format(standby_tor.hostname))
 
-    for port in ports:
-        active_side_commands.append("config mux mode active {}".format(port))
-        standby_side_commands.append("config mux mode standby {}".format(port))
+    # ports can be either string "all" or a list of mux ports
+    if ports == "all":
+        active_side_commands.append("config mux mode active all")
+        standby_side_commands.append("config mux mode standby all")
+    else:
+        for port in ports:
+            active_side_commands.append("config mux mode active {}".format(port))
+            standby_side_commands.append("config mux mode standby {}".format(port))
 
     if not check_active_active_port_status(active_tor, ports, 'active') or unconditionally:
         for cmd in active_side_commands:
@@ -1775,11 +1795,10 @@ def config_active_active_dualtor(active_tor, standby_tor, ports, unconditionally
             "Port was not present on mux cable after 90 seconds - '{}' failed".format(cmd)
         )
 
-    pt_assert(wait_until(30, 5, 0, check_active_active_port_status, active_tor, ports, 'active'),
+    pt_assert(wait_until(60, 5, 0, check_active_active_port_status, active_tor, ports, 'active'),
               "Could not config ports {} to active on {}".format(ports, active_tor.hostname))
-    pt_assert(wait_until(30, 5, 0, check_active_active_port_status, standby_tor, ports, 'standby'),
+    pt_assert(wait_until(60, 5, 0, check_active_active_port_status, standby_tor, ports, 'standby'),
               "Could not config ports {} to standby on {}".format(ports, standby_tor.hostname))
-    time.sleep(90)
 
 
 @pytest.fixture
@@ -1798,13 +1817,17 @@ def config_active_active_dualtor_active_standby(duthosts, active_active_ports, t
 
     def _config_active_active_dualtor_active_standby(active_tor, standby_tor, ports, unconditionally=False):
         wait_until(300, 10, 0, check_docker_status, standby_tor)
-        for port in ports:
-            if port not in active_active_ports:
-                raise ValueError("Port {} is not in the active-active ports".format(port))
+        if isinstance(ports, str):
+            if ports != "all":
+                raise ValueError("Invalid port string: {}".format(ports))
+        else:
+            for port in ports:
+                if port not in active_active_ports:
+                    raise ValueError("Port {} is not in the active-active ports".format(port))
 
         config_active_active_dualtor(active_tor, standby_tor, ports, unconditionally)
 
-        ports_to_restore.extend(ports)
+        ports_to_restore.extend(active_active_ports if ports == "all" else ports)
 
     ports_to_restore = []
 
@@ -1824,25 +1847,28 @@ def config_active_active_dualtor_active_standby(duthosts, active_active_ports, t
 
 @pytest.fixture
 def toggle_all_aa_ports_to_lower_tor(config_active_active_dualtor_active_standby,
-                                     lower_tor_host, upper_tor_host, active_active_ports):  # noqa: F811
+                                     lower_tor_host, upper_tor_host, active_active_ports, active_standby_ports):  # noqa: F811
     if active_active_ports:
-        config_active_active_dualtor_active_standby(lower_tor_host, upper_tor_host, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(lower_tor_host, upper_tor_host, ports_to_config)
     return
 
 
 @pytest.fixture
 def toggle_all_aa_ports_to_rand_selected_tor(config_active_active_dualtor_active_standby, rand_selected_dut,
-                                             rand_unselected_dut, active_active_ports):  # noqa: F811
+                                             rand_unselected_dut, active_active_ports, active_standby_ports):  # noqa: F811
     if active_active_ports:
-        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, ports_to_config)
     return
 
 
 @pytest.fixture
 def toggle_all_aa_ports_to_rand_unselected_tor(config_active_active_dualtor_active_standby, rand_selected_dut,
-                                               rand_unselected_dut, active_active_ports):  # noqa: F811
+                                               rand_unselected_dut, active_active_ports, active_standby_ports):  # noqa: F811
     if active_active_ports:
-        config_active_active_dualtor_active_standby(rand_unselected_dut, rand_selected_dut, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(rand_unselected_dut, rand_selected_dut, ports_to_config)
     return
 
 
@@ -1943,9 +1969,11 @@ def check_simulator_flap_counter(
 @pytest.fixture
 def setup_standby_ports_on_rand_selected_tor(active_active_ports, rand_selected_dut, rand_unselected_dut,  # noqa: F811
                                              config_active_active_dualtor_active_standby,                  # noqa: F811
-                                             validate_active_active_dualtor_setup):                        # noqa: F811
+                                             validate_active_active_dualtor_setup,                         # noqa: F811
+                                             active_standby_ports):                                        # noqa: F811
     if active_active_ports:
-        config_active_active_dualtor_active_standby(rand_unselected_dut, rand_selected_dut, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(rand_unselected_dut, rand_selected_dut, ports_to_config)
     return
 
 
@@ -1953,9 +1981,11 @@ def setup_standby_ports_on_rand_selected_tor(active_active_ports, rand_selected_
 def setup_standby_ports_on_rand_unselected_tor(active_active_ports, rand_selected_dut,      # noqa: F811
                                                rand_unselected_dut,
                                                config_active_active_dualtor_active_standby,
-                                               validate_active_active_dualtor_setup):
+                                               validate_active_active_dualtor_setup,
+                                               active_standby_ports):                       # noqa: F811
     if active_active_ports:
-        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, ports_to_config)
     return
 
 
@@ -1967,12 +1997,14 @@ def setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m(
     validate_active_active_dualtor_setup,
     upper_tor_host,
     lower_tor_host,
-    duthosts
+    duthosts,
+    active_standby_ports                                                   # noqa: F811
 ):
     if active_active_ports:
         active_tor = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         standby_tor = upper_tor_host if active_tor == lower_tor_host else lower_tor_host
-        config_active_active_dualtor_active_standby(active_tor, standby_tor, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(active_tor, standby_tor, ports_to_config)
     return
 
 
@@ -1984,12 +2016,14 @@ def setup_standby_ports_on_non_enum_rand_one_per_hwsku_host_m(
     validate_active_active_dualtor_setup,
     upper_tor_host,
     lower_tor_host,
-    duthosts
+    duthosts,
+    active_standby_ports                                                   # noqa F811
 ):
     if active_active_ports:
         active_tor = duthosts[enum_rand_one_per_hwsku_hostname]
         standby_tor = upper_tor_host if active_tor == lower_tor_host else lower_tor_host
-        config_active_active_dualtor_active_standby(active_tor, standby_tor, active_active_ports)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(active_tor, standby_tor, ports_to_config)
     return
 
 
@@ -1998,10 +2032,12 @@ def setup_standby_ports_on_rand_unselected_tor_unconditionally(
     active_active_ports,                                                   # noqa: F811
     rand_selected_dut,
     rand_unselected_dut,
-    config_active_active_dualtor_active_standby
+    config_active_active_dualtor_active_standby,
+    active_standby_ports                                                   # noqa: F811
 ):
     if active_active_ports:
-        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, active_active_ports, True)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, ports_to_config, True)
     return
 
 
@@ -2012,12 +2048,14 @@ def setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditi
     config_active_active_dualtor_active_standby,
     upper_tor_host,
     lower_tor_host,
-    duthosts
+    duthosts,
+    active_standby_ports                                                   # noqa: F811
 ):
     if active_active_ports:
         active_tor = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         standby_tor = upper_tor_host if active_tor == lower_tor_host else lower_tor_host
-        config_active_active_dualtor_active_standby(active_tor, standby_tor, active_active_ports, True)
+        ports_to_config = active_active_ports if active_standby_ports else "all"
+        config_active_active_dualtor_active_standby(active_tor, standby_tor, ports_to_config, True)
     return
 
 

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1846,8 +1846,10 @@ def config_active_active_dualtor_active_standby(duthosts, active_active_ports, t
 
 
 @pytest.fixture
-def toggle_all_aa_ports_to_lower_tor(config_active_active_dualtor_active_standby,
-                                     lower_tor_host, upper_tor_host, active_active_ports, active_standby_ports):  # noqa: F811
+def toggle_all_aa_ports_to_lower_tor(
+    config_active_active_dualtor_active_standby,
+    lower_tor_host, upper_tor_host, active_active_ports, active_standby_ports  # noqa: F811
+):
     if active_active_ports:
         ports_to_config = active_active_ports if active_standby_ports else "all"
         config_active_active_dualtor_active_standby(lower_tor_host, upper_tor_host, ports_to_config)
@@ -1855,8 +1857,10 @@ def toggle_all_aa_ports_to_lower_tor(config_active_active_dualtor_active_standby
 
 
 @pytest.fixture
-def toggle_all_aa_ports_to_rand_selected_tor(config_active_active_dualtor_active_standby, rand_selected_dut,
-                                             rand_unselected_dut, active_active_ports, active_standby_ports):  # noqa: F811
+def toggle_all_aa_ports_to_rand_selected_tor(
+    config_active_active_dualtor_active_standby, rand_selected_dut,
+    rand_unselected_dut, active_active_ports, active_standby_ports  # noqa: F811
+):
     if active_active_ports:
         ports_to_config = active_active_ports if active_standby_ports else "all"
         config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, ports_to_config)
@@ -1864,8 +1868,10 @@ def toggle_all_aa_ports_to_rand_selected_tor(config_active_active_dualtor_active
 
 
 @pytest.fixture
-def toggle_all_aa_ports_to_rand_unselected_tor(config_active_active_dualtor_active_standby, rand_selected_dut,
-                                               rand_unselected_dut, active_active_ports, active_standby_ports):  # noqa: F811
+def toggle_all_aa_ports_to_rand_unselected_tor(
+    config_active_active_dualtor_active_standby, rand_selected_dut,
+    rand_unselected_dut, active_active_ports, active_standby_ports  # noqa: F811
+):
     if active_active_ports:
         ports_to_config = active_active_ports if active_standby_ports else "all"
         config_active_active_dualtor_active_standby(rand_unselected_dut, rand_selected_dut, ports_to_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -441,7 +441,7 @@ def _load_testbed_config(tbfile, tbname):
         if tb.get('conf-name') == tbname:
             return tb
 
-    logger.warning(f"Testbed '{tbname}' not found in '{tbfile}'")
+    logger.warning(f"Testbed '{tbname}' not found in '{tbfile}'")  # noqa: E713
     return
 
 
@@ -497,7 +497,7 @@ def converge_topo_if_needed(config):
 
         os.chmod(topo_file, original_mode)
         os.chown(topo_file, original_uid, original_gid)
-        logger.info(f"File permissions restored to {original_uid}:{original_gid}")
+        logger.info(f"File permissions restored to {original_uid}:{original_gid}")  # noqa: E231
 
         config.cache.set("converged_topo_file", topo_file)
         config.cache.set("converged_topo_backup", backup_file)
@@ -1349,7 +1349,7 @@ def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, cred
 
             logging.debug(
                 f"Added serial port mapping: {dut_name} Console{host_port} -> "
-                f"{fanout_host}:{fanout_port} (baud={link_info.get('baud_rate', '9600')})"
+                f"{fanout_host}:{fanout_port} (baud={link_info.get('baud_rate', '9600')})"  # noqa: E231
             )
 
     logging.info(f"fanouthosts fixture initialized with {len(fanout_hosts)} fanout devices")
@@ -3780,7 +3780,7 @@ def build_gnmi_stubs(request):
             text=True,
             check=False  # Do not raise an exception automatically on non-zero exit
         )
-        logger.info(f"Output of {script_path}:\n{result.stdout}")
+        logger.info(f"Output of {script_path}:\n{result.stdout}")  # noqa: E231
 
         if result.returncode != 0:
             logger.error(f"{script_path} failed with exit code {result.returncode}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,6 @@ from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active 
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder_session                  # noqa: F401
 from tests.common.dualtor.dual_tor_utils import disable_timed_oscillation_active_standby    # noqa: F401
 from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor
-from tests.common.dualtor.dual_tor_common import active_active_ports                        # noqa: F401
 from tests.common.dualtor import mux_simulator_control                                      # noqa: F401
 
 from tests.common.helpers.constants import (
@@ -3916,7 +3915,7 @@ class DualtorMuxPortSetupConfig(enum.Flag):
 
 
 @pytest.fixture(autouse=True)
-def setup_dualtor_mux_ports(active_active_ports, duthost, duthosts, tbinfo, request, mux_server_url):       # noqa:F811
+def setup_dualtor_mux_ports(duthost, duthosts, tbinfo, request, mux_server_url):       # noqa:F811
     """Setup dualtor mux ports."""
     def _get_enumerated_dut_hostname(request):
         for k, v in request.node.callspec.params.items():
@@ -4011,7 +4010,7 @@ def setup_dualtor_mux_ports(active_active_ports, duthost, duthosts, tbinfo, requ
             config_active_active_dualtor(
                 duthosts[active_dut_hostname],
                 duthosts[standby_dut_hostname],
-                active_active_ports,
+                "all",
                 dualtor_setup_config & DualtorMuxPortSetupConfig.DUALTOR_SETUP_MUX_PORT_MANUAL_MODE
             )
         else:


### PR DESCRIPTION
### Description of PR
Summary:
Manual backport of https://github.com/sonic-net/sonic-mgmt/pull/26733 to 202605. This enables active-active dualtor setup to use `config mux mode <active|standby> all` when every mux port is active-active, while retaining per-port configuration for mixed topologies.

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: Source PR #26733
Failure type: other (manual cherry-pick conflict)

### Tested branch
- [ ] master
- [x] 202605
- [ ] N/A

### Test result
Source PR evidence (not rerun locally): validated on 202605 image `20260531.08`; applicable `route/test_static_route.py` cases passed, with documented topology/known-issue skips.

Local backport validation:
- `python -m py_compile tests/common/dualtor/dual_tor_utils.py tests/conftest.py` — passed
- `python -m flake8 --select=E999,F821,F822,F823 tests/common/dualtor/dual_tor_utils.py tests/conftest.py` — passed
- `git diff --check upstream/202605...HEAD` — passed

### Approach
#### What is the motivation for this PR?
Bring the source PR's batched mux-mode configuration support to the 202605 branch.

#### How did you do it?
Cherry-picked source commits `72e1d40e181e86ca3fe64181cd9b7494bb0fd7af` and `d03e141fb6cef51a0ca58d3a8b34182bce941bab` manually because the first commit conflicted with fixture refactoring already present on 202605.

The conflict was resolved semantically by preserving the target branch's function-scoped fixture and local `check_docker_status` helper, adding the source change's validation and restore handling for the special `"all"` value, and retaining the target branch's removal of the obsolete module-scoped fixture. All non-conflicting source intent was preserved.

#### How did you verify/test it?
See the Test result section. Local validation was static only; the hardware route test results above are source PR evidence.

#### Any platform specific information?
Active-active dualtor; mixed active-active/active-standby topologies continue using per-port commands.

#### Supported testbed topology if it's a new test case?
N/A; no new test case.

### Documentation
No documentation changes required.