### PR TITLE
[vrf] Account for VRF|default row in CONFIG_DB

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -735,7 +735,11 @@ class TestVrfCreateAndBind:
     def test_vrf_in_appl_db(self, duthosts, rand_one_dut_hostname, cfg_facts):
         duthost = duthosts[rand_one_dut_hostname]
         # verify vrf in app_db
-        for vrf in list(cfg_facts["VRF"].keys()):
+        # The 'default' VRF is the implicit/global routing instance. Newer SONiC
+        # builds ship a 'VRF|default' placeholder row in CONFIG_DB, so it shows
+        # up in cfg_facts['VRF'], but orchagent does not program a
+        # VRF_TABLE:default row in APPL_DB. Skip it here.
+        for vrf in (v for v in cfg_facts["VRF"].keys() if v != "default"):
             res = duthost.shell("redis-cli -n 0 keys VRF_TABLE:%s" % vrf)
             assert vrf in res["stdout"], "%s should be added in APPL_DB!" % vrf
 
@@ -747,8 +751,11 @@ class TestVrfCreateAndBind:
     def test_vrf_in_asic_db(self, duthosts, rand_one_dut_hostname, cfg_facts):
         duthost = duthosts[rand_one_dut_hostname]
         # verify vrf in asic_db
-        # plus default virtual router
-        vrf_count = len(list(cfg_facts["VRF"].keys())) + 1
+        # ASIC_DB always contains the implicit default virtual router. Older
+        # SONiC builds did not have a 'default' row in CONFIG_DB, so the test
+        # added '+1' for it. Newer builds include 'VRF|default' in CONFIG_DB
+        # which would double-count, so account for it here.
+        vrf_count = len(cfg_facts["VRF"]) + (0 if "default" in cfg_facts["VRF"] else 1)
         res = duthost.shell("redis-cli -n 1 keys *VIRTUAL_ROUTER*")
         assert len(res["stdout_lines"]) == vrf_count
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Newer SONiC builds ship a `VRF|default` placeholder row in CONFIG_DB, so
`default` now appears as a key in `cfg_facts['VRF']`. Two assertions in
`TestVrfCreateAndBind` were not aware of this and started failing:

- `test_vrf_in_appl_db` iterated over every `cfg_facts['VRF']` key and
  expected a corresponding `VRF_TABLE:<vrf>` row in APPL_DB. The default
  VRF is the implicit/global routing instance and orchagent does not
  program `VRF_TABLE:default`, so the iteration on `default` failed with
  "default should be added in APPL_DB!".
- `test_vrf_in_asic_db` computed the expected SAI_OBJECT_TYPE_VIRTUAL_ROUTER
  count as `len(cfg_facts['VRF']) + 1` to account for the implicit default
  VR. With `default` now present in CONFIG_DB this double-counted and
  failed with "assert 3 == 4".

Skip `default` in the APPL_DB check and only add the implicit `+1` to the
ASIC_DB count when `default` is not already in `cfg_facts['VRF']`. This
keeps the tests correct on both legacy and current SONiC builds.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

N/A — test fix only; not yet run on a testbed in this PR.

### Approach
#### What is the motivation for this PR?

Newer SONiC images include a `VRF|default` placeholder in CONFIG_DB. The
VRF test suite assumed `default` would not appear in `cfg_facts['VRF']`,
which caused `TestVrfCreateAndBind::test_vrf_in_appl_db` and
`TestVrfCreateAndBind::test_vrf_in_asic_db` to fail on those images.

#### How did you do it?

- Skip `default` when iterating VRF keys in `test_vrf_in_appl_db`, since
  orchagent does not program `VRF_TABLE:default` in APPL_DB.
- In `test_vrf_in_asic_db`, count the implicit default virtual router with
  `+1` only when `default` is absent from `cfg_facts['VRF']`, avoiding
  double-count on newer builds.

#### How did you verify/test it?

Logic validated against the failure modes described above. Test execution
on a VRF testbed is pending.

#### Any platform specific information?

None. Applies wherever newer SONiC images expose `VRF|default` in
CONFIG_DB.

#### Supported testbed topology if it's a new test case?

N/A — existing `TestVrfCreateAndBind` test case fix on VRF topology.

### Documentation

N/A