### PR TITLE
Fix KeyError and timing race in test_vxlan_route_advertisement

### DIFF
--- a/tests/vxlan/test_vxlan_route_advertisement.py
+++ b/tests/vxlan/test_vxlan_route_advertisement.py
@@ -20,13 +20,20 @@ ROUTE_PROPAGATION_TIMEOUT = 60
 
 def verify_route_in_t2(t2device, route, timeout=ROUTE_PROPAGATION_TIMEOUT):
     """
-    Poll until *route* appears in the T2 EOS neighbor's BGP table, or timeout.
+    Check whether *route* is in the T2 EOS neighbor's BGP table.
 
-    Returns True when the route is present, False if timeout is reached.
+    If timeout > 0, poll until the route appears or timeout is reached.
+    If timeout is 0, check once immediately (used when the route is expected
+    to be absent).
+
+    Returns True when the route is present, False otherwise.
     """
-    return wait_until(timeout, 5, 0,
-                      lambda: route in t2device['host'].get_route(route)
-                      .get('vrfs', {}).get('default', {}).get('bgpRouteEntries', {}))
+    def _route_present():
+        return route in t2device['host'].get_route(route).get('vrfs', {}).get('default', {}).get('bgpRouteEntries', {})
+
+    if timeout:
+        return wait_until(timeout, 5, 0, _route_present)
+    return _route_present()
 
 
 # This is the list of encapsulations that will be tested in this script.
@@ -290,7 +297,7 @@ class Test_VxLAN_route_Advertisement():
             for prefix in routes[vnet]:
                 route = f'{prefix}/{prefix_mask}'
                 for t2device in self.vxlan_test_setup['t2']:
-                    py_assert(not verify_route_in_t2(t2device, route),
+                    py_assert(not verify_route_in_t2(t2device, route, timeout=0),
                               "Route not propogated to the T2")
                     if community != "":
                         result = t2device['host'].get_route(route)

--- a/tests/vxlan/test_vxlan_route_advertisement.py
+++ b/tests/vxlan/test_vxlan_route_advertisement.py
@@ -8,12 +8,26 @@ import time
 import logging
 import pytest
 from tests.common.helpers.assertions import pytest_assert as py_assert
+from tests.common.utilities import wait_until
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 
 Logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()
 WAIT_TIME = 2
 WAIT_TIME_EXTRA = 5
+ROUTE_PROPAGATION_TIMEOUT = 60
+
+
+def verify_route_in_t2(t2device, route, timeout=ROUTE_PROPAGATION_TIMEOUT):
+    """
+    Poll until *route* appears in the T2 EOS neighbor's BGP table, or timeout.
+
+    Returns True when the route is present, False if timeout is reached.
+    """
+    return wait_until(timeout, 5, 0,
+                      lambda: route in t2device['host'].get_route(route)
+                      .get('vrfs', {}).get('default', {}).get('bgpRouteEntries', {}))
+
 
 # This is the list of encapsulations that will be tested in this script.
 SUPPORTED_ENCAP_TYPES = ['v4_in_v4', 'v6_in_v4']
@@ -260,10 +274,10 @@ class Test_VxLAN_route_Advertisement():
             for prefix in routes[vnet]:
                 route = f'{prefix}/{prefix_mask}'
                 for t2device in self.vxlan_test_setup['t2']:
-                    result = t2device['host'].get_route(route)
-                    py_assert(route in result['vrfs']['default']['bgpRouteEntries'],
-                              "Route not propogated to the T2")
+                    py_assert(verify_route_in_t2(t2device, route),
+                              f"Route {route} not propagated to T2 within {ROUTE_PROPAGATION_TIMEOUT}s")
                     if community != "":
+                        result = t2device['host'].get_route(route)
                         py_assert(community in str(result), "community not propogated.")
         return
 
@@ -276,10 +290,10 @@ class Test_VxLAN_route_Advertisement():
             for prefix in routes[vnet]:
                 route = f'{prefix}/{prefix_mask}'
                 for t2device in self.vxlan_test_setup['t2']:
-                    result = t2device['host'].get_route(route)
-                    py_assert(route not in result['vrfs']['default']['bgpRouteEntries'],
+                    py_assert(not verify_route_in_t2(t2device, route),
                               "Route not propogated to the T2")
                     if community != "":
+                        result = t2device['host'].get_route(route)
                         py_assert(community not in str(result), "community is still getting propogated.")
         return
 


### PR DESCRIPTION
Fix `KeyError: 'default'` crash and 2 s timing race in route advertisement verify methods by replacing direct dict access with a `wait_until`-based `verify_route_in_t2()` helper that polls up to 60 s using `.get()` chains.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes KeyError and timing race in test_vxlan_route_advertisement when verifying BGP route advertisement/withdrawal on T2 neighbors.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
verify_nighbor_has_routes / verify_nighbor_doesnt_have_routes accessed result['vrfs']['default']['bgpRouteEntries'] directly, which crashed with KeyError: 'default' when the EOS BGP response was incomplete or the route had not yet propagated.

A fixed time.sleep(WAIT_TIME) (2s) was also too short for BGP route propagation to T2, causing intermittent false failures.
#### How did you do it?
Added verify_route_in_t2() that uses wait_until (up to 60s, 5s interval) to poll until the route appears in the T2 BGP table.
Replaced direct dict indexing with safe .get() chains so missing keys return {} instead of raising KeyError.
Updated verify_nighbor_has_routes to assert via verify_route_in_t2.
Updated verify_nighbor_doesnt_have_routes to assert route absence using the same helper (negated).
#### How did you verify/test it?
Ran it on SPC1-6  Nvidia platform
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
