### PR TITLE
Add t0-vpp Elastictest nightly job

### DIFF
--- a/.azure-pipelines/sonic_vpp/sonic-vpp-nightly.yml
+++ b/.azure-pipelines/sonic_vpp/sonic-vpp-nightly.yml
@@ -32,6 +32,24 @@ stages:
         value: $(Build.SourceBranchName)
 
     jobs:
+      - job: t0_vpp_elastictest
+        displayName: "kvmtest-t0-vpp by Elastictest"
+        timeoutInMinutes: 480
+        continueOnError: false
+        pool: sonic-ubuntu-1c
+        steps:
+          - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
+            parameters:
+              TOPOLOGY: t0-vpp
+              MIN_WORKER: $(T0_VPP_INSTANCE_NUM)
+              MAX_WORKER: $(T0_VPP_INSTANCE_NUM)
+              KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+              MGMT_BRANCH: $(BUILD_BRANCH)
+              ASIC_TYPE: "vpp"
+              KVM_IMAGE_BUILD_PIPELINE_ID: "2818"
+              COMMON_EXTRA_PARAMS: "--disable_sai_validation --disable_loganalyzer"
+              STOP_ON_FAILURE: "False"
+
       - job: t1_lag_vpp_elastictest
         displayName: "kvmtest-t1-lag-vpp by Elastictest"
         timeoutInMinutes: 480

--- a/.azure-pipelines/sonic_vpp/sonic-vpp-nightly.yml
+++ b/.azure-pipelines/sonic_vpp/sonic-vpp-nightly.yml
@@ -28,8 +28,6 @@ stages:
         value: veos_vtb
       - name: testbed_file
         value: vtestbed.yaml
-      - name: T0_VPP_INSTANCE_NUM
-        value: 20
       - name: BUILD_BRANCH
         value: $(Build.SourceBranchName)
 
@@ -45,8 +43,8 @@ stages:
               TOPOLOGY: t0-vpp
               MIN_WORKER: $(T0_VPP_INSTANCE_NUM)
               MAX_WORKER: $(T0_VPP_INSTANCE_NUM)
-              KVM_IMAGE_BRANCH: master
-              MGMT_BRANCH: master
+              KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+              MGMT_BRANCH: $(BUILD_BRANCH)
               ASIC_TYPE: "vpp"
               KVM_IMAGE_BUILD_PIPELINE_ID: "2818"
               COMMON_EXTRA_PARAMS: "--disable_sai_validation --disable_loganalyzer"

--- a/.azure-pipelines/sonic_vpp/sonic-vpp-nightly.yml
+++ b/.azure-pipelines/sonic_vpp/sonic-vpp-nightly.yml
@@ -28,6 +28,8 @@ stages:
         value: veos_vtb
       - name: testbed_file
         value: vtestbed.yaml
+      - name: T0_VPP_INSTANCE_NUM
+        value: 20
       - name: BUILD_BRANCH
         value: $(Build.SourceBranchName)
 

--- a/.azure-pipelines/sonic_vpp/sonic-vpp-nightly.yml
+++ b/.azure-pipelines/sonic_vpp/sonic-vpp-nightly.yml
@@ -43,8 +43,8 @@ stages:
               TOPOLOGY: t0-vpp
               MIN_WORKER: $(T0_VPP_INSTANCE_NUM)
               MAX_WORKER: $(T0_VPP_INSTANCE_NUM)
-              KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-              MGMT_BRANCH: $(BUILD_BRANCH)
+              KVM_IMAGE_BRANCH: master
+              MGMT_BRANCH: master
               ASIC_TYPE: "vpp"
               KVM_IMAGE_BUILD_PIPELINE_ID: "2818"
               COMMON_EXTRA_PARAMS: "--disable_sai_validation --disable_loganalyzer"


### PR DESCRIPTION
### Description of PR

Summary:
- Add a dedicated `t0-vpp` job to the existing SONiC-VPP nightly Elastictest pipeline.
- Validate the internal layer-2 Elastictest onboarding path before enabling a public `t0-vpp` PR checker.
- Reuse the topology-agnostic SONiC-VPP KVM image from pipeline `2818` and the existing VPP nightly parameters.

Dependency: Add `T0_VPP_INSTANCE_NUM=20` to the `SONiC-Elastictest` ADO variable group before the merged nightly runs. Without it the new job cannot resolve its worker count.

Fixes # (issue) N/A

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- Nightly pipeline run: [sonic-vpp-nightly build 1191148](https://dev.azure.com/mssonic/build/_build/results?buildId=1191148), image `SONiC.master.1190446-1658c9049`.
- Internal `t0-vpp` Elastictest plan [`6a7ccc7019239aa976852d21`](https://elastictest.org/scheduler/testplan/6a7ccc7019239aa976852d21):
  - `LOCK_TESTBED`, `PREPARE_TESTBED`, and deployment all succeeded. The `t0-vpp` topology was allocated and brought up on the Elastictest fleet.
  - 2408 cases executed: 611 passed, 1479 skipped, 149 failed, 149 errored, 20 xfail.
  - Overall verdict was a `SANITY_CHECK_FAILED` gate on `bgp/test_passive_peering.py`. This proves the allocate, deploy, and execute path works end to end and isolates the remaining gap to individual test content, not to topology onboarding.
- Fresh revalidation on current master: Elastictest plan [`6aabf6fd3da8997c07bb03b4`](https://elastictest.org/scheduler/testplan/6aabf6fd3da8997c07bb03b4). Full `t0-vpp` suite against the latest master VPP KVM image from pipeline `2818`. The result summary will be added here once the run completes.
- The new `t0-vpp` job runs independently of the existing `t1-lag-vpp` job, so a failure in one does not block the other.

### Approach
#### What is the motivation for this PR?

`t0-vpp` has a sonic-mgmt testbed definition but has not been exercised by the internal SONiC-VPP nightly pipeline. A nightly run is needed to prove that the topology can be allocated, deployed, and executed on the Elastictest fleet before the separate PR-checker integration is enabled.

#### How did you do it?

Added a second job to `.azure-pipelines/sonic_vpp/sonic-vpp-nightly.yml`, mirroring the existing `t1-lag-vpp` job and changing only the topology and worker variable:

- `TOPOLOGY: t0-vpp`
- `MIN_WORKER` / `MAX_WORKER: $(T0_VPP_INSTANCE_NUM)`
- `ASIC_TYPE: vpp`
- `KVM_IMAGE_BUILD_PIPELINE_ID: 2818`

#### How did you verify/test it?

Queued the nightly pipeline against the PR merge ref (build 1191148). The `t0-vpp` job created Elastictest plan `6a7ccc7019239aa976852d21`, locked a testbed, completed testbed preparation and deployment, and executed 2408 cases (611 passed). A fresh full-suite revalidation on current master is tracked in plan `6aabf6fd3da8997c07bb03b4`.

#### Any platform specific information?

SONiC-VPP using the topology-agnostic VPP KVM image produced by pipeline `2818`.

#### Supported testbed topology if it is a new test case?

`t0-vpp`

### Documentation

N/A