### PR TITLE
[pfcwd] Fix test_pfcwd_all_port_storm on broadcom ut2 DUTs

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -10,6 +10,7 @@ import logging
 from tests.ptf_runner import ptf_runner
 from tests.common import constants
 from tests.common import config_reload
+from tests.common.broadcom_data import is_broadcom_device
 from tests.common.cisco_data import is_cisco_device
 from tests.common.devices.eos import EosHost
 from tests.common.mellanox_data import is_mellanox_device
@@ -567,7 +568,7 @@ numprocs=1
 @contextlib.contextmanager
 def send_background_traffic(duthost, ptfhost, storm_hndle, selected_test_ports, test_ports_info, pkt_count=100000):
     """Send background traffic, stop the background traffic when the context finish """
-    if is_mellanox_device(duthost) or is_cisco_device(duthost):
+    if is_mellanox_device(duthost) or is_cisco_device(duthost) or is_broadcom_device(duthost):
         background_traffic_params = _prepare_background_traffic_params(duthost, storm_hndle,
                                                                        selected_test_ports,
                                                                        test_ports_info,
@@ -576,7 +577,7 @@ def send_background_traffic(duthost, ptfhost, storm_hndle, selected_test_ports, 
         # Ensure the background traffic is running before moving on
         time.sleep(1)
     yield
-    if is_mellanox_device(duthost) or is_cisco_device(duthost):
+    if is_mellanox_device(duthost) or is_cisco_device(duthost) or is_broadcom_device(duthost):
         _stop_background_traffic(ptfhost, background_traffic_log)
 
 

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -359,20 +359,26 @@ class TestPfcwdAllPortStorm(object):
         # Track which ports actually enter storm state
         stormed_ports_list = []
 
-        # get all the tested ports
+        # get all the tested ports across every fanout peer. selected_test_ports must be built
+        # inside the peer loop; otherwise fanout_intfs/device_conn leak the last peer's values only
+        # and ports behind the other peers are never verified.
+        # Honor the port selection already made by select_test_ports() in setup_pfc_test: filter
+        # against setup_pfc_test['selected_test_ports'] (not the full 'test_ports'). For a 2-port
+        # mutual rx/tx pair this narrows to a single representative port, so the test does not
+        # require both a port and its own rx port to storm simultaneously.
         queues = []
+        selected_test_ports = []
         for peer in storm_hndle.peer_params.keys():
             fanout_intfs = storm_hndle.peer_params[peer]['intfs'].split(',')
             device_conn = storm_hndle.fanout_graph[peer]['device_conn']
             queues.append(storm_hndle.storm_handle[peer].pfc_queue_idx)
+            if duthost.facts['asic_type'] != 'vs':
+                for intf in fanout_intfs:
+                    test_port = device_conn[intf]['peerport']
+                    if test_port in setup_pfc_test['selected_test_ports'] \
+                            and test_port not in selected_test_ports:
+                        selected_test_ports.append(test_port)
         queues = list(set(queues))
-        selected_test_ports = []
-
-        if duthost.facts['asic_type'] != 'vs':
-            for intf in fanout_intfs:
-                test_port = device_conn[intf]['peerport']
-                if test_port in setup_pfc_test['test_ports']:
-                    selected_test_ports.append(test_port)
         resolve_arp(duthost, ptfhost, setup_pfc_test['test_ports'],
                     setup_pfc_test["vlan"], setup_pfc_test["ip_version"])
         try:


### PR DESCRIPTION
The all-port-storm test rebuilt its own selected_test_ports list by filtering the fanout peer ports against the full setup_pfc_test['test_ports'], which re-added a port's mutual rx/tx partner (e.g. Ethernet4 + Ethernet20). That 2-port list flows into the selected_test_ports filter in verify_all_ports_pfc_storm_in_expected_state, so the 75% threshold then required both a port and its own rx port to be stormed at the same poll -- which the single-threaded pfc_gen_t2.py generator cannot sustain, causing consistent failures on broadcom ut2 DUTs.

Honor the selection already made by select_test_ports() in setup_pfc_test: filter the per-peer ports against setup_pfc_test['selected_test_ports'] instead of the full test_ports. For a 2-port mutual rx/tx pair this narrows to a single representative port, so the test no longer requires both to storm simultaneously.

Also enable the background-traffic helper for broadcom devices so the selected port's egress queue has occupancy when PFCWD polls; without queue occupancy the storm is not detected on broadcom.

Result on 7280r4 min topo (ut2, broadcom): 2 passed (IPv4 + IPv6), previously 2 failed.

Port | stormed polls | operational polls
-- | -- | --
Ethernet4 | 4 | 18
Ethernet20 | 10 | 12
Ethernet16 | 2 | 20
Ethernet0 / 8 / 12 | 0 | 22 each

<!--EndFragment-->
</body>
</html>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/22342
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Verified on Arista ut2 min topo and Nexthop UT2 min topo

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
