### PR TITLE
Fix ipv6 nlri test to work with lt2 topo

### DIFF
--- a/tests/bgp/test_ipv6_nlri_over_ipv4.py
+++ b/tests/bgp/test_ipv6_nlri_over_ipv4.py
@@ -114,10 +114,23 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, request):
 
     dut_namespace = " -n " + namespace if duthost.is_multi_asic else ""
     vtysh_ns = " -n {}".format(asic_index) if duthost.is_multi_asic else ""
-    cmd = "show ipv6 bgp neighbor {} received-routes {}".format(neigh_ip_v6, dut_namespace)
-    dut_received_routes = duthost.shell(cmd, module_ignore_errors=True)['stdout']
-    dut_nlri_routes = parse_dut_received_routes(dut_received_routes)
-    dut_nlri_route = dut_nlri_routes[2]
+    dut_recv_cmd = "show ipv6 bgp neighbor {} received-routes {}".format(neigh_ip_v6, dut_namespace)
+
+    def dut_routes_available(cmd):
+        dut_routes = parse_dut_received_routes(duthost.shell(cmd, module_ignore_errors=True)['stdout'])
+        return len([r for r in dut_routes if r != "::/0"]) >= 1
+
+    pytest_assert(
+        wait_until(180, 10, 0, dut_routes_available, dut_recv_cmd),
+        "DUT didn't receive a non-default IPv6 NLRI route within 180s",
+    )
+    dut_received_routes = duthost.shell(dut_recv_cmd, module_ignore_errors=True)['stdout']
+    # Pick a tracer route that is not default route
+    dut_nlri_routes = [r for r in parse_dut_received_routes(dut_received_routes) if r != "::/0"]
+    if not dut_nlri_routes:
+        pytest.skip("No non-default IPv6 NLRI routes received from {}; cannot pick a "
+                    "tracer route on this topology".format(neigh_name))
+    dut_nlri_route = dut_nlri_routes[0]
     logger.debug("DUT NLRI route: {}".format(dut_nlri_route))
 
     neigh_host = nbrhosts[neigh_name]["host"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Fix bgp.test_ipv6_nlri_over_ipv4::test_nlri to work consistently on lt2 topology. This is a test-hardening fix, not a product regression.



<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
Test bgp.test_ipv6_nlri_over_ipv4::test_nlri failed on setup with `IndexError: list index out of range`. 

#### How did you do it?
The setup module fixture reads the DUT's IPv6 received-routes once, with no convergence wait, and then unconditionally indexes dut_nlri_routes[2] to pick a representative route to track through the test. This results on intermittent failures on runs where BGP had not yet converged. 

Also, select the first non-default received route instead of index [2] to work with UT2 neighbors which announces exactly two IPv6 routes (default and loopback routes). The default route is excluded because multiple UT2s advertise ::/0 simultaneously, making its reappearance inconclusive. On route-scale t2 topologies this picks the same class of fabric route as before; on lt2-min the tracer is the neighbor's uniquely-originated loopback /128, an unambiguous tracer.

Note there is no real requirement why index [2] route needs to be used based on the test logic that is being validated.

#### How did you verify/test it?
Test passes consistently on lt2-min topology.

<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
