### PR TITLE
Revert "[loganalyzer] Ignore syncd port_serdes_rid lane count information error"

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -522,9 +522,5 @@ r, ".* ERR auditd.*: auditd queue full reporting limit reached - ending dropped 
 r, ".* ERR ctrmgrd\.py: Refer file .* for troubleshooting tips.*"
 r, ".* ERR ctrmgrd\.py:.*\[WARNING SystemVerification\]:.*Docker version is not on the list of validated versions.*"
 
-# syncd port serdes lane count info not available (fixed in https://github.com/sonic-net/sonic-sairedis/pull/1945)
-# tracked by https://github.com/sonic-net/sonic-sairedis/issues/1946
-r, ".* ERR syncd\d*#syncd: :- initAttrData: PORT_PHY_SERDES_ATTR: port_serdes_rid:0x\w+ has no lane count information.*"
-
 # Ignore loganalyzer add marker logs in case the test name matches an error pattern
 r, ".*INFO.*ansible.*loganalyzer.py.*--action add.*marker.*"


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#26932 because the ignored syslog indicates a loss of Port PHY SerDes telemetry and should not be suppressed community-wide. 

The workaround will instead be maintained internally, scoped to Broadcom TH5 on SONiC 202511 while sonic-net/sonic-sairedis#1946 is worked upon with Broadcom CSP.