### PR TITLE
[action] [PR:23894] [macsec]: Add functionality/tests for per interface macsec

### DIFF
--- a/tests/common/macsec/__init__.py
+++ b/tests/common/macsec/__init__.py
@@ -170,10 +170,11 @@ class MacsecPlugin(object):
                         enable_macsec_port(macsec_duthost, dut_port, orig_name)
                         enable_macsec_port(nbr["host"], nbr["port"], orig_name)
                 for dut_port, nbr in list(ctrl_links.items()):
-                    wait_until(300, 3, 0,
-                               lambda dp=dut_port, n=nbr: macsec_duthost.iface_macsec_ok(dp) and
-                               n["host"].iface_macsec_ok(n["port"]))
-                # load_all_macsec_info(macsec_duthost, ctrl_links, tbinfo)
+                    # only check the port if it was actually put back to an old macsec configuration
+                    if orig.get(dut_port):
+                        wait_until(300, 3, 0,
+                                lambda dp=dut_port, n=nbr: macsec_duthost.iface_macsec_ok(dp) and
+                                n["host"].iface_macsec_ok(n["port"]))
             else:
                 cleanup_macsec_configuration(macsec_duthost, ctrl_links, profile['name'])
         return __shutdown_macsec

--- a/tests/common/macsec/__init__.py
+++ b/tests/common/macsec/__init__.py
@@ -18,10 +18,15 @@ from .macsec_config_helper import setup_macsec_configuration
 from .macsec_config_helper import cleanup_macsec_configuration
 from .macsec_config_helper import is_macsec_configured
 from .macsec_config_helper import get_macsec_enable_status, get_macsec_profile
-from .macsec_helper import load_all_macsec_info
+from .macsec_config_helper import generate_macsec_profile
+from .macsec_config_helper import setup_macsec_multi_profile_configuration
+from .macsec_config_helper import cleanup_macsec_multi_profile_configuration
+from .macsec_config_helper import enable_macsec_port
+from .macsec_helper import load_all_macsec_info, getns_prefix
 
 # flake8: noqa: F401
 from tests.common.plugins.sanity_check import sanity_check
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +70,32 @@ class MacsecPlugin(object):
         return NotImplementedError()
 
     @pytest.fixture(scope="module")
+    def port_profiles(self, request, ctrl_links, macsec_profile):
+        """Per-port profile mapping
+
+        Returns ``None`` in single-profile mode.
+        When ``--per_interface_macsec`` is set, generates a unique
+        ``MACSEC_PROFILE_<port>`` for every controlled port using the same
+        cipher_suite, policy, send_sci, priority, and rekey_period as the base
+        ``--macsec_profile``, but with unique CAK/CKN per port.
+        """
+        if not request.config.getoption("per_interface_macsec", default=False):
+            return None
+        if len(ctrl_links) < 2:
+            pytest.skip("Per-interface profile tests require at least 2 controlled links")
+        profiles = {}
+        for dut_port in ctrl_links:
+            profiles[dut_port] = generate_macsec_profile(
+                port_name=dut_port,
+                cipher_suite=macsec_profile["cipher_suite"],
+                priority=macsec_profile["priority"],
+                policy=macsec_profile["policy"],
+                send_sci=macsec_profile["send_sci"],
+                rekey_period=macsec_profile["rekey_period"],
+            )
+        return profiles
+
+    @pytest.fixture(scope="module")
     def start_macsec_service(self, macsec_duthost, macsec_nbrhosts):
         def __start_macsec_service():
             enable_macsec_feature(macsec_duthost, macsec_nbrhosts)
@@ -83,7 +114,7 @@ class MacsecPlugin(object):
         stop_macsec_service()
 
     @pytest.fixture(scope="module")
-    def startup_macsec(self, request, macsec_duthost, ctrl_links, macsec_profile, tbinfo):
+    def startup_macsec(self, request, macsec_duthost, ctrl_links, macsec_profile, port_profiles, tbinfo):
         topo_name = tbinfo['topo']['name']
         def __startup_macsec():
             profile = macsec_profile
@@ -94,34 +125,79 @@ class MacsecPlugin(object):
                     # will drop it for macsec kernel module does not correctly handle it.
                     pytest.skip(
                         "macsec on dut vsonic, neighbor eos, send_sci false")
-            if 't2' not in topo_name:
-                cleanup_macsec_configuration(macsec_duthost, ctrl_links, profile['name'])
-            setup_macsec_configuration(macsec_duthost, ctrl_links,
-                                       profile['name'], profile['priority'], profile['cipher_suite'],
-                                       profile['primary_cak'], profile['primary_ckn'], profile['policy'],
-                                       profile['send_sci'], profile['rekey_period'], tbinfo)
+
+            if port_profiles:
+                # Save original profile bindings so shutdown can restore them.
+                self._original_profile_per_port = {}
+                for dut_port in ctrl_links:
+                    ns = getns_prefix(macsec_duthost, dut_port)
+                    cmd = "sonic-db-cli {} CONFIG_DB HGET 'PORT|{}' 'macsec'".format(
+                        ns, dut_port)
+                    output = macsec_duthost.command(cmd)['stdout'].strip()
+                    self._original_profile_per_port[dut_port] = output if output else None
+
+                setup_macsec_multi_profile_configuration(
+                    macsec_duthost, ctrl_links, port_profiles, tbinfo)
+
+                logger.info(
+                    "Setup per-interface MACsec configuration with profiles:\n{}".format(
+                        {p: pp["name"] for p, pp in port_profiles.items()}))
+            else:
+
+                if 't2' not in topo_name:
+                    cleanup_macsec_configuration(macsec_duthost, ctrl_links, profile['name'])
+                setup_macsec_configuration(macsec_duthost, ctrl_links,
+                                        profile['name'], profile['priority'], profile['cipher_suite'],
+                                        profile['primary_cak'], profile['primary_ckn'], profile['policy'],
+                                        profile['send_sci'], profile['rekey_period'], tbinfo)
             logger.info(
                 "Setup MACsec configuration with arguments:\n{}".format(locals()))
+
         return __startup_macsec
 
     @pytest.fixture(scope="module")
-    def shutdown_macsec(self, macsec_duthost, ctrl_links, macsec_profile):
+    def shutdown_macsec(self, macsec_duthost, ctrl_links, macsec_profile, port_profiles, tbinfo):
         def __shutdown_macsec():
             profile = macsec_profile
-            cleanup_macsec_configuration(macsec_duthost, ctrl_links, profile['name'])
+            if port_profiles:
+                cleanup_macsec_multi_profile_configuration(
+                    macsec_duthost, ctrl_links, port_profiles)
+                # Restore original profile bindings.
+                orig = getattr(self, '_original_profile_per_port', {})
+                for dut_port, nbr in list(ctrl_links.items()):
+                    orig_name = orig.get(dut_port)
+                    if orig_name:
+                        enable_macsec_port(macsec_duthost, dut_port, orig_name)
+                        enable_macsec_port(nbr["host"], nbr["port"], orig_name)
+                for dut_port, nbr in list(ctrl_links.items()):
+                    wait_until(300, 3, 0,
+                               lambda dp=dut_port, n=nbr: macsec_duthost.iface_macsec_ok(dp) and
+                               n["host"].iface_macsec_ok(n["port"]))
+                # load_all_macsec_info(macsec_duthost, ctrl_links, tbinfo)
+            else:
+                cleanup_macsec_configuration(macsec_duthost, ctrl_links, profile['name'])
         return __shutdown_macsec
 
     @pytest.fixture(scope="module")
-    def macsec_setup(self, startup_macsec, shutdown_macsec, macsec_feature):
+    def macsec_setup(self, startup_macsec, shutdown_macsec, macsec_feature, macsec_duthost, macsec_profile, port_profiles, ctrl_links):
         '''
             setup macsec links
         '''
-        startup_macsec()
+        shutdown = False
+        if get_macsec_enable_status(macsec_duthost) and get_macsec_profile(macsec_duthost):
+
+            macsec_preconfigured = is_macsec_configured(macsec_duthost, macsec_profile, ctrl_links)
+            if not macsec_preconfigured or port_profiles is not None:
+                shutdown = True
+                startup_macsec()
+            if macsec_preconfigured:
+                logger.info(f"Macsec is already configured for {macsec_profile}, skipping setup")
         yield
-        shutdown_macsec()
+        if shutdown:
+            shutdown_macsec()
 
     @pytest.fixture(scope="module", autouse=True)
-    def load_macsec_info(self, request, macsec_duthost, ctrl_links, macsec_profile, tbinfo):
+    def load_macsec_info(self, request, macsec_setup, macsec_duthost, ctrl_links, macsec_profile, port_profiles, tbinfo):
         """Pre-load MACsec session info for all control links.
 
         If MACsec is enabled and configured for this DUT/profile, wait for
@@ -132,20 +208,12 @@ class MacsecPlugin(object):
         """
 
         if get_macsec_enable_status(macsec_duthost) and get_macsec_profile(macsec_duthost):
-            if is_macsec_configured(macsec_duthost, macsec_profile, ctrl_links):
-                # MACsec is already configured (e.g., carried over from a
-                # previous module). Wait for MKA sessions to be established
-                # (SC/SA present in DB, including SAK) before loading info, so
-                # we don't race wpa_supplicant writing the egress SA row.
-                # If the wait_mka_establish fixture isn't registered in this
-                # environment, fall back to loading directly.
-                try:
-                    request.getfixturevalue('wait_mka_establish')
-                except pytest.FixtureLookupError:
-                    pass
-                load_all_macsec_info(macsec_duthost, ctrl_links, tbinfo)
-            else:
-                request.getfixturevalue('macsec_setup')
+            try:
+                request.getfixturevalue('wait_mka_establish')
+            except pytest.FixtureLookupError:
+                pass
+
+            load_all_macsec_info(macsec_duthost, ctrl_links, tbinfo)
 
     @pytest.fixture(scope="module")
     def macsec_nbrhosts(self, ctrl_links):

--- a/tests/common/macsec/macsec_config_helper.py
+++ b/tests/common/macsec/macsec_config_helper.py
@@ -4,7 +4,7 @@ import time
 from passlib.hash import cisco_type7
 
 from tests.common.macsec.macsec_helper import get_mka_session, getns_prefix, wait_all_complete, \
-     submit_async_task, load_all_macsec_info
+     submit_async_task
 from tests.common.macsec.macsec_platform_helper import global_cmd, find_portchannel_from_member, get_portchannel
 from tests.common.devices.eos import EosHost
 from tests.common.utilities import wait_until

--- a/tests/common/macsec/macsec_config_helper.py
+++ b/tests/common/macsec/macsec_config_helper.py
@@ -1,5 +1,8 @@
 import logging
+import secrets
 import time
+from passlib.hash import cisco_type7
+
 from tests.common.macsec.macsec_helper import get_mka_session, getns_prefix, wait_all_complete, \
      submit_async_task, load_all_macsec_info
 from tests.common.macsec.macsec_platform_helper import global_cmd, find_portchannel_from_member, get_portchannel
@@ -17,7 +20,10 @@ __all__ = [
     'disable_macsec_port',
     'get_macsec_enable_status',
     'get_macsec_profile',
-    'wait_for_macsec_cleanup'
+    'wait_for_macsec_cleanup',
+    'generate_macsec_profile',
+    'setup_macsec_multi_profile_configuration',
+    'cleanup_macsec_multi_profile_configuration',
 ]
 
 logger = logging.getLogger(__name__)
@@ -172,6 +178,12 @@ def disable_macsec_port(host, port):
         host.command("sudo config portchannel {} member add {} {}".format(getns_prefix(host, port), pc["name"], port))
 
 
+def replace_macsec_port(host, port, profile_name):
+    disable_macsec_port(host, port)
+    time.sleep(10)
+    enable_macsec_port(host, port, profile_name)
+
+
 def enable_macsec_feature(duthost, macsec_nbrhosts):
     nbrhosts = macsec_nbrhosts
     num_asics = duthost.num_asics()
@@ -281,6 +293,169 @@ def setup_macsec_configuration(duthost, ctrl_links, profile_name, default_priori
 
     # Load the MACSEC_INFO, to have data of all macsec sessions
     load_all_macsec_info(duthost, ctrl_links, tbinfo)
+
+
+def generate_macsec_profile(port_name, cipher_suite="GCM-AES-128", priority=64,
+                            policy="security", send_sci="true", rekey_period=0):
+    """Generate a MACsec profile with random CAK/CKN for a specific port.
+
+    The profile is named ``MACSEC_PROFILE_<port_name>`` and the pre-shared keys
+    are generated using ``secrets.token_hex`` so that every port receives a
+    unique key pair.
+
+    Args:
+        port_name: Interface name (e.g. "Ethernet0"). Used in the profile name.
+        cipher_suite: Cipher suite string. Determines key lengths.
+        priority: MKA key-server priority (0-255).
+        policy: "security" (encrypt) or "integrity" (auth only).
+        send_sci: "true" or "false".
+        rekey_period: Seconds between rekeying (0 = disabled).
+
+    Returns:
+        dict: A profile dict compatible with set_macsec_profile().
+    """
+
+    # CAK length: AES-128 variants use 32 bytes (66 hex chars),
+    #             AES-256 variants use 64 bytes (130 hex chars).
+    # CKN length: AES-128 variants use 16 bytes (32 hex chars),
+    #             AES-256 variants use 32 bytes (64 hex chars).
+    if "128" in cipher_suite:
+        cak = secrets.token_hex(16)
+        # token_hex produces a string of n*2 chars (as each hex num is 2 chars)
+        # For CKN, this is interpreted as the literal password, so when passed to
+        # the type7 encoder each hex char is treated as its own byte.
+        # This is why the number passed to token hex is half the expected number of bytes,
+        # because the length of the string generated is double
+        ckn = secrets.token_hex(16)
+    else:
+        cak = secrets.token_hex(32)
+        ckn = secrets.token_hex(32)
+
+    # CAK is expected to be in "type7" encoding format
+    # This adds the extra byte to the cak / ckn length
+    cak = cisco_type7.hash(cak)
+
+    profile_name = "MACSEC_PROFILE_{}".format(port_name)
+    return {
+        "name": profile_name,
+        "priority": priority,
+        "cipher_suite": cipher_suite,
+        "primary_cak": cak,
+        "primary_ckn": ckn,
+        "policy": policy,
+        "send_sci": send_sci,
+        "rekey_period": rekey_period,
+    }
+
+
+def setup_macsec_multi_profile_configuration(duthost, ctrl_links, port_profiles, tbinfo):
+    """Set up MACsec with a different profile per port.
+
+    Each port in *ctrl_links* is configured with its own profile from
+    *port_profiles*.  The DUT uses ``default_priority`` from the profile while
+    neighbors alternate between ``priority - 1`` and ``priority + 1`` so the
+    DUT is elected MKA key-server on most links.
+
+    Args:
+        duthost: DUT host object.
+        ctrl_links: dict ``{dut_port: {name, host, port, ...}}``.
+        port_profiles: dict ``{dut_port: profile_dict}`` where each
+            ``profile_dict`` has keys matching ``generate_macsec_profile``
+            output.
+        tbinfo: Testbed info dict.
+    """
+    logger.info("Multi-profile setup step 1: set per-port macsec profiles")
+
+    for dut_port, profile in port_profiles.items():
+        set_macsec_profile(
+            duthost, profile["name"], profile["priority"],
+            profile["cipher_suite"], profile["primary_cak"],
+            profile["primary_ckn"], profile["policy"],
+            profile["send_sci"], profile["rekey_period"])
+    i = 0
+    for dut_port, nbr in ctrl_links.items():
+        profile = port_profiles[dut_port]
+
+        if i % 2 == 0:
+            nbr_priority = profile["priority"] - 1
+        else:
+            nbr_priority = profile["priority"] + 1
+        set_macsec_profile(
+            nbr["host"], profile["name"], nbr_priority,
+            profile["cipher_suite"], profile["primary_cak"],
+            profile["primary_ckn"], profile["policy"],
+            profile["send_sci"], profile["rekey_period"])
+        i += 1
+        time.sleep(3)
+
+    logger.info("Multi-profile setup step 2: enable per-port macsec")
+
+    for dut_port, nbr in list(ctrl_links.items()):
+        profile = port_profiles[dut_port]
+        time.sleep(3)
+        enable_macsec_port(duthost, dut_port, profile["name"])
+        enable_macsec_port(nbr["host"], nbr["port"], profile["name"])
+
+    logger.info("Multi-profile setup step 3: wait for macsec ready on each port")
+
+    for dut_port, nbr in list(ctrl_links.items()):
+        assert wait_until(300, 3, 0,
+                          lambda dp=dut_port, n=nbr: duthost.iface_macsec_ok(dp) and
+                          n["host"].iface_macsec_ok(n["port"]))
+
+    # Hold time for protocol recovery after link flaps.
+    time.sleep(60)
+    logger.info("Multi-profile setup finished")
+
+
+def cleanup_macsec_multi_profile_configuration(duthost, ctrl_links, port_profiles):
+    """Clean up per-port MACsec profiles.
+
+    Disables MACsec on every controlled port, then deletes each unique profile
+    from CONFIG_DB on both the DUT and neighbor devices.
+
+    Args:
+        duthost: DUT host object.
+        ctrl_links: dict ``{dut_port: {name, host, port, ...}}``.
+        port_profiles: dict ``{dut_port: profile_dict}``.
+    """
+    devices = set()
+    if duthost.facts["asic_type"] == "vs":
+        devices.add(duthost)
+
+    logger.info("Multi-profile cleanup step 1: disable macsec on all ports")
+    for dut_port, nbr in list(ctrl_links.items()):
+        time.sleep(3)
+        disable_macsec_port(duthost, dut_port)
+        disable_macsec_port(nbr["host"], nbr["port"])
+        devices.add(nbr["host"])
+
+    logger.info("Multi-profile cleanup step 2: delete per-port profiles")
+    deleted_profiles = set()
+    for dut_port, nbr in list(ctrl_links.items()):
+        profile_name = port_profiles[dut_port]["name"]
+        if profile_name not in deleted_profiles:
+            delete_macsec_profile(duthost, profile_name)
+            deleted_profiles.add(profile_name)
+
+    for d in devices:
+        for profile_name in deleted_profiles:
+            delete_macsec_profile(d, profile_name)
+
+    logger.info("Multi-profile cleanup step 3: wait for automatic cleanup")
+
+    interfaces = list(ctrl_links.keys())
+    wait_for_macsec_cleanup(duthost, interfaces)
+
+    for dut_port, nbr in list(ctrl_links.items()):
+        wait_for_macsec_cleanup(nbr["host"], [nbr["port"]])
+
+    logger.info("Multi-profile cleanup finished")
+
+    for d in devices:
+        if isinstance(d, EosHost):
+            continue
+        assert wait_until(30, 1, 0, lambda d=d: not get_mka_session(d))
 
 
 def wait_for_macsec_cleanup(host, interfaces, timeout=90):

--- a/tests/common/macsec/macsec_config_helper.py
+++ b/tests/common/macsec/macsec_config_helper.py
@@ -4,7 +4,7 @@ import time
 from passlib.hash import cisco_type7
 
 from tests.common.macsec.macsec_helper import get_mka_session, getns_prefix, wait_all_complete, \
-     submit_async_task
+     submit_async_task, load_all_macsec_info
 from tests.common.macsec.macsec_platform_helper import global_cmd, find_portchannel_from_member, get_portchannel
 from tests.common.devices.eos import EosHost
 from tests.common.utilities import wait_until

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -290,6 +290,9 @@ def pytest_addoption(parser):
                      help="Enable macsec on some links of testbed")
     parser.addoption("--macsec_profile", action="store", default="all",
                      type=str, help="profile name list in macsec/profile.json")
+    parser.addoption("--per_interface_macsec", action="store_true", default=False,
+                     help="Layer per-interface MACsec profiles (unique CAK/CKN per port) "
+                          "on top of the base profile for testing")
 
     ############################
     #   QoS options         #

--- a/tests/macsec/conftest.py
+++ b/tests/macsec/conftest.py
@@ -23,6 +23,23 @@ def profile_name(macsec_profile):
 
 
 @pytest.fixture(scope="module")
+def get_port_profile_name(macsec_profile, port_profiles):
+    """Return a callable ``f(dut_port)`` that resolves the MACsec profile
+    name for a given port.  In single-profile mode this always returns the
+    same name.  Tests that disable/re-enable MACsec on a port should use
+    this instead of ``profile_name``.
+    """
+    if port_profiles:
+        def _resolve(dut_port):
+            return port_profiles[dut_port]['name']
+    else:
+        name = macsec_profile['name']
+        def _resolve(dut_port):       # noqa: E306
+            return name
+    return _resolve
+
+
+@pytest.fixture(scope="module")
 def default_priority(macsec_profile):
     return macsec_profile['priority']
 
@@ -58,5 +75,21 @@ def rekey_period(macsec_profile):
 
 
 @pytest.fixture(scope="module")
-def wait_mka_establish(duthost, ctrl_links, policy, cipher_suite, send_sci):
-    assert wait_until(300, 6, 12, check_appl_db, duthost, ctrl_links, policy, cipher_suite, send_sci)
+def wait_mka_establish(duthost, ctrl_links, port_profiles, policy,
+                       cipher_suite, send_sci):
+    if port_profiles:
+        # If per interface, verify that each port is bound to its
+        # per-interface profile in CONFIG_DB.
+        from tests.common.macsec.macsec_helper import getns_prefix
+        for dut_port, profile in port_profiles.items():
+            cmd = "sonic-db-cli {} CONFIG_DB HGET 'PORT|{}' 'macsec'".format(
+                getns_prefix(duthost, dut_port), dut_port)
+            bound_profile = duthost.command(cmd)['stdout'].strip()
+            assert bound_profile == profile['name'], \
+                "Port {} bound to '{}', expected '{}'".format(
+                    dut_port, bound_profile, profile['name'])
+
+    # Validate APPL_DB tables — works for both single-profile and
+    # per-interface mode since cipher_suite/policy/send_sci are uniform.
+    assert wait_until(300, 6, 12, check_appl_db, duthost, ctrl_links,
+                      policy, cipher_suite, send_sci)

--- a/tests/macsec/test_controlplane.py
+++ b/tests/macsec/test_controlplane.py
@@ -89,9 +89,11 @@ class TestControlPlane():
         duthost.command("rm {}".format(tmp_file))
 
     @pytest.mark.disable_loganalyzer
-    def test_profile_replace(self, duthost, ctrl_links,
+    def test_profile_replace(self, duthost, ctrl_links, port_profiles,
                              profile_name, default_priority, cipher_suite,
                              primary_cak, primary_ckn, policy, send_sci, rekey_period, tbinfo, wait_mka_establish):
+        if port_profiles:
+            pytest.skip("Per-interface profile replacement tested in test_per_interface_profile")
         # Only pick one controlled link for profile replace test
         ctrl_link = dict([next(iter(ctrl_links.items()))])
         port_name, nbr = list(ctrl_link.items())[0]

--- a/tests/macsec/test_fault_handling.py
+++ b/tests/macsec/test_fault_handling.py
@@ -138,9 +138,11 @@ class TestFaultHandling():
         )
 
     @pytest.mark.disable_loganalyzer
-    def test_mismatch_macsec_configuration(self, duthost, unctrl_links,
+    def test_mismatch_macsec_configuration(self, duthost, unctrl_links, port_profiles,
                                            profile_name, default_priority, cipher_suite,
                                            primary_cak, primary_ckn, policy, send_sci, wait_mka_establish):
+        if port_profiles:
+            pytest.skip("Mismatch test uses single-profile CAK/CKN fixtures")
         # Only pick one uncontrolled link for mismatch macsec configuration test
         if not unctrl_links:
             pytest.skip('SKIP this test as there are no uncontrolled links in this dut')

--- a/tests/macsec/test_interop_protocol.py
+++ b/tests/macsec/test_interop_protocol.py
@@ -23,7 +23,7 @@ class TestInteropProtocol():
     '''
 
     @pytest.mark.disable_loganalyzer
-    def test_port_channel(self, duthost, profile_name, ctrl_links, wait_mka_establish):
+    def test_port_channel(self, duthost, get_port_profile_name, ctrl_links, wait_mka_establish):
         '''Verify lacp
         '''
         ctrl_port, _ = list(ctrl_links.items())[0]
@@ -44,7 +44,7 @@ class TestInteropProtocol():
             )
         )
 
-        enable_macsec_port(duthost, ctrl_port, profile_name)
+        enable_macsec_port(duthost, ctrl_port, get_port_profile_name(ctrl_port))
         # Add ethernet interface <ctrl_port> back to PortChannel interface <pc>
         duthost.command("sudo config portchannel {} member add {} {}"
                         .format(getns_prefix(duthost, ctrl_port), pc["name"], ctrl_port))
@@ -59,7 +59,7 @@ class TestInteropProtocol():
         )
 
     @pytest.mark.disable_loganalyzer
-    def test_lldp(self, duthost, ctrl_links, profile_name, wait_mka_establish):
+    def test_lldp(self, duthost, ctrl_links, get_port_profile_name, wait_mka_establish):
         '''Verify lldp
         '''
         LLDP_ADVERTISEMENT_INTERVAL = 30  # default interval in seconds
@@ -100,8 +100,8 @@ class TestInteropProtocol():
                     nbr["name"], get_lldp_list(duthost)
                 )
 
-            enable_macsec_port(duthost, ctrl_port, profile_name)
-            enable_macsec_port(nbr["host"], nbr["port"], profile_name)
+            enable_macsec_port(duthost, ctrl_port, get_port_profile_name(ctrl_port))
+            enable_macsec_port(nbr["host"], nbr["port"], get_port_profile_name(ctrl_port))
             wait_until(20, 3, 0,
                        lambda: duthost.iface_macsec_ok(ctrl_port) and
                        nbr["host"].iface_macsec_ok(nbr["port"]))
@@ -117,7 +117,7 @@ class TestInteropProtocol():
             )
 
     @pytest.mark.disable_loganalyzer
-    def test_bgp(self, duthost, ctrl_links, upstream_links, profile_name, wait_mka_establish):
+    def test_bgp(self, duthost, ctrl_links, upstream_links, get_port_profile_name, wait_mka_establish):
         '''Verify BGP neighbourship
         '''
         bgp_config = list(duthost.get_running_config_facts()[
@@ -171,8 +171,8 @@ class TestInteropProtocol():
 
         # Check the BGP sessions are present after port macsec enabled
         for ctrl_port, nbr in list(ctrl_links.items()):
-            enable_macsec_port(duthost, ctrl_port, profile_name)
-            enable_macsec_port(nbr["host"], nbr["port"], profile_name)
+            enable_macsec_port(duthost, ctrl_port, get_port_profile_name(ctrl_port))
+            enable_macsec_port(nbr["host"], nbr["port"], get_port_profile_name(ctrl_port))
             wait_until(BGP_TIMEOUT, 3, 0,
                        lambda: duthost.iface_macsec_ok(ctrl_port) and
                        nbr["host"].iface_macsec_ok(nbr["port"]))

--- a/tests/macsec/test_per_interface_profile.py
+++ b/tests/macsec/test_per_interface_profile.py
@@ -102,11 +102,12 @@ class TestPerInterfaceProfile():
                               lambda: duthost.iface_macsec_ok(target_port) and
                               target_nbr["host"].iface_macsec_ok(target_nbr["port"])), \
                 "MACsec did not recover on {}".format(target_port)
-    
-            target_ctrl_links = {target_port: ctrl_links.get(target_port), surviving_port: ctrl_links.get(surviving_port)}
+
+            target_ctrl_links = {target_port: ctrl_links.get(target_port),
+                                 surviving_port: ctrl_links.get(surviving_port)}
             assert wait_until(300, 3, 0,
                               check_appl_db, duthost, target_ctrl_links, policy, cipher_suite, send_sci),\
-                    "appl_db didnt recover"
+                "appl_db didnt recover"
 
         load_all_macsec_info(duthost, ctrl_links, tbinfo)
 

--- a/tests/macsec/test_per_interface_profile.py
+++ b/tests/macsec/test_per_interface_profile.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 import time
+import random
 
 from tests.common.utilities import wait_until
 from tests.common.macsec.macsec_helper import get_appl_db, get_ipnetns_prefix, load_all_macsec_info, check_appl_db
@@ -52,8 +53,9 @@ class TestPerInterfaceProfile():
         if not port_profiles:
             pytest.skip("Requires --per_interface_macsec")
         ports = list(ctrl_links.keys())
-        target_port = ports[0]
-        surviving_port = ports[1]
+        target_port = random.choice(ports)
+        ports.remove(target_port)
+        surviving_port = random.choice(ports)
         target_nbr = ctrl_links[target_port]
         target_profile = port_profiles[target_port]
 
@@ -116,8 +118,9 @@ class TestPerInterfaceProfile():
         if not port_profiles:
             pytest.skip("Requires --per_interface_macsec")
         ports = list(ctrl_links.keys())
-        target_port = ports[0]
-        other_port = ports[1]
+        target_port = random.choice(ports)
+        ports.remove(target_port)
+        other_port = random.choice(ports)
         target_nbr = ctrl_links[target_port]
         other_nbr = ctrl_links[other_port]
 

--- a/tests/macsec/test_per_interface_profile.py
+++ b/tests/macsec/test_per_interface_profile.py
@@ -1,0 +1,175 @@
+import pytest
+import logging
+import time
+
+from tests.common.utilities import wait_until
+from tests.common.macsec.macsec_helper import get_appl_db, get_ipnetns_prefix, load_all_macsec_info, check_appl_db
+from tests.common.macsec.macsec_config_helper import (
+    generate_macsec_profile,
+    setup_macsec_multi_profile_configuration,
+    disable_macsec_port,
+    enable_macsec_port,
+    delete_macsec_profile,
+    replace_macsec_port
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.macsec_required,
+    pytest.mark.topology("t0", "t2", "t0-sonic"),
+]
+
+
+class TestPerInterfaceProfile():
+    '''
+    Tests specific to per-interface MACsec profile functionality.
+    Validates behaviours that only exist when different ports use
+    different profiles simultaneously.
+    Requires ``--per_interface_macsec`` to be set.
+    '''
+
+    def test_unique_keys(self, port_profiles, wait_mka_establish):
+        '''Verify that each port was configured with a unique CAK/CKN pair
+        '''
+        if not port_profiles:
+            pytest.skip("Requires --per_interface_macsec")
+        profile_list = list(port_profiles.values())
+        for i in range(len(profile_list)):
+            for j in range(i + 1, len(profile_list)):
+                assert profile_list[i]["primary_cak"] != profile_list[j]["primary_cak"], \
+                    "CAK collision between {} and {}".format(
+                        profile_list[i]["name"], profile_list[j]["name"])
+                assert profile_list[i]["primary_ckn"] != profile_list[j]["primary_ckn"], \
+                    "CKN collision between {} and {}".format(
+                        profile_list[i]["name"], profile_list[j]["name"])
+
+    @pytest.mark.disable_loganalyzer
+    def test_profile_isolation(self, duthost, ctrl_links, upstream_links,
+                               port_profiles, policy, cipher_suite, send_sci, tbinfo, wait_mka_establish):
+        '''Disable MACsec on one port and verify other ports remain operational
+        '''
+        if not port_profiles:
+            pytest.skip("Requires --per_interface_macsec")
+        ports = list(ctrl_links.keys())
+        target_port = ports[0]
+        surviving_port = ports[1]
+        target_nbr = ctrl_links[target_port]
+        target_profile = port_profiles[target_port]
+
+
+        if surviving_port in upstream_links:
+            up = upstream_links[surviving_port]
+            ret = duthost.command(
+                "{} ping -c 4 {}".format(
+                    get_ipnetns_prefix(duthost, surviving_port),
+                    up["local_ipv4_addr"]), module_ignore_errors=True)
+            assert not ret["failed"], \
+                "Pre disable ping failed on surviving port {}".format(surviving_port)
+
+        disable_macsec_port(duthost, target_port)
+        disable_macsec_port(target_nbr["host"], target_nbr["port"])
+
+        # Allow some time for port channels to come back up
+        time.sleep(30)
+
+        try:
+            def _surviving_ok():
+                nbr = ctrl_links[surviving_port]
+                pt, esc, isc, esa, isa = get_appl_db(
+                    duthost, surviving_port, nbr["host"], nbr["port"])
+                return bool(pt and esc and isc and pt.get("enable") == "true")
+
+            assert wait_until(60, 3, 5, _surviving_ok), \
+                "Surviving port {} lost MACsec after disabling {}".format(
+                    surviving_port, target_port)
+
+            if surviving_port in upstream_links:
+                up = upstream_links[surviving_port]
+                ret = duthost.command(
+                    "{} ping -c 4 {}".format(
+                        get_ipnetns_prefix(duthost, surviving_port),
+                        up["local_ipv4_addr"]), module_ignore_errors=True)
+                assert not ret["failed"], \
+                    "Ping failed on surviving port {}".format(surviving_port)
+        finally:
+            enable_macsec_port(duthost, target_port, target_profile["name"])
+            enable_macsec_port(target_nbr["host"], target_nbr["port"],
+                               target_profile["name"])
+
+            assert wait_until(300, 3, 0,
+                              lambda: duthost.iface_macsec_ok(target_port) and
+                              target_nbr["host"].iface_macsec_ok(target_nbr["port"])), \
+                "MACsec did not recover on {}".format(target_port)
+    
+            target_ctrl_links = {target_port: ctrl_links.get(target_port), surviving_port: ctrl_links.get(surviving_port)}
+            assert wait_until(300, 3, 0, check_appl_db, duthost, target_ctrl_links, policy, cipher_suite, send_sci), "appl_db didnt recover"
+
+        load_all_macsec_info(duthost, ctrl_links, tbinfo)
+
+    @pytest.mark.disable_loganalyzer
+    def test_profile_replace(self, duthost, ctrl_links, port_profiles,
+                             cipher_suite, policy, send_sci, default_priority,
+                             rekey_period, tbinfo, wait_mka_establish):
+        '''Replace the profile on one port and verify other ports are unaffected
+        '''
+        if not port_profiles:
+            pytest.skip("Requires --per_interface_macsec")
+        ports = list(ctrl_links.keys())
+        target_port = ports[0]
+        other_port = ports[1]
+        target_nbr = ctrl_links[target_port]
+        other_nbr = ctrl_links[other_port]
+
+        _, _, _, orig_target_esa, _ = get_appl_db(
+            duthost, target_port, target_nbr["host"], target_nbr["port"])
+
+        new_profile = generate_macsec_profile(
+            port_name=target_port,
+            cipher_suite=cipher_suite,
+            priority=default_priority,
+            policy=policy,
+            send_sci=send_sci,
+            rekey_period=rekey_period,
+        )
+        new_profile["name"] = "MACSEC_PROFILE_{}_NEW".format(target_port)
+
+        new_port_profiles = {target_port: new_profile}
+        setup_macsec_multi_profile_configuration(
+            duthost, {target_port: target_nbr}, new_port_profiles, tbinfo)
+
+        try:
+            def _check_new_sa():
+                _, _, _, new_esa, _ = get_appl_db(
+                    duthost, target_port, target_nbr["host"],
+                    target_nbr["port"])
+                if not new_esa:
+                    return False
+                return new_esa != orig_target_esa
+            assert wait_until(60, 5, 2, _check_new_sa), \
+                "SA keys did not change on {} after profile replace".format(
+                    target_port)
+
+            pt, _, _, other_esa, _ = get_appl_db(
+                duthost, other_port, other_nbr["host"], other_nbr["port"])
+            assert other_esa, "Other port {} lost SA tables".format(other_port)
+            assert pt["cipher_suite"] == port_profiles[other_port]["cipher_suite"], \
+                "Other port cipher changed unexpectedly"
+        finally:
+            # Replace profile on port back to the original, and clean up the test profile
+            orig_port_profile = port_profiles[target_port]
+            replace_macsec_port(duthost, target_port, orig_port_profile["name"])
+            replace_macsec_port(target_nbr["host"], target_nbr["port"], orig_port_profile["name"])
+            delete_macsec_profile(duthost, new_profile["name"])
+            delete_macsec_profile(target_nbr["host"], new_profile["name"])
+
+            assert wait_until(300, 3, 0,
+                              lambda: duthost.iface_macsec_ok(target_port) and
+                              target_nbr["host"].iface_macsec_ok(target_nbr["port"])), \
+                "MACsec did not recover on {}".format(target_port)
+    
+            assert wait_until(300, 3, 0,
+                             check_appl_db, duthost, {target_port: ctrl_links.get(target_port)}, policy, cipher_suite, send_sci), \
+                "appl_db didnt recover"
+
+        load_all_macsec_info(duthost, ctrl_links, tbinfo)

--- a/tests/macsec/test_per_interface_profile.py
+++ b/tests/macsec/test_per_interface_profile.py
@@ -59,7 +59,6 @@ class TestPerInterfaceProfile():
         target_nbr = ctrl_links[target_port]
         target_profile = port_profiles[target_port]
 
-
         if surviving_port in upstream_links:
             up = upstream_links[surviving_port]
             ret = duthost.command(
@@ -105,7 +104,9 @@ class TestPerInterfaceProfile():
                 "MACsec did not recover on {}".format(target_port)
     
             target_ctrl_links = {target_port: ctrl_links.get(target_port), surviving_port: ctrl_links.get(surviving_port)}
-            assert wait_until(300, 3, 0, check_appl_db, duthost, target_ctrl_links, policy, cipher_suite, send_sci), "appl_db didnt recover"
+            assert wait_until(300, 3, 0,
+                              check_appl_db, duthost, target_ctrl_links, policy, cipher_suite, send_sci),\
+                    "appl_db didnt recover"
 
         load_all_macsec_info(duthost, ctrl_links, tbinfo)
 
@@ -170,9 +171,10 @@ class TestPerInterfaceProfile():
                               lambda: duthost.iface_macsec_ok(target_port) and
                               target_nbr["host"].iface_macsec_ok(target_nbr["port"])), \
                 "MACsec did not recover on {}".format(target_port)
-    
+
             assert wait_until(300, 3, 0,
-                             check_appl_db, duthost, {target_port: ctrl_links.get(target_port)}, policy, cipher_suite, send_sci), \
+                              check_appl_db, duthost,
+                              {target_port: ctrl_links.get(target_port)}, policy, cipher_suite, send_sci), \
                 "appl_db didnt recover"
 
         load_all_macsec_info(duthost, ctrl_links, tbinfo)

--- a/tests/macsec/test_per_interface_profile.py
+++ b/tests/macsec/test_per_interface_profile.py
@@ -4,7 +4,12 @@ import time
 import random
 
 from tests.common.utilities import wait_until
-from tests.common.macsec.macsec_helper import get_appl_db, get_ipnetns_prefix, load_all_macsec_info, check_appl_db
+from tests.common.macsec.macsec_helper import (
+    check_appl_db,
+    get_appl_db,
+    get_ipnetns_prefix,
+    load_all_macsec_info,
+)
 from tests.common.macsec.macsec_config_helper import (
     generate_macsec_profile,
     setup_macsec_multi_profile_configuration,
@@ -38,16 +43,23 @@ class TestPerInterfaceProfile():
         profile_list = list(port_profiles.values())
         for i in range(len(profile_list)):
             for j in range(i + 1, len(profile_list)):
-                assert profile_list[i]["primary_cak"] != profile_list[j]["primary_cak"], \
+                assert (
+                    profile_list[i]["primary_cak"] !=
+                    profile_list[j]["primary_cak"]
+                ), \
                     "CAK collision between {} and {}".format(
                         profile_list[i]["name"], profile_list[j]["name"])
-                assert profile_list[i]["primary_ckn"] != profile_list[j]["primary_ckn"], \
+                assert (
+                    profile_list[i]["primary_ckn"] !=
+                    profile_list[j]["primary_ckn"]
+                ), \
                     "CKN collision between {} and {}".format(
                         profile_list[i]["name"], profile_list[j]["name"])
 
     @pytest.mark.disable_loganalyzer
     def test_profile_isolation(self, duthost, ctrl_links, upstream_links,
-                               port_profiles, policy, cipher_suite, send_sci, tbinfo, wait_mka_establish):
+                               port_profiles, policy, cipher_suite, send_sci,
+                               tbinfo, wait_mka_establish):
         '''Disable MACsec on one port and verify other ports remain operational
         '''
         if not port_profiles:
@@ -66,7 +78,8 @@ class TestPerInterfaceProfile():
                     get_ipnetns_prefix(duthost, surviving_port),
                     up["local_ipv4_addr"]), module_ignore_errors=True)
             assert not ret["failed"], \
-                "Pre disable ping failed on surviving port {}".format(surviving_port)
+                "Pre disable ping failed on surviving port {}".format(
+                    surviving_port)
 
         disable_macsec_port(duthost, target_port)
         disable_macsec_port(target_nbr["host"], target_nbr["port"])
@@ -100,13 +113,16 @@ class TestPerInterfaceProfile():
 
             assert wait_until(300, 3, 0,
                               lambda: duthost.iface_macsec_ok(target_port) and
-                              target_nbr["host"].iface_macsec_ok(target_nbr["port"])), \
+                              target_nbr["host"].iface_macsec_ok(
+                                  target_nbr["port"])), \
                 "MACsec did not recover on {}".format(target_port)
 
             target_ctrl_links = {target_port: ctrl_links.get(target_port),
-                                 surviving_port: ctrl_links.get(surviving_port)}
+                                 surviving_port:
+                                     ctrl_links.get(surviving_port)}
             assert wait_until(300, 3, 0,
-                              check_appl_db, duthost, target_ctrl_links, policy, cipher_suite, send_sci),\
+                              check_appl_db, duthost, target_ctrl_links,
+                              policy, cipher_suite, send_sci), \
                 "appl_db didnt recover"
 
         load_all_macsec_info(duthost, ctrl_links, tbinfo)
@@ -115,7 +131,7 @@ class TestPerInterfaceProfile():
     def test_profile_replace(self, duthost, ctrl_links, port_profiles,
                              cipher_suite, policy, send_sci, default_priority,
                              rekey_period, tbinfo, wait_mka_establish):
-        '''Replace the profile on one port and verify other ports are unaffected
+        '''Replace a profile and verify other ports are unaffected
         '''
         if not port_profiles:
             pytest.skip("Requires --per_interface_macsec")
@@ -158,24 +174,32 @@ class TestPerInterfaceProfile():
             pt, _, _, other_esa, _ = get_appl_db(
                 duthost, other_port, other_nbr["host"], other_nbr["port"])
             assert other_esa, "Other port {} lost SA tables".format(other_port)
-            assert pt["cipher_suite"] == port_profiles[other_port]["cipher_suite"], \
+            assert (
+                pt["cipher_suite"] ==
+                port_profiles[other_port]["cipher_suite"]
+            ), \
                 "Other port cipher changed unexpectedly"
         finally:
-            # Replace profile on port back to the original, and clean up the test profile
+            # Restore the original profile and clean up the test profile.
             orig_port_profile = port_profiles[target_port]
-            replace_macsec_port(duthost, target_port, orig_port_profile["name"])
-            replace_macsec_port(target_nbr["host"], target_nbr["port"], orig_port_profile["name"])
+            replace_macsec_port(
+                duthost, target_port, orig_port_profile["name"])
+            replace_macsec_port(
+                target_nbr["host"], target_nbr["port"],
+                orig_port_profile["name"])
             delete_macsec_profile(duthost, new_profile["name"])
             delete_macsec_profile(target_nbr["host"], new_profile["name"])
 
             assert wait_until(300, 3, 0,
                               lambda: duthost.iface_macsec_ok(target_port) and
-                              target_nbr["host"].iface_macsec_ok(target_nbr["port"])), \
+                              target_nbr["host"].iface_macsec_ok(
+                                  target_nbr["port"])), \
                 "MACsec did not recover on {}".format(target_port)
 
             assert wait_until(300, 3, 0,
                               check_appl_db, duthost,
-                              {target_port: ctrl_links.get(target_port)}, policy, cipher_suite, send_sci), \
+                              {target_port: ctrl_links.get(target_port)},
+                              policy, cipher_suite, send_sci), \
                 "appl_db didnt recover"
 
         load_all_macsec_info(duthost, ctrl_links, tbinfo)


### PR DESCRIPTION
### Description of PR
Summary:
Manual 202605 backport of https://github.com/sonic-net/sonic-mgmt/pull/23894.

Fixes # https://github.com/sonic-net/sonic-mgmt/issues/23895

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?

Provide the per-interface MACsec profile functionality and tests from PR #23894 on the 202605 branch.

#### How did you do it?

Manually cherry-picked the five source commits in order because the automatic cherry-pick conflicted in `tests/common/macsec/__init__.py`. The resolution integrates per-interface profile setup/cleanup while preserving the newer 202605 behavior for preconfigured MACsec detection, MKA establishment waiting, and MACsec information reload. It also retains the target branch helper import required by that reload path.

#### How did you verify/test it?

- `python -m py_compile` for all changed Python files
- `python -m flake8 tests/macsec/test_per_interface_profile.py`
- Critical flake8 checks (`E9,F63,F7,F82`) for the changed MACsec modules
- `git diff --check upstream/202605...HEAD`
- Targeted pytest collection was attempted but is unavailable on Windows because the existing test infrastructure imports the Unix-only `fcntl` module.

#### Any platform specific information?

No additional platform-specific changes.

#### Supported testbed topology if it's a new test case?

`t0`, `t2`, and `t0-sonic`, matching the source PR.

### Documentation

No documentation changes; this is a manual branch backport of the source PR.