### PR TITLE
[vlan] Skip IP-in-IP check when decap is disabled

### DIFF
--- a/tests/vlan/test_vlan_ports_down.py
+++ b/tests/vlan/test_vlan_ports_down.py
@@ -113,6 +113,14 @@ def test_vlan_ports_down(vlan_ports_setup, duthosts, rand_one_dut_hostname, nbrh
         logger.info("Skipping IP-in-IP decapsulation test: VLAN has no IPv4 address (IPv6-only topology).")
         return
 
+    ip_decap_result = duthost.shell(
+        "sonic-cfggen -d -v 'SYSTEM_DEFAULTS.ip_decap.status'",
+        module_ignore_errors=True
+    )
+    ip_decap_status = ip_decap_result.get("stdout", "").strip().lower()
+    if ip_decap_status == "disabled":
+        pytest.skip("IP-in-IP decapsulation is disabled on this DUT")
+
     logger.info("Starting the IP-in-IP decapsulation test...")
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     if mg_facts["minigraph_portchannels"]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip the IP-in-IP decapsulation portion of
`vlan/test_vlan_ports_down.py::test_vlan_ports_down` when
`SYSTEM_DEFAULTS.ip_decap.status` is explicitly set to disabled.

The VLAN operational-state and BGP advertisement validations continue to
run and report failures normally.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
[Test plan: https://elastictest.org/scheduler/testplan/6a8742d451f39cced790f1ef](https://elastictest.org/scheduler/testplan/6a8746fba4d1c39d04745f9b)
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
`test_vlan_ports_down` validates VLAN operational state, BGP subnet
advertisement, and IP-in-IP decapsulation. Some DUTs intentionally disable
IP-in-IP decapsulation through `SYSTEM_DEFAULTS.ip_decap.status`.

Marking the entire test as xfail could hide regressions in the VLAN and BGP
validations. Only the unsupported decapsulation portion should be skipped.

#### How did you do it?
After completing the VLAN operational-state and BGP advertisement checks,
the test queries:

sonic-cfggen -d -v 'SYSTEM_DEFAULTS.ip_decap.status'

If the returned value is disabled, the test skips the IP-in-IP decapsulation
portion. When the value is enabled or undefined, decapsulation validation
continues normally.

#### How did you verify/test it?
- Validated the updated Python syntax.
- Verified that the decapsulation check is skipped only when
  SYSTEM_DEFAULTS.ip_decap.status is disabled.
- VLAN operational-state and BGP advertisement checks execute before the
  capability check

<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
Applies to these Mellanox lossy-only HwSKUs:
The change is capability-based and is not tied to a specific ASIC, platform,
HwSKU, or device type. It applies to any DUT that explicitly sets
`SYSTEM_DEFAULTS.ip_decap.status` to disabled

#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
