### PR TITLE
Update the portchannel functions to support all features

### DIFF
--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -576,18 +576,22 @@ class SonicAsic(object):
                                             intf=interface_name,
                                             ip=ip_address))
 
-    def config_portchannel(self, pc_name, op):
-        return self.sonichost.shell("sudo config portchannel {ns} {op} {pc}"
-                                    .format(ns=self.cli_ns_option,
-                                            op=op,
-                                            pc=pc_name))
+    def config_portchannel(self, pc_name, op, fast_mode=False, fallback=False, min_links=1):
+        if op == "add":
+            return self.sonichost.command(f"sudo config portchannel {self.cli_ns_option} {op} "
+                                          f"--fast-rate {"true" if fast_mode else "false"} "
+                                          f"{"--fallback true" if fallback else ""} "
+                                          f"--min-links {min_links} "
+                                          f"{pc_name}")
+        else:
+            return self.sonichost.command(f"sudo config portchannel {self.cli_ns_option} {op} {pc_name}")
 
     def config_portchannel_member(self, pc_name, interface_name, op):
-        return self.sonichost.shell("sudo config portchannel {ns} member {op} {pc} {intf}"
-                                    .format(ns=self.cli_ns_option,
-                                            op=op,
-                                            pc=pc_name,
-                                            intf=interface_name))
+        return self.sonichost.command("sudo config portchannel {ns} member {op} {pc} {intf}"
+                                      .format(ns=self.cli_ns_option,
+                                              op=op,
+                                              pc=pc_name,
+                                              intf=interface_name))
 
     def get_portchannel_members(self, pc_name):
         """

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -266,7 +266,7 @@ class LagTest:
         try:
             host.shutdown(neighbor_intf)
 
-            # Let PortalChannel react to neighbor interface shutdown
+            # Let PortChannel react to neighbor interface shutdown
             time.sleep(deselect_time)
             intf, po_interfaces = self.__get_lag_intf_info(lag_facts, lag_name)
             po_flap = self.__check_flap(lag_facts, lag_name)
@@ -392,9 +392,9 @@ class LagTest:
             # Refresh lag facts
             lag_facts = self.__get_lag_facts()
 
-            # Get teamshow result
-            teamshow_result = self.duthost.shell('teamshow')
-            logger.debug("Teamshow result: %s" % teamshow_result)
+            # Get show interface portchannel result
+            show_intf_pc_result = self.duthost.command('show interface portchannel')
+            logger.debug("Portchannel status: %s" % show_intf_pc_result)
 
             # Verify lag members
             # 1. All other lag should keep selected state

--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -4,7 +4,6 @@ import time
 import logging
 import ipaddress
 import json
-import sys
 from collections import Counter
 
 from tests.common.helpers.assertions import pytest_assert, pytest_require
@@ -20,12 +19,6 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.topology("t0")
 ]
-
-# TODO: Remove this once we no longer support Python 2
-if sys.version_info.major >= 3:
-    UNICODE_TYPE = str
-else:
-    UNICODE_TYPE = unicode      # noqa: F821
 
 PTF_LAG_NAME = "bond1"
 PTF_LAG_MAC = "00:11:22:33:44:66"
@@ -320,7 +313,7 @@ def generate_port_config(duthost, tbinfo, most_common_port_speed):
         "ip": "192.168.9.1/24"
     }
     ip_splits = vlan["ip"].split("/")
-    vlan_ip = ipaddress.ip_address(UNICODE_TYPE(ip_splits[0]))
+    vlan_ip = ipaddress.ip_address(str(ip_splits[0]))
     lag_ip = "{}/{}".format(vlan_ip + 1, ip_splits[1])
     port_not_behind_lag_ip = "{}/{}".format(vlan_ip + 2, ip_splits[1])
     ptf_ports["ip"] = {
@@ -361,13 +354,6 @@ def get_vlan_id(cfg_facts, number_of_lag_member):
         if src_vlan_id != -1:
             break
     return src_vlan_id
-
-
-@pytest.fixture(scope="module")
-def common_setup_teardown(copy_acstests_directory, ptfhost):  # noqa: F811
-    logger.info("########### Setup for lag testing ###########")
-
-    yield ptfhost
 
 
 @pytest.fixture(scope="module")
@@ -476,7 +462,7 @@ def run_lag_member_traffic_test(duthost, dut_vlan, ptf_ports, ptfhost):
     ptf_runner(ptfhost, 'acstests', "lag_test.LagMemberTrafficTest", "/root/ptftests", params=params, is_python3=True)
 
 
-def test_lag_member_traffic(common_setup_teardown, duthost, ptf_dut_setup_and_teardown):
+def test_lag_member_traffic(copy_acstests_directory, ptfhost, duthost, ptf_dut_setup_and_teardown):
     """
     Test traffic about ports in a lag
 
@@ -489,7 +475,6 @@ def test_lag_member_traffic(common_setup_teardown, duthost, ptf_dut_setup_and_te
         4.) Send ICMP request packet from port not behind lag in PTF to port behind lag in PTF,
             and then verify recieve the packet in port behind lag
     """
-    ptfhost = common_setup_teardown
     dut_ports, ptf_ports, vlan = ptf_dut_setup_and_teardown
     ping_format = "ping -c 5 -w 2 -l 5 -I {} {}"
 

--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -462,7 +462,7 @@ def run_lag_member_traffic_test(duthost, dut_vlan, ptf_ports, ptfhost):
     ptf_runner(ptfhost, 'acstests', "lag_test.LagMemberTrafficTest", "/root/ptftests", params=params, is_python3=True)
 
 
-def test_lag_member_traffic(copy_acstests_directory, ptfhost, duthost, ptf_dut_setup_and_teardown):
+def test_lag_member_traffic(copy_acstests_directory, ptfhost, duthost, ptf_dut_setup_and_teardown):  # noqa: F811
     """
     Test traffic about ports in a lag
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

Allow writing portchannel tests that relied on creating a fallback-enabled LAG or specifying a minimum number of links in the LAG.

#### How did you do it?

Update `config_portchannel` to support specifying the min links, fallback mode, and fast rate.

Also remove some dead code in other portchannel test files.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

Tested with a test case written for fallback LAG.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
