### PR TITLE
Use exact match in get_program_info to prevent false positives

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -272,10 +272,14 @@ def get_program_info(duthost, container_name, program_name):
     program_list = duthost.shell("docker exec {} supervisorctl status"
                                  .format(container_name), module_ignore_errors=True)
     for program_info in program_list["stdout_lines"]:
-        if program_info.find(program_name) != -1:
-            program_status = program_info.split()[1].strip()
+        fields = program_info.split()
+        # Match on the first field (program name) only to avoid false positives
+        # where the program name appears in other fields such as error message paths
+        # (e.g. "sub_program FATAL can't find command '/usr/vendor/program/sub_program'").
+        if fields and fields[0] == program_name:
+            program_status = fields[1].strip()
             if program_status == "RUNNING":
-                program_pid = int(program_info.split()[3].strip(','))
+                program_pid = int(fields[3].strip(','))
             break
 
     if program_pid != -1:

--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -35,6 +35,10 @@ def check_and_kill_process(duthost, container_name, program_name):
     elif program_status in ["EXITED", "STOPPED", "STARTING"]:
         pytest.fail("Program '{}' in container '{}' is in the '{}' state, expected 'RUNNING'"
                     .format(program_name, container_name, program_status))
+    elif program_status == "FATAL":
+        pytest.fail("Program '{}' in container '{}' is in the 'FATAL' state; "
+                    "the supervisor entry points to a missing or non-executable binary"
+                    .format(program_name, container_name))
     else:
         pytest.fail("Failed to find program '{}' in container '{}'"
                     .format(program_name, container_name))


### PR DESCRIPTION
## Summary
- Match supervisor program names by exact first-field comparison in `get_program_info` instead of substring search, avoiding false positives when the target name appears in error-message paths.
- Add an explicit `FATAL` failure branch in `check_and_kill_process` so missing or non-executable binaries produce a clear, actionable error.

## Test plan
- [x] Pre-commit checks passed on changed files (`flake8`, `check-ast`, trailing whitespace, EOF)
- [x] Run `test_route_consistency.py` on a DUT where the target supervisor program is RUNNING
- [x] Verify a genuinely FATAL supervisor entry reports the new explicit failure message