### PR TITLE
Fix wait_until_lldp_populate early return

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -463,7 +463,7 @@ def wait_until_lldp_populated(db_instance, after_event_str, expected_lldp_entry_
     def expected_keys_present():
         return set(expected_lldp_entry_keys) == set(get_lldp_entry_keys(db_instance))
 
-    keys_present = wait_until(90, 2, 0, expected_keys_present)
+    keys_present = wait_until(300, 2, 0, expected_keys_present)
     pytest_assert(keys_present,
                   "After {}, LLDP_ENTRY_TABLE missing expected keys: {}".format(
                       after_event_str,

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -459,18 +459,23 @@ def verify_all_interfaces_lldp_content(db_instance, lldp_entry_keys, lldpctl_out
         verify_each_interface_lldp_content(db_instance, interface, lldpctl_interfaces)
 
 
-def wait_until_lldp_populated(duthost, db_instance, after_event_str):
-    keys_match = wait_until(90, 2, 0, check_lldp_table_keys, duthost, db_instance)
-    pytest_assert(keys_match, "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output")
-    lldp_entry_keys = get_lldp_entry_keys(db_instance)
-    # Wait until all interfaces are up and lldp entries are populated
-    result = wait_until(300, 2, 0, verify_lldp_entry, db_instance, lldp_entry_keys)
+def wait_until_lldp_populated(db_instance, after_event_str, expected_lldp_entry_keys):
+    def expected_keys_present():
+        return set(expected_lldp_entry_keys) == set(get_lldp_entry_keys(db_instance))
+
+    keys_present = wait_until(90, 2, 0, expected_keys_present)
+    pytest_assert(keys_present,
+                  "After {}, LLDP_ENTRY_TABLE missing expected keys: {}".format(
+                      after_event_str,
+                      sorted(set(expected_lldp_entry_keys) - set(get_lldp_entry_keys(db_instance)))))
+
+    result = wait_until(300, 2, 0, verify_lldp_entry, db_instance, expected_lldp_entry_keys)
     if not result:
         failed_entries = {}
-        for interface in lldp_entry_keys:
+        for interface in expected_lldp_entry_keys:
             if not verify_lldp_entry(db_instance, [interface]):
                 failed_entries[interface] = get_lldp_entry_content(db_instance, interface)
-        msg = (f"After {after_event_str}, not all LLDP_ENTRY_TABLE entries are not correct: {failed_entries}")
+        msg = (f"After {after_event_str}, not all LLDP_ENTRY_TABLE entries are correct: {failed_entries}")
         pytest_assert(False, msg)
 
 
@@ -525,7 +530,7 @@ def test_lldp_entry_table_after_syncd_orchagent(
         wait_until(300, 10, 30, duthost.check_bgp_session_state, bgp_neighbors),
         "BGP sessions did not reach Established state after swss restart",
     )
-    wait_until_lldp_populated(duthost, db_instance, "restart swss and syncd")
+    wait_until_lldp_populated(db_instance, "restart swss and syncd", lldp_entry_keys)
 
     # To get lldp entry keys again after all interfaces are up
     lldp_entry_keys, show_lldp_table_int_list, lldpctl_output = get_lldp_data(duthost, db_instance)
@@ -610,7 +615,7 @@ def test_lldp_entry_table_after_lldp_restart(
             "active (running)" in result,
             "LLDP service is not running",
         )
-    wait_until_lldp_populated(duthost, db_instance, "lldp restart")
+    wait_until_lldp_populated(db_instance, "lldp restart", lldp_entry_keys)
     verify_all_interfaces_lldp_content(db_instance, lldp_entry_keys, lldpctl_output, show_lldp_table_int_list)
 
 
@@ -620,6 +625,7 @@ def test_lldp_entry_table_after_reboot(
     localhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, db_instance
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    lldp_entry_keys = get_lldp_entry_keys(db_instance)
 
     # reboot
     logging.info("Run cold reboot on DUT")
@@ -635,6 +641,6 @@ def test_lldp_entry_table_after_reboot(
 
     # Wait till we have all lldp entries in the DB after reboot. It's found in scaling
     # setup this may take some time to happen.
-    wait_until_lldp_populated(duthost, db_instance, "cold reboot")
+    wait_until_lldp_populated(db_instance, "cold reboot", lldp_entry_keys)
     lldp_entry_keys, show_lldp_table_int_list, lldpctl_output = get_lldp_data(duthost, db_instance)
     verify_all_interfaces_lldp_content(db_instance, lldp_entry_keys, lldpctl_output, show_lldp_table_int_list)


### PR DESCRIPTION
for lldp/test_lldp_syncd add a check for if all interfaces are up rather than just checking if the db and cli agree on the lldp interfaces up. This prevents an early return on
wait_until_lldp_populated

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #27006 (issue)
Related to #25177
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
This helper function `wait_until_lldp_populate` returns early due to checking db and cli matches.

#### How did you do it?
Fix the early return by also adding a list of expected interfaces.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Re-ran test on 202605 Citrine
Re-ran all of lldp/ aswell
