### PR TITLE
Add a t0-vpp test set to pr_test_scripts.yaml for sonic-vpp

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -740,9 +740,70 @@ t1-lag-vpp:
   - vxlan/test_vxlan_route_advertisement.py
   - vxlan/test_vnet_route_leak.py
   - vxlan/test_vxlan_crm.py
-  - vxlan/test_vnet_bgp_route_precedence.py
   - vxlan/test_vxlan_multi_tunnel.py
-  - vxlan/test_vxlan_route_advertisement.py
+
+
+t0-vpp:
+  - acl/test_acl.py
+  - arp/test_neighbor_mac_noptf.py
+  - arp/test_tagged_arp.py
+  - autorestart/test_container_autorestart.py
+  - bgp/test_bgp_command.py
+  - bgp/test_bgp_dual_asn.py
+  - bgp/test_bgp_fact.py
+  - bgp/test_bgp_gr_helper.py
+  - bgp/test_bgp_peer_shutdown.py
+  - bgp/test_bgp_route_neigh_learning.py
+  - bgp/test_bgp_router_id.py
+  - bgp/test_bgp_session.py
+  - bgp/test_bgp_stress_link_flap.py
+  - bgp/test_bgp_update_timer.py
+  - bgp/test_bgpmon.py
+  - cacl/test_cacl_function.py
+  - cacl/test_ebtables_application.py
+  - clock/test_clock.py
+  - container_checker/test_container_checker.py
+  - container_hardening/test_container_hardening.py
+  - crm/test_crm_available.py
+  - database/test_db_config.py
+  - database/test_db_scripts.py
+  - db_migrator/test_migrate_dns.py
+  - decap/test_decap.py
+  - dhcp_relay/test_dhcp_relay.py
+  - dhcp_relay/test_dhcp_relay_stress.py
+  - disk/test_disk_exhaustion.py
+  - dns/test_dns_resolv_conf.py
+  - fdb/test_fdb_flush.py
+  - fips/test_fips.py
+  - generic_config_updater/test_aaa.py
+  - generic_config_updater/test_bgp_speaker.py
+  - generic_config_updater/test_bgpl.py
+  - generic_config_updater/test_cacl.py
+  - generic_config_updater/test_dhcp_relay.py
+  - generic_config_updater/test_ecn_config_update.py
+  - generic_config_updater/test_eth_interface.py
+  - generic_config_updater/test_incremental_qos.py
+  - generic_config_updater/test_ip_bgp.py
+  - generic_config_updater/test_kubernetes_config.py
+  - generic_config_updater/test_lo_interface.py
+  - generic_config_updater/test_mgmt_interface.py
+  - generic_config_updater/test_monitor_config.py
+  - generic_config_updater/test_ntp.py
+  - generic_config_updater/test_pg_headroom_update.py
+  - generic_config_updater/test_portchannel_interface.py
+  - generic_config_updater/test_syslog.py
+  - generic_config_updater/test_vlan_interface.py
+  - gnmi/test_gnmi.py
+  - gnmi/test_gnmi_configdb.py
+  - gnmi/test_gnmi_countersdb.py
+  - gnmi/test_gnoi_os.py
+  - gnmi/test_gnoi_system.py
+  - hash/test_generic_hash.py
+  - http/test_http_copy.py
+  - iface_namingmode/test_iface_namingmode.py
+  - ip/test_ip_packet.py
+  - ip/test_mgmt_ipv6_only.py
+  - ipfwd/test_dip_sip.py
 
 
 multi-asic-t1-lag:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
- Introduce a fully passing `t0-vpp` test set to `.azure-pipelines/pr_test_scripts.yaml`. The set includes **60 test files, 635 passing test cases**, 0 failures/0 errors, verified 100% green across 5 consecutive sonic-vpp t0 Cisco-internal nightly runs (2026-08-08 → 08-12). Test files that are always-skipped, always-failing, or only partially passing on t0 were intentionally excluded from this commit.
- Remove two duplicate entries from the existing `t1-lag-vpp` set which were causing them to be run twice in our nightly t1-lag runs.

Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
- Validated across 5 consecutive SONiC-VPP t0 nightly runs (2026-08-08 through 2026-08-12). Every one of the 60 listed test files reported **0 failures / 0 errors** in all 5 runs:

| Test file | Pass | Skip | Total |
|---|---:|---:|---:|
| **TOTAL (60 files)** | **635** | **735** | **1370** |
| acl/test_acl.py | 384 | 616 | 1000 |
| arp/test_neighbor_mac_noptf.py | 2 | 0 | 2 |
| arp/test_tagged_arp.py | 1 | 0 | 1 |
| autorestart/test_container_autorestart.py | 12 | 7 | 19 |
| bgp/test_bgp_command.py | 4 | 0 | 4 |
| bgp/test_bgp_dual_asn.py | 1 | 0 | 1 |
| bgp/test_bgp_fact.py | 1 | 0 | 1 |
| bgp/test_bgp_gr_helper.py | 1 | 0 | 1 |
| bgp/test_bgp_peer_shutdown.py | 1 | 0 | 1 |
| bgp/test_bgp_route_neigh_learning.py | 1 | 0 | 1 |
| bgp/test_bgp_router_id.py | 3 | 1 | 4 |
| bgp/test_bgp_session.py | 2 | 4 | 6 |
| bgp/test_bgp_stress_link_flap.py | 5 | 2 | 7 |
| bgp/test_bgp_update_timer.py | 2 | 0 | 2 |
| bgp/test_bgpmon.py | 3 | 0 | 3 |
| cacl/test_cacl_function.py | 1 | 0 | 1 |
| cacl/test_ebtables_application.py | 1 | 0 | 1 |
| clock/test_clock.py | 2 | 1 | 3 |
| container_checker/test_container_checker.py | 13 | 6 | 19 |
| container_hardening/test_container_hardening.py | 11 | 9 | 20 |
| crm/test_crm_available.py | 1 | 0 | 1 |
| database/test_db_config.py | 3 | 0 | 3 |
| database/test_db_scripts.py | 1 | 0 | 1 |
| db_migrator/test_migrate_dns.py | 4 | 0 | 4 |
| decap/test_decap.py | 1 | 0 | 1 |
| dhcp_relay/test_dhcp_relay.py | 16 | 2 | 18 |
| dhcp_relay/test_dhcp_relay_stress.py | 6 | 4 | 10 |
| disk/test_disk_exhaustion.py | 1 | 0 | 1 |
| dns/test_dns_resolv_conf.py | 1 | 0 | 1 |
| fdb/test_fdb_flush.py | 4 | 0 | 4 |
| fips/test_fips.py | 1 | 0 | 1 |
| generic_config_updater/test_aaa.py | 4 | 0 | 4 |
| generic_config_updater/test_bgp_speaker.py | 1 | 0 | 1 |
| generic_config_updater/test_bgpl.py | 1 | 0 | 1 |
| generic_config_updater/test_cacl.py | 9 | 3 | 12 |
| generic_config_updater/test_dhcp_relay.py | 4 | 0 | 4 |
| generic_config_updater/test_ecn_config_update.py | 4 | 0 | 4 |
| generic_config_updater/test_eth_interface.py | 9 | 5 | 14 |
| generic_config_updater/test_incremental_qos.py | 1 | 9 | 10 |
| generic_config_updater/test_ip_bgp.py | 2 | 0 | 2 |
| generic_config_updater/test_kubernetes_config.py | 1 | 0 | 1 |
| generic_config_updater/test_lo_interface.py | 2 | 0 | 2 |
| generic_config_updater/test_mgmt_interface.py | 1 | 0 | 1 |
| generic_config_updater/test_monitor_config.py | 1 | 0 | 1 |
| generic_config_updater/test_ntp.py | 1 | 1 | 2 |
| generic_config_updater/test_pg_headroom_update.py | 1 | 0 | 1 |
| generic_config_updater/test_portchannel_interface.py | 2 | 0 | 2 |
| generic_config_updater/test_syslog.py | 1 | 0 | 1 |
| generic_config_updater/test_vlan_interface.py | 2 | 0 | 2 |
| gnmi/test_gnmi.py | 3 | 2 | 5 |
| gnmi/test_gnmi_configdb.py | 21 | 27 | 48 |
| gnmi/test_gnmi_countersdb.py | 3 | 5 | 8 |
| gnmi/test_gnoi_os.py | 3 | 0 | 3 |
| gnmi/test_gnoi_system.py | 2 | 0 | 2 |
| hash/test_generic_hash.py | 6 | 4 | 10 |
| http/test_http_copy.py | 1 | 0 | 1 |
| iface_namingmode/test_iface_namingmode.py | 38 | 24 | 62 |
| ip/test_ip_packet.py | 6 | 2 | 8 |
| ip/test_mgmt_ipv6_only.py | 9 | 1 | 10 |
| ipfwd/test_dip_sip.py | 6 | 0 | 6 |
| **TOTAL (60 files)** | **635** | **735** | **1370** |

Summary: **1370 testcases** across the 60 files — **635 pass**, **735
conditionally skipped** (not applicable on VPP t0), **0 failing / 0 erroring**.

### Approach
#### What is the motivation for this PR?
sonic-vpp t0 does not currently have a curated list of passing tests in `.azure-pipelines/pr_test_scripts.yaml` (unlike t1-lag-vpp)

#### How did you do it?
Added a `t0-vpp:` key with 60 consistently-passing tests

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Nightly runs on master have shown these tests to be consistently passing

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
