### PR TITLE
[qos] Fix redis-cli parsing in mellanox_calculate_headroom_data

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -3369,7 +3369,7 @@ def mellanox_calculate_headroom_data(duthost, port_to_test):
     # Get over_subscribe_ratio from config DB
     # Command: redis-cli -n 4 hget "DEFAULT_LOSSLESS_BUFFER_PARAMETER|AZURE" 'over_subscribe_ratio'
     default_lossless_param_keys = duthost.shell(
-        'redis-cli -n 4 keys DEFAULT_LOSSLESS_BUFFER_PARAMETER*')['stdout'][0]
+        'redis-cli -n 4 keys DEFAULT_LOSSLESS_BUFFER_PARAMETER*')['stdout'].splitlines()[0]
     over_subscribe_ratio_raw = duthost.shell(
         'redis-cli -n 4 hget "{}" "over_subscribe_ratio"'.format(default_lossless_param_keys))['stdout']
     if over_subscribe_ratio_raw:
@@ -3378,7 +3378,7 @@ def mellanox_calculate_headroom_data(duthost, port_to_test):
         over_subscribe_ratio = None
 
     shp_size_raw = duthost.shell(
-        'redis-cli -n 4 hget "BUFFER_POOL|ingress_lossless_pool", "xoff"')['stdout']
+        'redis-cli -n 4 hget "BUFFER_POOL|ingress_lossless_pool" "xoff"')['stdout']
     if shp_size_raw:
         shp_size = float(shp_size_raw)
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Summary:
Fix two redis-cli parsing bugs in `mellanox_calculate_headroom_data` that prevented SHP from being detected:
1. `duthost.shell('redis-cli -n 4 keys DEFAULT_LOSSLESS_BUFFER_PARAMETER*')['stdout'][0]` took the first character instead of the first key line, so `over_subscribe_ratio` was always empty.
2. A trailing comma in `hget "BUFFER_POOL|ingress_lossless_pool", "xoff"` made the key invalid, so `shp_size` was always empty.

Because SHP is enabled only when:
`if (shp_size and shp_size != 0) or (over_subscribe_ratio and over_subscribe_ratio != 0)`
both lookups failing left `shp_enabled=False`, and the oracle incorrectly expected non-SHP XOFF (`+2048`).

Summary:
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
With SHP enabled, `test_buffer.py` incorrectly expected non-SHP XOFF values (`xoff + 2048`) because SHP state and default lossless parameter key parsing from Redis were broken.

#### How did you do it?
- Removed the trailing comma from the `BUFFER_POOL|ingress_lossless_pool` redis-cli key.
- Changed key parsing to use `['stdout'].splitlines()[0]` instead of `['stdout'][0]`.

#### How did you verify/test it?
Ran QoS buffer tests with shared headroom pool enabled and confirmed expected profile values match DUT-generated profiles.

#### Any platform specific information?
NA

### Documentation
NA