### PR TITLE
[system_health]: Fix Mellanox PSU temperature selection

### DIFF
--- a/tests/system_health/mellanox/mellanox_device_mocker.py
+++ b/tests/system_health/mellanox/mellanox_device_mocker.py
@@ -40,9 +40,29 @@ class PsuData(object):
         power_status_file = PsuData.PSU_POWER_STATUS_FILE.format(index)
         out = self.helper.dut.stat(path=power_status_file)
         if out['stat']['exists']:
-            self.power_on = True
+            self.power_on = self.helper.read_value(power_status_file) == '1'
         else:
             self.power_on = False
+
+    def get_temperature_file(self):
+        hw_mgmt_version = get_hw_management_version(self.helper.dut)
+        if parse_version(hw_mgmt_version) < parse_version(HW_MANAGE_VER):
+            return PsuData.PSU_TEMPERATURE_FILE.format(self.index)
+        return PsuData.PSU_TEMPERATURE_FILE_NEW.format(self.index)
+
+    def get_temperature_threshold_file(self):
+        hw_mgmt_version = get_hw_management_version(self.helper.dut)
+        if parse_version(hw_mgmt_version) < parse_version(HW_MANAGE_VER):
+            return PsuData.PSU_TEMP_THRESHOLD_FILE.format(self.index)
+        return PsuData.PSU_TEMP_THRESHOLD_FILE_NEW.format(self.index)
+
+    def is_temperature_supported(self):
+        temperature_file = self.get_temperature_file()
+        threshold_file = self.get_temperature_threshold_file()
+        temperature_stat = self.helper.dut.stat(path=temperature_file)
+        threshold_stat = self.helper.dut.stat(path=threshold_file)
+        return temperature_stat['stat']['exists'] and \
+            threshold_stat['stat']['exists']
 
     def mock_presence(self, status):
         value = 1 if status else 0
@@ -55,25 +75,16 @@ class PsuData(object):
         self.helper.mock_value(power_status_file, str(value))
 
     def mock_temperature(self, value):
-        hw_mgmt_version = get_hw_management_version(self.helper.dut)
-        temperature_file = PsuData.PSU_TEMPERATURE_FILE_NEW.format(self.index)
-        if parse_version(hw_mgmt_version) < parse_version(HW_MANAGE_VER):
-            temperature_file = PsuData.PSU_TEMPERATURE_FILE.format(self.index)
-        self.helper.mock_value(temperature_file, str(value))
+        self.helper.mock_value(self.get_temperature_file(), str(value))
 
     def get_psu_temperature_threshold(self):
-        hw_mgmt_version = get_hw_management_version(self.helper.dut)
-        threshold_file = PsuData.PSU_TEMP_THRESHOLD_FILE_NEW.format(self.index)
-        if parse_version(hw_mgmt_version) < parse_version(HW_MANAGE_VER):
-            threshold_file = PsuData.PSU_TEMP_THRESHOLD_FILE.format(self.index)
-        value = self.helper.read_value(threshold_file)
+        value = self.helper.read_value(self.get_temperature_threshold_file())
         return int(value)
 
 
 class MellanoxDeviceMocker(DeviceMocker):
     TARGET_SPEED_VALUE = 60
     SPEED_TOLERANCE = 50
-    PSU_NUM = 2
 
     def __init__(self, dut):
         self.mock_helper = MockerHelper(dut)
@@ -82,10 +93,17 @@ class MellanoxDeviceMocker(DeviceMocker):
         self.fan_drawer_data = FanDrawerData(self.mock_helper, naming_rule, 1)
         self.fan_data = FanData(self.mock_helper, naming_rule, 1)
 
-        for i in range(MellanoxDeviceMocker.PSU_NUM):
-            self.psu_data = PsuData(self.mock_helper, i + 1)
-            if self.psu_data.power_on:
+        platform_data = get_platform_data(dut)
+        self.psu_data = None
+        for i in range(platform_data['psus']['number']):
+            psu_data = PsuData(self.mock_helper, i + 1)
+            if psu_data.power_on and self.psu_data is None:
+                self.psu_data = psu_data
+            if psu_data.power_on and psu_data.is_temperature_supported():
+                self.psu_data = psu_data
                 break
+        if self.psu_data is None:
+            raise RuntimeError('No powered PSU found for system health mocking')
 
     def deinit(self):
         self.mock_helper.deinit()


### PR DESCRIPTION
Select a powered PSU from the platform-reported PSU slots and prefer one that exposes the required temperature sysfs nodes. Fail explicitly when no powered PSU is available.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix Mellanox system-health PSU selection when a PSU does not expose the
temperature sysfs nodes required for temperature mocking.

Fixes #27025

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
`system_health/test_system_health.py::test_device_checker` fails on the
Mellanox SN5640 when the selected PSU does not expose the required
`psu1_temp1_max` sysfs node.

The mocker assumed a fixed number of PSU slots, considered a PSU powered
based only on the existence of its power-status file, and did not verify
temperature-node support before selecting it.

Failure:
https://elastictest.org/scheduler/testplan/6a7d0a2b1c6297f01e8546b4?testcase=system_health%2Ftest_system_health.py&type=console

#### How did you do it?

- Read the PSU count from platform data instead of assuming two slots.
- Check the value of the PSU power-status node.
- Detect whether the PSU exposes both temperature and threshold nodes.
- Prefer a powered PSU that supports temperature mocking.
- Raise an explicit error when no powered PSU is available.
- Reuse helpers for resolving version-specific temperature sysfs paths.

#### How did you verify/test it?

Manual test run: https://elastictest.org/scheduler/testplan/6a7d145bd8c30ddb818dc064
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
The failure was observed on a Mellanox SN5640 using hw-management
version `7.0050.3005`. The change applies to Mellanox platforms using
the system-health device mocker.

#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
