### PR TITLE
Pfcwd report undetected pfc storm

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -1306,6 +1306,24 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                 logger.info("--- Stop PFCWD ---")
                 self.dut.command("pfcwd stop")
 
+    def _assert_storm_detected(self, dut, port, queue, action):
+        """Fail naming the real condition when pfcwd never reports the storm."""
+        pytest_assert(
+            wait_until(30, 2, 5, verify_pfc_storm_in_expected_state, dut, port, queue, "storm"),
+            "PFC storm not detected on port {} queue {} within 30s (pfcwd action '{}')".format(
+                port, queue, action))
+
+    @staticmethod
+    def _pfcwd_counter(snap, port, queue, counter):
+        """Read one 'show pfcwd stats' counter, failing clearly when the row is absent.
+
+        The CLI omits all-zero rows, so an empty parse means pfcwd recorded nothing for
+        this queue. Indexing straight into it surfaces an opaque IndexError instead.
+        """
+        pytest_assert(snap, "No 'show pfcwd stats' entry for port {} queue {} - pfcwd recorded "
+                            "no counters for this queue".format(port, queue))
+        return int(snap[0][counter])
+
     def run_pfcwd_storm_with_active_traffic(self, dut, port, action):
         restore_time = self.timers['pfc_wd_restore_time_large']
         # Hardware PFCwd platforms (e.g., Broadcom DNX) cap pfcwd
@@ -1322,22 +1340,16 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             time.sleep(2)
             self.storm_hndle.start_storm()
             # Wait for storm detection
-            pytest_assert(
-                wait_until(30, 2, 5, verify_pfc_storm_in_expected_state,
-                           dut, port, queue, "storm"),
-                "PFC storm was not detected on port {} queue {}".format(port, queue))
-            # Ensure storm is active → wait full polling window → snap
+            self._assert_storm_detected(dut, port, queue, action)
+            # Ensure storm is active -> wait full polling window -> snap
             time.sleep(PFCWD_POLL_WINDOW_SEC)
-            wait_until(30, 2, 5, verify_pfc_storm_in_expected_state,
-                       dut, port, queue, "storm")
+            self._assert_storm_detected(dut, port, queue, action)
             snap1 = parser_show_pfcwd_stat(dut, port, queue)
 
-            # Again: confirm storm → wait poll window → snap
-            wait_until(30, 2, 5, verify_pfc_storm_in_expected_state,
-                       dut, port, queue, "storm")
+            # Again: confirm storm -> wait poll window -> snap
+            self._assert_storm_detected(dut, port, queue, action)
             time.sleep(PFCWD_POLL_WINDOW_SEC)
-            wait_until(30, 2, 5, verify_pfc_storm_in_expected_state,
-                       dut, port, queue, "storm")
+            self._assert_storm_detected(dut, port, queue, action)
             snap2 = parser_show_pfcwd_stat(dut, port, queue)
 
             if dut.facts['asic_type'] != 'vs':
@@ -1350,10 +1362,10 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                     counter = 'storm_detect_count'
                 else:
                     counter = 'tx_drop_count' if action == 'drop' else 'tx_ok_count'
-                val1 = int(snap1[0][counter])
-                val2 = int(snap2[0][counter])
+                val1 = self._pfcwd_counter(snap1, port, queue, counter)
+                val2 = self._pfcwd_counter(snap2, port, queue, counter)
                 logger.info("PFCWD storm traffic check: port={} queue={} counter={} snap1={} snap2={}".format(
-                            port, queue, counter, val1, val2))
+                    port, queue, counter, val1, val2))
                 pytest_assert(val1 > 0, "{} not incrementing after storm on port {} queue {}".format(
                     counter, port, queue))
                 pytest_assert(val2 >= val1, "{} regressed during storm on port {} queue {}".format(
@@ -1362,10 +1374,12 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         finally:
             self.ptf.shell("pkill -f 'pfc_wd.PfcWdTest'", module_ignore_errors=True)
             self.storm_hndle.stop_storm()
-            pytest_assert(
-                wait_until(30, 2, 5, verify_pfc_storm_in_expected_state,
-                           dut, port, queue, "restored"),
-                "PFC storm was not restored on port {} queue {}".format(port, queue))
+            # Warn rather than assert: raising here would mask any exception already
+            # propagating out of the try block above.
+            if not wait_until(30, 2, 5, verify_pfc_storm_in_expected_state,
+                              dut, port, queue, "restored"):
+                logger.warning("PFC storm on port %s queue %s did not restore within 30s "
+                               "after pfcwd action '%s'", port, queue, action)
 
     def test_pfcwd_storm_during_traffic(self, request, setup_pfc_test, manage_lag_config,    # noqa: F811
                                         setup_dut_test_params, enum_fanout_graph_facts, ptfhost,  # noqa: F811


### PR DESCRIPTION
### Description of PR

Summary:
`run_pfcwd_storm_with_active_traffic` fails with an opaque
`IndexError: list index out of range` when PFCwd never reports a storm, instead
of naming the actual condition. This makes the real failure visible.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A - no backport requested

### Tested branch

- [x] master

### Test result

- master: <image version> - test_pfcwd_storm_during_traffic passes; induced a
  missing-storm condition and confirmed the failure message now names the port
  and queue instead of raising IndexError.

### Approach

#### What is the motivation for this PR?

`run_pfcwd_storm_with_active_traffic` has two related blind spots.

Three of its four storm checks call
`wait_until(30, 2, 5, verify_pfc_storm_in_expected_state, ...)` and discard the
return value, so a storm that never forms passes them silently.

It then reads counters with `int(snap1[0][counter])`, where `snap1` comes from
`parser_show_pfcwd_stat()`. `show pfcwd stats` omits all-zero rows, so that parse
is empty whenever PFCwd recorded nothing for the queue under test. The bare `[0]`
raises `IndexError: list index out of range`, which tells you nothing about why
the test failed — the storm was never detected.

#### How did you do it?

Added two small helpers on `TestPfcwdFunc`:

- `_assert_storm_detected()` — wraps the storm check in `pytest_assert` so a
  storm that never forms fails immediately, naming the port, queue, timeout and
  pfcwd action. Replaces all four bare/partially-checked call sites.
- `_pfcwd_counter()` — asserts the stats row exists before indexing it, so an
  empty parse fails with "No 'show pfcwd stats' entry for port X queue Y" rather
  than an `IndexError`.

In the `finally` block, a failed storm restore now logs a warning instead of
asserting. Asserting there can replace an exception already propagating out of
the `try` block, hiding the original failure.

No change to which counter is sampled or to the pass/fail thresholds — the
existing `is_pfcwd_hw_recovery_enabled()` / `storm_detect_count` handling and the
`val2 >= val1` comparison are untouched.

#### How did you verify/test it?

`py_compile` and `flake8 --max-line-length=120` clean. Ran
`test_pfcwd_storm_during_traffic` on master and confirmed it still passes, then
induced a missing-storm condition and confirmed the failure now reports the port
and queue instead of `IndexError`.

#### Any platform specific information?

None. The change is platform-independent — it only improves failure reporting on
a path all platforms share.

#### Supported testbed topology if it's a new test case?

N/A - not a new test case.

### Documentation

N/A