### PR TITLE
Dom basic tc4

### DIFF
--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -23,6 +23,7 @@ from tests.transceiver.common.db_helpers import (
 logger = logging.getLogger(__name__)
 
 STATE_DB_SENSOR_TABLE = "TRANSCEIVER_DOM_SENSOR"
+STATE_DB_STATUS_TABLE = "TRANSCEIVER_STATUS"
 STATE_DB_THRESHOLD_TABLE = "TRANSCEIVER_DOM_THRESHOLD"
 
 OPERATIONAL_SUFFIX = "_operational_range"
@@ -489,6 +490,11 @@ def _read_dom_table_data(duthost, ports, table_name):
 def read_dom_sensor_data(duthost, ports):
     """Return ``({port: {field: value}}, errors)`` for current DOM sensor data."""
     return _read_dom_table_data(duthost, ports, STATE_DB_SENSOR_TABLE)
+
+
+def read_dom_status_data(duthost, ports):
+    """Return ``({port: {field: value}}, errors)`` for current transceiver status data."""
+    return _read_dom_table_data(duthost, ports, STATE_DB_STATUS_TABLE)
 
 
 def read_dom_threshold_data(duthost, ports):

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -178,7 +178,7 @@ def _operational_attr_for_threshold(attr_name):
     return THRESHOLD_TO_OPERATIONAL_ATTR.get(base_name)
 
 
-def build_dom_availability_plan(port_attributes_dict, dom_primary_ports, lport_to_first_subport_mapping):
+def build_dom_sensor_plan(port_attributes_dict, dom_primary_ports, lport_to_first_subport_mapping):
     """Return each port's expected DOM fields, active lanes, errors, and age limit.
 
     ``expected_fields`` is a ``{field: DomMappedField(source_attr, attr_value)}``
@@ -321,7 +321,7 @@ def format_dom_port_failure(
     field_label="expected field(s)",
 ):
     """Prefix a port's failure block with its expected shape."""
-    lane_context = "" if active_lanes is None else ", lanes {}".format(active_lanes or "none")
+    lane_context = "" if active_lanes is None else ", media lanes {}".format(active_lanes or "none")
     return "{} [{} {}{}]:\n  {}".format(
         port,
         len(expected_fields),
@@ -396,7 +396,7 @@ def validate_dom_plan_fields(
             continue
 
         freshness_age_min = None
-        if max_age_min is not None and (has_field_checks or include_freshness_only):
+        if max_age_min is not None:
             if now_utc is None:
                 now_utc = duthost.get_now_time(utc_timezone=True)
             freshness_result = check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -23,11 +23,33 @@ from tests.transceiver.common.db_helpers import (
 logger = logging.getLogger(__name__)
 
 STATE_DB_SENSOR_TABLE = "TRANSCEIVER_DOM_SENSOR"
+STATE_DB_THRESHOLD_TABLE = "TRANSCEIVER_DOM_THRESHOLD"
 
 OPERATIONAL_SUFFIX = "_operational_range"
+THRESHOLD_SUFFIX = "_threshold_range"
 LANE_NUM_PLACEHOLDER = "LANE_NUM"
 MEDIA_LANE_MASK_KEY = "media_lane_mask"
 DomMappedField = namedtuple("DomMappedField", ("source_attr", "attr_value"))
+DomThresholdMappedField = namedtuple("DomThresholdMappedField", ("source_attr", "attr_value", "threshold_key"))
+
+THRESHOLD_FIELD_SUFFIXES = ("lowalarm", "lowwarning", "highwarning", "highalarm")
+THRESHOLD_FIELD_PREFIXES = {
+    "temperature": "temp",
+    "voltage": "vcc",
+    "laser_temperature": "lasertemp",
+    "tx_bias": "txbias",
+    "tx_power": "txpower",
+    "rx_power": "rxpower",
+}
+THRESHOLD_TO_OPERATIONAL_ATTR = {
+    "temperature": "temperature_operational_range",
+    "voltage": "voltage_operational_range",
+    "laser_temperature": "laser_temperature_operational_range",
+    "tx_bias": "txLANE_NUMbias_operational_range",
+    "tx_power": "txLANE_NUMpower_operational_range",
+    "rx_power": "rxLANE_NUMpower_operational_range",
+}
+THRESHOLD_VALUE_TOLERANCE = 0.01
 
 DOM_POLLING_ENABLED_VALUES = ("", "enabled")
 DOM_POLLING_DISABLED_VALUE = "disabled"
@@ -117,15 +139,43 @@ DOM_FIELD_MAPPERS = (
 def map_dom_attribute_to_fields(attr_name, attr_value, active_media_lanes):
     """Map one DOM attribute to current STATE_DB field metadata.
 
-    The suffix dispatch is DOM-local: TC1/TC2 use the operational mapper today,
-    and future threshold/consistency families can add their own mapper here
-    without duplicating the LANE_NUM expansion path.
+    The suffix dispatch is DOM-local. TC1/TC2 use this operational mapper for
+    ``TRANSCEIVER_DOM_SENSOR``; TC3 uses separate threshold helpers because
+    ``TRANSCEIVER_DOM_THRESHOLD`` is transceiver-level and does not expand
+    LANE_NUM.
     """
     for suffix, mapper in DOM_FIELD_MAPPERS:
         if attr_name.endswith(suffix):
             return mapper(attr_name, attr_value, active_media_lanes)
     logger.debug("DOM attribute %s matched no field mapper; skipped", attr_name)
     return {}, []
+
+
+def map_dom_threshold_attribute_to_fields(attr_name, attr_value):
+    """Return ``({field: DomThresholdMappedField(source_attr, attr_value, threshold_key)}, errors)``."""
+    if not attr_name.endswith(THRESHOLD_SUFFIX):
+        logger.debug("DOM attribute %s is not a threshold range; skipped", attr_name)
+        return {}, []
+
+    base_name = attr_name[:-len(THRESHOLD_SUFFIX)]
+    prefix = THRESHOLD_FIELD_PREFIXES.get(base_name)
+    if prefix is None:
+        return {}, ["{} has no DOM threshold field mapping".format(attr_name)]
+
+    return {
+        "{}{}".format(prefix, suffix): DomThresholdMappedField(
+            attr_name,
+            attr_value,
+            suffix,
+        )
+        for suffix in THRESHOLD_FIELD_SUFFIXES
+    }, []
+
+
+def _operational_attr_for_threshold(attr_name):
+    """Return the configured operational-range attribute paired with a threshold attribute."""
+    base_name = attr_name[:-len(THRESHOLD_SUFFIX)]
+    return THRESHOLD_TO_OPERATIONAL_ATTR.get(base_name)
 
 
 def build_dom_availability_plan(port_attributes_dict, dom_primary_ports, lport_to_first_subport_mapping):
@@ -167,6 +217,55 @@ def build_dom_availability_plan(port_attributes_dict, dom_primary_ports, lport_t
             len(expected_fields),
             active_media_lanes or "none",
             dom_attrs.get("data_max_age_min"),
+        )
+
+    return plan_by_port
+
+
+def build_dom_threshold_plan(port_attributes_dict, dom_primary_ports):
+    """Return each port's expected threshold fields and paired operational ranges.
+
+    ``expected_fields`` is a ``{field: DomThresholdMappedField(...)}`` map for
+    ``TRANSCEIVER_DOM_THRESHOLD``. Threshold validation is transceiver-level, so
+    no LANE_NUM expansion is applied here.
+    """
+    plan_by_port = {}
+    for port in dom_primary_ports:
+        dom_attrs = port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {})
+        expected_fields = {}
+        threshold_attrs = {}
+        operational_ranges = {}
+        errors = []
+
+        for attr_name, attr_value in sorted(dom_attrs.items()):
+            if not attr_name.endswith(THRESHOLD_SUFFIX):
+                continue
+
+            threshold_attrs[attr_name] = attr_value
+            mapped_fields, field_errors = map_dom_threshold_attribute_to_fields(attr_name, attr_value)
+            expected_fields.update(mapped_fields)
+            errors.extend(field_errors)
+
+            operational_attr = _operational_attr_for_threshold(attr_name)
+            if operational_attr in dom_attrs:
+                operational_ranges[attr_name] = DomMappedField(
+                    operational_attr,
+                    dom_attrs[operational_attr],
+                )
+
+        plan_by_port[port] = {
+            "expected_fields": {field: expected_fields[field] for field in sorted(expected_fields)},
+            "threshold_attrs": threshold_attrs,
+            "operational_ranges": operational_ranges,
+            "errors": errors,
+        }
+        logger.debug(
+            "%s DOM threshold plan: %d expected field(s), %d threshold attr(s), "
+            "%d paired operational range attr(s)",
+            port,
+            len(expected_fields),
+            len(threshold_attrs),
+            len(operational_ranges),
         )
 
     return plan_by_port
@@ -214,12 +313,20 @@ def format_optional_float(value):
     return "{:.2f}".format(value) if value is not None else "not-available"
 
 
-def format_dom_port_failure(port, active_lanes, expected_fields, field_failures):
+def format_dom_port_failure(
+    port,
+    active_lanes,
+    expected_fields,
+    field_failures,
+    field_label="expected field(s)",
+):
     """Prefix a port's failure block with its expected shape."""
-    return "{} [{} expected field(s), lanes {}]:\n  {}".format(
+    lane_context = "" if active_lanes is None else ", lanes {}".format(active_lanes or "none")
+    return "{} [{} {}{}]:\n  {}".format(
         port,
         len(expected_fields),
-        active_lanes or "none",
+        field_label,
+        lane_context,
         "\n  ".join(field_failures),
     )
 
@@ -337,10 +444,10 @@ def validate_dom_plan_fields(
     return failures, checked_field_count, checked_port_count
 
 
-def read_dom_sensor_data(duthost, ports):
-    """Return ``({port: {field: value}}, errors)`` for current DOM sensor data."""
+def _read_dom_table_data(duthost, ports, table_name):
+    """Return ``({port: {field: value}}, errors)`` for a current DOM STATE_DB table."""
     ports = list(ports)
-    sensor_data = {port: {} for port in ports}
+    table_data_by_port = {port: {} for port in ports}
     errors = []
     ports_by_namespace = defaultdict(list)
 
@@ -349,15 +456,15 @@ def read_dom_sensor_data(duthost, ports):
         ports_by_namespace[namespace].append(port)
 
     for namespace, namespace_ports in ports_by_namespace.items():
-        sensor_table, err = get_state_db_table(
+        dom_table, err = get_state_db_table(
             duthost,
-            STATE_DB_SENSOR_TABLE,
+            table_name,
             namespace=namespace,
         )
         if err:
             errors.append(
                 "{} namespace {}: {}".format(
-                    STATE_DB_SENSOR_TABLE,
+                    table_name,
                     namespace or "default",
                     err,
                 )
@@ -365,17 +472,28 @@ def read_dom_sensor_data(duthost, ports):
             continue
 
         for port in namespace_ports:
-            sensor_data[port] = sensor_table.get(port, {}) or {}
+            table_data_by_port[port] = dom_table.get(port, {}) or {}
 
     logger.debug(
-        "Read DOM sensor data for %d port(s) across %d namespace(s); "
+        "Read %s data for %d port(s) across %d namespace(s); "
         "%d port(s) returned data",
+        table_name,
         len(ports),
         len(ports_by_namespace),
-        sum(1 for port_data in sensor_data.values() if port_data),
+        sum(1 for port_data in table_data_by_port.values() if port_data),
     )
 
-    return sensor_data, errors
+    return table_data_by_port, errors
+
+
+def read_dom_sensor_data(duthost, ports):
+    """Return ``({port: {field: value}}, errors)`` for current DOM sensor data."""
+    return _read_dom_table_data(duthost, ports, STATE_DB_SENSOR_TABLE)
+
+
+def read_dom_threshold_data(duthost, ports):
+    """Return ``({port: {field: value}}, errors)`` for current DOM threshold data."""
+    return _read_dom_table_data(duthost, ports, STATE_DB_THRESHOLD_TABLE)
 
 
 def check_dom_sensor_freshness(sensor_data, max_age_min, now_utc):

--- a/tests/transceiver/dom/test_dom_availability.py
+++ b/tests/transceiver/dom/test_dom_availability.py
@@ -6,7 +6,7 @@ from natsort import natsorted
 
 from tests.transceiver.common.db_helpers import parse_numeric
 from tests.transceiver.dom.dom_helpers import (
-    build_dom_availability_plan,
+    build_dom_sensor_plan,
     read_dom_sensor_data,
     validate_dom_plan_fields,
 )
@@ -59,7 +59,7 @@ def test_dom_data_availability_verification(
     """Verify configured DOM sensor data is present and fresh in STATE_DB."""
     sensor_ports = natsorted(set(dom_primary_ports) | set(dom_non_primary_ports))
     sensor_by_port, sensor_read_errors = read_dom_sensor_data(duthost, sensor_ports)
-    availability_plan_by_port = build_dom_availability_plan(
+    sensor_plan_by_port = build_dom_sensor_plan(
         port_attributes_dict,
         dom_primary_ports,
         lport_to_first_subport_mapping,
@@ -70,7 +70,7 @@ def test_dom_data_availability_verification(
         duthost,
         dom_primary_ports,
         sensor_by_port,
-        availability_plan_by_port,
+        sensor_plan_by_port,
         _availability_field_check,
         include_freshness_only=True,
     )

--- a/tests/transceiver/dom/test_dom_consistency.py
+++ b/tests/transceiver/dom/test_dom_consistency.py
@@ -1,0 +1,570 @@
+import logging
+import math
+import time
+
+import pytest
+
+from tests.transceiver.attribute_parser.attribute_keys import DOM_ATTRIBUTES_KEY
+from tests.transceiver.common.db_helpers import (
+    STATE_DB_UPDATE_TIME_FIELD,
+    parse_numeric,
+    parse_update_time,
+)
+from tests.transceiver.dom.dom_helpers import (
+    STATE_DB_SENSOR_TABLE,
+    build_dom_sensor_plan,
+    format_dom_port_failure,
+    read_dom_sensor_data,
+    read_dom_status_data,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONSISTENCY_CHECK_POLL_COUNT = 3
+DEFAULT_MAX_UPDATE_TIME_SEC = 60
+TX_BIAS_THRESHOLD_ATTR = "tx_bias_threshold_range"
+DP_ACTIVATED_VALUES = ("DPActivated", "DataPathActivated")
+
+ABSOLUTE_CONSISTENCY_FIELDS = {
+    "temperature_consistency_variation_threshold": ("temperature", "C"),
+    "voltage_consistency_variation_threshold": ("voltage", "V"),
+    "laser_temperature_consistency_variation_threshold": ("laser_temperature", "C"),
+}
+LANE_CONSISTENCY_FIELDS = {
+    "tx_power_consistency_variation_threshold": ("tx{}power", "dB", "absolute"),
+    "rx_power_consistency_variation_threshold": ("rx{}power", "dB", "absolute"),
+    "tx_bias_consistency_variation_threshold": ("tx{}bias", "percent", "percent"),
+}
+
+
+def _parse_positive_int(attr_name, raw_value, default_value, minimum):
+    """Return ``(value, error)`` for positive integer DOM timing attributes."""
+    if raw_value is None:
+        return default_value, None
+
+    value = parse_numeric(raw_value)
+    if value is None or not math.isfinite(value) or int(value) != value or value < minimum:
+        return None, "{} must be an integer >= {} in DOM_ATTRIBUTES (got {!r})".format(
+            attr_name,
+            minimum,
+            raw_value,
+        )
+    return int(value), None
+
+
+def _parse_non_negative_threshold(attr_name, raw_value):
+    """Return ``(threshold, error)`` for configured consistency thresholds."""
+    value = parse_numeric(raw_value)
+    if value is None or not math.isfinite(value) or value < 0:
+        return None, "{} must be a finite non-negative number in DOM_ATTRIBUTES (got {!r})".format(
+            attr_name,
+            raw_value,
+        )
+    return value, None
+
+
+def _parse_tx_bias_warning_range(dom_attrs):
+    """Return ``(lowwarning, highwarning, reason)`` for Tx-bias percentage gating."""
+    attr_value = dom_attrs.get(TX_BIAS_THRESHOLD_ATTR)
+    if not isinstance(attr_value, dict):
+        return None, None, "{} not configured as a dict".format(TX_BIAS_THRESHOLD_ATTR)
+
+    lowwarning = parse_numeric(attr_value.get("lowwarning"))
+    highwarning = parse_numeric(attr_value.get("highwarning"))
+    if (
+        lowwarning is None
+        or highwarning is None
+        or not math.isfinite(lowwarning)
+        or not math.isfinite(highwarning)
+        or lowwarning > highwarning
+    ):
+        return None, None, "{} has no valid lowwarning/highwarning range".format(TX_BIAS_THRESHOLD_ATTR)
+
+    return lowwarning, highwarning, None
+
+
+def _build_dom_consistency_plan(port_attributes_dict, dom_primary_ports, sensor_plan_by_port):
+    """Build per-port TC4 timing and field-variation checks from DOM attributes."""
+    plan_by_port = {}
+    for port in dom_primary_ports:
+        dom_attrs = port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {})
+        sensor_plan = sensor_plan_by_port.get(port, {})
+        active_lanes = sensor_plan.get("active_media_lanes", [])
+        errors = []
+        field_checks = {}
+
+        poll_count, poll_count_error = _parse_positive_int(
+            "consistency_check_poll_count",
+            dom_attrs.get("consistency_check_poll_count"),
+            DEFAULT_CONSISTENCY_CHECK_POLL_COUNT,
+            minimum=2,
+        )
+        if poll_count_error:
+            errors.append(poll_count_error)
+            poll_count = DEFAULT_CONSISTENCY_CHECK_POLL_COUNT
+
+        update_interval_sec, update_interval_error = _parse_positive_int(
+            "max_update_time_sec",
+            dom_attrs.get("max_update_time_sec"),
+            DEFAULT_MAX_UPDATE_TIME_SEC,
+            minimum=1,
+        )
+        if update_interval_error:
+            errors.append(update_interval_error)
+            update_interval_sec = DEFAULT_MAX_UPDATE_TIME_SEC
+
+        for attr_name, (field, unit) in sorted(ABSOLUTE_CONSISTENCY_FIELDS.items()):
+            if attr_name not in dom_attrs:
+                continue
+            threshold, threshold_error = _parse_non_negative_threshold(attr_name, dom_attrs[attr_name])
+            if threshold_error:
+                errors.append(threshold_error)
+                continue
+            field_checks[field] = {
+                "source_attr": attr_name,
+                "threshold": threshold,
+                "mode": "absolute",
+                "unit": unit,
+            }
+
+        has_lane_checks = any(attr_name in dom_attrs for attr_name in LANE_CONSISTENCY_FIELDS)
+        if has_lane_checks and sensor_plan.get("errors"):
+            errors.extend(sensor_plan.get("errors", []))
+
+        for attr_name, (field_template, unit, mode) in sorted(LANE_CONSISTENCY_FIELDS.items()):
+            if attr_name not in dom_attrs:
+                continue
+            threshold, threshold_error = _parse_non_negative_threshold(attr_name, dom_attrs[attr_name])
+            if threshold_error:
+                errors.append(threshold_error)
+                continue
+            if not active_lanes:
+                errors.append("{} configured but no active media lanes resolved".format(attr_name))
+                continue
+
+            lowwarning = highwarning = warning_range_error = None
+            if mode == "percent":
+                lowwarning, highwarning, warning_range_error = _parse_tx_bias_warning_range(dom_attrs)
+
+            for lane in active_lanes:
+                field_checks[field_template.format(lane)] = {
+                    "source_attr": attr_name,
+                    "threshold": threshold,
+                    "mode": mode,
+                    "unit": unit,
+                    "lane": lane,
+                    "warning_low": lowwarning,
+                    "warning_high": highwarning,
+                    "warning_range_error": warning_range_error,
+                }
+
+        plan_by_port[port] = {
+            "active_media_lanes": active_lanes,
+            "errors": errors,
+            "field_checks": {field: field_checks[field] for field in sorted(field_checks)},
+            "poll_count": poll_count,
+            "update_interval_sec": update_interval_sec,
+        }
+        logger.debug(
+            "%s DOM consistency plan: poll_count=%s update_interval_sec=%s "
+            "field_checks=%s active_media_lanes=%s",
+            port,
+            poll_count,
+            update_interval_sec,
+            sorted(field_checks),
+            active_lanes or "none",
+        )
+
+    return plan_by_port
+
+
+def _collect_dom_samples(duthost, dom_primary_ports, sample_count, interval_sec, read_status):
+    """Read DOM sensor/status samples with a fixed interval between samples."""
+    samples = []
+    for sample_index in range(sample_count):
+        sensor_by_port, sensor_errors = read_dom_sensor_data(duthost, dom_primary_ports)
+        status_by_port = {}
+        status_errors = []
+        if read_status:
+            status_by_port, status_errors = read_dom_status_data(duthost, dom_primary_ports)
+        samples.append(
+            {
+                "sensor_by_port": sensor_by_port,
+                "status_by_port": status_by_port,
+                "sensor_errors": sensor_errors,
+                "status_errors": status_errors,
+            }
+        )
+        logger.debug("Collected DOM consistency sample %d/%d", sample_index + 1, sample_count)
+        if sample_index + 1 < sample_count:
+            time.sleep(interval_sec)
+    return samples
+
+
+def _sensor_sample_for_port(samples, sample_index, port):
+    return samples[sample_index]["sensor_by_port"].get(port, {}) or {}
+
+
+def _status_sample_for_port(samples, sample_index, port):
+    return samples[sample_index]["status_by_port"].get(port, {}) or {}
+
+
+def _validate_last_update_time(port, samples, poll_count):
+    """Validate last_update_time exists and advances between TC4 samples."""
+    failures = []
+    parsed_times = []
+
+    for sample_index in range(poll_count):
+        sensor_data = _sensor_sample_for_port(samples, sample_index, port)
+        if not sensor_data:
+            failures.append(
+                "sample {}: no {} entry published for port".format(
+                    sample_index + 1,
+                    STATE_DB_SENSOR_TABLE,
+                )
+            )
+            parsed_times.append(None)
+            continue
+
+        raw_update_time = sensor_data.get(STATE_DB_UPDATE_TIME_FIELD)
+        parsed_time = parse_update_time(raw_update_time)
+        if parsed_time is None:
+            failures.append(
+                "sample {}: {} missing or unparsable (raw={!r})".format(
+                    sample_index + 1,
+                    STATE_DB_UPDATE_TIME_FIELD,
+                    raw_update_time,
+                )
+            )
+        parsed_times.append(parsed_time)
+
+    for sample_index in range(1, poll_count):
+        previous_time = parsed_times[sample_index - 1]
+        current_time = parsed_times[sample_index]
+        if previous_time is None or current_time is None:
+            continue
+        if current_time <= previous_time:
+            failures.append(
+                "{} did not advance between sample {} and {} (prev={!r}, curr={!r})".format(
+                    STATE_DB_UPDATE_TIME_FIELD,
+                    sample_index,
+                    sample_index + 1,
+                    _sensor_sample_for_port(samples, sample_index - 1, port).get(STATE_DB_UPDATE_TIME_FIELD),
+                    _sensor_sample_for_port(samples, sample_index, port).get(STATE_DB_UPDATE_TIME_FIELD),
+                )
+            )
+
+    return failures
+
+
+def _numeric_sensor_value(sensor_data, field):
+    value = parse_numeric(sensor_data.get(field))
+    if value is None or not math.isfinite(value):
+        return None
+    return value
+
+
+def _dp_state_activated(status_data, lane):
+    return status_data.get("DP{}State".format(lane)) in DP_ACTIVATED_VALUES
+
+
+def _validate_absolute_delta(port, field, check, previous_sensor, current_sensor, sample_index):
+    previous_value = _numeric_sensor_value(previous_sensor, field)
+    current_value = _numeric_sensor_value(current_sensor, field)
+    if previous_value is None or current_value is None:
+        return (
+            "{} sample {}->{}: missing/non-finite value (prev={!r}, curr={!r})".format(
+                field,
+                sample_index,
+                sample_index + 1,
+                previous_sensor.get(field),
+                current_sensor.get(field),
+            )
+        )
+
+    delta = abs(current_value - previous_value)
+    if delta > check["threshold"]:
+        return (
+            "{} sample {}->{} delta {}{} exceeds {}{} "
+            "(prev={}, curr={})".format(
+                field,
+                sample_index,
+                sample_index + 1,
+                delta,
+                check["unit"],
+                check["threshold"],
+                check["unit"],
+                previous_value,
+                current_value,
+            )
+        )
+
+    logger.debug(
+        "DOM consistency PASS %s %s sample %d->%d: delta=%s%s limit=%s%s",
+        port,
+        field,
+        sample_index,
+        sample_index + 1,
+        delta,
+        check["unit"],
+        check["threshold"],
+        check["unit"],
+    )
+    return None
+
+
+def _tx_bias_skip_reason(field, check, previous_sensor, current_sensor, previous_status, current_status):
+    if check.get("warning_range_error"):
+        return check["warning_range_error"]
+
+    lane = check["lane"]
+    previous_state = previous_status.get("DP{}State".format(lane))
+    current_state = current_status.get("DP{}State".format(lane))
+    if not (_dp_state_activated(previous_status, lane) and _dp_state_activated(current_status, lane)):
+        return "DP{}State not activated (prev={!r}, curr={!r})".format(
+            lane,
+            previous_state,
+            current_state,
+        )
+
+    previous_value = _numeric_sensor_value(previous_sensor, field)
+    current_value = _numeric_sensor_value(current_sensor, field)
+    if previous_value is None or current_value is None:
+        return "missing/non-finite value (prev={!r}, curr={!r})".format(
+            previous_sensor.get(field),
+            current_sensor.get(field),
+        )
+
+    lowwarning = check["warning_low"]
+    highwarning = check["warning_high"]
+    if not (lowwarning <= previous_value <= highwarning and lowwarning <= current_value <= highwarning):
+        return "value outside tx_bias warning range [{}, {}] (prev={}, curr={})".format(
+            lowwarning,
+            highwarning,
+            previous_value,
+            current_value,
+        )
+
+    if previous_value == 0:
+        return "previous value is zero; percent change is undefined"
+
+    return None
+
+
+def _validate_tx_bias_percent_delta(
+    port,
+    field,
+    check,
+    previous_sensor,
+    current_sensor,
+    previous_status,
+    current_status,
+    sample_index,
+):
+    skip_reason = _tx_bias_skip_reason(field, check, previous_sensor, current_sensor, previous_status, current_status)
+    if skip_reason:
+        logger.info(
+            "DOM consistency SKIP %s %s sample %d->%d: %s",
+            port,
+            field,
+            sample_index,
+            sample_index + 1,
+            skip_reason,
+        )
+        return None, False
+
+    previous_value = _numeric_sensor_value(previous_sensor, field)
+    current_value = _numeric_sensor_value(current_sensor, field)
+    delta_percent = abs(current_value - previous_value) / abs(previous_value) * 100
+    if delta_percent > check["threshold"]:
+        return (
+            "{} sample {}->{} delta {:.2f}% exceeds {}% "
+            "(prev={}, curr={})".format(
+                field,
+                sample_index,
+                sample_index + 1,
+                delta_percent,
+                check["threshold"],
+                previous_value,
+                current_value,
+            ),
+            True,
+        )
+
+    logger.debug(
+        "DOM consistency PASS %s %s sample %d->%d: delta=%.2f%% limit=%s%%",
+        port,
+        field,
+        sample_index,
+        sample_index + 1,
+        delta_percent,
+        check["threshold"],
+    )
+    return None, True
+
+
+def _validate_variation_checks(port, samples, plan):
+    """Validate configured variation checks for one port across samples."""
+    failures = []
+    checked_pair_count = 0
+    field_checks = plan.get("field_checks", {})
+    poll_count = plan["poll_count"]
+
+    for sample_index in range(1, poll_count):
+        previous_sensor = _sensor_sample_for_port(samples, sample_index - 1, port)
+        current_sensor = _sensor_sample_for_port(samples, sample_index, port)
+        previous_status = _status_sample_for_port(samples, sample_index - 1, port)
+        current_status = _status_sample_for_port(samples, sample_index, port)
+
+        for field, check in field_checks.items():
+            if check["mode"] == "percent":
+                error, checked = _validate_tx_bias_percent_delta(
+                    port,
+                    field,
+                    check,
+                    previous_sensor,
+                    current_sensor,
+                    previous_status,
+                    current_status,
+                    sample_index,
+                )
+                if checked:
+                    checked_pair_count += 1
+            else:
+                error = _validate_absolute_delta(
+                    port,
+                    field,
+                    check,
+                    previous_sensor,
+                    current_sensor,
+                    sample_index,
+                )
+                checked_pair_count += 1
+
+            if error:
+                failures.append(error)
+
+    return failures, checked_pair_count
+
+
+def _validate_dom_consistency(dom_primary_ports, samples, consistency_plan_by_port):
+    failures = []
+    checked_pair_count = 0
+    checked_port_count = 0
+
+    for port in dom_primary_ports:
+        plan = consistency_plan_by_port.get(port, {})
+        expected_fields = plan.get("field_checks", {})
+        field_failures = list(plan.get("errors", []))
+        active_lanes = plan.get("active_media_lanes", [])
+
+        last_update_failures = _validate_last_update_time(port, samples, plan["poll_count"])
+        variation_failures, port_checked_pair_count = _validate_variation_checks(port, samples, plan)
+        field_failures.extend(last_update_failures)
+        field_failures.extend(variation_failures)
+
+        checked_port_count += 1
+        checked_pair_count += port_checked_pair_count
+
+        if field_failures:
+            failures.append(
+                format_dom_port_failure(
+                    port,
+                    active_lanes,
+                    expected_fields,
+                    field_failures,
+                    field_label="configured consistency field(s)",
+                )
+            )
+
+    return failures, checked_pair_count, checked_port_count
+
+
+def _format_consistency_plan_failures(dom_primary_ports, consistency_plan_by_port):
+    failures = []
+    for port in dom_primary_ports:
+        plan = consistency_plan_by_port.get(port, {})
+        field_failures = list(plan.get("errors", []))
+        if not field_failures:
+            continue
+        failures.append(
+            format_dom_port_failure(
+                port,
+                plan.get("active_media_lanes", []),
+                plan.get("field_checks", {}),
+                field_failures,
+                field_label="configured consistency field(s)",
+            )
+        )
+    return failures
+
+
+def test_dom_data_consistency_verification(
+    duthost,
+    dom_primary_ports,
+    port_attributes_dict,
+    lport_to_first_subport_mapping,
+):
+    """Verify DOM sensor update cadence and configured variation thresholds."""
+    sensor_plan_by_port = build_dom_sensor_plan(
+        port_attributes_dict,
+        dom_primary_ports,
+        lport_to_first_subport_mapping,
+    )
+    consistency_plan_by_port = _build_dom_consistency_plan(
+        port_attributes_dict,
+        dom_primary_ports,
+        sensor_plan_by_port,
+    )
+    plan_failures = _format_consistency_plan_failures(dom_primary_ports, consistency_plan_by_port)
+    if plan_failures:
+        pytest.fail("DOM consistency validation failures:\n" + "\n".join(plan_failures))
+
+    sample_count = max(plan["poll_count"] for plan in consistency_plan_by_port.values())
+    interval_sec = max(plan["update_interval_sec"] for plan in consistency_plan_by_port.values())
+    read_status = any(
+        check["mode"] == "percent"
+        for plan in consistency_plan_by_port.values()
+        for check in plan.get("field_checks", {}).values()
+    )
+    logger.info(
+        "DOM consistency sampling: %d sample(s), %d second interval, status_table=%s",
+        sample_count,
+        interval_sec,
+        read_status,
+    )
+
+    samples = _collect_dom_samples(
+        duthost,
+        dom_primary_ports,
+        sample_count,
+        interval_sec,
+        read_status,
+    )
+    all_failures = []
+    for sample_index, sample in enumerate(samples, start=1):
+        all_failures.extend(
+            "STATE_DB sample {} sensor read:\n  {}".format(sample_index, error)
+            for error in sample["sensor_errors"]
+        )
+        all_failures.extend(
+            "STATE_DB sample {} status read:\n  {}".format(sample_index, error)
+            for error in sample["status_errors"]
+        )
+
+    consistency_failures, checked_pair_count, checked_port_count = _validate_dom_consistency(
+        dom_primary_ports,
+        samples,
+        consistency_plan_by_port,
+    )
+    all_failures.extend(consistency_failures)
+
+    if all_failures:
+        pytest.fail("DOM consistency validation failures:\n" + "\n".join(all_failures))
+
+    logger.info(
+        "DOM consistency validation passed: %d variation pair(s), %d port(s), %d sample(s)",
+        checked_pair_count,
+        checked_port_count,
+        sample_count,
+    )

--- a/tests/transceiver/dom/test_dom_operational_range.py
+++ b/tests/transceiver/dom/test_dom_operational_range.py
@@ -7,7 +7,7 @@ from tests.transceiver.attribute_parser.attribute_keys import DOM_ATTRIBUTES_KEY
 from tests.transceiver.common.db_helpers import parse_numeric
 from tests.transceiver.dom.dom_helpers import (
     OPERATIONAL_SUFFIX,
-    build_dom_availability_plan,
+    build_dom_sensor_plan,
     parse_min_max_range,
     read_dom_sensor_data,
     validate_dom_plan_fields,
@@ -55,22 +55,22 @@ def test_dom_sensor_operational_range_validation(
     port_attributes_dict,
     lport_to_first_subport_mapping,
 ):
-    """Verify configured DOM sensor values are fresh and within operational ranges."""
-    availability_plan_by_port = build_dom_availability_plan(
+    """Validate configured DOM operational ranges; freshness is checked with range fields."""
+    if not _has_operational_range_attributes(port_attributes_dict, dom_primary_ports):
+        pytest.skip("No *_operational_range attributes configured for DOM operational range validation")
+
+    sensor_plan_by_port = build_dom_sensor_plan(
         port_attributes_dict,
         dom_primary_ports,
         lport_to_first_subport_mapping,
     )
-    if not _has_operational_range_attributes(port_attributes_dict, dom_primary_ports):
-        pytest.skip("No *_operational_range attributes configured for DOM operational range validation")
-
     sensor_by_port, sensor_read_errors = read_dom_sensor_data(duthost, dom_primary_ports)
     all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in sensor_read_errors]
     range_failures, checked_field_count, checked_port_count = validate_dom_plan_fields(
         duthost,
         dom_primary_ports,
         sensor_by_port,
-        availability_plan_by_port,
+        sensor_plan_by_port,
         _operational_range_field_check,
     )
     all_failures.extend(range_failures)

--- a/tests/transceiver/dom/test_dom_threshold.py
+++ b/tests/transceiver/dom/test_dom_threshold.py
@@ -1,0 +1,247 @@
+import logging
+import math
+
+import pytest
+
+from tests.transceiver.common.db_helpers import parse_numeric
+from tests.transceiver.dom.dom_helpers import (
+    STATE_DB_THRESHOLD_TABLE,
+    THRESHOLD_FIELD_SUFFIXES,
+    THRESHOLD_VALUE_TOLERANCE,
+    build_dom_threshold_plan,
+    format_dom_port_failure,
+    parse_min_max_range,
+    read_dom_threshold_data,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_threshold_range(attr_name, attr_value):
+    """Return ``(thresholds, errors)`` for one configured threshold attribute."""
+    if not isinstance(attr_value, dict):
+        return {}, [
+            "{} must be a dict with {} in DOM_ATTRIBUTES".format(
+                attr_name,
+                THRESHOLD_FIELD_SUFFIXES,
+            )
+        ]
+
+    thresholds = {}
+    errors = []
+    for threshold_key in THRESHOLD_FIELD_SUFFIXES:
+        value = parse_numeric(attr_value.get(threshold_key))
+        if value is None or not math.isfinite(value):
+            errors.append(
+                "{} missing/non-finite numeric {} in DOM_ATTRIBUTES".format(
+                    attr_name,
+                    threshold_key,
+                )
+            )
+            continue
+        thresholds[threshold_key] = value
+
+    if errors:
+        return {}, errors
+
+    hierarchy_error = _threshold_hierarchy_error(attr_name, thresholds, "configured")
+    if hierarchy_error:
+        return {}, [hierarchy_error]
+
+    return thresholds, []
+
+
+def _threshold_hierarchy_error(attr_name, thresholds, source):
+    if (
+        thresholds["lowalarm"]
+        < thresholds["lowwarning"]
+        < thresholds["highwarning"]
+        < thresholds["highalarm"]
+    ):
+        return None
+    return (
+        "{} {} hierarchy lowalarm < lowwarning < highwarning < highalarm "
+        "is violated".format(attr_name, source)
+    )
+
+
+def _validate_operational_range_within_warning(threshold_attr, thresholds, operational_mapped_field):
+    """Validate a paired operational range sits inside threshold warning bounds."""
+    op_min, op_max, range_error = parse_min_max_range(operational_mapped_field)
+    if range_error:
+        return [range_error]
+
+    if thresholds["lowwarning"] < op_min and op_max < thresholds["highwarning"]:
+        return []
+
+    return [
+        "{} operational range [{}, {}] is not within {} warning bounds ({}, {})".format(
+            operational_mapped_field.source_attr,
+            op_min,
+            op_max,
+            threshold_attr,
+            thresholds["lowwarning"],
+            thresholds["highwarning"],
+        )
+    ]
+
+
+def _has_threshold_range_attributes(threshold_plan_by_port):
+    """Return True when any primary port has configured threshold-range checks."""
+    return any(
+        plan.get("threshold_attrs") or plan.get("errors")
+        for plan in threshold_plan_by_port.values()
+    )
+
+
+def _validate_dom_threshold_ranges(dom_primary_ports, threshold_by_port, threshold_plan_by_port):
+    """Validate configured DOM threshold fields against STATE_DB threshold data."""
+    failures = []
+    checked_attr_count = 0
+    checked_field_count = 0
+    checked_port_count = 0
+
+    for port in dom_primary_ports:
+        threshold_data = threshold_by_port.get(port, {})
+        threshold_plan = threshold_plan_by_port.get(port, {})
+        expected_fields = threshold_plan.get("expected_fields", {})
+        threshold_attrs = threshold_plan.get("threshold_attrs", {})
+        operational_ranges = threshold_plan.get("operational_ranges", {})
+        field_failures = list(threshold_plan.get("errors", []))
+        has_threshold_checks = bool(expected_fields or threshold_attrs or field_failures)
+
+        if has_threshold_checks:
+            checked_port_count += 1
+
+        if has_threshold_checks and not threshold_data:
+            field_failures.append(
+                "no {} entry published for port".format(STATE_DB_THRESHOLD_TABLE)
+            )
+            failures.append(
+                format_dom_port_failure(
+                    port,
+                    None,
+                    expected_fields,
+                    field_failures,
+                    field_label="expected threshold field(s)",
+                )
+            )
+            continue
+
+        for attr_name, attr_value in sorted(threshold_attrs.items()):
+            attr_failure_count = len(field_failures)
+            attr_expected_fields = {
+                field: mapped_field
+                for field, mapped_field in expected_fields.items()
+                if mapped_field.source_attr == attr_name
+            }
+
+            expected_thresholds, threshold_errors = _parse_threshold_range(attr_name, attr_value)
+            field_failures.extend(threshold_errors)
+            if threshold_errors:
+                continue
+
+            if not attr_expected_fields:
+                field_failures.append("{} has no expected STATE_DB threshold fields".format(attr_name))
+                continue
+
+            actual_thresholds = {}
+            for field, mapped_field in attr_expected_fields.items():
+                raw_value = threshold_data.get(field)
+                actual_value = parse_numeric(raw_value)
+                if actual_value is None or not math.isfinite(actual_value):
+                    field_failures.append(
+                        "{} threshold field {} missing/non-finite in STATE_DB (raw={!r})".format(
+                            attr_name,
+                            field,
+                            raw_value,
+                        )
+                    )
+                    continue
+                actual_thresholds[mapped_field.threshold_key] = actual_value
+
+            if len(actual_thresholds) != len(THRESHOLD_FIELD_SUFFIXES):
+                continue
+
+            for threshold_key in THRESHOLD_FIELD_SUFFIXES:
+                expected_value = expected_thresholds[threshold_key]
+                actual_value = actual_thresholds[threshold_key]
+                if abs(actual_value - expected_value) > THRESHOLD_VALUE_TOLERANCE:
+                    field_failures.append(
+                        "{} expected {}={}, got {} from STATE_DB".format(
+                            attr_name,
+                            threshold_key,
+                            expected_value,
+                            actual_value,
+                        )
+                    )
+
+            hierarchy_error = _threshold_hierarchy_error(attr_name, actual_thresholds, "STATE_DB")
+            if hierarchy_error:
+                field_failures.append(hierarchy_error)
+
+            operational_mapped_field = operational_ranges.get(attr_name)
+            if operational_mapped_field:
+                field_failures.extend(
+                    _validate_operational_range_within_warning(
+                        attr_name,
+                        actual_thresholds,
+                        operational_mapped_field,
+                    )
+                )
+
+            if len(field_failures) == attr_failure_count:
+                checked_attr_count += 1
+                checked_field_count += len(attr_expected_fields)
+                logger.debug(
+                    "DOM threshold PASS %s %s fields=%s operational_attr=%s",
+                    port,
+                    attr_name,
+                    sorted(attr_expected_fields),
+                    operational_mapped_field.source_attr if operational_mapped_field else "not-configured",
+                )
+
+        if field_failures:
+            failures.append(
+                format_dom_port_failure(
+                    port,
+                    None,
+                    expected_fields,
+                    field_failures,
+                    field_label="expected threshold field(s)",
+                )
+            )
+
+    return failures, checked_attr_count, checked_field_count, checked_port_count
+
+
+def test_dom_threshold_validation(
+    duthost,
+    dom_primary_ports,
+    port_attributes_dict,
+):
+    """Verify configured DOM threshold ranges against STATE_DB threshold data."""
+    threshold_plan_by_port = build_dom_threshold_plan(port_attributes_dict, dom_primary_ports)
+    if not _has_threshold_range_attributes(threshold_plan_by_port):
+        pytest.skip("No *_threshold_range attributes configured for DOM threshold validation")
+
+    threshold_by_port, threshold_read_errors = read_dom_threshold_data(duthost, dom_primary_ports)
+    all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in threshold_read_errors]
+    threshold_failures, checked_attr_count, checked_field_count, checked_port_count = (
+        _validate_dom_threshold_ranges(
+            dom_primary_ports,
+            threshold_by_port,
+            threshold_plan_by_port,
+        )
+    )
+    all_failures.extend(threshold_failures)
+
+    if all_failures:
+        pytest.fail("DOM threshold validation failures:\n" + "\n".join(all_failures))
+
+    logger.info(
+        "DOM threshold validation passed: %d threshold attribute(s), %d field(s) across %d port(s)",
+        checked_attr_count,
+        checked_field_count,
+        checked_port_count,
+    )


### PR DESCRIPTION
  ### Description of PR

  Summary:
  Add DOM Basic TC4 consistency validation for transceiver DOM sensor data.

  This PR adds a new DOM test case to verify that DOM sensor data continues to update over multiple samples and that configured DOM values
  remain stable within vendor-provided consistency thresholds. The test follows the existing TC1/TC2/TC3 shared DOM helper architecture and
  is fully configuration-driven through `DOM_ATTRIBUTES`.

  Fixes # N/A

  ### Type of change

  - [ ] Bug fix
  - [ ] Testbed and Framework(new/improvement)
  - [x] New Test case
      - [x] Skipped for non-supported platforms
  - [ ] Test case improvement


  ### Back port request

  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511
  - [ ] 202512
  - [ ] 202605

  Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
  Failure type: N/A

  ### Tested branch

  - [x] master
  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511
  - [ ] 202512
  - [ ] 202605
  - [ ] N/A

  ### Test result

  - master: tested on `single-dut-mgmt60` with DUT `str-nexthop_4010-01`

  ```text
  tests/transceiver/dom/test_dom_consistency.py::test_dom_data_consistency_verification PASSED

  Results (326.16s):
      1 passed

  ### Approach

  #### What is the motivation for this PR?

  This PR implements DOM Basic TC4 from the DOM test plan. TC4 validates DOM sensor consistency over time by sampling live DOM sensor data
  multiple times and checking that configured values do not vary beyond expected thresholds.

  The test covers both module-level and lane-level DOM fields, including temperature, voltage, laser temperature, TX power, RX power, and
  TX bias.

  #### How did you do it?

  Added tests/transceiver/dom/test_dom_consistency.py.

  The test:

  - Reuses build_dom_sensor_plan() to resolve DOM-capable primary ports and active media lanes.
  - Builds a per-port consistency plan from DOM_ATTRIBUTES.
  - Reads TRANSCEIVER_DOM_SENSOR from STATE_DB for each sample.
  - Reads TRANSCEIVER_STATUS from STATE_DB when TX bias consistency validation is configured.
  - Verifies last_update_time exists and advances between samples.
  - Checks absolute variation thresholds for temperature, voltage, laser temperature, TX power, and RX power.
  - Checks TX bias percentage variation only when the datapath is activated and values are within the configured warning range.

  Extended DOM helper support for reading TRANSCEIVER_STATUS through the existing namespace-aware STATE_DB table read path.

  #### How did you verify/test it?

  Verified with:

  ./tests/run_tests.sh \
  -c "tests/transceiver/dom/test_dom_consistency.py" \
  -n single-dut-mgmt60 \
  -d str-nexthop_4010-01 \
  -i "ansible/my_inventory/lab" \
  -f "ansible/testbed.yaml" \
  -u \
  -e "-rs -n 0 -p no:tests.common.plugins.memory_utilization --ignore-conditional-mark --skip_sanity --skip_yang --disable-warnings
  --skip_transceiver_template_validation --html=dom_tests.html --self-contained-html"

  Result:

  tests/transceiver/dom/test_dom_consistency.py::test_dom_data_consistency_verification PASSED

  Results (326.16s):
      1 passed

  #### Any platform specific information?

  Tested with Accelight AGP80SC0CW41002 transceivers on str-nexthop_4010-01.

  The test is configuration-driven and depends on DOM attributes being present for the transceiver under test. Unsupported or unconfigured
  DOM attributes are skipped according to the existing DOM test behavior.

  #### Supported testbed topology if it's a new test case?

  PTP topology / real transceiver hardware testbed.

  The transceiver suite applies the topology marker through tests/transceiver/conftest.py.

  ### Documentation

  DOM TC4 behavior follows docs/testplan/transceiver/dom_test_plan.md.
