### PR TITLE
[202605][pfcwd] Backport #24563: fix pfcwd_all_port_storm cleanup

### DIFF
--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -1,3 +1,4 @@
+import ipaddress
 import logging
 import os
 import pytest
@@ -181,23 +182,103 @@ def set_storm_params(duthost, fanout_graph, fanouthosts, peer_params):
 
 def resolve_arp(duthost, ptfhost, test_ports_info, vlan, ip_version):
     """
-    Populate ARP info for the DUT vlan port
+    Populate ARP info for DUT vlan ports.
+
+    For Cisco-8000: assigns a unique IP to each PTF port within the vlan subnet
+    so that background traffic creates independent egress flows on each server port.
+
+    For other platforms: uses the single test_neighbor_addr from the first VLAN port
+
+    Args:
+        duthost: DUT host instance
+        ptfhost: ptf host instance
+        test_ports_info: test ports information (modified in place for Cisco)
+        vlan: vlan info dict with 'addr' and 'prefix'
+        ip_version: "IPv4" or "IPv6"
+    """
+    # In T1, T2 topology there are no VLANs - nothing to resolve
+    if vlan is None:
+        return
+
+    if duthost.facts['asic_type'] == 'cisco-8000':
+        # Assign unique IPs to each VLAN port starting from gateway + 1
+        vlan_addr = vlan['addr']
+        prefix = vlan['prefix']
+        if ip_version == "IPv4":
+            base_ip = ipaddress.IPv4Address(vlan_addr) + 1
+            # Set arp_ignore=1 so each PTF interface only responds to ARP for its own IP.
+            # Without this, Linux's weak host model causes all interfaces to respond to
+            # ARP requests for any local IP, polluting the DUT's ARP table.
+            ptfhost.command("sysctl -w net.ipv4.conf.all.arp_ignore=1")
+            ptfhost.command("sysctl -w net.ipv4.conf.all.arp_announce=2")
+        else:
+            base_ip = ipaddress.IPv6Address(vlan_addr) + 1
+
+        idx = 0
+        for port, port_info in test_ports_info.items():
+            if port_info['test_port_type'] == 'vlan':
+                unique_ip = str(base_ip + idx)
+                port_info['test_neighbor_addr'] = unique_ip
+                ptf_port = f"eth{port_info['test_port_id']}"
+                if ip_version == "IPv4":
+                    ptfhost.command(f"ifconfig {ptf_port} {unique_ip} netmask "
+                                    f"{ipaddress.IPv4Network(f'0.0.0.0/{prefix}').netmask}")
+                else:
+                    ptfhost.command(f"ip -6 addr add {unique_ip}/{prefix} dev {ptf_port}")
+                idx += 1
+
+        # Resolve ARP/NDP after all IPs are configured so each arping gets a single response
+        if ip_version == "IPv4":
+            for port, port_info in test_ports_info.items():
+                if port_info['test_port_type'] == 'vlan':
+                    duthost.command(f"docker exec -i swss arping {port_info['test_neighbor_addr']} -c 3")
+        else:
+            for port, port_info in test_ports_info.items():
+                if port_info['test_port_type'] == 'vlan':
+                    duthost.command(f"docker exec -i swss ping -6 -c 3 {port_info['test_neighbor_addr']}")
+    else:
+        # Original behavior: resolve ARP for the first VLAN port only
+        for port, port_info in test_ports_info.items():
+            if port_info['test_port_type'] == 'vlan':
+                neighbor_ip = port_info['test_neighbor_addr']
+                ptf_port = f"eth{port_info['test_port_id']}"
+                if ip_version == "IPv4":
+                    ptfhost.command(f"ifconfig {ptf_port} {neighbor_ip}")
+                    duthost.command(f"docker exec -i swss arping {neighbor_ip} -c 5")
+                else:
+                    ptfhost.command(f"ip -6 addr add {neighbor_ip}/{vlan['prefix']} dev {ptf_port}")
+                    duthost.command(f"docker exec -i swss ping -6 -c 5 {neighbor_ip}")
+                break
+
+
+def cleanup_ptf_ips(ptfhost, test_ports_info, vlan, ip_version):
+    """
+    Remove IPs configured on PTF ports by resolve_arp.
 
     Args:
         ptfhost: ptf host instance
         test_ports_info: test ports information
+        vlan: vlan info dict with 'addr' and 'prefix'
+        ip_version: "IPv4" or "IPv6"
     """
+    if vlan is None:
+        return
+
+    prefix = vlan['prefix']
     for port, port_info in test_ports_info.items():
         if port_info['test_port_type'] == 'vlan':
-            neighbor_ip = port_info['test_neighbor_addr']
             ptf_port = f"eth{port_info['test_port_id']}"
+            ip_addr = port_info['test_neighbor_addr']
             if ip_version == "IPv4":
-                ptfhost.command(f"ifconfig {ptf_port} {neighbor_ip}")
-                duthost.command(f"docker exec -i swss arping {neighbor_ip} -c 5")
+                ptfhost.command(f"ifconfig {ptf_port} 0.0.0.0", module_ignore_errors=True)
             else:
-                ptfhost.command(f"ip -6 addr add {neighbor_ip}/{vlan['prefix']} dev {ptf_port}")
-                duthost.command(f"docker exec -i swss ping -6 -c 5 {neighbor_ip}")
-            break
+                ptfhost.command(f"ip -6 addr del {ip_addr}/{prefix} dev {ptf_port}",
+                                module_ignore_errors=True)
+
+    if ip_version == "IPv4":
+        # Restore default arp_ignore/arp_announce settings
+        ptfhost.command("sysctl -w net.ipv4.conf.all.arp_ignore=0", module_ignore_errors=True)
+        ptfhost.command("sysctl -w net.ipv4.conf.all.arp_announce=0", module_ignore_errors=True)
 
 
 @pytest.mark.usefixtures('degrade_pfcwd_detection', 'stop_pfcwd', 'storm_test_setup_restore', 'start_background_traffic')  # noqa: E501
@@ -303,3 +384,7 @@ class TestPfcwdAllPortStorm(object):
                       stormed_ports_list=stormed_ports_list,
                       selected_test_ports=selected_test_ports,
                       tbinfo=tbinfo)
+
+        if duthost.facts['asic_type'] == 'cisco-8000':
+            cleanup_ptf_ips(ptfhost, setup_pfc_test['test_ports'],
+                            setup_pfc_test["vlan"], setup_pfc_test["ip_version"])

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -184,7 +184,7 @@ def resolve_arp(duthost, ptfhost, test_ports_info, vlan, ip_version):
     """
     Populate ARP info for DUT vlan ports.
 
-    For Cisco-8000: assigns a unique IP to each PTF port within the vlan subnet
+    For Cisco-8000: assign a unique IP to each PTF port within the vlan subnet
     so that background traffic creates independent egress flows on each server port.
 
     For other platforms: uses the single test_neighbor_addr from the first VLAN port
@@ -366,25 +366,30 @@ class TestPfcwdAllPortStorm(object):
                     selected_test_ports.append(test_port)
         resolve_arp(duthost, ptfhost, setup_pfc_test['test_ports'],
                     setup_pfc_test["vlan"], setup_pfc_test["ip_version"])
-        with send_background_traffic(duthost, ptfhost, queues, selected_test_ports, setup_pfc_test['test_ports'],
-                                     pkt_count=500):
-            self.run_test(duthost,
-                          storm_hndle,
-                          expect_regex=[EXPECT_PFC_WD_DETECT_RE + fetch_vendor_specific_diagnosis_re(duthost)],
-                          syslog_marker="all_port_storm",
-                          action="storm",
+        try:
+            with send_background_traffic(duthost, ptfhost, queues, selected_test_ports,
+                                         setup_pfc_test['test_ports'],
+                                         pkt_count=500):
+                self.run_test(duthost,
+                              storm_hndle,
+                              expect_regex=[EXPECT_PFC_WD_DETECT_RE +
+                                            fetch_vendor_specific_diagnosis_re(duthost)],
+                              syslog_marker="all_port_storm",
+                              action="storm",
+                              stormed_ports_list=stormed_ports_list,
+                              selected_test_ports=selected_test_ports,
+                              tbinfo=tbinfo)
+
+            logger.info(f"--- {len(stormed_ports_list)} ports entered storm state ---")
+            logger.info("--- Testing if PFC storm is restored on stormed ports ---")
+            # test_ports_info is intentionally not passed during restore: the duplicate-neighbor
+            # adjustment in verify_all_ports_pfc_storm_in_expected_state only applies to the storm
+            # phase, so it has no effect here.
+            self.run_test(duthost, storm_hndle, expect_regex=[EXPECT_PFC_WD_RESTORE_RE],
+                          syslog_marker="all_port_storm_restore", action="restore",
                           stormed_ports_list=stormed_ports_list,
                           selected_test_ports=selected_test_ports,
                           tbinfo=tbinfo)
-
-        logger.info(f"--- {len(stormed_ports_list)} ports entered storm state ---")
-        logger.info("--- Testing if PFC storm is restored on stormed ports ---")
-        self.run_test(duthost, storm_hndle, expect_regex=[EXPECT_PFC_WD_RESTORE_RE],
-                      syslog_marker="all_port_storm_restore", action="restore",
-                      stormed_ports_list=stormed_ports_list,
-                      selected_test_ports=selected_test_ports,
-                      tbinfo=tbinfo)
-
-        if duthost.facts['asic_type'] == 'cisco-8000':
+        finally:
             cleanup_ptf_ips(ptfhost, setup_pfc_test['test_ports'],
                             setup_pfc_test["vlan"], setup_pfc_test["ip_version"])

--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -639,3 +639,6 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                     self.storm_hndle.stop_storm()
                 logger.info("--- Stop PFC WD ---")
                 self.dut.command("pfcwd stop")
+                # Reset global ARP settings modified by resolve_arp
+                self.ptf.command("sysctl -w net.ipv4.conf.all.arp_ignore=0",
+                                 module_ignore_errors=True)


### PR DESCRIPTION
### Description of PR

Summary:
Manual backport of #24563 to 202605 with conflict resolution in `tests/pfcwd/test_pfcwd_all_port_storm.py`.
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Tested branch
- [x] 202605

### Test result
- 202605:
cisco dualtor https://elastictest.org/scheduler/testplan/6aacf26880f8f7db7163b58f
4600 t0: https://elastictest.org/scheduler/testplan/6aacf222fd5723194bf878d2
7260 t1: https://elastictest.org/scheduler/testplan/6aaf713480f8f7db7163b992

  - 
### Approach
#### What is the motivation for this PR?

`Cherry Pick Conflict_202605` was reported for #24563. This PR manually backports the same fix to 202605.

#### How did you do it?

- Cherry-picked commits from #24563 onto `origin/202605`:
  - `2a4759631a926741fada39b51be1be27a45f2a81`
  - `79906280eaa9337a855dcf82ddc06bf8e1335b66`
- Resolved conflict in `tests/pfcwd/test_pfcwd_all_port_storm.py` by keeping the `try/finally` cleanup flow (`cleanup_ptf_ips(...)`) from upstream fix.

#### How did you verify/test it?

- Referred to source PR #24563 verification intent and preserved the same fix behavior in this 202605 backport.
- Code parity check against source PR #24563:
  - Backported commits:
    - `2a4759631a926741fada39b51be1be27a45f2a81`
    - `79906280eaa9337a855dcf82ddc06bf8e1335b66`
  - Conflict in `tests/pfcwd/test_pfcwd_all_port_storm.py` was resolved by keeping the same `try/finally` cleanup flow (`cleanup_ptf_ips(...)`) as source PR.
- Syntax validation:
  - `python -m py_compile tests/pfcwd/test_pfcwd_all_port_storm.py tests/pfcwd/test_pfcwd_cli.py`
- CI validation on this backport PR:
  - Azure.sonic-mgmt checks passed
  - GitHub checks passed (Analyze/Semgrep/CodeQL/DCO/EasyCLA)

#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
