### PR TITLE
`test_qos_probe.py`: use dynamically_compensate_leakout

### DIFF
--- a/tests/saitests/probe/buffer_occupancy_controller.py
+++ b/tests/saitests/probe/buffer_occupancy_controller.py
@@ -148,7 +148,7 @@ class BufferOccupancyController:
         count: int = 1,
         auto_restore: bool = True,
         **traffic_keys
-    ) -> None:
+    ) -> str:
         """
         Send traffic from src_port to dst_port with automatic buffer restoration.
 
@@ -181,6 +181,8 @@ class BufferOccupancyController:
         if self.is_buffer_held(dst_port_id):
             key = (src_port_id, dst_port_id, frozenset(traffic_keys.items()))
             self._actual_cached_packets[key] = self._actual_cached_packets.get(key, 0) + count
+
+         return pkt
 
     def persist_buffer_occupancy(
         self,

--- a/tests/saitests/probe/ingress_drop_probing_executor.py
+++ b/tests/saitests/probe/ingress_drop_probing_executor.py
@@ -46,6 +46,7 @@ try:
     import os
     parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     sys.path.insert(0, os.path.join(parent_dir, 'py3'))
+    from sai_qos_tests import dynamically_compensate_leakout, check_leackout_compensation_support, TRANSMITTED_PKTS
     try:
         from sai_qos_tests import PORT_TX_CTRL_DELAY, PFC_TRIGGER_DELAY, INGRESS_DROP, INGRESS_PORT_BUFFER_DROP
     except ImportError:
@@ -179,6 +180,10 @@ class IngressDropProbingExecutor:
                     time.sleep(PORT_TX_CTRL_DELAY)
 
                 # ===== Step 2: Baseline measurement =====
+                xmit_counters_base, _ = sai_thrift_read_port_counters(
+                    self.ptftest.dst_client,
+                    self.ptftest.asic_type,
+                    port_list['dst'][dst_port])
                 if self.counter_mode == 'pg_drop':
                     # Level 1: Per-PG drop counter via sai_thrift_read_pg_drop_counters
                     # Reads PG-specific drop count; noise-immune, most precise
@@ -209,13 +214,22 @@ class IngressDropProbingExecutor:
 
                 # ===== Step 3: Traffic injection =====
                 # Send 'value' packets (currently 64-byte = 1 cell each)
+                pkt = None
                 if value > 0:
-                    self.ptftest.buffer_ctrl.send_traffic(src_port, dst_port, value, **traffic_keys)
+                    pkt = self.ptftest.buffer_ctrl.send_traffic(src_port, dst_port, value, **traffic_keys)
 
                 # ===== Step 4: Wait for counter refresh =====
                 time.sleep(PFC_TRIGGER_DELAY)
 
-                # ===== Step 5: Ingress Drop detection =====
+                # ===== Step 5: Check for leakout packets =====
+                if check_leackout_compensation_support(self.ptftest.asic_type, self.ptftest.hwsku) and pkt:
+                    dynamically_compensate_leakout(self.ptftest.dst_client, self.ptftest.asic_type, sai_thrift_read_port_counters,
+                                                   port_list['dst'][dst_port], TRANSMITTED_PKTS,
+                                                   xmit_counters_base, self.ptftest, src_port, pkt, 10)
+                    # ===== Step 5.1: Wait for counter refresh =====
+                    time.sleep(PFC_TRIGGER_DELAY)
+
+                # ===== Step 6: Ingress Drop detection =====
                 if self.counter_mode == 'pg_drop':
                     # Level 1: sai_thrift_read_pg_drop_counters (per-PG, noise-immune)
                     pg_drop_curr = sai_thrift_read_pg_drop_counters(

--- a/tests/saitests/probe/pfc_xoff_probing_executor.py
+++ b/tests/saitests/probe/pfc_xoff_probing_executor.py
@@ -40,6 +40,7 @@ try:
     import os
     parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     sys.path.insert(0, os.path.join(parent_dir, 'py3'))
+    from sai_qos_tests import dynamically_compensate_leakout, check_leackout_compensation_support, TRANSMITTED_PKTS
     try:
         from sai_qos_tests import PORT_TX_CTRL_DELAY, PFC_TRIGGER_DELAY
     except ImportError:
@@ -197,6 +198,10 @@ class PfcXoffProbingExecutor:
                         send_count = max(0, value + pkts_num_leak_out - 1)
 
                 # ===== Step 2: Baseline measurement =====
+                xmit_counters_base, _ = sai_thrift_read_port_counters(
+                    self.ptftest.dst_client,
+                    self.ptftest.asic_type,
+                    port_list['dst'][dst_port])
                 sport_cnt_base, _ = sai_thrift_read_port_counters(
                     self.ptftest.src_client,
                     self.ptftest.asic_type,
@@ -204,13 +209,22 @@ class PfcXoffProbingExecutor:
                 )
 
                 # ===== Step 3: Traffic injection =====
+                pkt = None
                 if send_count > 0:
-                    self.ptftest.buffer_ctrl.send_traffic(src_port, dst_port, send_count, **traffic_keys)
+                    pkt = self.ptftest.buffer_ctrl.send_traffic(src_port, dst_port, send_count, **traffic_keys)
 
                 # ===== Step 4: Wait for counter refresh =====
                 time.sleep(PFC_TRIGGER_DELAY)
 
-                # ===== Step 5: PFC Xoff detection =====
+                # ===== Step 5: Check for leakout packets =====
+                if check_leackout_compensation_support(self.ptftest.asic_type, self.ptftest.hwsku) and pkt:
+                    dynamically_compensate_leakout(self.ptftest.dst_client, self.ptftest.asic_type, sai_thrift_read_port_counters,
+                                                   port_list['dst'][dst_port], TRANSMITTED_PKTS,
+                                                   xmit_counters_base, self.ptftest, src_port, pkt, 10)
+                    # ===== Step 5.1: Wait for counter refresh =====
+                    time.sleep(PFC_TRIGGER_DELAY)
+
+                # ===== Step 6: PFC Xoff detection =====
                 sport_cnt_curr, _ = sai_thrift_read_port_counters(
                     self.ptftest.src_client,
                     self.ptftest.asic_type,


### PR DESCRIPTION
### Description of PR
In test_qos_probe.py it tries to figure out the right amount of packets for things like xoff and ingress drop but it doesn't account for the leakout packets on broadcom devices. This change adds that support.

Summary:
Fixes #27076 

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- 202605: Some subsequent issues still seen on Broadcom devices in this test, need to investigate

### Approach
#### What is the motivation for this PR?
We need to handle the leakout packets on broadcom devices if we want to accurately estimate the xoff and ingress drop packet count

#### How did you do it?
Reuse the `dynamically_compensate_leakout` function used by test_qos_sai.py

#### How did you verify/test it?
Ran the tests `testQosPfcXoffProbe` and `testQosIngressDropProbe` and see they pass on broadcom devices.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
