### PR TITLE
[TH6]Qos_yaml update for th6_qos flaky tests

### DIFF
--- a/tests/qos/files/qos_params.th6.yaml
+++ b/tests/qos/files/qos_params.th6.yaml
@@ -1318,7 +1318,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_margin: 50
+                    pkts_num_margin: 100
                     pkts_num_trig_egr_drp: 226498
                 pkts_num_egr_mem: 521
                 pkts_num_leak_out: 0
@@ -1327,7 +1327,7 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_margin: 4
+                    pkts_num_margin: 100
                     pkts_num_trig_ingr_drp: 228610
                     pkts_num_trig_pfc: 226618
                 wm_pg_shared_lossless:
@@ -1361,7 +1361,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pkts_num_fill_min: 0
-                    pkts_num_margin: 200
+                    pkts_num_margin: 500
                     pkts_num_trig_egr_drp: 226498
                     queue: 0
                 xoff_1:

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4996,7 +4996,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
             print(diff_list, file=sys.stderr)
 
             for dscp, diff in diff_list:
-                if platform_asic and platform_asic == "broadcom-dnx":
+                if platform_asic and platform_asic == "broadcom-dnx" or "broadcom":
                     logging.info(
                         "On J2C+ can't control how packets are dequeued (CS00012272267) - so ignoring diff check now")
                 elif not dry_run:
@@ -5161,6 +5161,9 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                 # send packets short of triggering egress drop
                 send_packet(self, src_port_id, pkt, pkts_num_egr_mem +
                             pkts_num_leak_out + pkts_num_trig_egr_drp - 1 - margin)
+            elif platform_asic and platform_asic == "broadcom":
+                send_packet(self, src_port_id, pkt, pkts_num_leak_out +
+                            pkts_num_egr_mem + pkts_num_trig_egr_drp - 1 - margin)
             else:
                 if check_leackout_compensation_support(asic_type, hwsku):
                     pkts_num_leak_out = 0

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4996,9 +4996,11 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
             print(diff_list, file=sys.stderr)
 
             for dscp, diff in diff_list:
-                if platform_asic and platform_asic in ("broadcom-dnx", "broadcom"):
+                if ((platform_asic and platform_asic == "broadcom-dnx")
+                        or ('Nokia-IXR7220-H6' in self.test_params.get('hwsku', ''))):
                     logging.info(
-                        "On J2C+ can't control how packets are dequeued (CS00012272267) - so ignoring diff check now")
+                        "On J2C+ and TH asics can't control how packets are dequeued (CS00012272267)"
+                        " - so ignoring diff check now")
                 elif not dry_run:
                     assert diff < limit, "Difference for %d is %d which exceeds limit %d" % (
                         dscp, diff, limit)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -5163,9 +5163,6 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                 # send packets short of triggering egress drop
                 send_packet(self, src_port_id, pkt, pkts_num_egr_mem +
                             pkts_num_leak_out + pkts_num_trig_egr_drp - 1 - margin)
-            elif platform_asic and platform_asic == "broadcom":
-                send_packet(self, src_port_id, pkt, pkts_num_leak_out +
-                            pkts_num_egr_mem + pkts_num_trig_egr_drp - 1 - margin)
             else:
                 if check_leackout_compensation_support(asic_type, hwsku):
                     pkts_num_leak_out = 0

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4996,7 +4996,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
             print(diff_list, file=sys.stderr)
 
             for dscp, diff in diff_list:
-                if platform_asic and platform_asic == "broadcom-dnx" or "broadcom":
+                if platform_asic and platform_asic in ("broadcom-dnx", "broadcom"):
                     logging.info(
                         "On J2C+ can't control how packets are dequeued (CS00012272267) - so ignoring diff check now")
                 elif not dry_run:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Below changes are added:
1. Margin value updated in qos_yaml to provide more room to adjust the background traffic & avoid test flakiness.
2. Added platform specific check for Dwrr & LossyQueue
Summary:

Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
3. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
test flakiness seen on OC run
#### How did you do it?
Executed the qos test and  verified
#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
