### PR TITLE
Adapt dhcp relay stress test to vpp

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -740,9 +740,7 @@ t1-lag-vpp:
   - vxlan/test_vxlan_route_advertisement.py
   - vxlan/test_vnet_route_leak.py
   - vxlan/test_vxlan_crm.py
-  - vxlan/test_vnet_bgp_route_precedence.py
   - vxlan/test_vxlan_multi_tunnel.py
-  - vxlan/test_vxlan_route_advertisement.py
 
 
 t0-vpp:

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -772,6 +772,7 @@ t0-vpp:
   - db_migrator/test_migrate_dns.py
   - decap/test_decap.py
   - dhcp_relay/test_dhcp_relay.py
+  - dhcp_relay/test_dhcp_relay_stress.py
   - disk/test_disk_exhaustion.py
   - dns/test_dns_resolv_conf.py
   - fdb/test_fdb_flush.py

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -120,7 +120,8 @@ def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_du
     """
     testing_mode, duthost = testing_config
     packets_send_duration = 120
-    client_packets_per_sec = 10000
+    is_vpp_kvm = duthost.facts.get("asic_type") == "vpp" and "kvm" in duthost.facts.get("platform", "")
+    client_packets_per_sec = 1000 if is_vpp_kvm else 10000
 
     for dhcp_relay in dut_dhcp_relay_data:
         client_port_name = str(dhcp_relay['client_iface']['name'])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adapt dhcp relay stress test to vpp
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
1. Adapt test_dhcp_relay_stress for vpp kvm platform. Because kvm platform is limited with resource, it can't support the same load in the test as hardware platform. We need to tune down the dhcp relay rate.
2. Also cleaned up duplicate vxlan/test_vnet_bgp_route_precedence.py and vxlan/test_vxlan_route_advertisement.py from t1-lag-vpp list.
#### How did you do it?
Reduce the rate to 1000 from 10000 per/sec for vpp kvm platform.
#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Run t0-vpp sanity
#### Any platform specific information?
vpp specific
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
