### PR TITLE
[link_local]: Fix VLAN port configuration on lit-mode SmartSwitch

### DIFF
--- a/tests/ip/link_local/test_link_local_ip.py
+++ b/tests/ip/link_local/test_link_local_ip.py
@@ -357,6 +357,7 @@ class TestLinkLocalIPacket:
         config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
 
         vlan_member = config_facts.get('VLAN_MEMBER')
+        ports_added = False
         if vlan_member:
             for vlan_interface, vlan_members in vlan_member.items():
                 vlan_id = re.search(r"Vlan(\d+)", vlan_interface).group(1)
@@ -370,7 +371,9 @@ class TestLinkLocalIPacket:
                         cleanup_list.append((duthost.command,
                                              ("config vlan member add {} {} {}".format(vlan_id,
                                                                                        iface, tagging_mode), ), {}))
-        else:
+                    ports_added = True
+                    break
+        if not ports_added:
             for iface in [rx_iface, tx_iface]:
                 duthost.command("config vlan member add {} {} -u".format(VLAN_ID, iface))
                 cleanup_list.append((duthost.command,


### PR DESCRIPTION
```markdown
### Description of PR

Summary:
Fixes test failures in `test_link_local_dst_ipv4_packet` and `test_link_local_dst_ipv6_packet` on lit-mode SmartSwitch devices.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (Microsoft ADO):39059741

Failure type: day-one test issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
Master: 05/05 tests in ip/link_local/test_link_local_ip.py PASSED
202605: 05/05 tests in ip/link_local/test_link_local_ip.py PASSED

### Approach

#### What is the motivation for this PR?

Link-local tests were failing on lit-mode SmartSwitch devices but passing on dark-mode devices. Root cause analysis revealed a logic bug in the `add_vlan_configuration()` function in `tests/ip/link_local/test_link_local_ip.py`.

The bug occurred when:
- Existing VLANs were present in the device config (e.g., VLAN 55 for DPU backplane on lit-mode SmartSwitch)
- The `VLAN_MEMBER` dict was truthy
- But test ports were not members of any existing VLAN
- The `else` branch that adds ports to VLAN 10 never executed
- Result: Test ports were never added to VLAN 10, L2 bridging had no members, 0 packets forwarded, test failed

#### How did you do it?

Modified `add_vlan_configuration()` to use a `ports_added` flag pattern instead of if/else branching:

**Before:**
```python
if vlan_member:
    for vlan_interface, vlan_members in vlan_member.items():
        ...
        if vlan_members.get(rx_iface):
            # move ports to VLAN 10
else:
    # add ports to VLAN 10
```

**After:**
```python
ports_added = False
if vlan_member:
    for vlan_interface, vlan_members in vlan_member.items():
        ...
        if vlan_members.get(rx_iface):
            # move ports to VLAN 10
            ports_added = True
            break
if not ports_added:
    # add ports to VLAN 10
```

This pattern ensures ports are added to VLAN 10 if they weren't found in any existing VLAN, while still handling the case where ports exist in an existing VLAN and need to be moved.

#### How did you verify/test it?

- Verified on dark-mode SmartSwitch: `show vlan brief` shows no VLANs; ports correctly added to VLAN 10
- Verified on lit-mode SmartSwitch: `show vlan brief` shows VLAN 55 (DPU backplane: Ethernet224-248); test ports (Ethernet128/184) correctly added to VLAN 10
- Confirmed all targeted test ports remain oper UP on lit-mode device
- Tests should now pass on both lit-mode and dark-mode SmartSwitch topologies

#### Any platform specific information?

This fix is specific to SmartSwitch devices, particularly those running in lit-mode (DPUs administratively up). Dark-mode SmartSwitch and standard SONiC switches are unaffected by this change.

#### Supported testbed topology if it's a new test case?

SmartSwitch topology (both lit-mode and dark-mode configurations).

### Documentation

No documentation updates required. The fix improves existing test robustness via corrected VLAN configuration logic.
```