### PR TITLE
fix(arp): align VPP test interface MACs

### DIFF
--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -71,6 +71,7 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     ports = list(sorted(external_ports, key=lambda item: int(item.replace('Ethernet', ''))))
     po1 = None
     po2 = None
+    original_intf_macs = {}
 
     is_storage_backend = 'backend' in tbinfo['topo']['name']
     is_isolated_topo = 'isolated' in tbinfo['topo']['name']
@@ -131,6 +132,15 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
             po1 = get_po(mg_facts, intf1)
             po2 = get_po(mg_facts, intf2)
 
+            if duthost.facts['asic_type'] == 'vpp':
+                for intf in (intf1, intf2):
+                    original_mac = duthost.get_dut_iface_mac(intf)
+                    if not original_mac:
+                        pytest.fail(
+                            "Failed to get MAC address for {}".format(intf)
+                        )
+                    original_intf_macs[intf] = original_mac
+
             if po1:
                 asic.config_portchannel_member(po1, intf1, "del")
                 collect_info(duthost)
@@ -159,11 +169,27 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
         asic.config_ip_intf(intf1, "10.10.1.2/28", "add")
         asic.config_ip_intf(intf2, "10.10.1.20/28", "add")
 
+    if original_intf_macs:
+        # VPP can recreate the Linux LCP tap with a per-port MAC after the
+        # port leaves a LAG. Align it with the router MAC expected by SONiC.
+        router_mac = asic.get_router_mac()
+        for intf in (intf1, intf2):
+            duthost.shell(
+                "sudo ip link set dev {0} address {1}".format(
+                    intf, router_mac
+                )
+            )
+
     yield intf1, intf2, intf1_indice, intf2_indice
 
     if tbinfo['topo']['type'] != 't0':
         asic.config_ip_intf(intf1, "10.10.1.2/28", "remove")
         asic.config_ip_intf(intf2, "10.10.1.20/28", "remove")
+
+    for intf, mac in original_intf_macs.items():
+        duthost.shell(
+            "sudo ip link set dev {0} address {1}".format(intf, mac)
+        )
 
     if tbinfo['topo']['type'] != 't0':
         if po1:


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue): N/A

Fix VPP flakiness in `arp/test_arpall.py::test_arp_unicast_reply`.

Representative failed test plans:
- [6a7c9f43cba07d4884e06b38](https://elastictest.org/scheduler/testplan/6a7c9f43cba07d4884e06b38?searchTestCase=arp&testcase=arp%2Ftest_arpall.py&type=console)
- [6a7c81c21c6297f01e854596](https://elastictest.org/scheduler/testplan/6a7c81c21c6297f01e854596?searchTestCase=arp&testcase=arp%2Ftest_arpall.py&type=console)
- [6a7bbfa719239aa976852b82](https://elastictest.org/scheduler/testplan/6a7bbfa719239aa976852b82?searchTestCase=arp&testcase=arp%2Ftest_arpall.py&type=console)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: Other - VPP-specific test fixture behavior

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- `SONiC.master.1184302-c57e683ce`: the original setup reproduced the unicast ARP failure on the first controlled cycle. Aligning the Linux LCP tap MAC with the router MAC passed 10/10 controlled cycles, and the complete `arp/test_arpall.py` module passed 5/5 cases.
- `SONiC.master.1190446-1658c9049`: the complete `arp/test_arpall.py` module passed 5/5 cases, and the final focused unicast ARP run passed.

### Approach
#### What is the motivation for this PR?

The ARP fixture temporarily removes selected physical interfaces from a LAG and configures them as routed interfaces. On VPP, recreating the Linux LCP tap can assign a per-port MAC address instead of the common router MAC.

`VerifyUnicastARPReply` sends its unicast ARP request to the router MAC. When the Linux tap has a different MAC, the kernel ARP responder does not answer and PTF reports `Expected packet was not received ... 0 total packets`. Broadcast ARP is unaffected, which explains why only the unicast case flakes.

#### How did you do it?

Before changing LAG membership, preserve the selected interfaces' original MAC addresses. After configuring the routed interface IPs, align the VPP Linux LCP tap MACs with the router MAC expected by SONiC and the PTF test. During teardown, restore the original MAC addresses before adding the interfaces back to their PortChannels.

#### How did you verify/test it?

The failure was reproduced deterministically on a VPP image where both the original same-LAG setup and a different-LAG setup failed on their first cycle. Reapplying interface admin-up did not help. The failing state showed the VPP interface using the router MAC while its Linux LCP peer used a different per-port MAC.

Setting the Linux LCP tap MAC to the router MAC changed only that mismatch and passed 10/10 controlled cycles. The complete ARP module then passed on both the deterministic reproducer image and the current master image.

#### Any platform specific information?

The change is limited to VPP. Non-VPP interface selection and MAC handling are unchanged.

#### Supported testbed topology if it's a new test case?

N/A. This is not a new test case. Validation used `t1-lag-vpp`.

### Documentation

N/A. No user-facing documentation change is required.
