### PR TITLE
[sanity_check] Skip interface, BGP, and orchagent checks for BMC topology

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -123,6 +123,12 @@ def print_logs(duthosts, ptfhost, print_dual_tor_logs=False, check_ptf_mgmt=True
 def filter_check_items(tbinfo, duthosts, check_items):
     filtered_check_items = copy.deepcopy(check_items)
 
+    # ignore interface, BGP, and orchagent checks for BMC topology
+    if tbinfo["topo"]["type"] == "bmc":
+        for item in ["check_interfaces", "check_bgp", "check_orchagent_usage"]:
+            if item in filtered_check_items:
+                filtered_check_items.remove(item)
+
     # ignore BGP check for particular topology type
     if tbinfo['topo']['type'] == 'ptf' and 'check_bgp' in filtered_check_items:
         filtered_check_items.remove('check_bgp')


### PR DESCRIPTION
### Description of PR

Summary:
Skip `check_interfaces`, `check_bgp`, and `check_orchagent_usage` sanity checks for BMC topology. BMC boards have no physical interfaces, no BGP, and no orchagent (swss disabled), so these checks always fail and make the sanity_check framework unusable on BMC testbeds.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: day-one issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: SONiC.20260810.05 — Ran `test_features.py` with sanity enabled on Nexthop Komodo BMC (arm64-nexthop_b27-r0, NH-B27). Post-test sanity check correctly runs remaining checks (`check_processes`, `check_dbmemory`, `check_monit`, `check_secureboot`, `check_ipv4_mgmt`, `check_ipv6_mgmt`, `check_disk_usage`) and passes. Full `test_pretest.py`: 11 passed, 3 skipped, 0 failures.

### Approach
#### What is the motivation for this PR?
BMC boards run SONiC without a data-plane ASIC — no physical interfaces, no BGP, no orchagent. The sanity check `check_interfaces` fails because there are no ports, `check_bgp` fails because BGP is disabled, and `check_orchagent_usage` fails because swss is not running. This forces BMC test runs to use `--skip_sanity`, losing the benefit of detecting real issues (container crashes, process failures) between test modules.

#### How did you do it?
Added a BMC topology filter in `filter_check_items()`, following the same pattern as the existing PTF filter. When `tbinfo["topo"]["type"] == "bmc"`, the three inapplicable checks are removed from the check list.

#### How did you verify/test it?
1. Ran `test_features.py` without `--skip_sanity` — sanity check passed (only applicable checks ran)
2. Verified post-test sanity detects real issues (e.g., stopped `lldp-syncd` correctly flagged by `check_processes`)
3. Full pretest suite: 11 passed, 3 skipped

#### Any platform specific information?
- arm64-nexthop_b27-r0 (Nexthop Komodo BMC)
- arm64-aspeed_ast2700_evb-r0 (DVT/EVB)

#### Supported testbed topology if it's a new test case?
N/A — this is a bug fix for BMC topology support.

### Documentation
N/A
