### PR TITLE
Fix wait_until thresholds in test_bgp_update_replication

### DIFF
--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -307,8 +307,8 @@ def test_bgp_update_replication(
 
     results = [measure_stats(duthost, is_ipv6)]
     base_rib = int(results[0]["num_rib"])
-    min_expected_rib = base_rib + NUM_ROUTES
-    max_expected_rib = base_rib + (2 * NUM_ROUTES)
+    # FRR "RIB entries" counts radix tree nodes, not prefixes — N routes produce ~2N entries.
+    expected_rib_after_inject = base_rib + (2 * NUM_ROUTES)
 
     # Inject and withdraw routes with a specified interval in between iterations
     for interval in duthost_intervals:
@@ -322,7 +322,7 @@ def test_bgp_update_replication(
                 )
             )
             wait_until(ROUTE_WAIT_TIMEOUT, 2, 0,
-                       _check_rib_routes_received, duthost, is_ipv6, min_expected_rib)
+                       _check_rib_routes_received, duthost, is_ipv6, expected_rib_after_inject)
 
             # Measure after injection
             results.append(measure_stats(duthost, is_ipv6))
@@ -330,13 +330,9 @@ def test_bgp_update_replication(
             # Validate all routes have been received
             curr_num_rib = int(results[-1]["num_rib"])
             pytest_assert(
-                curr_num_rib >= min_expected_rib,
-                f"All routes have not been received: current '{curr_num_rib}', expected: '{min_expected_rib}'"
+                curr_num_rib >= expected_rib_after_inject,
+                f"All routes have not been received: current '{curr_num_rib}', expected: '{expected_rib_after_inject}'"
             )
-            if curr_num_rib < max_expected_rib:
-                logger.warning(
-                    f"All routes have not been announced: current '{curr_num_rib}', expected: '{max_expected_rib}'"
-                )
 
             # Remove routes
             route_injector.withdraw_routes_batch(
@@ -346,7 +342,7 @@ def test_bgp_update_replication(
                 )
             )
             wait_until(ROUTE_WAIT_TIMEOUT, 2, 0,
-                       _check_rib_routes_withdrawn, duthost, is_ipv6, min_expected_rib)
+                       _check_rib_routes_withdrawn, duthost, is_ipv6, base_rib)
 
             # Measure after removal
             results.append(measure_stats(duthost, is_ipv6))
@@ -354,13 +350,9 @@ def test_bgp_update_replication(
             # Validate all routes have been withdrawn
             curr_num_rib = int(results[-1]["num_rib"])
             pytest_assert(
-                curr_num_rib <= min_expected_rib,
-                f"All withdrawls have not been received: current '{curr_num_rib}', expected: '{min_expected_rib}'"
+                curr_num_rib <= base_rib,
+                f"All withdrawals have not been received: current '{curr_num_rib}', expected: '{base_rib}'"
             )
-            if curr_num_rib > base_rib:
-                logger.warning(
-                    f"All announcements have not been withdrawn: current '{curr_num_rib}', expected: '{base_rib}'"
-                )
 
     results.append(measure_stats(duthost, is_ipv6))
 

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -1,3 +1,4 @@
+import json
 import time
 import math
 import datetime
@@ -259,16 +260,26 @@ def setup_bgp_peers(
 '''
 
 
-def _check_rib_routes_received(duthost, is_ipv6, min_expected_rib):
-    """Return True when RIB entry count reaches min_expected_rib."""
-    stats = measure_stats(duthost, is_ipv6)
-    return int(stats["num_rib"]) >= min_expected_rib
+def _get_injector_pfx_count(duthost, is_ipv6, injector_ip):
+    """Return the accepted-prefix count (pfxRcd) for *injector_ip* from the BGP summary."""
+    cmd = "vtysh -c 'show {} bgp summary json'".format('ipv6' if is_ipv6 else 'ip')
+    output = duthost.shell(cmd, module_ignore_errors=True)['stdout']
+    try:
+        data = json.loads(output)
+    except (json.JSONDecodeError, ValueError):
+        return -1
+    af_key = 'ipv6Unicast' if is_ipv6 else 'ipv4Unicast'
+    return int(data.get(af_key, {}).get('peers', {}).get(injector_ip, {}).get('pfxRcd', -1))
 
 
-def _check_rib_routes_withdrawn(duthost, is_ipv6, min_expected_rib):
-    """Return True when RIB entry count drops to or below min_expected_rib."""
-    stats = measure_stats(duthost, is_ipv6)
-    return int(stats["num_rib"]) <= min_expected_rib
+def _check_pfx_received(duthost, is_ipv6, injector_ip, expected_count):
+    """Return True when the injector's pfxRcd reaches *expected_count*."""
+    return _get_injector_pfx_count(duthost, is_ipv6, injector_ip) >= expected_count
+
+
+def _check_pfx_withdrawn(duthost, is_ipv6, injector_ip):
+    """Return True when the injector's pfxRcd drops to 0."""
+    return _get_injector_pfx_count(duthost, is_ipv6, injector_ip) == 0
 
 
 '''
@@ -306,9 +317,7 @@ def test_bgp_update_replication(
     logger.info(f"Route injector: '{route_injector}', route receivers: '{route_receivers}'")
 
     results = [measure_stats(duthost, is_ipv6)]
-    base_rib = int(results[0]["num_rib"])
-    # FRR "RIB entries" counts radix tree nodes, not prefixes — N routes produce ~2N entries.
-    expected_rib_after_inject = base_rib + (2 * NUM_ROUTES)
+    injector_ip = route_injector.ip
 
     # Inject and withdraw routes with a specified interval in between iterations
     for interval in duthost_intervals:
@@ -317,41 +326,41 @@ def test_bgp_update_replication(
             # Inject 10000 routes
             route_injector.announce_routes_batch(
                 generate_routes(
-                    num_routes=NUM_ROUTES, nexthop=route_injector.ip,
+                    num_routes=NUM_ROUTES, nexthop=injector_ip,
                     is_ipv6=is_ipv6
                 )
             )
             wait_until(ROUTE_WAIT_TIMEOUT, 2, 0,
-                       _check_rib_routes_received, duthost, is_ipv6, expected_rib_after_inject)
+                       _check_pfx_received, duthost, is_ipv6, injector_ip, NUM_ROUTES)
 
             # Measure after injection
             results.append(measure_stats(duthost, is_ipv6))
 
             # Validate all routes have been received
-            curr_num_rib = int(results[-1]["num_rib"])
+            curr_pfx = _get_injector_pfx_count(duthost, is_ipv6, injector_ip)
             pytest_assert(
-                curr_num_rib >= expected_rib_after_inject,
-                f"All routes have not been received: current '{curr_num_rib}', expected: '{expected_rib_after_inject}'"
+                curr_pfx >= NUM_ROUTES,
+                f"All routes have not been received: pfxRcd '{curr_pfx}', expected: '{NUM_ROUTES}'"
             )
 
             # Remove routes
             route_injector.withdraw_routes_batch(
                 generate_routes(
-                    num_routes=NUM_ROUTES, nexthop=route_injector.ip,
+                    num_routes=NUM_ROUTES, nexthop=injector_ip,
                     is_ipv6=is_ipv6
                 )
             )
             wait_until(ROUTE_WAIT_TIMEOUT, 2, 0,
-                       _check_rib_routes_withdrawn, duthost, is_ipv6, base_rib)
+                       _check_pfx_withdrawn, duthost, is_ipv6, injector_ip)
 
             # Measure after removal
             results.append(measure_stats(duthost, is_ipv6))
 
             # Validate all routes have been withdrawn
-            curr_num_rib = int(results[-1]["num_rib"])
+            curr_pfx = _get_injector_pfx_count(duthost, is_ipv6, injector_ip)
             pytest_assert(
-                curr_num_rib <= base_rib,
-                f"All withdrawals have not been received: current '{curr_num_rib}', expected: '{base_rib}'"
+                curr_pfx == 0,
+                f"All withdrawals have not been received: pfxRcd '{curr_pfx}', expected: '0'"
             )
 
     results.append(measure_stats(duthost, is_ipv6))


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fix wait_until thresholds in test_bgp_update_replication
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/27018
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 38666756
Failure type: <!-- day-one issue / regression / other --> regression

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
202605: `SONiC.branch.202605-ars.7e8617e7-buildimage.c02e69d876b983e5923a6f501c56ac6940dba346-review.759356.4-2026.09.04.09.20` - 
[test_bgp_update_replication.xml](https://github.com/user-attachments/files/31885452/test_bgp_update_replication.xml)

<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
`bgp/test_bgp_update_replication.py` is failing with `Failed: All withdrawls have not been received: current '29159', expected: '22809'`

The wait_until calls added in https://github.com/sonic-net/sonic-mgmt/pull/22801/ used `base_rib + NUM_ROUTES` as the threshold for both injection and withdrawal checks. This is incorrect because FRR's "RIB entries" counter (printed by `bgp_vty.c` via `bgp_table_count -> route_table_count`) counts radix tree nodes, not actual BGP prefixes. Each prefix inserted into the tree creates both a leaf node and typically one intermediate splitting node. So N routes produce ~2N RIB entries.

```shell
admin@ld480:~$ vtysh -c "show ip bgp summary" | tail -5
10.0.1.59       4      64600     34197     29951     6410    0    0 21:59:48         6402     6406 ARISTA02T1
10.0.1.61       4      64600     34228     29951     6410    0    0 21:59:49         6402     6406 ARISTA03T1
10.0.1.63       4      64600     34173     29950     6410    0    0 21:59:48         6402     6406 ARISTA04T1

Total number of neighbors 4

admin@ld480:~$ vtysh -c "show ip bgp" | tail -3
 *=                   10.0.1.63                              0 64600 65534 64799 65515 i

Displayed 6406 routes and 25610 total paths
admin@ld480:~$ vtysh -c "show ip bgp summary" | grep "RIB entries"
RIB entries 12809, using 1601 KiB of memory
```

The original test correctly used 2 * num_routes for the expected RIB delta. The later refactoring dropped the 2x factor, causing wait_until to return True at ~50% route installation. Withdrawals sent while routes were still being installed raced with in-flight announcements, routes arriving after their withdrawal was already processed became permanently orphaned in the RIB, failing the withdrawal assertion.

#### How did you do it?
Rather than restoring the 2x multiplier on the radix node count, which is only approximate, switch the wait condition to FRR's per-peer pfxRcd field from `vtysh -c 'show ip bgp summary json'`. pfxRcd is `peer->pcount[afi][safi]`, a true accepted-prefix count maintained synchronously in `bgp_pcount_adjust()` during the same `bgp_update()` call. This gives an exact threshold: `NUM_ROUTES` after injection, 0 after withdrawal. Tighten the post-loop assertions to match.

#### How did you verify/test it?
Ran the test
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
