### PR TITLE
fix(setup-container): retry Docker image pulls

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -6,6 +6,8 @@ declare -r SCRIPT_DIR="$(dirname "${SCRIPT_PATH}")"
 
 declare -r DOCKER_REGISTRY="sonicdev-microsoft.azurecr.io:443"
 declare -r DOCKER_SONIC_MGMT="docker-sonic-mgmt:latest"
+declare -r DOCKER_PULL_MAX_ATTEMPTS="3"
+declare -r DOCKER_PULL_RETRY_DELAY_SECONDS="10"
 
 declare -r ROOT_PASS="root"
 declare -r USER_PASS="12345"
@@ -149,11 +151,31 @@ function show_local_container_login() {
     fi
 }
 
+function pull_docker_image_with_retry() {
+    local image="$1"
+    local attempt
+
+    for ((attempt = 1; attempt <= DOCKER_PULL_MAX_ATTEMPTS; attempt++)); do
+        log_info "pulling docker image ${image} (attempt ${attempt}/${DOCKER_PULL_MAX_ATTEMPTS}) ..."
+        if docker pull "${image}"; then
+            return "${EXIT_SUCCESS}"
+        fi
+
+        if [[ "${attempt}" -lt "${DOCKER_PULL_MAX_ATTEMPTS}" ]]; then
+            log_notice "docker pull attempt ${attempt}/${DOCKER_PULL_MAX_ATTEMPTS} failed;" \
+                "retrying in ${DOCKER_PULL_RETRY_DELAY_SECONDS} seconds ..."
+            sleep "${DOCKER_PULL_RETRY_DELAY_SECONDS}"
+        fi
+    done
+
+    return "${EXIT_FAILURE}"
+}
+
 function pull_sonic_mgmt_docker_image() {
     if [[ -z "${IMAGE_ID}" ]]; then
         if docker image inspect "${DOCKER_SONIC_MGMT}" &> /dev/null; then
             IMAGE_ID="${DOCKER_SONIC_MGMT}"
-        elif log_info "pulling docker image from a registry ..." && docker pull "${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}"; then
+        elif pull_docker_image_with_retry "${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}"; then
             IMAGE_ID="${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}"
         else
             exit_failure "unable to find a usable default docker image, please specify one manually"


### PR DESCRIPTION
### Description of PR

Summary:
Retry the default `docker-sonic-mgmt` image pull when transient registry layer downloads fail. The setup script now makes up to three attempts with a 10-second delay and retains Docker's completed layers between attempts.

Fixes # (issue): N/A

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: Other - transient registry network failure

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `bash -n setup-container.sh`

### Approach
#### What is the motivation for this PR?

`setup-container.sh` fails immediately when an Azure Container Registry layer download encounters a transient network timeout. Re-running the full testbed preparation can hit another layer timeout even though Docker retains layers downloaded by the previous attempt.

#### How did you do it?

Added a focused retry helper around the default registry pull. It retries up to three times with a 10-second delay, logs each attempt, and preserves the existing failure behavior after the retry limit.

#### How did you verify/test it?

Validated the updated script with `bash -n setup-container.sh`.

#### Any platform specific information?

Applies to hosts that create the sonic-mgmt Docker container.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

No documentation change is required.
