### PR TITLE
[eos]: Reclaim stale configure sessions on eos_config failure

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -366,11 +366,54 @@ class EosHost(AnsibleHostBase):
         ansible_eos_command = self.__getattr__('eos_command')
         return ansible_eos_command(*args, **kwargs)
 
+    def _abort_pending_config_sessions(self):
+        """Best-effort abort of stale pending EOS ``configure session``s.
+
+        EOS permits only a handful of pending config sessions. When an
+        ``eos_config`` commit times out it strands its ``ansible_*`` session;
+        enough stranded sessions exhaust the pool and every later
+        ``eos_config`` fails with "Maximum number of pending sessions has been
+        reached". Aborting them frees the pool so a retry can succeed.
+        """
+        try:
+            out = self.eos_command(
+                commands=['show configuration sessions detail | json']
+            )
+            sessions = out['stdout'][0].get('sessions', {})
+        except Exception as e:
+            logging.warning('Could not list EOS config sessions on %s: %s',
+                            self.hostname, e)
+            return
+        for sess_name, sess_info in sessions.items():
+            # Only reclaim sessions this framework created; never touch a
+            # session that has already been committed ('completed').
+            if not sess_name.startswith('ansible_'):
+                continue
+            if sess_info.get('state') == 'completed':
+                continue
+            try:
+                self.eos_command(
+                    commands=['configure session {} abort'.format(sess_name)]
+                )
+                logging.info('Aborted stale EOS config session [%s] on %s',
+                             sess_name, self.hostname)
+            except Exception as e:
+                logging.warning('Failed to abort EOS config session [%s] on %s: %s',
+                                sess_name, self.hostname, e)
+
     @retry(RunAnsibleModuleFail, tries=3, delay=5)
     def shutdown(self, interface_name):
-        out = self.eos_config(
-            lines=['shutdown'],
-            parents=['interface {}'.format(interface_name)])
+        try:
+            out = self.eos_config(
+                lines=['shutdown'],
+                parents=['interface {}'.format(interface_name)],
+                diff_against='running')
+        except RunAnsibleModuleFail:
+            # A timed-out commit strands a pending 'configure session'; free
+            # stale sessions so the @retry attempt is not blocked by
+            # 'Maximum number of pending sessions has been reached'.
+            self._abort_pending_config_sessions()
+            raise
         logging.info('Shut interface [%s]' % interface_name)
         return out
 
@@ -380,9 +423,15 @@ class EosHost(AnsibleHostBase):
 
     @retry(RunAnsibleModuleFail, tries=3, delay=5)
     def no_shutdown(self, interface_name):
-        out = self.eos_config(
-            lines=['no shutdown'],
-            parents=['interface {}'.format(interface_name)])
+        try:
+            out = self.eos_config(
+                lines=['no shutdown'],
+                parents=['interface {}'.format(interface_name)],
+                diff_against='running')
+        except RunAnsibleModuleFail:
+            # See shutdown(): reclaim stranded sessions before @retry re-runs.
+            self._abort_pending_config_sessions()
+            raise
         logging.info('No shut interface [%s]' % interface_name)
         return out
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 39219113
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: 20260510.10

```
dualtor_mgmt/test_server_failure.py::test_server_reboot[active-active] PASSED                                                                                                                                                                                                                                                                [100%]


============================================================================================================================================ 1 passed, 1 deselected, 138 warnings in 311.25s (0:05:11) =============================================================================================================================================
```

* MS work item id: 39219113


### Approach
#### What is the motivation for this PR?
Fix the following issue:

```
tests.common.errors.RunAnsibleModuleFail: run module eos_config failed, Ansible Results => failed = True data = configure session ansible_178636093349 % Maximum number of pending sessions has been reached. Please commit or abort previous sessions before creating a new one. svcstr-7260cx3-acs-8# msg = configure session ansible_178636093349 % Maximum number of pending sessions has been reached. Please commit or abort previous sessions before creating a new one. svcstr-7260cx3-acs-8# invocation = {'module_args': {'lines': ['shutdown'], 'parents': ['interface Ethernet2/1,Ethernet3/1,Ethernet4/1,Ethernet5/1,Ethernet6/1,Ethernet7/1,Ethernet8/1,Ethernet9/1,Ethernet10/1,Ethernet11/1,Ethernet12/1,Ethernet13/1,Ethernet14/1,Ethernet15/1,Ethernet16/1,Ethernet17/1,Ethernet18/1,Ethernet19/1,Ethernet20/1,Ethernet21/1,Ethernet22/1,Ethernet23/1,Ethernet24/1,Ethernet25/1'], 'match': 'line', 'replace': 'line', 'defaults': False, 'backup': False, 'save_when': 'never', 'diff_against': 'session', 'src': None, 'before': None, '
```

#### How did you do it?

`EosHost` config writes go through the eos_config Ansible module, which
applies config inside a `configure session ansible_<id>` and commits it
with `end`. If that commit times out (e.g. when a degraded fanout makes
each privileged command slow), the session is left pending. EOS allows
only a handful of pending sessions, so stranded sessions accumulate
across the shutdown() @Retry and the dualtor fanout-shutdown retry loop
until every later eos_config fails with "Maximum number of pending
sessions has been reached".

Add EosHost._abort_pending_config_sessions(), which lists
`show configuration sessions detail | json` and aborts each pending
`ansible_*` session (never touching non-ansible or already-committed
sessions). shutdown()/no_shutdown() call it on RunAnsibleModuleFail and
re-raise, so the existing @Retry runs against a freed pool. Also set
diff_against='running' so an idempotent retry opens no session at all.

#### How did you verify/test it?
run the failing case with this patch:

```
dualtor_mgmt/test_server_failure.py::test_server_reboot[active-active] PASSED                                                                                                                                                                                                                                                                [100%]


============================================================================================================================================ 1 passed, 1 deselected, 138 warnings in 311.25s (0:05:11) =============================================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
