### PR TITLE
crm: harden verify_thresholds threshold-log detection

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 import time
 import json
 import ipaddress
@@ -34,6 +35,13 @@ FDB_CLEAR_TIMEOUT = 20
 ROUTE_COUNTER_POLL_TIMEOUT = 15
 CRM_COUNTER_TOLERANCE = 2
 ACL_TABLE_NAME = "DATAACL"
+
+# CRM THRESHOLD_EXCEEDED/CLEAR messages are emitted by orchagent once per CRM polling
+# cycle, so poll syslog for them (up to CRM_THRESHOLD_LOG_TIMEOUT, checking every
+# CRM_THRESHOLD_LOG_INTERVAL) instead of relying on a single fixed-window read. This
+# removes the dependency on the poll happening to fall inside a fixed window.
+CRM_THRESHOLD_LOG_TIMEOUT = CRM_UPDATE_TIME * 3
+CRM_THRESHOLD_LOG_INTERVAL = 3
 
 RESTORE_CMDS = {"test_crm_route": [],
                 "test_crm_nexthop": [],
@@ -255,6 +263,38 @@ def get_acl_tbl_key(asichost):
     return "CRM:ACL_TABLE_STATS:{0}".format(oid.replace("oid:", ""))
 
 
+def get_crm_polling_interval(duthost):
+    """Return the currently configured CRM polling interval (in seconds) on the DUT."""
+    output = duthost.command('crm show summary')['stdout']
+    parsed = re.findall(r'Polling Interval: +(\d+) +second', output)
+    return int(parsed[0]) if parsed else None
+
+
+def wait_for_threshold_log(loganalyzer, asichost, cmd):
+    """
+    Apply a CRM threshold-config command and wait until the expected THRESHOLD_EXCEEDED /
+    THRESHOLD_CLEAR message appears in syslog.
+
+    orchagent emits these messages only on a CRM polling cycle, so relying on a single
+    fixed-window read (time.sleep + one analyze) can intermittently miss the message when
+    the poll lands just outside the window. Instead, add a start marker, run the command,
+    and poll loganalyzer until the expected message is present (or time out).
+    """
+    marker = loganalyzer.init()
+    asichost.command(cmd)
+
+    def _expected_log_present():
+        summary = loganalyzer.analyze(marker, fail=False)
+        return (summary["total"]["expected_missing_match"] == 0 and
+                summary["total"]["expected_match"] > 0)
+
+    if not wait_until(CRM_THRESHOLD_LOG_TIMEOUT, CRM_THRESHOLD_LOG_INTERVAL,
+                      CRM_POLLING_INTERVAL, _expected_log_present):
+        # Final strict analysis to raise LogAnalyzerError with full details if the
+        # expected message is still missing after the timeout.
+        loganalyzer.analyze(marker, fail=True)
+
+
 def verify_thresholds(duthost, asichost, **kwargs):
     """
     Verifies that WARNING message logged if there are any resources that exceeds a pre-defined threshold value.
@@ -268,6 +308,16 @@ def verify_thresholds(duthost, asichost, **kwargs):
         )
         return
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='crm_test')
+    # THRESHOLD_EXCEEDED/CLEAR messages are emitted by orchagent only on a CRM polling
+    # cycle. If the polling interval is not the expected low value, those messages may not
+    # appear within the verification window, causing false failures. Fail early with a
+    # clear message. The set_polling_interval fixture (crm/conftest.py) configures this.
+    polling_interval = get_crm_polling_interval(duthost)
+    pytest_assert(
+        polling_interval == CRM_POLLING_INTERVAL,
+        "CRM polling interval is {}s, expected {}s. THRESHOLD_EXCEEDED/CLEAR syslog messages "
+        "may not appear within the verification window; ensure the set_polling_interval "
+        "fixture is active.".format(polling_interval, CRM_POLLING_INTERVAL))
     for key, value in list(THR_VERIFY_CMDS.items()):
         logger.info("Verifying CRM threshold '{}'".format(key))
         template = Template(value)
@@ -309,10 +359,9 @@ def verify_thresholds(duthost, asichost, **kwargs):
         kwargs['crm_used'], kwargs['crm_avail'] = get_crm_stats(kwargs['crm_cmd'], duthost)
         cmd = template.render(**kwargs)
 
-        with loganalyzer:
-            asichost.command(cmd)
-            # Make sure CRM counters updated
-            wait_until(CRM_UPDATE_TIME, CRM_POLLING_INTERVAL, 0, lambda: True)
+        # Poll for the expected THRESHOLD_EXCEEDED/CLEAR message instead of relying on a
+        # single fixed-window read, so a slow/late CRM poll does not cause a false failure.
+        wait_for_threshold_log(loganalyzer, asichost, cmd)
 
 
 def get_crm_stats(cmd, duthost):


### PR DESCRIPTION
Poll syslog for THRESHOLD_EXCEEDED/CLEAR (wait_for_threshold_log) instead of a single fixed-window read, so a late CRM polling cycle does not cause false failures in loganalyzer find regex. Add get_crm_polling_interval and assert the CRM polling interval matches CRM_POLLING_INTERVAL (set_polling_interval fixture) before verifying.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
without the fix, sometimes loganalyzer failed to find the regex like bbelow:
```
  File "/var/src/sonic-mgmt_vmstr-ut2-7280r4-4/tests/crm/test_crm.py", line 1164, in test_crm_nexthop_group
    verify_thresholds(duthost, asichost, crm_cli_res=redis_threshold, crm_cmd=get_nexthop_group_stats)
  File "/var/src/sonic-mgmt_vmstr-ut2-7280r4-4/tests/crm/test_crm.py", line 293, in verify_thresholds
    with loganalyzer:
  File "/var/src/sonic-mgmt_vmstr-ut2-7280r4-4/tests/common/plugins/loganalyzer/loganalyzer.py", line 140, in __exit__
    self.analyze(self._markers.pop(), fail=self.fail)
  File "/var/src/sonic-mgmt_vmstr-ut2-7280r4-4/tests/common/plugins/loganalyzer/loganalyzer.py", line 447, in analyze
    self._verify_log(analyzer_summary)
  File "/var/src/sonic-mgmt_vmstr-ut2-7280r4-4/tests/common/plugins/loganalyzer/loganalyzer.py", line 153, in _verify_log
    raise LogAnalyzerError(result_str)
tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 0
expected_match: 0
expected_missing_match: 1

Expected Messages that are missing:
.* THRESHOLD_EXCEEDED .*

FAILED    
```

with the fix I see crm test consistently passing on 7280r4 ut2, no failure yet.
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
