### PR TITLE
fix(gnmi): recover telemetry after TLS rollback

### DIFF
--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -26,7 +26,7 @@ from tests.common.cert_utils import create_gnmi_cert_generator
 from tests.common.grpc_config import grpc_config
 from tests.common.gu_utils import create_checkpoint, rollback
 from tests.common.platform.processes_utils import wait_critical_processes
-from tests.common.helpers.gnmi_utils import GNMIEnvironment
+from tests.common.helpers.gnmi_utils import GNMIEnvironment, recover_telemetry_container
 from tests.common.ptf_grpc import PtfGrpc
 from tests.common.ptf_gnoi import PtfGnoi
 from tests.common.pygnmi_client import PygnmiClient
@@ -351,6 +351,12 @@ def gnmi_tls(request, duthosts, ptfhost):
             logger.info("All critical processes are healthy")
         except Exception as e:
             logger.error("Waiting for critical processes failed with exception: %s", e)
+
+        logger.info("Recovering telemetry container health after rollback")
+        if recover_telemetry_container(duthost):
+            logger.info("Telemetry container and Monit container_checker are healthy")
+        else:
+            logger.error("Telemetry container health did not recover after rollback")
 
         try:
             _delete_gnoi_certs(cert_dir)

--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -352,11 +352,13 @@ def gnmi_tls(request, duthosts, ptfhost):
         except Exception as e:
             logger.error("Waiting for critical processes failed with exception: %s", e)
 
-        logger.info("Recovering telemetry container health after rollback")
+        logger.info("Checking telemetry container health after rollback")
         if recover_telemetry_container(duthost):
-            logger.info("Telemetry container and Monit container_checker are healthy")
+            logger.info("Telemetry recovery check completed")
         else:
-            logger.error("Telemetry container health did not recover after rollback")
+            logger.error(
+                "Telemetry container health did not recover after rollback"
+            )
 
         try:
             _delete_gnoi_certs(cert_dir)

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -41,13 +41,77 @@ def _check_monit_container_checker(duthost):
     return status in ("OK", "Status ok")
 
 
+def _check_telemetry_health(duthost):
+    """Check that telemetry is running and Monit reports healthy containers."""
+    container_running = check_container_state(
+        duthost,
+        TELEMETRY_CONTAINER,
+        should_be_running=True,
+    )
+    return container_running and _check_monit_container_checker(duthost)
+
+
 def recover_telemetry_container(duthost):
     """Restart telemetry when needed and wait for container_checker recovery."""
-    if not check_container_state(duthost, TELEMETRY_CONTAINER, should_be_running=True):
-        logger.info("Telemetry container is not running after gNMI recovery, restarting it")
-        duthost.shell("sudo systemctl restart telemetry", module_ignore_errors=True)
+    feature_status, status_available = duthost.get_feature_status()
+    if status_available:
+        telemetry_status = feature_status.get(TELEMETRY_CONTAINER)
+        if telemetry_status in (None, "disabled", "always_disabled"):
+            logger.info(
+                "Telemetry feature is %s; skipping container recovery",
+                telemetry_status or "absent",
+            )
+            return True
+    else:
+        logger.warning(
+            "Unable to read telemetry feature status; attempting recovery"
+        )
 
-    return wait_until(120, 10, 30, _check_monit_container_checker, duthost)
+    telemetry_restarted = False
+    if not check_container_state(
+        duthost,
+        TELEMETRY_CONTAINER,
+        should_be_running=True,
+    ):
+        logger.info(
+            "Telemetry container is not running after gNMI recovery, "
+            "restarting it"
+        )
+        result = duthost.shell(
+            "sudo systemctl restart telemetry",
+            module_ignore_errors=True,
+        )
+        if result.get("rc", 1) != 0:
+            logger.warning(
+                "Failed to restart telemetry container: %s",
+                result.get("stderr", ""),
+            )
+            return False
+
+        if not wait_until(
+                120,
+                10,
+                0,
+                check_container_state,
+                duthost,
+                TELEMETRY_CONTAINER,
+                True):
+            logger.warning(
+                "Telemetry container did not recover after gNMI "
+                "configuration cleanup"
+            )
+            return False
+        telemetry_restarted = True
+
+    monit_delay = 30 if telemetry_restarted else 0
+    if not wait_until(120, 10, monit_delay, _check_telemetry_health, duthost):
+        logger.warning(
+            "Monit container_checker did not recover after gNMI "
+            "configuration cleanup"
+        )
+        return False
+
+    return True
 
 
 def _cert_validity_period(days):

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -7,6 +7,9 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.x509.oid import NameOID
 
+from tests.common.helpers.dut_utils import check_container_state
+from tests.common.utilities import wait_until
+
 logger = logging.getLogger(__name__)
 
 
@@ -21,6 +24,30 @@ TELEMETRY_CONTAINER = "telemetry"
 # cryptography because the openssl 3.0.x CLI on the runner has no flag
 # to set notBefore on `req -x509` / `x509 -req` (added only in 3.5).
 _CERT_BACKDATE_DAYS = 7
+
+
+def _check_monit_container_checker(duthost):
+    """Check if monit container_checker service is healthy.
+
+    After gNMI cert config recovery, monit needs time to re-evaluate
+    container status. This function checks if container_checker has
+    returned to a healthy state (OK or Status ok).
+    """
+    monit_services = duthost.get_monit_services_status()
+    if not monit_services:
+        return False
+    container_checker = monit_services.get("container_checker", {})
+    status = container_checker.get("service_status", "")
+    return status in ("OK", "Status ok")
+
+
+def recover_telemetry_container(duthost):
+    """Restart telemetry when needed and wait for container_checker recovery."""
+    if not check_container_state(duthost, TELEMETRY_CONTAINER, should_be_running=True):
+        logger.info("Telemetry container is not running after gNMI recovery, restarting it")
+        duthost.shell("sudo systemctl restart telemetry", module_ignore_errors=True)
+
+    return wait_until(120, 10, 30, _check_monit_container_checker, duthost)
 
 
 def _cert_validity_period(days):

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -6,9 +6,8 @@ import ipaddress
 from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import get_dpu_ip, get_dpu_port
 from tests.common.helpers.gnmi_utils import GNMIEnvironment, add_gnmi_client_common_name, del_gnmi_client_common_name, \
-                                            dump_gnmi_log, dump_system_status
+                                            dump_gnmi_log, dump_system_status, recover_telemetry_container
 from tests.common.helpers.ntp_helper import NtpDaemon, get_ntp_daemon_in_use   # noqa: F401
-from tests.common.helpers.dut_utils import check_container_state
 
 
 logger = logging.getLogger(__name__)
@@ -102,21 +101,6 @@ def check_gnmi_status(duthost):
     return "RUNNING" in output['stdout']
 
 
-def _check_monit_container_checker(duthost):
-    """Check if monit container_checker service is healthy.
-
-    After gNMI cert config recovery, monit needs time to re-evaluate
-    container status. This function checks if container_checker has
-    returned to a healthy state (OK or Status ok).
-    """
-    monit_services = duthost.get_monit_services_status()
-    if not monit_services:
-        return False
-    container_checker = monit_services.get("container_checker", {})
-    status = container_checker.get("service_status", "")
-    return status in ("OK", "Status ok")
-
-
 def recover_cert_config(duthost, stopped_programs=None):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     # Kill the GNMI process
@@ -140,18 +124,7 @@ def recover_cert_config(duthost, stopped_programs=None):
         logger.error("GNMI service failed to start. GNMI log: {}".format(output['stdout']))
         pytest.fail("Failed to recover GNMI client cert configuration.")
 
-    # Restart telemetry container if it was stopped during cert config change
-    # apply_cert_config may trigger ctrmgrd to stop the telemetry container
-    if not check_container_state(duthost, "telemetry", should_be_running=True):
-        logger.info("Telemetry container is not running after cert config recovery, restarting it")
-        duthost.shell("sudo systemctl restart telemetry", module_ignore_errors=True)
-
-    # Wait for monit container_checker to report healthy status.
-    # After restarting processes/containers, monit needs time to re-evaluate
-    # service status. Without this wait, post-test sanity check may see stale
-    # "Status failed" from container_checker and fail the test on teardown.
-    if not wait_until(120, 10, 30, _check_monit_container_checker, duthost):
-        logger.warning("Monit container_checker did not recover to healthy status after cert config recovery")
+    recover_telemetry_container(duthost)
 
 
 def check_ntp_sync_status(duthost):

--- a/tests/gnmi/unit_tests/unit_test_gnmi_utils.py
+++ b/tests/gnmi/unit_tests/unit_test_gnmi_utils.py
@@ -1,0 +1,134 @@
+"""Unit tests for gNMI telemetry container recovery."""
+
+import ast
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, call
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "common"
+    / "helpers"
+    / "gnmi_utils.py"
+)
+FUNCTION_NAMES = {
+    "_check_monit_container_checker",
+    "_check_telemetry_health",
+    "recover_telemetry_container",
+}
+CONSTANT_NAMES = {"TELEMETRY_CONTAINER"}
+
+
+def _load_target_module():
+    """Load only the telemetry recovery code and replace external helpers."""
+    tree = ast.parse(MODULE_PATH.read_text())
+    selected_nodes = []
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in FUNCTION_NAMES:
+            selected_nodes.append(node)
+        elif isinstance(node, ast.Assign):
+            target_names = {
+                target.id
+                for target in node.targets
+                if isinstance(target, ast.Name)
+            }
+            if target_names & CONSTANT_NAMES:
+                selected_nodes.append(node)
+
+    module = types.ModuleType("unit_target_gnmi_utils")
+    module.logger = MagicMock()
+    module.check_container_state = MagicMock()
+    module.wait_until = MagicMock()
+    code = compile(
+        ast.Module(body=selected_nodes, type_ignores=[]),
+        str(MODULE_PATH),
+        "exec",
+    )
+    exec(code, module.__dict__)
+    return module
+
+
+@pytest.fixture
+def gnmi_utils():
+    return _load_target_module()
+
+
+@pytest.mark.parametrize(
+    "feature_status",
+    [
+        {},
+        {"telemetry": "disabled"},
+        {"telemetry": "always_disabled"},
+    ],
+)
+def test_recover_telemetry_skips_disabled_or_absent_feature(
+        gnmi_utils, feature_status):
+    duthost = MagicMock()
+    duthost.get_feature_status.return_value = (feature_status, True)
+
+    assert gnmi_utils.recover_telemetry_container(duthost)
+
+    gnmi_utils.check_container_state.assert_not_called()
+    gnmi_utils.wait_until.assert_not_called()
+    duthost.shell.assert_not_called()
+
+
+def test_recover_telemetry_returns_false_when_restart_fails(gnmi_utils):
+    duthost = MagicMock()
+    duthost.get_feature_status.return_value = (
+        {"telemetry": "enabled"},
+        True,
+    )
+    duthost.shell.return_value = {
+        "rc": 1,
+        "stderr": "Unit telemetry.service not found",
+    }
+    gnmi_utils.check_container_state.return_value = False
+
+    assert not gnmi_utils.recover_telemetry_container(duthost)
+
+    gnmi_utils.wait_until.assert_not_called()
+
+
+def test_recover_telemetry_verifies_successful_restart_and_monit(gnmi_utils):
+    duthost = MagicMock()
+    duthost.get_feature_status.return_value = (
+        {"telemetry": "enabled"},
+        True,
+    )
+    duthost.get_monit_services_status.return_value = {
+        "container_checker": {"service_status": "Status ok"}
+    }
+    duthost.shell.return_value = {"rc": 0}
+    gnmi_utils.check_container_state.side_effect = [False, True, True]
+    gnmi_utils.wait_until.side_effect = (
+        lambda timeout, interval, delay, condition, *args: condition(*args)
+    )
+
+    assert gnmi_utils.recover_telemetry_container(duthost)
+
+    duthost.shell.assert_called_once_with(
+        "sudo systemctl restart telemetry",
+        module_ignore_errors=True,
+    )
+    assert gnmi_utils.wait_until.call_args_list == [
+        call(
+            120,
+            10,
+            0,
+            gnmi_utils.check_container_state,
+            duthost,
+            "telemetry",
+            True,
+        ),
+        call(
+            120,
+            10,
+            30,
+            gnmi_utils._check_telemetry_health,
+            duthost,
+        ),
+    ]


### PR DESCRIPTION
### Description of PR

Summary:

Restore the telemetry container and wait for Monit `container_checker` after the `gnmi_tls` fixture rolls back its temporary configuration.

Changing gNMI certificate configuration can cause `ctrmgrd` to stop the separate telemetry container. The fixture previously waited only for the standard critical-service list, which does not include telemetry, so post-test sanity could observe `container_checker: Status failed`.

Telemetry recovery is skipped when the feature is disabled or absent. When telemetry is expected, the cleanup verifies the systemd restart, waits for the container to run, and requires both the running container and a fresh healthy Monit result.

Fixes # (no public issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: regression

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `d2ff8208e4` - focused telemetry recovery unit tests pass; PR CI rerun is in progress.

### Approach
#### What is the motivation for this PR?

Physical dual-ToR nightly runs on both Arista 7050 and 7260 platforms completed the gNOI OS test body but failed post-test sanity because Monit reported:

```text
'container_checker' status failed (3) -- Expected containers not running: telemetry
```

Sample failed test plans:

- [Arista 7050 dual-ToR](https://elastictest.org/scheduler/testplan/6a717fe0c738d690ad9c242d?searchTestCase=test_gnoi_os_activate_valid_image&testcase=gnmi%2Ftest_gnoi_os.py&type=console)
- [Arista 7260 dual-ToR](https://elastictest.org/scheduler/testplan/6a7422e0101ed2146e80a3e0?searchTestCase=test_gnoi_os_activate_valid_image&testcase=gnmi%2Ftest_gnoi_os.py&type=console)

#### How did you do it?

Extracted the existing telemetry restart and Monit wait from `recover_cert_config()` into a reusable helper, then called that helper from the newer function-scoped `gnmi_tls` teardown after configuration rollback.

The helper now skips images where telemetry is disabled or absent. For enabled telemetry, it checks the restart result, waits for the container to run, and verifies container state together with Monit health.

#### How did you verify/test it?

Added focused regression coverage for disabled or absent telemetry, a failed restart, and a successful restart with container and Monit verification.

#### Any platform specific information?

The failure was observed on Broadcom Arista 7050 and 7260 physical dual-ToR testbeds, but the cleanup path is shared and is not platform-specific.

#### Supported testbed topology if it's a new test case?

Not applicable.

### Documentation

Not applicable.