### PR TITLE
[Cisco] Fix register updates for G200X and optimize update process

### DIFF
--- a/tests/pfcwd/cisco/default_pfc_time.py
+++ b/tests/pfcwd/cisco/default_pfc_time.py
@@ -77,7 +77,7 @@ def find_default_bit_time(interface):
             if field.startswith(starter_str):
                 poss_speed_enum_val = getattr(mac_port, field)
                 if mac_port_speed_enum_val == poss_speed_enum_val:
-                    speed = field[len(starter_str) :]
+                    speed = field[len(starter_str):]
                     break
         assert speed is not None, "Failed to find matching speed for mac port enum value {}".format(
             mac_port_speed_enum_val

--- a/tests/pfcwd/cisco/default_pfc_time.py
+++ b/tests/pfcwd/cisco/default_pfc_time.py
@@ -24,15 +24,21 @@ def get_ifgb(ifg_root):
     return ifgb
 
 
+def get_fc_port_cfg0(ifg_root, lane):
+    if is_graphene2:  # noqa: F821
+        return ifg_root.mac_pool8[lane // 8].fc_port_cfg0[lane % 8]
+    return get_ifgb(ifg_root).fc_port_cfg0[lane]
+
+
 def set_pfc_512bit_time(interface, bit_time, num_serdes_lanes):
     sai_lane = port_to_sai_lane_map[interface]                               # noqa: F821
     slice_idx, ifg_idx, serdes_idx = sai_lane_to_slice_ifg_pif(sai_lane)     # noqa: F821
     for i in range(num_serdes_lanes):
         ifg_root = get_ifg_reg_list(slice_idx)[ifg_idx]
-        ifg_mac = get_ifgb(ifg_root)
-        regval = dd0.read_register(ifg_mac.fc_port_cfg0[serdes_idx + i])     # noqa: F821
+        reg = get_fc_port_cfg0(ifg_root, serdes_idx + i)
+        regval = dd0.read_register(reg)  # noqa: F821
         regval.port_512bit_time = bit_time
-        dd0.write_register(ifg_mac.fc_port_cfg0[serdes_idx + i], regval)     # noqa: F821
+        dd0.write_register(reg, regval)  # noqa: F821
 
 
 def compute_fractional_512bit_value(mac_freq_khz, port_gbps):

--- a/tests/pfcwd/cisco/default_pfc_time.py
+++ b/tests/pfcwd/cisco/default_pfc_time.py
@@ -1,23 +1,28 @@
 # Verified on Q200 @ 100G port speed. e.g. 687 is bit time to pause for 50ms (clock at 900Mhz).
+import traceback
 from common import is_graphene2, is_palladium2, tree, is_gr, port_to_sai_lane_map, \
-    sai_lane_to_slice_ifg_pif, dd0, is_pac, is_gb, sdk, get_mac_port, d0
+    sai_lane_to_slice_ifg_pif, dd0, is_pac, is_gb, sdk, get_mac_port, d0, is_g2ll
+
+# Input parameters replaced via 'sed'
+param_interfaces = __PARAM_INTERFACES__  # noqa: F821
+param_success = __PARAM_SUCCESS__  # noqa: F821
 
 
 def get_ifg_reg_list(slice_idx):
-    ''' Gr2 does not have an ifg list, listify '''
-    if is_graphene2 or is_palladium2:                 # noqa: F821
-        ifg_root = [tree.slice[slice_idx].ifg]       # noqa: F821
+    """Gr2 does not have an ifg list, listify"""
+    if is_graphene2 or is_palladium2:
+        ifg_root = [tree.slice[slice_idx].ifg]
     else:
-        ifg_root = tree.slice[slice_idx].ifg       # noqa: F821
+        ifg_root = tree.slice[slice_idx].ifg
     return ifg_root
 
 
 def get_ifgb(ifg_root):
-    ''' Complex tree register differences for ifgb per asic.
-            Takes tree.slice[slice_idx].ifg[ifg_idx] '''
-    if is_graphene2 or is_palladium2:               # noqa: F821
+    """Complex tree register differences for ifgb per asic.
+    Takes tree.slice[slice_idx].ifg[ifg_idx]"""
+    if is_graphene2 or is_palladium2:
         ifgb = ifg_root.ifgbe_ra
-    elif is_gr:                               # noqa: F821
+    elif is_gr:
         ifgb = ifg_root.ifgbe_mac
     else:
         ifgb = ifg_root.ifgb
@@ -25,20 +30,22 @@ def get_ifgb(ifg_root):
 
 
 def get_fc_port_cfg0(ifg_root, lane):
-    if is_graphene2:  # noqa: F821
+    if is_g2ll:
         return ifg_root.mac_pool8[lane // 8].fc_port_cfg0[lane % 8]
     return get_ifgb(ifg_root).fc_port_cfg0[lane]
 
 
 def set_pfc_512bit_time(interface, bit_time, num_serdes_lanes):
-    sai_lane = port_to_sai_lane_map[interface]                               # noqa: F821
-    slice_idx, ifg_idx, serdes_idx = sai_lane_to_slice_ifg_pif(sai_lane)     # noqa: F821
+    sai_lane = port_to_sai_lane_map[interface]
+    slice_idx, ifg_idx, serdes_idx = sai_lane_to_slice_ifg_pif(sai_lane)
     for i in range(num_serdes_lanes):
         ifg_root = get_ifg_reg_list(slice_idx)[ifg_idx]
         reg = get_fc_port_cfg0(ifg_root, serdes_idx + i)
-        regval = dd0.read_register(reg)  # noqa: F821
+        print("[DEBUG-REGPATH] {} slice={} ifg={} lane={} reg_type={}".format(
+            interface, slice_idx, ifg_idx, serdes_idx + i, type(reg).__name__))
+        regval = dd0.read_register(reg)
         regval.port_512bit_time = bit_time
-        dd0.write_register(reg, regval)  # noqa: F821
+        dd0.write_register(reg, regval)
 
 
 def compute_fractional_512bit_value(mac_freq_khz, port_gbps):
@@ -53,39 +60,61 @@ def compute_fractional_512bit_value(mac_freq_khz, port_gbps):
     return bit_time
 
 
-bit_time = None
-if is_pac or is_gb:                                                       # noqa: F821
-    bit_time = 5
-elif is_gr or is_graphene2 or is_palladium2:                              # noqa: F821
-    mac_freq_khz = d0.get_int_property(sdk.la_device_property_e_MAC_FREQUENCY)      # noqa: F821
-    print("Mac frequency khz: {}".format(mac_freq_khz))
+def find_default_bit_time(interface):
+    bit_time = None
+    if is_pac or is_gb:
+        bit_time = 5
+    elif is_gr or is_graphene2 or is_g2ll or is_palladium2:
+        mac_freq_khz = d0.get_int_property(sdk.la_device_property_e_MAC_FREQUENCY)
+        print("Mac frequency khz: {}".format(mac_freq_khz))
+        mac_port = get_mac_port(interface)
+        mac_port_speed_enum_val = mac_port.get_speed()
 
-    mac_port = get_mac_port("INTERFACE")                                    # noqa: F821
-    mac_port_speed_enum_val = mac_port.get_speed()
+        # Find matching speed enum
+        speed = None
+        for field in dir(mac_port):
+            starter_str = "port_speed_e_E_"
+            if field.startswith(starter_str):
+                poss_speed_enum_val = getattr(mac_port, field)
+                if mac_port_speed_enum_val == poss_speed_enum_val:
+                    speed = field[len(starter_str) :]
+                    break
+        assert speed is not None, "Failed to find matching speed for mac port enum value {}".format(
+            mac_port_speed_enum_val
+        )
+        print("Speed string: {}".format(speed))
+        assert speed[-1] == "G", "Unexpected speed, expected trailing 'G'"
+        gbps_str = speed[:-1]
+        assert gbps_str.isdigit(), "Non-digit speed {}".format(gbps_str)
+        gbps = int(gbps_str)
+        if is_palladium2 and gbps == 800:
+            print("Reducing 800G to 400G for P200 PFC 512 bit time calculation")
+            gbps = 400
+        print("Port speed gbps: {}".format(gbps))
+        bit_time = compute_fractional_512bit_value(mac_freq_khz, gbps)
+    assert bit_time is not None, "Failed to find an appropriate 512bit time on this device"
+    return bit_time
 
-    # Find matching speed enum
-    speed = None
-    for field in dir(mac_port):
-        starter_str = "port_speed_e_E_"
-        if field.startswith(starter_str):
-            poss_speed_enum_val = getattr(mac_port, field)
-            if mac_port_speed_enum_val == poss_speed_enum_val:
-                speed = field[len(starter_str):]
-                break
-    assert speed is not None, "Failed to find matching speed for mac port enum value {}".format(mac_port_speed_enum_val)
-    print("Speed string: {}".format(speed))
-    assert speed[-1] == "G", "Unexpected speed, expected trailing 'G'"
-    gbps_str = speed[:-1]
-    assert gbps_str.isdigit(), "Non-digit speed {}".format(gbps_str)
-    gbps = int(gbps_str)
-    if is_palladium2 and gbps == 800:
-        print("Reducing 800G to 400G for P200 PFC 512 bit time calculation")
-        gbps = 400
-    print("Port speed gbps: {}".format(gbps))
-    bit_time = compute_fractional_512bit_value(mac_freq_khz, gbps)
 
-
-assert bit_time is not None, "Failed to find an appropriate 512bit time on this device"
-print("Setting 512bit register to normal value {}".format(bit_time))
-set_pfc_512bit_time("INTERFACE", bit_time, 1)
-print("Done")
+if __name__ == "__main__":
+    try:
+        asic_product = (
+            "G200X" if is_g2ll else
+            "G200" if is_graphene2 else
+            "P200" if is_palladium2 else
+            "G100" if is_gr else
+            "Q200" if is_gb else
+            "Q100" if is_pac else
+            "unknown"
+        )
+        print("[DEBUG-ASIC] product={}".format(asic_product))
+        for intf in param_interfaces:
+            bit_time = find_default_bit_time(intf)
+            print("Setting 512bit register to normal value {}".format(bit_time))
+            set_pfc_512bit_time(intf, bit_time, 1)
+        print(param_success)
+    except Exception as e:
+        print("Failed to set default PFC time: {}".format(e))
+        tb = traceback.format_exc()
+        for line in tb.splitlines():
+            print(line)

--- a/tests/pfcwd/cisco/set_pfc_time.py
+++ b/tests/pfcwd/cisco/set_pfc_time.py
@@ -1,27 +1,29 @@
 import math
+import traceback
 from common import is_graphene2, is_palladium2, tree, is_gr, port_to_sai_lane_map, \
-    sai_lane_to_slice_ifg_pif, dd0, is_pac, is_gb, sdk, d0
+    sai_lane_to_slice_ifg_pif, dd0, is_pac, is_gb, sdk, d0, is_g2ll
 
+# Input parameters replaced via 'sed'
+param_interfaces = __PARAM_INTERFACES__  # noqa: F821
+param_success = __PARAM_SUCCESS__  # noqa: F821
 
-# Replace INTERFACE with appropriate port when used
-arg_interface = "INTERFACE"
-
+# Note: If is_g2ll == True, then is_graphene2 == True. See common.py.
 
 def get_ifg_reg_list(slice_idx):
-    ''' Gr2 does not have an ifg list, listify '''
-    if is_graphene2 or is_palladium2:               # noqa: F821
-        ifg_root = [tree.slice[slice_idx].ifg]     # noqa: F821
+    """Gr2 does not have an ifg list, listify"""
+    if is_graphene2 or is_palladium2:
+        ifg_root = [tree.slice[slice_idx].ifg]
     else:
-        ifg_root = tree.slice[slice_idx].ifg     # noqa: F821
+        ifg_root = tree.slice[slice_idx].ifg
     return ifg_root
 
 
 def get_ifgb(ifg_root):
-    ''' Complex tree register differences for ifgb per asic.
-            Takes tree.slice[slice_idx].ifg[ifg_idx] '''
-    if is_graphene2 or is_palladium2:             # noqa: F821
+    """Complex tree register differences for ifgb per asic.
+    Takes tree.slice[slice_idx].ifg[ifg_idx]"""
+    if is_graphene2 or is_palladium2:
         ifgb = ifg_root.ifgbe_ra
-    elif is_gr:                                 # noqa: F821
+    elif is_gr:
         ifgb = ifg_root.ifgbe_mac
     else:
         ifgb = ifg_root.ifgb
@@ -29,52 +31,76 @@ def get_ifgb(ifg_root):
 
 
 def get_fc_port_cfg0(ifg_root, lane):
-    if is_graphene2:  # noqa: F821
+    if is_g2ll:
         return ifg_root.mac_pool8[lane // 8].fc_port_cfg0[lane % 8]
     return get_ifgb(ifg_root).fc_port_cfg0[lane]
 
 
 def set_pfc_512bit_time(interface, bit_time, num_serdes_lanes):
-    sai_lane = port_to_sai_lane_map[interface]           # noqa: F821
-    slice_idx, ifg_idx, serdes_idx = sai_lane_to_slice_ifg_pif(sai_lane)      # noqa: F821
+    print("Setting bit_time (number of clocks) to {}".format(bit_time))    
+    sai_lane = port_to_sai_lane_map[interface]
+    slice_idx, ifg_idx, serdes_idx = sai_lane_to_slice_ifg_pif(sai_lane)
     for i in range(num_serdes_lanes):
         ifg_root = get_ifg_reg_list(slice_idx)[ifg_idx]
         reg = get_fc_port_cfg0(ifg_root, serdes_idx + i)
-        regval = dd0.read_register(reg)  # noqa: F821
+        print("[DEBUG-REGPATH] {} slice={} ifg={} lane={} reg_type={}".format(
+            interface, slice_idx, ifg_idx, serdes_idx + i, type(reg).__name__))
+        regval = dd0.read_register(reg)
         regval.port_512bit_time = bit_time
-        dd0.write_register(reg, regval)  # noqa: F821
+        dd0.write_register(reg, regval)
 
 
-def set_pfc512_bit_sec(interface, time_sec):
-    if is_gb or is_pac:          # noqa: F821
-        khz = d0.get_int_property(sdk.la_device_property_e_DEVICE_FREQUENCY)       # noqa: F821
+def find_pfc_512bit_time(time_sec):
+    if is_gb or is_pac:
+        khz = d0.get_int_property(sdk.la_device_property_e_DEVICE_FREQUENCY)
         print("Device frequency khz: {}".format(khz))
-    elif is_gr or is_graphene2 or is_palladium2:                                # noqa: F821
-        khz = d0.get_int_property(sdk.la_device_property_e_MAC_FREQUENCY)      # noqa: F821
+    elif is_gr or is_graphene2 or is_palladium2:
+        khz = d0.get_int_property(sdk.la_device_property_e_MAC_FREQUENCY)
         print("Mac frequency khz: {}".format(khz))
     else:
         assert False, "Unsupported device type"
     clock_time = 1. / (khz * 1000)
     num_clocks_float = time_sec / (65535 * clock_time)
 
-    if is_gb or is_pac:                                                      # noqa: F821
-        bit_time = math.ceil(num_clocks_float)
-    elif is_gr or is_graphene2 or is_palladium2:                          # noqa: F821
+    if is_gb or is_pac:
+        return math.ceil(num_clocks_float)
+    if is_gr or is_graphene2 or is_palladium2:
         int_part = int(num_clocks_float)
         float_part = num_clocks_float - int_part
         print("Integer: {}".format(int_part))
         print("Float: {}".format(float_part))
         bit_time = (int_part << 10) + int(float_part * 1024)
-        if bit_time >= 2 ** 18:
-            print("Maxed out, setting bit time {} instead of {}".format((2 ** 18) - 1, bit_time))
-            bit_time = (2 ** 18) - 1
-    else:
-        assert False, "Unsupported device type"
-    print("Setting bit_time (number of clocks) to {}".format(bit_time))
+        if bit_time >= 2**18:
+            print("Maxed out, setting bit time {} instead of {}".format((2**18) - 1, bit_time))
+            bit_time = (2**18) - 1
+        return bit_time
+
+
+def set_pfc512_bit_sec(interface, time_sec):
+    bit_time = find_pfc_512bit_time(time_sec)
     set_pfc_512bit_time(interface, bit_time, num_serdes_lanes=1)
 
 
-# Increase PFC pause time
-num_ms = 50
-print("Setting PFC frame time to {}ms".format(num_ms))
-set_pfc512_bit_sec(arg_interface, num_ms / 1000)
+if __name__ == "__main__":
+    # Increase PFC pause time
+    try:
+        asic_product = (
+            "G200X" if is_g2ll else
+            "G200" if is_graphene2 else
+            "P200" if is_palladium2 else
+            "G100" if is_gr else
+            "Q200" if is_gb else
+            "Q100" if is_pac else
+            "unknown"
+        )
+        print("[DEBUG-ASIC] product={}".format(asic_product))
+        num_ms = 50
+        print("Setting PFC frame time to {}ms".format(num_ms))
+        for intf in param_interfaces:
+            set_pfc512_bit_sec(intf, num_ms / 1000)
+        print(param_success)
+    except Exception as e:
+        print("Failed to set PFC frame time: {}".format(e))
+        tb = traceback.format_exc()
+        for line in tb.splitlines():
+            print(line)

--- a/tests/pfcwd/cisco/set_pfc_time.py
+++ b/tests/pfcwd/cisco/set_pfc_time.py
@@ -38,7 +38,7 @@ def get_fc_port_cfg0(ifg_root, lane):
 
 
 def set_pfc_512bit_time(interface, bit_time, num_serdes_lanes):
-    print("Setting bit_time (number of clocks) to {}".format(bit_time))    
+    print("Setting bit_time (number of clocks) to {}".format(bit_time))
     sai_lane = port_to_sai_lane_map[interface]
     slice_idx, ifg_idx, serdes_idx = sai_lane_to_slice_ifg_pif(sai_lane)
     for i in range(num_serdes_lanes):

--- a/tests/pfcwd/cisco/set_pfc_time.py
+++ b/tests/pfcwd/cisco/set_pfc_time.py
@@ -28,15 +28,21 @@ def get_ifgb(ifg_root):
     return ifgb
 
 
+def get_fc_port_cfg0(ifg_root, lane):
+    if is_graphene2:  # noqa: F821
+        return ifg_root.mac_pool8[lane // 8].fc_port_cfg0[lane % 8]
+    return get_ifgb(ifg_root).fc_port_cfg0[lane]
+
+
 def set_pfc_512bit_time(interface, bit_time, num_serdes_lanes):
     sai_lane = port_to_sai_lane_map[interface]           # noqa: F821
     slice_idx, ifg_idx, serdes_idx = sai_lane_to_slice_ifg_pif(sai_lane)      # noqa: F821
     for i in range(num_serdes_lanes):
         ifg_root = get_ifg_reg_list(slice_idx)[ifg_idx]
-        ifg_mac = get_ifgb(ifg_root)
-        regval = dd0.read_register(ifg_mac.fc_port_cfg0[serdes_idx + i])      # noqa: F821
+        reg = get_fc_port_cfg0(ifg_root, serdes_idx + i)
+        regval = dd0.read_register(reg)  # noqa: F821
         regval.port_512bit_time = bit_time
-        dd0.write_register(ifg_mac.fc_port_cfg0[serdes_idx + i], regval)      # noqa: F821
+        dd0.write_register(reg, regval)  # noqa: F821
 
 
 def set_pfc512_bit_sec(interface, time_sec):

--- a/tests/pfcwd/cisco/set_pfc_time.py
+++ b/tests/pfcwd/cisco/set_pfc_time.py
@@ -9,6 +9,7 @@ param_success = __PARAM_SUCCESS__  # noqa: F821
 
 # Note: If is_g2ll == True, then is_graphene2 == True. See common.py.
 
+
 def get_ifg_reg_list(slice_idx):
     """Gr2 does not have an ifg list, listify"""
     if is_graphene2 or is_palladium2:

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -7,12 +7,14 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts         # no
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa: F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa: F401
-from tests.common.fixtures.ptfhost_utils import pause_garp_service          # noqa: F401
+from tests.common.fixtures.ptfhost_utils import pause_garp_service           # noqa: F401
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from tests.common.cisco_data import is_cisco_device
 from tests.common.utilities import str2bool
 
 logger = logging.getLogger(__name__)
+
+SET_PFC_TIME_SUCCESS_MSG = "PFC bit time set successful"
 
 
 def pytest_addoption(parser):
@@ -56,9 +58,9 @@ def two_queues(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fan
     if dut_asic_type == "mellanox":
         for fanouthost in list(fanouthosts.values()):
             fanout_os = fanouthost.get_fanout_os()
-            if fanout_os == 'eos':
+            if fanout_os == "eos":
                 return False
-    return request.config.getoption('--two-queues')
+    return request.config.getoption("--two-queues")
 
 
 @pytest.fixture(scope="module")
@@ -83,7 +85,7 @@ def fake_storm(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
 
 @pytest.fixture(scope="module")
 def setup_dut_test_params(
-    duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, conn_graph_facts, tbinfo,     # noqa: F811
+    duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, conn_graph_facts, tbinfo,    # noqa: F811
 ):
     """
     Sets up all the parameters needed for the PFCWD tests
@@ -96,16 +98,16 @@ def setup_dut_test_params(
     Yields:
         dut_info: dictionary containing dut information
     """
-    dut_test_params = {'basicParams': {'is_dualtor': False}}
+    dut_test_params = {"basicParams": {"is_dualtor": False}}
     if "dualtor" in tbinfo["topo"]["name"]:
         dut_test_params["basicParams"]["is_dualtor"] = True
-        vlan_cfgs = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']
-        if vlan_cfgs and 'default_vlan_config' in vlan_cfgs:
-            default_vlan_name = vlan_cfgs['default_vlan_config']
+        vlan_cfgs = tbinfo["topo"]["properties"]["topology"]["DUT"]["vlan_configs"]
+        if vlan_cfgs and "default_vlan_config" in vlan_cfgs:
+            default_vlan_name = vlan_cfgs["default_vlan_config"]
             if default_vlan_name:
                 for vlan in list(vlan_cfgs[default_vlan_name].values()):
-                    if 'mac' in vlan and vlan['mac']:
-                        dut_test_params["basicParams"]["def_vlan_mac"] = vlan['mac']
+                    if "mac" in vlan and vlan["mac"]:
+                        dut_test_params["basicParams"]["def_vlan_mac"] = vlan["mac"]
                         break
 
     logger.info("dut_test_params : {}".format(dut_test_params))
@@ -119,12 +121,12 @@ def pfcwd_pause_service(ptfhost):
     needs_resume = {"icmp_responder": False, "garp_service": False}
 
     out = ptfhost.shell("supervisorctl status icmp_responder", module_ignore_errors=True).get("stdout", "")
-    if 'RUNNING' in out:
+    if "RUNNING" in out:
         needs_resume["icmp_responder"] = True
         ptfhost.shell("supervisorctl stop icmp_responder")
 
     out = ptfhost.shell("supervisorctl status garp_service", module_ignore_errors=True).get("stdout", "")
-    if 'RUNNING' in out:
+    if "RUNNING" in out:
         needs_resume["garp_service"] = True
         ptfhost.shell("supervisorctl stop garp_service")
 
@@ -149,57 +151,66 @@ def set_pfc_time_cisco_8000(
         setup_pfc_test):
 
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    test_ports = setup_pfc_test['test_ports']
+    test_ports = setup_pfc_test["test_ports"]
 
     # Lets limit this to cisco and T2 only.
-    if duthost.facts['asic_type'] != "cisco-8000":
+    if duthost.facts["asic_type"] != "cisco-8000":
         yield
         return
 
     PFC_TIME_SET_SCRIPT = "pfcwd/cisco/set_pfc_time.py"
     PFC_TIME_RESET_SCRIPT = "pfcwd/cisco/default_pfc_time.py"
 
-    for port in test_ports:
-        asic_id = ""
-        if duthost.sonichost.is_multi_asic:
-            asic_id = duthost.get_port_asic_instance(port).asic_index
-        set_pfc_timer_cisco_8000(
-            duthost,
-            asic_id,
-            PFC_TIME_SET_SCRIPT,
-            port)
+    # Construct a map of asic_id to list of ports for multi-asic devices
+    # Recycle the keys from ports for single-asic devices
+
+    if duthost.sonichost.is_multi_asic:
+        asic_to_ports = dict()
+        for port in test_ports.keys():
+            asic_instance = duthost.get_port_asic_instance(port)
+            if asic_instance:
+                if asic_instance.asic_index not in asic_to_ports:
+                    asic_to_ports[asic_instance.asic_index] = [port]
+                else:
+                    asic_to_ports[asic_instance.asic_index].append(port)
+    else:
+        asic_to_ports = list(test_ports.keys())
+
+    set_pfc_timer_cisco_8000(duthost, PFC_TIME_SET_SCRIPT, asic_to_ports)
 
     yield
 
-    for port in test_ports:
-        asic_id = ""
-        if duthost.sonichost.is_multi_asic:
-            asic_id = duthost.get_port_asic_instance(port).asic_index
-        set_pfc_timer_cisco_8000(
-            duthost,
-            asic_id,
-            PFC_TIME_RESET_SCRIPT,
-            port)
+    set_pfc_timer_cisco_8000(duthost, PFC_TIME_RESET_SCRIPT, asic_to_ports)
 
 
-def set_pfc_timer_cisco_8000(duthost, asic_id, script, port):
-
+def set_pfc_timer_cisco_8000(duthost, script, asic_to_ports):
     script_name = os.path.basename(script)
-    dut_script_path = f"/tmp/{script_name}"
-    duthost.copy(src=script, dest=dut_script_path)
-    duthost.shell(f"sed -i 's/INTERFACE/{port}/' {dut_script_path}")
-    duthost.docker_copy_to_all_asics(
-        container_name=f"syncd{asic_id}",
-        src=dut_script_path,
-        dst="/")
 
-    asic_arg = ""
-    if asic_id != "":
-        asic_arg = f"-n asic{asic_id}"
-    duthost.shell(f"show platform npu script {asic_arg} -s {script_name}")
+    def copy_and_run(dut_script_path, port_list, asic=None):
+        duthost.copy(src=script, dest=dut_script_path)
+        ports_as_str = "[" + ",".join([f'"{port}"' for port in port_list]) + "]"
+        duthost.shell(f"sed -i 's/__PARAM_INTERFACES__/{ports_as_str}/' {dut_script_path}")
+        duthost.shell(f"sed -i 's/__PARAM_SUCCESS__/\"{SET_PFC_TIME_SUCCESS_MSG}\"/' {dut_script_path}")
+        asic_str = str(asic) if asic is not None else ""
+        duthost.docker_copy_to_all_asics(container_name=f"syncd{asic_str}", src=dut_script_path, dst="/")
+        container_script_path = "/" + os.path.basename(dut_script_path)
+        asic_str = f"-n asic{asic}" if asic is not None else ""
+        result = duthost.shell(f"show platform npu script {asic_str} -s {container_script_path}")
+        success = SET_PFC_TIME_SUCCESS_MSG in result["stdout"]
+        assert success, f"Script {script_name} failed to execute correctly, output: {result['stdout']}"
+
+    if type(asic_to_ports) is dict:
+        for asic_id, ports in asic_to_ports.items():
+            dut_script_path = f"/tmp/asic{asic_id}_{script_name}"
+            copy_and_run(dut_script_path, ports, asic=asic_id)
+    elif type(asic_to_ports) is list:
+        dut_script_path = f"/tmp/{script_name}"
+        copy_and_run(dut_script_path, asic_to_ports)
+    else:
+        assert False, f"Invalid type of port info sent to PFC timer script: {type(asic_to_ports).__name__}."
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def save_and_restore_pfcwd_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Fixture that saves PFCWD configuration before each test and restores it after
@@ -216,11 +227,12 @@ def save_and_restore_pfcwd_config(duthosts, enum_rand_one_per_hwsku_frontend_hos
     # Get current PFCWD configuration from config_db.json
     cmd = "jq '.PFC_WD' /etc/sonic/config_db.json"
     result = duthost.shell(cmd, module_ignore_errors=True)
-    original_config = result.get('stdout', '{}')
+    original_config = result.get("stdout", "{}")
     logger.info("Original PFCWD config before test: {}".format(original_config))
 
     # Parse the configuration to extract settings
     import json
+
     try:
         pfcwd_config = json.loads(original_config)
     except Exception as e:
@@ -237,8 +249,8 @@ def save_and_restore_pfcwd_config(duthosts, enum_rand_one_per_hwsku_frontend_hos
 
     if pfcwd_config:
         # Restore POLL_INTERVAL if it exists
-        if 'GLOBAL' in pfcwd_config and 'POLL_INTERVAL' in pfcwd_config['GLOBAL']:
-            poll_interval = pfcwd_config['GLOBAL']['POLL_INTERVAL']
+        if "GLOBAL" in pfcwd_config and "POLL_INTERVAL" in pfcwd_config["GLOBAL"]:
+            poll_interval = pfcwd_config["GLOBAL"]["POLL_INTERVAL"]
             cmd = "pfcwd interval {}".format(poll_interval)
             duthost.shell(cmd, module_ignore_errors=True)
             logger.info("Restored POLL_INTERVAL to {}".format(poll_interval))
@@ -247,12 +259,12 @@ def save_and_restore_pfcwd_config(duthosts, enum_rand_one_per_hwsku_frontend_hos
         # Group ports by their configuration (action, detection_time, restoration_time)
         config_groups = {}
         for port, settings in pfcwd_config.items():
-            if port == 'GLOBAL':
+            if port == "GLOBAL":
                 continue
 
-            action = settings.get('action', 'drop')
-            detection_time = settings.get('detection_time', '200')
-            restoration_time = settings.get('restoration_time', '200')
+            action = settings.get("action", "drop")
+            detection_time = settings.get("detection_time", "200")
+            restoration_time = settings.get("restoration_time", "200")
 
             key = (action, detection_time, restoration_time)
             if key not in config_groups:
@@ -261,7 +273,7 @@ def save_and_restore_pfcwd_config(duthosts, enum_rand_one_per_hwsku_frontend_hos
 
         # Start PFCWD for each configuration group
         for (action, detection_time, restoration_time), ports in config_groups.items():
-            ports_str = ' '.join(ports)
+            ports_str = " ".join(ports)
             cmd = "pfcwd start --action {} --restoration-time {} {} {}".format(
                 action, restoration_time, ports_str, detection_time
             )


### PR DESCRIPTION
### Description of PR

Summary:
Fixes the PFCWD pause-time setup on Cisco 8000 so it works on a newer ASIC variant, and hardens the surrounding test fixture so a failure in that setup can no longer pass silently.

The PFCWD tests configure the PFC "512-bit time" (pause quanta) on the DUT through two on-box helper scripts (`tests/pfcwd/cisco/set_pfc_time.py` and `tests/pfcwd/cisco/default_pfc_time.py`). On a newer Cisco 8000 ASIC variant the flow-control port-config register lives at a different location in the low-level register tree than on the older variants. The scripts assumed a single layout for the whole ASIC family, so on the newer variant they raised `AttributeError: ... has no attribute 'fc_port_cfg0'` and never set the pause time. Because the fixture did not check the script result, the failure went unnoticed and the tests ran with an unconfigured PFC pause time.

Fixes # (Internal to Cisco)

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

On a newer Cisco 8000 ASIC variant, the PFCWD pause-time helper scripts crashed while writing the flow-control port-config register because that register is at a different point in the register tree than on the older variants of the same
ASIC family. The failure was also masked: the fixture that runs these scripts did not verify their output, so tests proceeded as if the pause time had been set. The goal of this PR is to make the register access correct on the newer variant without changing behavior on existing platforms, and to make a script failure fail the test loudly.

#### How did you do it?

- Corrected the register lookup. Added a small helper (`get_fc_port_cfg0`) that resolves the flow-control register through the correct register-tree path for the newer ASIC variant. The corrected path is scoped by a platform-detection  flag so it applies only to that variant; every other Cisco 8000 ASIC keeps its original register path unchanged.
- Reworked the two on-box scripts to accept a batch of interfaces in a single invocation (via placeholder substitution) instead of being copied and run once per port, and to print an explicit success sentinel when they finish.
- Updated `set_pfc_time_cisco_8000` / `set_pfc_timer_cisco_8000` in `tests/pfcwd/conftest.py` to build a per-ASIC map of ports, run each script once per ASIC with the full port list, and assert on the success sentinel. A script failure now fails the test instead of passing silently. Both single-ASIC and multi-ASIC devices are handled.
- Added debug logging that reports the detected ASIC product and the resolved register type to make future triage easier.

### Test result

202605: see below

#### How did you verify/test it?

Ran the PFCWD storm tests on a Cisco 8000 T0 testbed built on the affected ASIC
variant and inspected the run logs. Confirmed that:

- the DUT was correctly identified,
- every interface resolved to a valid low-level register (no `fc_port_cfg0` AttributeError and no fallback to the old path),
- both the set and reset scripts reported success for all ports, and
- the fixture's new success assertion passed.


#### How did it go?

202605:  with both G200X and other NPUs (site-specific info redacted):

G200X results:

The same change was also applied to the 202605 branch and verified to behave identically there. Proof of efficacy:

Check | Result
-- | --
product=G200X (DUT identified via is_g2ll) | 4
reg_type=lld_register (valid register objects via mac_pool8) | 56
PFC bit time set successful | 10
has no attribute 'fc_port_cfg0' (the old crash) | 0
ifgbe_ra references (old broken path) | 0
Tracebacks originating from the PFC npu scripts | 0

The DUT was positively identified as G200X, and every register lookup in both set_pfc_time.py and default_pfc_time.py resolved to a valid is_g2ll → mac_pool8 path is working, with no fc_port_cfg0 AttributeError anywhere.

Note: the file does contain 4 Traceback lines, but decoding every show platform npu script shell result shows 0 tracebacks came from our scripts — they're elsewhere in the pytest/framework logging (unrelated to the register-path change, and out of scope per our test results).

Bottom line: the port to 202605 works — G200X is detected and the PFC register path resolves cleanly. 


Q200 results:

```
sonic@******:~/cicd_prod_202605/sonic-test/sonic-mgmt/tests$ git status
On branch t1_*****_202605
Your branch is up to date with 'origin/t1_*****_202605'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   ../ansible/lab
	modified:   ../ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
	modified:   ../ansible/testbed.yaml
	modified:   common/cisco_data.py
	modified:   pfcwd/cisco/default_pfc_time.py
	modified:   pfcwd/cisco/set_pfc_time.py
	modified:   pfcwd/conftest.py

sonic@sonic-******:/data/tests$ ./run_tests.sh -n trndo-t0 -l debug -e -s -m individual -u -e --skip_sanity  -t t0,any -p /run_logs/******_test_gr2x-pfcwd-storm-fixes-202605 -c pfcwd/test_pfcwd_all_port_storm.py
========================================================== short test summary info ==========================================================
XPASS pfcwd/test_pfcwd_all_port_storm.py::TestPfcwdAllPortStorm::test_all_port_storm_restore[IPv6-tornado-t1-dut] - Xfail due to https://github.com/sonic-net/sonic-mgmt/issues/21082
========================================== 1 passed, 1 xpassed, 426 warnings in 578.27s (0:09:38) ===========================================
sonic@sonic-******:/data/tests$


sonic@sonic-******:/data/tests$
sonic@sonic-******:/data/tests$ ./run_tests.sh -n trndo-t0 -l debug -e -s -m individual -u -e --skip_sanity  -t t0,any -p /run_logs/******test_gr2x-pfcwd-storm-fixes-202605 -c pfcwd/test_pfcwd_function.py

========================================================== short test summary info ==========================================================
XFAIL pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[IPv6-tornado-t1-dut] - Xfail due to https://github.com/sonic-net/sonic-mgmt/issues/21082
XPASS pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[IPv6-tornado-t1-dut] - Xfail due to https://github.com/sonic-net/sonic-mgmt/issues/21082
XPASS pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[IPv6-tornado-t1-dut] - Xfail due to https://github.com/sonic-net/sonic-mgmt/issues/21082
XPASS pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[IPv6-tornado-t1-dut] - Xfail due to https://github.com/sonic-net/sonic-mgmt/issues/21082
XPASS pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[IPv6-tornado-t1-dut] - Xfail due to https://github.com/sonic-net/sonic-mgmt/issues/21082
==================================== 5 passed, 1 xfailed, 4 xpassed, 4338 warnings in 3724.11s (1:02:04) ====================================
sonic@sonic-*******:/data/tests$
```

#### Any platform specific information?

The behavior change is limited to Cisco 8000 (`asic_type == "cisco-8000"`); the fixture early-returns on other platforms. The corrected register path is applied only to the specific newer ASIC variant, so there is no functional change for the other Cisco 8000 ASICs, which continue to use their previous register path.

#### Supported testbed topology if it's a new test case?

Not a new test case. Applies to the existing PFCWD topologies (t0/t1/t2).

### Documentation

No documentation changes required.
