### PR TITLE
Adapt test_arp_update to vpp

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -747,9 +747,10 @@ t1-lag-vpp:
 
 t0-vpp:
   - acl/test_acl.py
+  - arp/test_arp_update.py
+  - arp/test_neighbor_mac_aging.py
   - arp/test_neighbor_mac_noptf.py
   - arp/test_tagged_arp.py
-  - arp/test_arp_update.py
   - autorestart/test_container_autorestart.py
   - bgp/test_bgp_command.py
   - bgp/test_bgp_dual_asn.py

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -749,6 +749,7 @@ t0-vpp:
   - acl/test_acl.py
   - arp/test_neighbor_mac_noptf.py
   - arp/test_tagged_arp.py
+  - arp/test_arp_update.py
   - autorestart/test_container_autorestart.py
   - bgp/test_bgp_command.py
   - bgp/test_bgp_dual_asn.py

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -253,8 +253,8 @@ def test_ptf_arp_learns_mac(
         logger.info("DUT VLAN IPv4: {}".format(dut_info['ipv4']))
         # VPP software dataplane does not pad ARP replies to Ethernet minimum frame size
         # and in kvm there is no hardware NIC to pad either
-        no_padding = (dut_info['host'].facts.get('asic_type') == 'vpp' and
-                  'kvm' in dut_info['host'].facts.get('platform', ''))
+        platform_name = dut_info['host'].facts.get('platform', '')
+        no_padding = dut_info['host'].facts.get('asic_type') == 'vpp' and 'kvm' in platform_name
         exp_pktlen = 42 if no_padding else 60
 
         arp_req = testutils.simple_arp_packet(

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -251,6 +251,11 @@ def test_ptf_arp_learns_mac(
     else:
         # IPv4: send ARP request
         logger.info("DUT VLAN IPv4: {}".format(dut_info['ipv4']))
+        # VPP software dataplane does not pad ARP replies to Ethernet minimum frame size
+        # and in kvm there is no hardware NIC to pad either
+        no_padding = (dut_info['host'].facts.get('asic_type') == 'vpp' and
+                  'kvm' in dut_info['host'].facts.get('platform', ''))
+        exp_pktlen = 42 if no_padding else 60
 
         arp_req = testutils.simple_arp_packet(
             pktlen=60,
@@ -265,6 +270,7 @@ def test_ptf_arp_learns_mac(
         )
 
         arp_reply = testutils.simple_arp_packet(
+            pktlen=exp_pktlen,
             eth_dst=ptf_info['mac'],
             eth_src=dut_info['mac'],
             arp_op=2,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adapt test_arp_update to vpp kvm platform
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
test_arp_update.py::test_ptf_arp_learns_mac failed in vpp kvm. This is because vpp software dataplane doesn't pad ARP reply ethernet frame that is smaller than 60 bytes. It relies on hardware NIC when it is sent out to the wire. In t0 KVM test environment, there is no NIC to pad the ethernet frame. The test needs to adapt to it in verifying ARP reply.
#### How did you do it?
for vpp kvm platform, build expected ARP reply packet without padding
#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Run t0 sonic-mgmt test
#### Any platform specific information?
vpp specific
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
