### PR TITLE
Fix test_chassis: skip optional syseeprom_info comparison when inventory lacks it

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -248,6 +248,15 @@ class TestChassisApi(PlatformApiTestBase):
         pytest_assert(re.match(REGEX_SERIAL_NUMBER, serial), "Serial number appears to be incorrect")
         host_vars = get_host_visible_vars(self.inv_files, duthost.hostname)
         expected_syseeprom_info_dict = host_vars.get('syseeprom_info')
+        # The comparison below against inventory-provided values is optional: it only runs when the
+        # host defines a 'syseeprom_info' block. When it is absent, host_vars.get() returns None and the
+        # EEPROM read from the device has already been fully validated above, so skip the comparison
+        # instead of raising AttributeError on None.
+        if expected_syseeprom_info_dict is None:
+            logger.info("No 'syseeprom_info' reference data is defined in the inventory for host '{}'; "
+                        "skipping comparison of EEPROM contents against expected values."
+                        .format(duthost.hostname))
+            return
         # Ignore case of keys in syseeprom_info
         expected_syseeprom_info_dict = {k.lower(): v for k, v in list(expected_syseeprom_info_dict.items())}
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes intermittent `AttributeError: 'NoneType' object has no attribute 'items'` in
`platform_tests/api/test_chassis.py::TestChassisApi::test_get_system_eeprom_info`.

ADO: https://dev.azure.com/msazure/One/_workitems/edit/38946826

The test reads the system EEPROM from the device via the platform API and validates it, then
optionally cross-checks the result against a `syseeprom_info` reference block defined in the
inventory. On testbeds/hosts whose inventory does **not** define `syseeprom_info`,
`host_vars.get('syseeprom_info')` returns `None` and the very next line calls `.items()` on it,
raising `AttributeError` even though the device EEPROM was read and validated successfully. This
shows up as an intermittent nightly failure on the hwskus/testbeds that lack the inventory block.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): ADO 38946826
Failure type: day-one issue (missing None-guard on optional inventory data)

### Tested branch
- [x] master
- [ ] N/A

### Test result
Root cause confirmed from the nightly console log (ElasticTest testplan 6a5eeec00b7e95197e91eb09,
host strtk5a-7050cx3-02): the device EEPROM read returned a fully populated dict
(`{'0x21': 'DCS-7050CX3-32S', '0x23': 'JPN2426P0BH', ...}`), while
`expected_syseeprom_info_dict = None` because the host inventory has no `syseeprom_info` block,
so `list(expected_syseeprom_info_dict.items())` raised `AttributeError`. With this change the
optional comparison is skipped (with an informative log) when no reference data is present, and the
device-side EEPROM validation is unchanged.

### Approach
#### What is the motivation for this PR?
Stop the platform EEPROM test from crashing with an `AttributeError` when a host has no
`syseeprom_info` reference data in the inventory, which is optional.

#### How did you do it?
Added a guard: if `host_vars.get('syseeprom_info')` is `None`, log that no reference data is
defined for the host and return before the optional expected-value comparison. All the device-side
EEPROM sanity checks (type codes, base MAC, serial number) run unchanged before this point.

#### How did you verify/test it?
- `python -m py_compile` and repo `pre-commit` (flake8 etc.) pass on the changed file.
- Traced the exact failure to inventory hosts without `syseeprom_info` in the nightly console log;
  the guard removes the `AttributeError` path while preserving the comparison when the block exists.

#### Any platform specific information?
Affects any hwsku/testbed whose inventory omits the optional `syseeprom_info` block.

#### Supported testbed topology if it's a new test case?
N/A - existing test.

### Documentation
N/A