### PR TITLE
Fix common sonic-db-cli functions to be multi asic aware

### DIFF
--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -222,20 +222,29 @@ CONFIG_DB = 'CONFIG_DB'
 STATE_DB = 'STATE_DB'
 
 
+def _run_sonic_db_cli(duthost, command):
+    """Run sonic-db-cli in the host's ASIC namespace without raising on failure"""
+    cli = duthost.sonic_db_cli if isinstance(duthost, SonicAsic) else 'sonic-db-cli'
+    return duthost.shell(
+        "{} {}".format(cli, command),
+        module_ignore_errors=True
+    )
+
+
 def redis_hget(duthost, db, key, field):
     """Return HGET value (stripped str) or '' if absent."""
-    r = duthost.shell(
-        "sonic-db-cli {db} HGET '{key}' {field}".format(db=db, key=key, field=field),
-        module_ignore_errors=True
+    r = _run_sonic_db_cli(
+        duthost,
+        "{db} HGET '{key}' {field}".format(db=db, key=key, field=field)
     )
     return (r.get('stdout', '') or '').strip()
 
 
 def redis_hgetall(duthost, db, key):
     """Return HGETALL as dict; empty dict on miss."""
-    r = duthost.shell(
-        "sonic-db-cli {db} HGETALL '{key}'".format(db=db, key=key),
-        module_ignore_errors=True
+    r = _run_sonic_db_cli(
+        duthost,
+        "{db} HGETALL '{key}'".format(db=db, key=key)
     )
     out = (r.get('stdout', '') or '').strip()
     if not out:
@@ -266,13 +275,13 @@ def redis_hset(duthost, db, key, **fields):
         )
         for field_name, field_value in fields.items()
     )
-    return duthost.shell(
-        "sonic-db-cli {db} -- HSET {key} {parts}".format(
+    return _run_sonic_db_cli(
+        duthost,
+        "{db} -- HSET {key} {parts}".format(
             db=db,
             key=shlex.quote(str(key)),
             parts=parts,
         ),
-        module_ignore_errors=True
     )
 
 
@@ -280,13 +289,13 @@ def redis_hdel(duthost, db, key, *fields):
     """HDEL one or more fields from a hash."""
     if not fields:
         return None
-    return duthost.shell(
-        "sonic-db-cli {db} -- HDEL {key} {fields}".format(
+    return _run_sonic_db_cli(
+        duthost,
+        "{db} -- HDEL {key} {fields}".format(
             db=db,
             key=shlex.quote(str(key)),
             fields=' '.join(shlex.quote(str(field)) for field in fields),
         ),
-        module_ignore_errors=True
     )
 
 
@@ -295,12 +304,12 @@ def redis_del(duthost, db, *keys):
     results = []
     for k in keys:
         results.append(
-            duthost.shell(
-                "sonic-db-cli {db} -- DEL {key}".format(
+            _run_sonic_db_cli(
+                duthost,
+                "{db} -- DEL {key}".format(
                     db=db,
                     key=shlex.quote(str(k)),
                 ),
-                module_ignore_errors=True,
             )
         )
     return results
@@ -308,9 +317,9 @@ def redis_del(duthost, db, *keys):
 
 def redis_keys(duthost, db, pattern):
     """KEYS pattern → list of key names."""
-    r = duthost.shell(
-        "sonic-db-cli {db} KEYS '{pattern}'".format(db=db, pattern=pattern),
-        module_ignore_errors=True
+    r = _run_sonic_db_cli(
+        duthost,
+        "{db} KEYS '{pattern}'".format(db=db, pattern=pattern)
     )
     out = (r.get('stdout', '') or '').strip()
     return out.split('\n') if out else []


### PR DESCRIPTION
https://github.com/sonic-net/sonic-mgmt/pull/24453 added functionality to tests/common/helpers/sonic_db.py
for common redis commands. The requirements being lightweight wrappers that return empty values instead of raising errors.

These commands call `sonic-db-cli` directly over duthost.shell which is not namespace aware. We can use duthost.sonic_db_cli to get the appropriate string instead. That way if the asic-host is passed it will use the correct db.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #27046
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

calls to redis_hget etc now return data when previously they did not.

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/pull/24453 added functionality to tests/common/helpers/sonic_db.py
for common redis commands. The sonic-db-cli command used does not pass an asic namespace even if an asic duthost is used to make the call.

We should expect that if you pass asic0 host then the db cli command will be run in the asic0 namespace. This way we can make use of these commands for accessing the asic-specific databases.

#### How did you do it?
Added a helper function to wrap a check if the duthost is a SonicAsic then we should use the function string provided by duthost.sonic_db_cli in duthost.shell. This way we can preserve the original intent of having a lightweight redis caller that does not throw errors on empty return strings.


#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

I ran tests that call this function on multi asic systems. They would fail before because the data appeared empty but they now passed because the proper redis db was accessed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
