### PR TITLE
[qos] Skip test_qos_probe on Nexthop platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4421,6 +4421,8 @@ qos/test_qos_probe.py:
       - "hwsku in ['Mellanox-SN2700'] and https://github.com/sonic-net/sonic-mgmt/issues/22607"
       # Mellanox SPC3 (Spectrum 3)
       - "hwsku in ['Mellanox-SN4600C-C64'] and https://github.com/sonic-net/sonic-mgmt/issues/22608"
+      # Nexthop (NH-4010 / NH-4210 / NH-4220 / NH-5010)
+      - "platform in ['x86_64-nexthop_4010-r0', 'x86_64-nexthop_4010-r1', 'x86_64-nexthop_4210-r0021', 'x86_64-nexthop_4220-r1021', 'x86_64-nexthop_5010-r0'] and https://github.com/sonic-net/sonic-mgmt/issues/27057"
 
 qos/test_qos_probe.py::TestQosProbe::testQosHeadroomPoolProbe:
   xfail:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4421,8 +4421,8 @@ qos/test_qos_probe.py:
       - "hwsku in ['Mellanox-SN2700'] and https://github.com/sonic-net/sonic-mgmt/issues/22607"
       # Mellanox SPC3 (Spectrum 3)
       - "hwsku in ['Mellanox-SN4600C-C64'] and https://github.com/sonic-net/sonic-mgmt/issues/22608"
-      # Nexthop (NH-4010 / NH-4210 / NH-4220 / NH-5010)
-      - "platform in ['x86_64-nexthop_4010-r0', 'x86_64-nexthop_4010-r1', 'x86_64-nexthop_4210-r0021', 'x86_64-nexthop_4220-r1021', 'x86_64-nexthop_5010-r0'] and https://github.com/sonic-net/sonic-mgmt/issues/27057"
+      # Nexthop (NH-4010 / NH-4210 / NH-4220)
+      - "platform in ['x86_64-nexthop_4010-r0', 'x86_64-nexthop_4010-r1', 'x86_64-nexthop_4210-r0021', 'x86_64-nexthop_4220-r1021'] and https://github.com/sonic-net/sonic-mgmt/issues/27057"
 
 qos/test_qos_probe.py::TestQosProbe::testQosHeadroomPoolProbe:
   xfail:


### PR DESCRIPTION
Buffer threshold probing has not been validated on Nexthop platforms (NH-4010, NH-4210, NH-4220, NH-5010), and test_qos_probe fails there in two distinct ways.

testQosIngressDropProbe converges but the measured probe range falls 0.4-1.2% below the expected pkts_num_trig_ingr_drp derived in qos_sai_base, so assert_probing_result fails. Separately, on NH-4010 all single_asic parameterizations error during setup because testPortIds is empty and qos_sai_base.py:974 calls next(iter(testPortIds)) unconditionally.

Adds a platform condition to the existing qos/test_qos_probe.py skip block, which already uses conditions_logical_operator: or, so the change is additive and does not affect any other platform.

Tracked by #27057 .

### Description of PR

Summary:
Skips `qos/test_qos_probe.py` on Nexthop platforms (NH-4010, NH-4210, NH-4220,
NH-5010) pending platform-specific validation of buffer threshold probing.

Fixes #<27057>

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #<ISSUE>
Failure type: day-one issue

### Tested branch

- [x] master
- [x] 202605

### Test result

- master: <image version> - test_qos_probe collected as skipped on Nexthop platforms
- 202605: <image version> - test_qos_probe collected as skipped on Nexthop platforms

### Approach

#### What is the motivation for this PR?

`test_qos_probe.py` does not pass on any Nexthop platform, in two distinct ways.
`testQosIngressDropProbe` converges but measures a range 0.4-1.2% below the
expected `pkts_num_trig_ingr_drp` derived in `qos_sai_base`. On NH-4010, setup
errors out entirely on an empty `testPortIds` dict. This is the same class of
"probing not yet validated on this ASIC" gap already tracked in this skip block
for Cisco-8000, Broadcom TD3/TH/TH2/TH5, and Mellanox SPC1/SPC3
(#22599, #22601-#22608).

Details and measurements: #<ISSUE>

#### How did you do it?

Added one condition to the existing `qos/test_qos_probe.py` skip block in
`tests_mark_conditions.yaml`. The block already uses
`conditions_logical_operator: or`, so the change is additive and does not affect
any other platform.

#### How did you verify/test it?

YAML parses and the skip block resolves correctly. The new condition evaluates
true for all five Nexthop platform identifiers and false for non-Nexthop
platforms. No existing conditions modified.

#### Any platform specific information?

Applies only to platforms matching `x86_64-nexthop_*`:
`x86_64-nexthop_4010-r0`, `x86_64-nexthop_4010-r1`, `x86_64-nexthop_4210-r0021`,
`x86_64-nexthop_4220-r1021`, `x86_64-nexthop_5010-r0`.

#### Supported testbed topology if it's a new test case?

N/A - no new test case; existing test skipped on unsupported platforms.
Observed on t1-8, ptf8 and t2.

### Documentation

N/A
