### PR TITLE
ci: enable t0-vpp impacted-area PR checks

### DIFF
--- a/.azure-pipelines/impacted_area_testing/constant.py
+++ b/.azure-pipelines/impacted_area_testing/constant.py
@@ -5,10 +5,11 @@
 # - t0
 # - t0-2vlans
 # - t0-sonic
+# - t0-vpp
 # - t1-lag
 # - t1-lag-vpp
-PR_TOPOLOGY_TYPE = ["t0_checker", "t0-2vlans_checker", "t0-sonic_checker", "t1_checker",
-                    "t1-multi-asic_checker", "t1-lag-vpp_checker", "dpu_checker",
+PR_TOPOLOGY_TYPE = ["t0_checker", "t0-2vlans_checker", "t0-sonic_checker", "t0-vpp_checker",
+                    "t1_checker", "t1-multi-asic_checker", "t1-lag-vpp_checker", "dpu_checker",
                     "dualtor_checker", "t2_checker"]
 
 EXCLUDE_TEST_SCRIPTS = [
@@ -21,6 +22,7 @@ PR_CHECKER_TOPOLOGY_NAME = {
     "t0": ["t0", "kvmtest-t0_"],
     "t0-2vlans": ["t0", "kvmtest-t0-2vlans_"],
     "t0-sonic": ["t0-64-32", "kvmtest-t0-sonic_"],
+    "t0-vpp": ["t0-vpp", "kvmtest-t0-vpp_"],
     "t1": ["t1-lag", "kvmtest-t1-lag_"],
     "t1-multi-asic": ["t1-8-lag", "kvmtest-multi-asic-t1-lag_"],
     "t1-lag-vpp": ["t1-lag-vpp", "kvmtest-t1-lag-vpp_"],

--- a/.azure-pipelines/impacted_area_testing/get_test_scripts.py
+++ b/.azure-pipelines/impacted_area_testing/get_test_scripts.py
@@ -16,8 +16,10 @@ import functools
 from natsort import natsorted
 from constant import PR_TOPOLOGY_TYPE, EXCLUDE_TEST_SCRIPTS, CONTROL_PLANE_DEDUP_RULES
 
-VPP_TOPOLOGY = "t1-lag-vpp"
-VPP_CHECKER = "t1-lag-vpp_checker"
+VPP_TOPOLOGY_CHECKERS = {
+    "t0-vpp": "t0-vpp_checker",
+    "t1-lag-vpp": "t1-lag-vpp_checker",
+}
 
 
 def topo_name_to_topo_checker(topo_name):
@@ -59,7 +61,7 @@ def distribute_scripts_to_PR_checkers(match, script_name, test_scripts_per_topol
                 test_scripts_per_topology_checker[topology_checker].append(script_name)
 
 
-def load_vpp_test_scripts_allowlist():
+def load_vpp_test_scripts_allowlist(vpp_topology):
     pr_test_scripts_path = os.path.abspath(os.path.join(
         os.path.dirname(os.path.dirname(__file__)),
         "pr_test_scripts.yaml"
@@ -81,18 +83,18 @@ def load_vpp_test_scripts_allowlist():
             )
         )
 
-    if not isinstance(pr_test_scripts, dict) or VPP_TOPOLOGY not in pr_test_scripts:
+    if not isinstance(pr_test_scripts, dict) or vpp_topology not in pr_test_scripts:
         raise Exception(
             "Missing {} allowlist in {}".format(
-                VPP_TOPOLOGY, pr_test_scripts_path
+                vpp_topology, pr_test_scripts_path
             )
         )
 
-    vpp_scripts = pr_test_scripts[VPP_TOPOLOGY]
+    vpp_scripts = pr_test_scripts[vpp_topology]
     if not isinstance(vpp_scripts, list):
         raise Exception(
             "{} allowlist in {} must be a list".format(
-                VPP_TOPOLOGY, pr_test_scripts_path
+                vpp_topology, pr_test_scripts_path
             )
         )
 
@@ -160,12 +162,13 @@ def collect_scripts_by_topology_type(features: str, location: str) -> dict:
         except Exception as e:
             raise Exception('Exception occurred while trying to get topology in {}, error {}'.format(s, e))
 
-    vpp_scripts = build_vpp_impacted_scripts(
-        raw_impacted_scripts,
-        load_vpp_test_scripts_allowlist()
-    )
-    if vpp_scripts:
-        test_scripts_per_topology_checker[VPP_CHECKER] = vpp_scripts
+    for vpp_topology, vpp_checker in VPP_TOPOLOGY_CHECKERS.items():
+        vpp_scripts = build_vpp_impacted_scripts(
+            raw_impacted_scripts,
+            load_vpp_test_scripts_allowlist(vpp_topology)
+        )
+        if vpp_scripts:
+            test_scripts_per_topology_checker[vpp_checker] = vpp_scripts
 
     return {k: v for k, v in test_scripts_per_topology_checker.items() if v}
 

--- a/.azure-pipelines/impacted_area_testing/test_get_test_scripts.py
+++ b/.azure-pipelines/impacted_area_testing/test_get_test_scripts.py
@@ -12,8 +12,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 import pytest  # noqa: E402
 from get_test_scripts import (  # noqa: E402
-    VPP_CHECKER,
-    VPP_TOPOLOGY,
+    VPP_TOPOLOGY_CHECKERS,
     build_vpp_impacted_scripts,
     collect_scripts_by_topology_type,
     dedup_control_plane_tests,
@@ -44,84 +43,116 @@ def _write_file(directory, relpath, content=""):
     return full
 
 
-# ── t1-lag-vpp allowlist intersection ─────────────────────
+# ── VPP allowlist intersection ────────────────────────────
 
 class TestVppImpactedArea:
 
+    @pytest.mark.parametrize(
+        "topology,checker", VPP_TOPOLOGY_CHECKERS.items()
+    )
     def test_vpp_allowlist_intersection_includes_raw_script(
-        self, test_dir, monkeypatch
+        self, test_dir, monkeypatch, topology, checker
     ):
+        """Verify each VPP checker intersects impacted scripts with its allowlist."""
         tests_dir = os.path.join(test_dir, "tests")
         _write_file(tests_dir, "bgp/test_allowed.py", "import pytest\n")
         _write_file(tests_dir, "bgp/test_not_allowed.py", "import pytest\n")
         monkeypatch.setattr(
             "get_test_scripts.load_vpp_test_scripts_allowlist",
-            lambda: ["bgp/test_allowed.py"],
+            lambda requested_topology: (
+                ["bgp/test_allowed.py"]
+                if requested_topology == topology else []
+            ),
         )
 
         result = collect_scripts_by_topology_type("bgp", tests_dir)
 
-        assert result[VPP_CHECKER] == ["bgp/test_allowed.py"]
-        assert "bgp/test_not_allowed.py" not in result[VPP_CHECKER]
+        assert result[checker] == ["bgp/test_allowed.py"]
+        assert "bgp/test_not_allowed.py" not in result[checker]
 
+    @pytest.mark.parametrize(
+        "topology,checker", VPP_TOPOLOGY_CHECKERS.items()
+    )
     def test_vpp_checker_omitted_when_no_allowlisted_impacted_scripts(
-        self, test_dir, monkeypatch
+        self, test_dir, monkeypatch, topology, checker
     ):
+        """Verify a VPP checker is omitted when its allowlist has no impact."""
         tests_dir = os.path.join(test_dir, "tests")
         _write_file(tests_dir, "bgp/test_not_allowed.py", "import pytest\n")
         monkeypatch.setattr(
             "get_test_scripts.load_vpp_test_scripts_allowlist",
-            lambda: ["route/test_default_route.py"],
+            lambda requested_topology: (
+                ["route/test_default_route.py"]
+                if requested_topology == topology else []
+            ),
         )
 
         result = collect_scripts_by_topology_type("bgp", tests_dir)
 
-        assert VPP_CHECKER not in result
+        assert checker not in result
 
+    @pytest.mark.parametrize(
+        "topology,checker", VPP_TOPOLOGY_CHECKERS.items()
+    )
     def test_vpp_output_order_follows_allowlist(
-        self, test_dir, monkeypatch
+        self, test_dir, monkeypatch, topology, checker
     ):
+        """Verify each VPP checker preserves its allowlist order."""
         tests_dir = os.path.join(test_dir, "tests")
         _write_file(tests_dir, "bgp/test_first.py", "import pytest\n")
         _write_file(tests_dir, "bgp/test_second.py", "import pytest\n")
         monkeypatch.setattr(
             "get_test_scripts.load_vpp_test_scripts_allowlist",
-            lambda: ["bgp/test_second.py", "bgp/test_first.py"],
+            lambda requested_topology: (
+                ["bgp/test_second.py", "bgp/test_first.py"]
+                if requested_topology == topology else []
+            ),
         )
 
         result = collect_scripts_by_topology_type("bgp", tests_dir)
 
-        assert result[VPP_CHECKER] == [
+        assert result[checker] == [
             "bgp/test_second.py",
             "bgp/test_first.py",
         ]
 
+    @pytest.mark.parametrize(
+        "topology,checker", VPP_TOPOLOGY_CHECKERS.items()
+    )
     def test_vpp_broad_impact_filters_by_allowlist(
-        self, test_dir, monkeypatch
+        self, test_dir, monkeypatch, topology, checker
     ):
+        """Verify broad impacts remain restricted to each VPP allowlist."""
         tests_dir = os.path.join(test_dir, "tests")
         _write_file(tests_dir, "bgp/test_allowed.py", "import pytest\n")
         _write_file(tests_dir, "bgp/test_not_allowed.py", "import pytest\n")
         _write_file(tests_dir, "route/test_allowed.py", "import pytest\n")
         monkeypatch.setattr(
             "get_test_scripts.load_vpp_test_scripts_allowlist",
-            lambda: [
-                "route/test_allowed.py",
-                "bgp/test_allowed.py",
-                "missing/test_missing.py",
-            ],
+            lambda requested_topology: (
+                [
+                    "route/test_allowed.py",
+                    "bgp/test_allowed.py",
+                    "missing/test_missing.py",
+                ]
+                if requested_topology == topology else []
+            ),
         )
 
         result = collect_scripts_by_topology_type("", tests_dir)
 
-        assert result[VPP_CHECKER] == [
+        assert result[checker] == [
             "route/test_allowed.py",
             "bgp/test_allowed.py",
         ]
 
+    @pytest.mark.parametrize(
+        "topology,checker", VPP_TOPOLOGY_CHECKERS.items()
+    )
     def test_vpp_includes_allowlisted_scripts_for_any_marker_shape(
-        self, test_dir, monkeypatch
+        self, test_dir, monkeypatch, topology, checker
     ):
+        """Verify VPP selection is based on allowlists, not topology markers."""
         tests_dir = os.path.join(test_dir, "tests")
         scripts = [
             "bgp/test_t0.py",
@@ -147,12 +178,37 @@ class TestVppImpactedArea:
         _write_file(tests_dir, scripts[3], "import pytest\n")
         monkeypatch.setattr(
             "get_test_scripts.load_vpp_test_scripts_allowlist",
-            lambda: scripts,
+            lambda requested_topology: (
+                scripts if requested_topology == topology else []
+            ),
         )
 
         result = collect_scripts_by_topology_type("bgp", tests_dir)
 
-        assert result[VPP_CHECKER] == scripts
+        assert result[checker] == scripts
+
+    def test_vpp_topologies_use_independent_allowlists(
+        self, test_dir, monkeypatch
+    ):
+        """Verify t0-vpp and t1-lag-vpp build independent checker lists."""
+        tests_dir = os.path.join(test_dir, "tests")
+        _write_file(tests_dir, "bgp/test_t0_vpp.py", "import pytest\n")
+        _write_file(tests_dir, "bgp/test_t1_lag_vpp.py", "import pytest\n")
+        allowlists = {
+            "t0-vpp": ["bgp/test_t0_vpp.py"],
+            "t1-lag-vpp": ["bgp/test_t1_lag_vpp.py"],
+        }
+        monkeypatch.setattr(
+            "get_test_scripts.load_vpp_test_scripts_allowlist",
+            lambda topology: allowlists[topology],
+        )
+
+        result = collect_scripts_by_topology_type("bgp", tests_dir)
+
+        assert result["t0-vpp_checker"] == ["bgp/test_t0_vpp.py"]
+        assert result["t1-lag-vpp_checker"] == [
+            "bgp/test_t1_lag_vpp.py"
+        ]
 
     def test_build_vpp_impacted_scripts_preserves_allowlist_order(self):
         result = build_vpp_impacted_scripts(
@@ -162,9 +218,11 @@ class TestVppImpactedArea:
 
         assert result == ["bgp/test_second.py", "bgp/test_first.py"]
 
+    @pytest.mark.parametrize("topology", VPP_TOPOLOGY_CHECKERS)
     def test_load_vpp_allowlist_requires_yaml_key(
-        self, test_dir, monkeypatch
+        self, test_dir, monkeypatch, topology
     ):
+        """Verify a missing VPP topology allowlist is rejected."""
         pipeline_dir = os.path.join(test_dir, ".azure-pipelines")
         _write_file(pipeline_dir, "pr_test_scripts.yaml", "t0: []\n")
         monkeypatch.setattr(
@@ -178,18 +236,20 @@ class TestVppImpactedArea:
 
         with pytest.raises(
             Exception,
-            match="Missing {} allowlist".format(VPP_TOPOLOGY)
+            match="Missing {} allowlist".format(topology)
         ):
-            load_vpp_test_scripts_allowlist()
+            load_vpp_test_scripts_allowlist(topology)
 
+    @pytest.mark.parametrize("topology", VPP_TOPOLOGY_CHECKERS)
     def test_load_vpp_allowlist_requires_list(
-        self, test_dir, monkeypatch
+        self, test_dir, monkeypatch, topology
     ):
+        """Verify each VPP topology allowlist must be a list."""
         pipeline_dir = os.path.join(test_dir, ".azure-pipelines")
         _write_file(
             pipeline_dir,
             "pr_test_scripts.yaml",
-            "{}: invalid\n".format(VPP_TOPOLOGY),
+            "{}: invalid\n".format(topology),
         )
         monkeypatch.setattr(
             "get_test_scripts.__file__",
@@ -201,11 +261,12 @@ class TestVppImpactedArea:
         )
 
         with pytest.raises(Exception, match="must be a list"):
-            load_vpp_test_scripts_allowlist()
+            load_vpp_test_scripts_allowlist(topology)
 
     def test_load_vpp_allowlist_reports_load_error(
         self, test_dir, monkeypatch
     ):
+        """Verify YAML loading failures identify the allowlist file."""
         pipeline_dir = os.path.join(test_dir, ".azure-pipelines")
         monkeypatch.setattr(
             "get_test_scripts.__file__",
@@ -217,16 +278,17 @@ class TestVppImpactedArea:
         )
 
         with pytest.raises(Exception, match="trying to load"):
-            load_vpp_test_scripts_allowlist()
+            load_vpp_test_scripts_allowlist("t0-vpp")
 
     def test_load_vpp_allowlist_reports_missing_pyyaml(
         self, test_dir, monkeypatch
     ):
+        """Verify a missing PyYAML dependency produces a clear error."""
         pipeline_dir = os.path.join(test_dir, ".azure-pipelines")
         _write_file(
             pipeline_dir,
             "pr_test_scripts.yaml",
-            "{}: []\n".format(VPP_TOPOLOGY),
+            "t0-vpp: []\n",
         )
         monkeypatch.setattr(
             "get_test_scripts.__file__",
@@ -246,7 +308,7 @@ class TestVppImpactedArea:
         monkeypatch.setattr(builtins, "__import__", fake_import)
 
         with pytest.raises(Exception, match="PyYAML is required"):
-            load_vpp_test_scripts_allowlist()
+            load_vpp_test_scripts_allowlist("t0-vpp")
 
 
 # ── dedup_control_plane_tests ──────────────────────────────

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -772,7 +772,6 @@ t0-vpp:
   - db_migrator/test_migrate_dns.py
   - decap/test_decap.py
   - dhcp_relay/test_dhcp_relay.py
-  - dhcp_relay/test_dhcp_relay_stress.py
   - disk/test_disk_exhaustion.py
   - dns/test_dns_resolv_conf.py
   - fdb/test_fdb_flush.py

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -745,6 +745,69 @@ t1-lag-vpp:
   - vxlan/test_vxlan_route_advertisement.py
 
 
+t0-vpp:
+  - acl/test_acl.py
+  - arp/test_neighbor_mac_noptf.py
+  - arp/test_tagged_arp.py
+  - autorestart/test_container_autorestart.py
+  - bgp/test_bgp_command.py
+  - bgp/test_bgp_dual_asn.py
+  - bgp/test_bgp_fact.py
+  - bgp/test_bgp_gr_helper.py
+  - bgp/test_bgp_peer_shutdown.py
+  - bgp/test_bgp_route_neigh_learning.py
+  - bgp/test_bgp_router_id.py
+  - bgp/test_bgp_session.py
+  - bgp/test_bgp_stress_link_flap.py
+  - bgp/test_bgp_update_timer.py
+  - bgp/test_bgpmon.py
+  - cacl/test_cacl_function.py
+  - cacl/test_ebtables_application.py
+  - clock/test_clock.py
+  - container_checker/test_container_checker.py
+  - container_hardening/test_container_hardening.py
+  - crm/test_crm_available.py
+  - database/test_db_config.py
+  - database/test_db_scripts.py
+  - db_migrator/test_migrate_dns.py
+  - decap/test_decap.py
+  - dhcp_relay/test_dhcp_relay.py
+  - dhcp_relay/test_dhcp_relay_stress.py
+  - disk/test_disk_exhaustion.py
+  - dns/test_dns_resolv_conf.py
+  - fdb/test_fdb_flush.py
+  - fips/test_fips.py
+  - generic_config_updater/test_aaa.py
+  - generic_config_updater/test_bgp_speaker.py
+  - generic_config_updater/test_bgpl.py
+  - generic_config_updater/test_cacl.py
+  - generic_config_updater/test_dhcp_relay.py
+  - generic_config_updater/test_ecn_config_update.py
+  - generic_config_updater/test_eth_interface.py
+  - generic_config_updater/test_incremental_qos.py
+  - generic_config_updater/test_ip_bgp.py
+  - generic_config_updater/test_kubernetes_config.py
+  - generic_config_updater/test_lo_interface.py
+  - generic_config_updater/test_mgmt_interface.py
+  - generic_config_updater/test_monitor_config.py
+  - generic_config_updater/test_ntp.py
+  - generic_config_updater/test_pg_headroom_update.py
+  - generic_config_updater/test_portchannel_interface.py
+  - generic_config_updater/test_syslog.py
+  - generic_config_updater/test_vlan_interface.py
+  - gnmi/test_gnmi.py
+  - gnmi/test_gnmi_configdb.py
+  - gnmi/test_gnmi_countersdb.py
+  - gnmi/test_gnoi_os.py
+  - gnmi/test_gnoi_system.py
+  - hash/test_generic_hash.py
+  - http/test_http_copy.py
+  - iface_namingmode/test_iface_namingmode.py
+  - ip/test_ip_packet.py
+  - ip/test_mgmt_ipv6_only.py
+  - ipfwd/test_dip_sip.py
+
+
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py
   - bgp/test_bgp_fact.py

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -57,7 +57,7 @@ parameters:
   type: string
   default: "sonic-mgmt"
 
-# Keys: "dpu_checker","dualtor_checker","t0-2vlans_checker","t0-sonic_checker","t0_checker","t1-lag-vpp_checker","t1-multi-asic_checker","t1_checker","t2_checker"
+# Keys: "dpu_checker","dualtor_checker","t0-2vlans_checker","t0-sonic_checker","t0_checker","t0-vpp_checker","t1-lag-vpp_checker","t1-multi-asic_checker","t1_checker","t2_checker"
 # Example: {"t0_checker": ["bgp/test_bgp_command.py", "bgp/test_ping_bgp_neighbor.py"], "t1_checker": ["bgp/test_bgp_fact.py"]}
 - name: IMPACT_AREA_INFO
   type: object
@@ -507,6 +507,52 @@ jobs:
           PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
           EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
           TOPOLOGY: t1-lag-vpp
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
+          KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+          KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
+          MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
+          ASIC_TYPE: "vpp"
+          KVM_IMAGE_BUILD_PIPELINE_ID: "2818"
+          COMMON_EXTRA_PARAMS: "--disable_sai_validation --disable_loganalyzer"
+          ${{ each param in parameters.OVERRIDE_PARAMS }}:
+            ${{ param.key }}: ${{ param.value }}
+
+  - job: t0_vpp_elastictest
+    displayName: "impacted-area-kvmtest-t0-vpp by Elastictest"
+    dependsOn:
+    - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      RUN_BY_INCLUDE_JOBS: ${{ or(eq(parameters.INCLUDE_JOBS, 'all'), contains(parameters.INCLUDE_JOBS, 't0_vpp_job')) }}
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-vpp_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+    continueOnError: false
+    pool: ${{ parameters.RUN_TEST_AGENT_POOL }}
+    steps:
+      - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+        - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+          displayName: "Checkout sonic-mgmt repository"
+
+      - template: impacted_area_testing/calculate-instance-numbers.yml
+        parameters:
+          TOPOLOGY: t0-vpp
+          BUILD_BRANCH: $(BUILD_BRANCH)
+
+      - template: run-test-elastictest-template.yml
+        parameters:
+          BUILD_REASON: ${{ parameters.BUILD_REASON }}
+          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+          STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+          MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+          PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
+          PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+          EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+          TOPOLOGY: t0-vpp
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)

--- a/.azure-pipelines/pre_defined_pr_test.yml
+++ b/.azure-pipelines/pre_defined_pr_test.yml
@@ -28,7 +28,7 @@ parameters:
   type: string
   default: " "
 
-# Keys: "dpu_checker","dualtor_checker","t0-2vlans_checker","t0-sonic_checker","t0_checker","t1-lag-vpp_checker","t1-multi-asic_checker","t1_checker","t2_checker"
+# Keys: "dpu_checker","dualtor_checker","t0-2vlans_checker","t0-sonic_checker","t0_checker","t0-vpp_checker","t1-lag-vpp_checker","t1-multi-asic_checker","t1_checker","t2_checker"
 # Example: {"t0_checker": ["bgp/test_bgp_command.py", "bgp/test_ping_bgp_neighbor.py"], "t1_checker": ["bgp/test_bgp_fact.py"]}
 - name: IMPACT_AREA_INFO
   type: object

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -299,7 +299,7 @@ class TestPlanManager(object):
         # Add topo and device type args for PR test
         if test_plan_type == "PR":
             # Add topo arg
-            if topology in ["t0", "t0-64-32"]:
+            if topology in ["t0", "t0-64-32", "t0-vpp"]:
                 common_extra_params = common_extra_params + " --topology=t0,any"
             elif topology in ["t1-lag", "t1-8-lag", "t1-vpp", "t1-lag-vpp"]:
                 common_extra_params = common_extra_params + " --topology=t1,any"


### PR DESCRIPTION
### Description of PR

Summary:
- Enable impacted-area PR checks on the `t0-vpp` topology.
- Register the `t0-vpp_checker` and its Kusto topology and test-plan name mapping.
- Generalize VPP impacted-area selection so `t0-vpp` and `t1-lag-vpp` use independent allowlists.
- Add the `t0_vpp_elastictest` job using ASIC type `vpp` and KVM image pipeline `2818`.
- Add the `--topology=t0,any` filter for t0-vpp PR test plans.
- Add unit coverage for both VPP checkers.

The t0-vpp test-script allowlist is sourced from Akeel Ali's validation in https://github.com/sonic-net/sonic-mgmt/pull/27011, which reports five consecutive stable internal t0-vpp nightly runs.

Fixes # (issue) N/A

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 39251333 
Failure type: N/A

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Approach
#### What is the motivation for this PR?

The public sonic-mgmt PR pipeline supports impacted-area testing for `t1-lag-vpp`, but it does not currently register or launch a corresponding `t0-vpp` checker. This can cause t0-vpp validation to rely on broad manual or nightly runs instead of selecting only impacted, validated tests.

#### How did you do it?

Added the t0-vpp checker registration, allowlist, topology-to-test-plan mapping, PR job, topology filter, and dynamic worker calculation. The VPP allowlist logic now handles both supported VPP topologies independently.

#### Any platform specific information?

The job uses topology `t0-vpp`, ASIC type `vpp`, and the shared SONiC-VPP KVM image pipeline `2818`.

#### Supported testbed topology if it's a new test case?

`t0-vpp`

### Documentation

N/A
