### PR TITLE
[202605] platform: fix passive SFP+ detection

### DIFF
--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -344,7 +344,7 @@ def parse_one_sfp_eeprom_info(sfp_eeprom_info):
     """
     pattern_top_layer_key_value = r"^(?P<key>Ethernet\d+):(?P<value>.*)"
     pattern_second_layer_key_value = r"(^\s{8}|\t{1})(?P<key>[a-zA-Z0-9][a-zA-Z0-9\s\/\(\)-]+):(?P<value>.*)"
-    pattern_third_layer_key_value = r"(^\s{16}|\t{2})(?P<key>[a-zA-Z0-9][a-zA-Z0-9\s\/]+):(?P<value>.*)"
+    pattern_third_layer_key_value = r"(^\s{16}|\t{2})(?P<key>[a-zA-Z0-9][a-zA-Z0-9\s\/\+]+):(?P<value>.*)"
 
     one_sfp_eeprom_info_dict = {}
     second_layer_dict = {}

--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -93,7 +93,8 @@ def check_transceiver_details(dut, asic_index, interfaces, xcvr_skip_list):
     docker_cmd_keys = asichost.get_docker_cmd(cmd_keys, "database")
     docker_cmd_hgetall = asichost.get_docker_cmd(cmd_hgetall, "database")
 
-    docker_cmd = f'for key in $({docker_cmd_keys}); do echo "$key : $({docker_cmd_hgetall})" ; done'
+    docker_cmd = 'for key in $({}); do echo "$key : $({})" ; done'.format(
+        docker_cmd_keys, docker_cmd_hgetall)
     port_xcvr_info = dut.command(docker_cmd, _uses_shell=True)
     port_xcvr_info_dict = {}
     for line in port_xcvr_info["stdout_lines"]:
@@ -146,7 +147,8 @@ def check_transceiver_dom_sensor_details(dut, asic_index, interfaces, xcvr_skip_
     docker_cmd_keys = asichost.get_docker_cmd(cmd_keys, "database")
     docker_cmd_hgetall = asichost.get_docker_cmd(cmd_hgetall, "database")
 
-    docker_cmd = f'for key in $({docker_cmd_keys}); do echo "$key : $({docker_cmd_hgetall})" ; done'
+    docker_cmd = 'for key in $({}); do echo "$key : $({})" ; done'.format(
+        docker_cmd_keys, docker_cmd_hgetall)
     port_xcvr_dom_sensor = dut.command(docker_cmd, _uses_shell=True)
 
     port_xcvr_dom_dict = {}
@@ -190,7 +192,7 @@ def get_sfp_eeprom_map_per_port(eeprom_infos):
         if res_port_name:
             port_name = res_port_name.groupdict()["key"].strip()
             line_start_num_list_per_port.append([port_name, index])
-    logging.info(f"line_start_num_list_per_port :{line_start_num_list_per_port}")
+    logging.info("line_start_num_list_per_port: %s", line_start_num_list_per_port)
 
     for index in range(len(line_start_num_list_per_port)):
         if index == len(line_start_num_list_per_port) - 1:
@@ -202,7 +204,7 @@ def get_sfp_eeprom_map_per_port(eeprom_infos):
         sfp_eeprom_map_per_port[line_start_num_list_per_port[index][0]] = deepcopy(
             sfp_eeprom_list[line_start_num_for_current_port:line_end_num_for_current_port+1])
 
-    logging.info(f"sfp_eeprom_map_per_port :{sfp_eeprom_map_per_port}")
+    logging.info("sfp_eeprom_map_per_port: %s", sfp_eeprom_map_per_port)
 
     return sfp_eeprom_map_per_port
 
@@ -447,7 +449,7 @@ def get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled(
             expected_state = 'ModuleLowPwr' if cmis_cable_ports_and_ver[intf] == '3.0' else 'OK'
         else:
             expected_state = 'Not supported'
-    logging.info(f"port {intf}, expected error state:{expected_state}")
+    logging.info("port %s, expected error state: %s", intf, expected_state)
     return expected_state
 
 


### PR DESCRIPTION
### Description of PR

This is a manual cherry-pick of #26319 for the `202605` branch. It replaces the auto-generated backport #26677, whose static-analysis check fails because touching `tests/common/platform/transceiver_utils.py` exposes existing flake8 violations in that legacy file.

The functional change preserves `SFP+CableTechnology` in parsed EEPROM output so passive SFP+ copper cables follow the expected passive-cable handling path. The manual backport also makes the five minimal, behavior-preserving formatting updates required for the release pre-commit hook to pass.

Summary:
Related to #26318
Source PR: #26319
Replaces auto cherry-pick PR: #26677

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

The `202605` nightly test `platform_tests/test_sfp_thermal_state_db.py::TestSfpThermalStateDb::test_sfp_thresholds_match_xcvrd_tables[ld201]` can fail when a passive copper cable reports `N/A` DOM thresholds. The parser dropped the `SFP+CableTechnology` key because its third-level key regular expression did not accept `+`, so the passive cable was treated as non-passive or unknown.

The auto cherry-pick #26677 carries the correct functional fix but fails the release static-analysis check.

#### How did you do it?

- Cherry-picked the functional commit from #26319 onto the latest `202605` branch.
- Allowed `+` in third-level EEPROM keys.
- Replaced five legacy f-string logging/command expressions flagged by the `202605` flake8 pre-commit hook with behavior-equivalent formatting.

#### How did you verify/test it?

- Ran the repository pre-commit hooks on `tests/common/platform/transceiver_utils.py`; all hooks passed, including flake8.
- Compiled the changed Python file with `py_compile`.
- Parsed representative EEPROM output containing `SFP+CableTechnology: Passive Cable` and confirmed `is_passive_cable()` returns true.
- The source fix was validated on the `202605` target branch by rerunning `platform_tests/test_sfp_thermal_state_db.py::TestSfpThermalStateDb::test_sfp_thresholds_match_xcvrd_tables[ld201]` and confirming it passed, as documented in #26319.

#### Any platform specific information?

The reported failure used an Arista passive copper cable (`CAB-Q-S-1M`) on the `202605` branch. The parser change is platform-independent.

#### Supported testbed topology if it's a new test case?

N/A; this is not a new test case.

### Documentation

N/A