### PR TITLE
[dualtor] Backport loganalyzer TACACS ignore fixes to 202605

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -236,7 +236,7 @@ r, ". *ERR swss#orchagent.*Failed to get port by bridge port ID.*"
 # https://github.com/Azure/sonic-sairedis/issues/582
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_PORT_ATTR_ISOLATION_GROUP"
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_ATTR_UNKNOWN_UNICAST_FLOOD_GROUP"
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_ATTR_UNKNOWN_MULTICAST_FLOOD_GROUP
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_ATTR_UNKNOWN_MULTICAST_FLOOD_GROUP"
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_ATTR_BROADCAST_FLOOD_GROUP"
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_PORT_ATTR_PORT_ID"
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- sai_get_attributes: Failed attribs dispatch"
@@ -357,7 +357,8 @@ r, ".* ERR ntpd\[\d*\]: nss_tacplus: .*"
 r, ".* ERR chronyd\[\d*\]: nss_tacplus: .*"
 
 # ignore iptable nss_tacplus error, some change iptable operations may temporarily disrupt the DUT-to-PTF network connection, which triggers the error. It is safe to ignore this message during such transitions.
-r, ".* ERR iptables: nss_tacplus: failed to connect TACACS+ server .*"
+r, ".* ERR iptables: nss_tacplus: failed to connect TACACS\+ server .*"
+r, ".* ERR iptables: tac_connect_single: connection to .* failed: Network is unreachable.*"
 
 # ignore leap second file NTP daemon (ntpd) is using has passed its expiration date
 r, ".* ERR ntpd\[\d*\]:.*leapsecond file \('/usr/share/zoneinfo/leap-seconds\.list'\): expired.*"


### PR DESCRIPTION
### Description of PR

Summary:
Backport of #26087 to 202605 to avoid false loganalyzer failures caused by benign TACACS-related iptables ERR logs during transient config/topology transitions.
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
False-positive loganalyzer failures were observed on 202605 when iptables reports transient TACACS connectivity errors (for example, `nss_tacplus` / `tac_connect_single` with "Network is unreachable") during short disruption windows.

#### How did you do it?
- Escaped `TACACS+` to `TACACS\+` in the iptables ignore regex so literal `TACACS+` logs are matched correctly.
- Added ignore for `iptables: tac_connect_single: connection to .* failed: Network is unreachable`.
- Included the same missing-closing-quote regex fix from #26087 to keep the file aligned with upstream fix set.

#### How did you verify/test it?
- Verified file diff on branch `yyynini/bugfix-202605-tacacs-ignore` against `origin/202605` contains only the expected backport hunks from #26087.
- Confirmed PR targets `sonic-net/sonic-mgmt:202605` and commit includes DCO sign-off.

#### Any platform specific information?
No platform-specific behavior change; this updates loganalyzer ignore patterns only.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
