### PR TITLE
[platform_tests]: skip additional chassis/module API tests on BMC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1064,6 +1064,12 @@ platform_tests/cli/test_show_platform.py::test_show_platform_firmware_status:
     conditions:
       - "is_multi_asic==True and release in ['201911']"
 
+platform_tests/cli/test_show_platform.py::test_show_platform_pcieinfo:
+  skip:
+    reason: "PCIe info is not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 platform_tests/cli/test_show_platform.py::test_show_platform_psustatus:
   xfail:
     reason: "Testcase consistently fails, raised issue to track"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1051,6 +1051,12 @@ platform_tests/cli/test_show_chassis_module.py::test_show_chassis_module_status:
 #######################################
 #####  cli/test_show_platform.py  #####
 #######################################
+platform_tests/cli/test_show_platform.py::test_show_platform_current:
+  skip:
+    reason: "Current sensor CLI is not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 platform_tests/cli/test_show_platform.py::test_show_platform_fan:
   skip:
     reason: "Unsupported platform API"
@@ -1098,6 +1104,12 @@ platform_tests/cli/test_show_platform.py::test_show_platform_psustatus_json:
       - "platform in ['arm64-elba-asic-flash128-r0']"
       - "'bmc' in topo_type"
 
+platform_tests/cli/test_show_platform.py::test_show_platform_ssdhealth:
+  skip:
+    reason: "SSD health check is not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom:
   xfail:
     reason: "Testcase consistently fails, raised issue to track. Or test case has issue on the t0-isolated-d256u256s2 topo."
@@ -1105,6 +1117,12 @@ platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom:
     conditions:
       - "hwsku in ['Celestica-DX010-C32'] and https://github.com/sonic-net/sonic-mgmt/issues/6518"
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
+
+platform_tests/cli/test_show_platform.py::test_show_platform_voltage:
+  skip:
+    reason: "Voltage sensor CLI is not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
 
 ###############################################
 ## counterpoll/test_counterpoll_watermark.py ##

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -43,7 +43,6 @@ BMC_SKIPPED_CHASSIS_TESTS = {
     "test_get_status",
     "test_get_position_in_parent",
     "test_is_replaceable",
-    "test_components",
     "test_fans",
     "test_fan_drawers",
     "test_psus",

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -35,7 +35,12 @@ pytestmark = [
 REGEX_MAC_ADDRESS = r'^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$'
 REGEX_SERIAL_NUMBER = r'^[A-Za-z0-9\-]+$'
 
+# Chassis API tests that are not available/applicable on BMC topologies
 BMC_SKIPPED_CHASSIS_TESTS = {
+    "test_get_presence",
+    "test_get_model",
+    "test_get_revision",
+    "test_get_status",
     "test_get_position_in_parent",
     "test_is_replaceable",
     "test_components",
@@ -45,6 +50,7 @@ BMC_SKIPPED_CHASSIS_TESTS = {
     "test_thermals",
     "test_sfps",
     "test_status_led",
+    "test_get_thermal_manager",
     "test_get_supervisor_slot",
     "test_get_my_slot",
 }

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -36,6 +36,27 @@ MIDPLANE_SUPP_MODULE = ['SUPERVISOR', 'LINE-CARD']
 
 MODULE_STATUS = ['Empty', 'Offline', 'PoweredDown', 'Present', 'Fault', 'Online']
 
+# Module API tests that are not available/applicable on BMC topologies
+BMC_SKIPPED_MODULE_TESTS = {
+    "test_get_presence",
+    "test_get_model",
+    "test_get_status",
+    "test_get_position_in_parent",
+    "test_is_replaceable",
+    "test_get_base_mac",
+    "test_get_system_eeprom_info",
+    "test_components",
+    "test_fans",
+    "test_psus",
+    "test_thermals",
+    "test_sfps",
+    "test_get_slot",
+    "test_get_type",
+    "test_get_maximum_consumed_power",
+    "test_get_midplane_ip",
+    "test_is_midplane_reachable",
+}
+
 # TODO: EEPROM info is duplicated with chassis.py. Break out into a shared module
 # Valid OCP ONIE TlvInfo EEPROM type codes as defined here:
 # https://opencomputeproject.github.io/onie/design-spec/hw_requirements.html
@@ -62,6 +83,16 @@ class TestModuleApi(PlatformApiTestBase):
     """Platform API test cases for the Module class"""
 
     num_modules = None
+
+    @pytest.fixture(autouse=True)
+    def skip_bmc_blocklisted_tests(self, request, tbinfo):
+        topo_type = (tbinfo.get("topo", {}).get("type") or "").lower()
+        if "bmc" not in topo_type:
+            return
+
+        test_name = request.function.__name__
+        if test_name in BMC_SKIPPED_MODULE_TESTS:
+            pytest.skip("Skipped on BMC: {} is in BMC skip list".format(test_name))
 
     # This fixture would probably be better scoped at the class level, but
     # it relies on the platform_api_conn_per_supervisor fixture, which is scoped at the function


### PR DESCRIPTION
### Description of PR
Summary:

Extends BMC skip coverage for platform tests so that chassis/module platform API tests and `show platform` CLI tests that are not available or applicable on a BMC topology are skipped instead of producing spurious failures.

Changes on `bmc` topologies (`'bmc' in topo_type`):

**`tests/platform_tests/api/test_chassis.py`** — updated `BMC_SKIPPED_CHASSIS_TESTS`:
- Added: `test_get_presence`, `test_get_model`, `test_get_revision`, `test_get_status`, `test_get_thermal_manager`
- Removed: `test_components` (this test is now exercised on BMC)

**`tests/platform_tests/api/test_module.py`** (new) — added `BMC_SKIPPED_MODULE_TESTS` and an `autouse` skip fixture in `TestModuleApi`. Skipped tests:
`test_get_presence`, `test_get_model`, `test_get_status`, `test_get_position_in_parent`, `test_is_replaceable`, `test_get_base_mac`, `test_get_system_eeprom_info`, `test_components`, `test_fans`, `test_psus`, `test_thermals`, `test_sfps`, `test_get_slot`, `test_get_type`, `test_get_maximum_consumed_power`, `test_get_midplane_ip`, `test_is_midplane_reachable`

**`tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml`** — new `conditional_mark` skips for `platform_tests/cli/test_show_platform.py`:
`test_show_platform_current`, `test_show_platform_voltage`, `test_show_platform_pcieinfo`, `test_show_platform_ssdhealth`

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202608

### Approach
#### What is the motivation for this PR?
Several chassis and module platform API tests, and a few `show platform` CLI tests, exercise hardware components (fans, PSUs, thermals, SFPs, midplane, slots, EEPROM, voltage/current sensors, PCIe info, SSD health) that are not available or applicable when running on a BMC topology. Running them there produces spurious failures.

#### How did you do it?
- For `test_chassis.py` and `test_module.py`: an `autouse` fixture in `TestChassisApi` / `TestModuleApi` inspects `tbinfo["topo"]["type"]`. When the type contains `bmc`, tests listed in the per-file BMC skip set are skipped via `pytest.skip`.
- For the `show platform` CLI tests: added `conditional_mark` entries gated on `'bmc' in topo_type`, consistent with the existing BMC skips in the same file.

#### How did you verify/test it?
- `python -m py_compile` / `ast.parse` clean on the modified Python files.
- YAML validated with `yaml.safe_load` on `tests_mark_conditions_platform_tests.yaml`.

#### Any platform specific information?
Only affects topologies whose `type` contains `bmc`; all other topologies are unchanged.

#### Supported testbed topology if it's a new test case?
N/A — test case improvement (skip logic only).

### Documentation
N/A