### PR TITLE
[202605][generic_config_updater]: Fix nonexistent BGP prefix removal

### DIFF
--- a/tests/generic_config_updater/test_bgp_prefix.py
+++ b/tests/generic_config_updater/test_bgp_prefix.py
@@ -141,22 +141,24 @@ def bgp_prefix_tc1_add_config(duthost, community, community_table, cli_namespace
 def bgp_prefix_tc1_xfail(duthost, community_table, namespace=None):
     """ Test input with invalid prefixes
     """
+    # JSON Patch remove resolves leaf-list entries by index, not by value. Use index 1
+    # for remove operations because these lists contain only the valid entry at index 0.
     xfail_input = [
-        ("add", "10.256.0.0/16", PREFIXES_V6_DUMMY),        # Invalid v4 prefix
-        ("add", PREFIXES_V4_DUMMY, "fc01:xyz::/64"),        # Invalid v6 prefix
-        ("remove", PREFIXES_V4_DUMMY, PREFIXES_V6_INIT),    # Unexisted v4 prefix
-        ("remove", PREFIXES_V4_INIT, PREFIXES_V6_DUMMY)     # Unexisted v6 prefix
+        ("add", 0, "10.256.0.0/16", PREFIXES_V6_DUMMY),        # Invalid v4 prefix
+        ("add", 0, PREFIXES_V4_DUMMY, "fc01:xyz::/64"),        # Invalid v6 prefix
+        ("remove", 1, PREFIXES_V4_DUMMY, PREFIXES_V6_INIT),    # Unexisted v4 prefix
+        ("remove", 1, PREFIXES_V4_INIT, PREFIXES_V6_DUMMY)     # Unexisted v6 prefix
     ]
-    for op, prefixes_v4, prefixes_v6 in xfail_input:
+    for op, index, prefixes_v4, prefixes_v6 in xfail_input:
         json_patch = [
             {
                 "op": op,
-                "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0{}/prefixes_v6/0".format(community_table),
+                "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0{}/prefixes_v6/{}".format(community_table, index),
                 "value": prefixes_v6
             },
             {
                 "op": op,
-                "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0{}/prefixes_v4/0".format(community_table),
+                "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0{}/prefixes_v4/{}".format(community_table, index),
                 "value": prefixes_v4
             }
         ]


### PR DESCRIPTION
### Description of PR

Summary:
Backport the negative-remove index correction from #26865 to the 202605 branch.

Fixes #25549

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

The negative cases for removing nonexistent BGP prefixes used leaf-list index `0`. JSON Patch resolves a `remove` operation by index and ignores its supplied value, so those cases removed the valid prefix instead of exercising an invalid removal. That corrupted the state consumed by later test steps and caused both parameterizations of `test_bgp_prefix_tc1_suite` to fail.

#### How did you do it?

Added the leaf-list index to the negative-test inputs. Invalid add operations continue to use index `0`, while nonexistent remove operations now use out-of-range index `1`.

This is the targeted 202605 portion of #26865. The additional empty-leaf-list coverage from that PR is not included because it depends on accompanying behavior that is not present in the current 202605 image.

#### How did you verify/test it?

- `python -m py_compile tests/generic_config_updater/test_bgp_prefix.py`
- `python -m flake8 --max-line-length=120 tests/generic_config_updater/test_bgp_prefix.py`
- Targeted physical T1 Elastictest run: pretest 12 passed, target module 2 passed, posttest 5 passed; 0 failures and 0 errors

#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

N/A - no new test case.

### Documentation

N/A - test-only change.
