### PR TITLE
[bgp][test_bgp_gr_helper] Wait for neighbor routes to converge before GR baseline

### DIFF
--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -169,6 +169,22 @@ def test_bgp_gr_helper_routes_perserved(duthosts, rand_one_dut_hostname, nbrhost
     logging.info("Select neighbor %s to verify that all bgp routes are preserved during graceful restart",
                  test_neighbor_name)
 
+    # Wait for neighbor routes to stabilize before snapshotting the baseline
+    _prev_learned_routes = {}
+
+    def _neighbor_routes_stable(bgp_neighbor):
+        cur = set(_get_learned_bgp_routes_from_neighbor(duthost, bgp_neighbor).keys())
+        stable = bool(cur) and cur == _prev_learned_routes.get(bgp_neighbor)
+        _prev_learned_routes[bgp_neighbor] = cur
+        return stable
+
+    for test_bgp_neighbor in test_bgp_neighbors:
+        pytest_assert(
+            wait_until(180, 10, 0, _neighbor_routes_stable, test_bgp_neighbor),
+            "routes learned from neighbor %s did not stabilize before graceful restart"
+            % test_bgp_neighbor,
+        )
+
     # get all routes received from neighbor before GR
     all_neighbor_routes_before_gr = {}
     for test_bgp_neighbor in test_bgp_neighbors:


### PR DESCRIPTION
issue#5171381

Change-Id: Icc5c78fd154b3084efa6e7669a5ed9c3aeadac25

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_bgp_gr_helper_routes_perserved intermittently fails with "Route to prefix doesn't originate from BGP neighbor " because it snapshots the neighbor's advertised routes ("before GR" baseline) while the topology is still converging after setup_bgp_graceful_restart resets every BGP session.

On topologies where the DUT re-advertises a shorter default back up to a transit uplink (a T0<->T1 advertise/withdraw feedback loop), 0.0.0.0/0 and ::/0 flap for tens of seconds after the session bounce. If the baseline snapshot lands during that transient it captures a route the neighbor is about to legitimately withdraw; the route is then absent at the graceful- restart check and the test fails on behavior that is not an FRR/GR-helper bug -- purely a race between the post-bounce convergence and the snapshot.


Fix:
Wait until the set of prefixes learned from each test neighbor is unchanged across two consecutive samples (i.e. converged) before recording the baseline. On a converged topology the neighbor no longer advertises the flapping default (its best path is via the DUT), so it isn't in the baseline and the race is removed, while a genuine GR reap of a stably-advertised route is still caught.

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
Wait until the set of prefixes learned from each test neighbor is unchanged across two consecutive samples (i.e. converged) before recording the baseline. On a converged topology the neighbor no longer advertises the flapping default (its best path is via the DUT), so it isn't in the baseline and the race is removed, while a genuine GR reap of a stably-advertised route is still caught.

#### How did you do it?
Wait until the set of prefixes learned from each test neighbor is unchanged across two consecutive samples (i.e. converged) before recording the baseline. On a converged topology the neighbor no longer advertises the flapping default (its best path is via the DUT), so it isn't in the baseline and the race is removed, while a genuine GR reap of a stably-advertised route is still caught.
#### How did you verify/test it?
Ran it over regression
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
SPC1-6 on Nvidia platforms

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
