### PR TITLE
Dom basic tc3 tc4

### DIFF
--- a/tests/transceiver/common/cmis_helper.py
+++ b/tests/transceiver/common/cmis_helper.py
@@ -12,6 +12,7 @@ __all__ = [
     "CMIS_DP_STATE_DEACTIVATED",
     "CMIS_DP_STATE_NIBBLE_MASK",
     "CMIS_DP_STATE_LANES_PER_BYTE",
+    "STATE_DB_DP_STATE_ACTIVATED",
 
     # ── Constants: CMIS page 01h (CDB capability) ──────────────────────────
     "CMIS_PAGE_01_CDB_CAP_PAGE",
@@ -21,6 +22,7 @@ __all__ = [
     # ── Public helpers ──────────────────────────────────────────────────────
     "check_dp_state",
     "check_dp_state_activated",
+    "is_state_db_dp_state_activated",
 ]
 
 # CMIS upper page 11h: DataPath state registers (2 lanes per byte, nibble-encoded).
@@ -31,6 +33,10 @@ CMIS_DP_STATE_LANES_PER_BYTE = 2
 CMIS_DP_STATE_ACTIVATED = 0x4   # DPActivated nibble value per CMIS spec
 CMIS_DP_STATE_DEACTIVATED = 0x1   # DPDeactivated nibble value per CMIS spec
 CMIS_DP_STATE_NIBBLE_MASK = 0x0F
+
+# STATE_DB TRANSCEIVER_STATUS uses the CLI/user-facing string form, not the
+# CMIS page 11h enum label. For example: DP1State = "DataPathActivated".
+STATE_DB_DP_STATE_ACTIVATED = "DataPathActivated"
 
 # CMIS Page 01h: CDB capability register
 # CMIS global byte 163 (decimal) = 0xA3 (hex).
@@ -106,3 +112,8 @@ def check_dp_state_activated(page_11_data, num_lanes):
     return check_dp_state(
         page_11_data, num_lanes, CMIS_DP_STATE_ACTIVATED, state_label="DPActivated"
     )
+
+
+def is_state_db_dp_state_activated(status_data, lane):
+    """Return True when ``TRANSCEIVER_STATUS`` reports an activated datapath lane."""
+    return status_data.get("DP{}State".format(lane)) == STATE_DB_DP_STATE_ACTIVATED

--- a/tests/transceiver/common/cmis_helper.py
+++ b/tests/transceiver/common/cmis_helper.py
@@ -12,7 +12,6 @@ __all__ = [
     "CMIS_DP_STATE_DEACTIVATED",
     "CMIS_DP_STATE_NIBBLE_MASK",
     "CMIS_DP_STATE_LANES_PER_BYTE",
-    "STATE_DB_DP_STATE_ACTIVATED",
 
     # ── Constants: CMIS page 01h (CDB capability) ──────────────────────────
     "CMIS_PAGE_01_CDB_CAP_PAGE",
@@ -22,7 +21,6 @@ __all__ = [
     # ── Public helpers ──────────────────────────────────────────────────────
     "check_dp_state",
     "check_dp_state_activated",
-    "is_state_db_dp_state_activated",
 ]
 
 # CMIS upper page 11h: DataPath state registers (2 lanes per byte, nibble-encoded).
@@ -33,10 +31,6 @@ CMIS_DP_STATE_LANES_PER_BYTE = 2
 CMIS_DP_STATE_ACTIVATED = 0x4   # DPActivated nibble value per CMIS spec
 CMIS_DP_STATE_DEACTIVATED = 0x1   # DPDeactivated nibble value per CMIS spec
 CMIS_DP_STATE_NIBBLE_MASK = 0x0F
-
-# STATE_DB TRANSCEIVER_STATUS uses the CLI/user-facing string form, not the
-# CMIS page 11h enum label. For example: DP1State = "DataPathActivated".
-STATE_DB_DP_STATE_ACTIVATED = "DataPathActivated"
 
 # CMIS Page 01h: CDB capability register
 # CMIS global byte 163 (decimal) = 0xA3 (hex).
@@ -112,8 +106,3 @@ def check_dp_state_activated(page_11_data, num_lanes):
     return check_dp_state(
         page_11_data, num_lanes, CMIS_DP_STATE_ACTIVATED, state_label="DPActivated"
     )
-
-
-def is_state_db_dp_state_activated(status_data, lane):
-    """Return True when ``TRANSCEIVER_STATUS`` reports an activated datapath lane."""
-    return status_data.get("DP{}State".format(lane)) == STATE_DB_DP_STATE_ACTIVATED

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -28,6 +28,7 @@ STATE_DB_THRESHOLD_TABLE = "TRANSCEIVER_DOM_THRESHOLD"
 
 OPERATIONAL_SUFFIX = "_operational_range"
 THRESHOLD_SUFFIX = "_threshold_range"
+CONSISTENCY_SUFFIX = "_consistency_variation_threshold"
 LANE_NUM_PLACEHOLDER = "LANE_NUM"
 MEDIA_LANE_MASK_KEY = "media_lane_mask"
 DomMappedField = namedtuple("DomMappedField", ("source_attr", "attr_value"))
@@ -51,6 +52,14 @@ THRESHOLD_TO_OPERATIONAL_ATTR = {
     "rx_power": "rxLANE_NUMpower_operational_range",
 }
 THRESHOLD_VALUE_TOLERANCE = 0.01
+CONSISTENCY_FIELD_TEMPLATES_BY_BASE = {
+    "temperature": "temperature",
+    "voltage": "voltage",
+    "laser_temperature": "laser_temperature",
+    "tx_power": "tx{}power",
+    "rx_power": "rx{}power",
+    "tx_bias": "tx{}bias",
+}
 
 DOM_POLLING_ENABLED_VALUES = ("", "enabled")
 DOM_POLLING_DISABLED_VALUE = "disabled"
@@ -150,6 +159,7 @@ def _map_threshold_attribute_to_fields(attr_name, attr_value):
 
 
 def _map_threshold_attribute_to_fields_for_dispatch(attr_name, attr_value, _active_media_lanes):
+    """Return threshold mapping through the 3-argument DOM field-dispatch contract."""
     return _map_threshold_attribute_to_fields(attr_name, attr_value)
 
 
@@ -178,6 +188,19 @@ def _operational_attr_for_threshold(attr_name):
     """Return the configured operational-range attribute paired with a threshold attribute."""
     base_name = attr_name[:-len(THRESHOLD_SUFFIX)]
     return THRESHOLD_TO_OPERATIONAL_ATTR.get(base_name)
+
+
+def consistency_field_template_for_attr(attr_name):
+    """Return the STATE_DB sensor field template for a consistency attribute."""
+    if not attr_name.endswith(CONSISTENCY_SUFFIX):
+        return None
+    base_name = attr_name[:-len(CONSISTENCY_SUFFIX)]
+    return CONSISTENCY_FIELD_TEMPLATES_BY_BASE.get(base_name)
+
+
+def field_template_is_lane_expanded(field_template):
+    """Return True when a STATE_DB field template expects a lane number."""
+    return "{}" in field_template
 
 
 def build_dom_sensor_plan(port_attributes_dict, dom_primary_ports, lport_to_first_subport_mapping):
@@ -237,30 +260,40 @@ def build_dom_threshold_plan(port_attributes_dict, dom_primary_ports):
     for port in dom_primary_ports:
         dom_attrs = port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {})
         expected_fields = {}
-        threshold_attrs = {}
-        operational_ranges = {}
+        configured_by_attr = {}
+        db_fields_by_threshold_attr = defaultdict(dict)
+        operational_range_by_threshold_attr = {}
         errors = []
 
         for attr_name, attr_value in sorted(dom_attrs.items()):
             if not attr_name.endswith(THRESHOLD_SUFFIX):
                 continue
 
-            threshold_attrs[attr_name] = attr_value
+            configured_by_attr[attr_name] = attr_value
             mapped_fields, field_errors = map_dom_attribute_to_fields(attr_name, attr_value, active_media_lanes=None)
             expected_fields.update(mapped_fields)
+            for field, mapped_field in mapped_fields.items():
+                db_fields_by_threshold_attr[attr_name][field] = mapped_field
             errors.extend(field_errors)
 
             operational_attr = _operational_attr_for_threshold(attr_name)
             if operational_attr in dom_attrs:
-                operational_ranges[attr_name] = DomMappedField(
+                operational_range_by_threshold_attr[attr_name] = DomMappedField(
                     operational_attr,
                     dom_attrs[operational_attr],
                 )
 
         plan_by_port[port] = {
             "expected_fields": {field: expected_fields[field] for field in sorted(expected_fields)},
-            "threshold_attrs": threshold_attrs,
-            "operational_ranges": operational_ranges,
+            "configured_by_attr": configured_by_attr,
+            "db_fields_by_threshold_attr": {
+                attr_name: {
+                    field: db_fields_by_threshold_attr[attr_name][field]
+                    for field in sorted(db_fields_by_threshold_attr[attr_name])
+                }
+                for attr_name in sorted(db_fields_by_threshold_attr)
+            },
+            "operational_range_by_threshold_attr": operational_range_by_threshold_attr,
             "errors": errors,
         }
         logger.debug(
@@ -268,8 +301,8 @@ def build_dom_threshold_plan(port_attributes_dict, dom_primary_ports):
             "%d paired operational range attr(s)",
             port,
             len(expected_fields),
-            len(threshold_attrs),
-            len(operational_ranges),
+            len(configured_by_attr),
+            len(operational_range_by_threshold_attr),
         )
 
     return plan_by_port
@@ -393,6 +426,13 @@ def validate_dom_plan_fields(
             continue
         checked_port_count += 1
 
+        if sensor_data is None:
+            field_failures.append(
+                "could not read {} for port (namespace read failed)".format(STATE_DB_SENSOR_TABLE)
+            )
+            failures.append(format_dom_port_failure(port, active_lanes, expected_fields, field_failures))
+            continue
+
         if not sensor_data:
             field_failures.append(
                 "no {} entry published for port".format(STATE_DB_SENSOR_TABLE)
@@ -450,7 +490,11 @@ def validate_dom_plan_fields(
 
 
 def _read_dom_table_data(duthost, ports, table_name):
-    """Return ``({port: {field: value}}, errors)`` for a current DOM STATE_DB table."""
+    """Return ``({port: data_or_None}, errors)`` for a current DOM STATE_DB table.
+
+    A value of ``None`` means the namespace-level table read failed, while an
+    empty dict means the table read succeeded and the port entry was absent.
+    """
     ports = list(ports)
     table_data_by_port = {port: {} for port in ports}
     errors = []
@@ -468,12 +512,22 @@ def _read_dom_table_data(duthost, ports, table_name):
         )
         if err:
             errors.append(
-                "{} namespace {}: {}".format(
+                "{} namespace {} ({} port(s) under test): {}".format(
                     table_name,
                     namespace or "default",
+                    len(namespace_ports),
                     err,
                 )
             )
+            logger.warning(
+                "Failed to read %s namespace %s for %d port(s): %s",
+                table_name,
+                namespace or "default",
+                len(namespace_ports),
+                err,
+            )
+            for port in namespace_ports:
+                table_data_by_port[port] = None
             continue
 
         for port in namespace_ports:
@@ -492,17 +546,17 @@ def _read_dom_table_data(duthost, ports, table_name):
 
 
 def read_dom_sensor_data(duthost, ports):
-    """Return ``({port: {field: value}}, errors)`` for current DOM sensor data."""
+    """Return ``({port: data_or_None}, errors)`` for current DOM sensor data."""
     return _read_dom_table_data(duthost, ports, STATE_DB_SENSOR_TABLE)
 
 
 def read_transceiver_status_data(duthost, ports):
-    """Return ``({port: {field: value}}, errors)`` for current transceiver status data."""
+    """Return ``({port: data_or_None}, errors)`` for current transceiver status data."""
     return _read_dom_table_data(duthost, ports, STATE_DB_STATUS_TABLE)
 
 
 def read_dom_threshold_data(duthost, ports):
-    """Return ``({port: {field: value}}, errors)`` for current DOM threshold data."""
+    """Return ``({port: data_or_None}, errors)`` for current DOM threshold data."""
     return _read_dom_table_data(duthost, ports, STATE_DB_THRESHOLD_TABLE)
 
 

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -141,7 +141,7 @@ def _map_operational_attribute_to_fields(attr_name, attr_value, active_media_lan
     }, []
 
 
-def _map_threshold_attribute_to_fields(attr_name, attr_value):
+def _map_threshold_attribute_to_fields(attr_name, attr_value, _active_media_lanes=None):
     """Return ``({field: DomThresholdMappedField(...)}, errors)`` for one threshold range."""
     base_name = attr_name[:-len(THRESHOLD_SUFFIX)]
     prefix = THRESHOLD_FIELD_PREFIXES.get(base_name)
@@ -158,14 +158,9 @@ def _map_threshold_attribute_to_fields(attr_name, attr_value):
     }, []
 
 
-def _map_threshold_attribute_to_fields_for_dispatch(attr_name, attr_value, _active_media_lanes):
-    """Return threshold mapping through the 3-argument DOM field-dispatch contract."""
-    return _map_threshold_attribute_to_fields(attr_name, attr_value)
-
-
 DOM_FIELD_MAPPERS = (
     (OPERATIONAL_SUFFIX, _map_operational_attribute_to_fields),
-    (THRESHOLD_SUFFIX, _map_threshold_attribute_to_fields_for_dispatch),
+    (THRESHOLD_SUFFIX, _map_threshold_attribute_to_fields),
 )
 
 

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -23,7 +23,6 @@ from tests.transceiver.common.db_helpers import (
 logger = logging.getLogger(__name__)
 
 STATE_DB_SENSOR_TABLE = "TRANSCEIVER_DOM_SENSOR"
-STATE_DB_STATUS_TABLE = "TRANSCEIVER_STATUS"
 STATE_DB_THRESHOLD_TABLE = "TRANSCEIVER_DOM_THRESHOLD"
 
 OPERATIONAL_SUFFIX = "_operational_range"
@@ -540,11 +539,6 @@ def _read_dom_table_data(duthost, ports, table_name):
 def read_dom_sensor_data(duthost, ports):
     """Return ``({port: data_or_None}, errors)`` for current DOM sensor data."""
     return _read_dom_table_data(duthost, ports, STATE_DB_SENSOR_TABLE)
-
-
-def read_transceiver_status_data(duthost, ports):
-    """Return ``({port: data_or_None}, errors)`` for current transceiver status data."""
-    return _read_dom_table_data(duthost, ports, STATE_DB_STATUS_TABLE)
 
 
 def read_dom_threshold_data(duthost, ports):

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -132,32 +132,8 @@ def _map_operational_attribute_to_fields(attr_name, attr_value, active_media_lan
     }, []
 
 
-DOM_FIELD_MAPPERS = (
-    (OPERATIONAL_SUFFIX, _map_operational_attribute_to_fields),
-)
-
-
-def map_dom_attribute_to_fields(attr_name, attr_value, active_media_lanes):
-    """Map one DOM attribute to current STATE_DB field metadata.
-
-    The suffix dispatch is DOM-local. TC1/TC2 use this operational mapper for
-    ``TRANSCEIVER_DOM_SENSOR``; TC3 uses separate threshold helpers because
-    ``TRANSCEIVER_DOM_THRESHOLD`` is transceiver-level and does not expand
-    LANE_NUM.
-    """
-    for suffix, mapper in DOM_FIELD_MAPPERS:
-        if attr_name.endswith(suffix):
-            return mapper(attr_name, attr_value, active_media_lanes)
-    logger.debug("DOM attribute %s matched no field mapper; skipped", attr_name)
-    return {}, []
-
-
-def map_dom_threshold_attribute_to_fields(attr_name, attr_value):
-    """Return ``({field: DomThresholdMappedField(source_attr, attr_value, threshold_key)}, errors)``."""
-    if not attr_name.endswith(THRESHOLD_SUFFIX):
-        logger.debug("DOM attribute %s is not a threshold range; skipped", attr_name)
-        return {}, []
-
+def _map_threshold_attribute_to_fields(attr_name, attr_value):
+    """Return ``({field: DomThresholdMappedField(...)}, errors)`` for one threshold range."""
     base_name = attr_name[:-len(THRESHOLD_SUFFIX)]
     prefix = THRESHOLD_FIELD_PREFIXES.get(base_name)
     if prefix is None:
@@ -171,6 +147,31 @@ def map_dom_threshold_attribute_to_fields(attr_name, attr_value):
         )
         for suffix in THRESHOLD_FIELD_SUFFIXES
     }, []
+
+
+def _map_threshold_attribute_to_fields_for_dispatch(attr_name, attr_value, _active_media_lanes):
+    return _map_threshold_attribute_to_fields(attr_name, attr_value)
+
+
+DOM_FIELD_MAPPERS = (
+    (OPERATIONAL_SUFFIX, _map_operational_attribute_to_fields),
+    (THRESHOLD_SUFFIX, _map_threshold_attribute_to_fields_for_dispatch),
+)
+
+
+def map_dom_attribute_to_fields(attr_name, attr_value, active_media_lanes):
+    """Map one DOM attribute to current STATE_DB field metadata.
+
+    The suffix dispatch is DOM-local. Sensor-table operational ranges expand
+    ``LANE_NUM`` across active media lanes. Threshold ranges are transceiver-
+    level and return ``DomThresholdMappedField`` entries without lane expansion.
+    Callers build table-specific plans from the mapped field type they need.
+    """
+    for suffix, mapper in DOM_FIELD_MAPPERS:
+        if attr_name.endswith(suffix):
+            return mapper(attr_name, attr_value, active_media_lanes)
+    logger.debug("DOM attribute %s matched no field mapper; skipped", attr_name)
+    return {}, []
 
 
 def _operational_attr_for_threshold(attr_name):
@@ -198,6 +199,8 @@ def build_dom_sensor_plan(port_attributes_dict, dom_primary_ports, lport_to_firs
         errors = list(lane_errors)
 
         for attr_name, attr_value in sorted(dom_attrs.items()):
+            if not attr_name.endswith(OPERATIONAL_SUFFIX):
+                continue
             mapped_fields, field_errors = map_dom_attribute_to_fields(
                 attr_name,
                 attr_value,
@@ -243,7 +246,7 @@ def build_dom_threshold_plan(port_attributes_dict, dom_primary_ports):
                 continue
 
             threshold_attrs[attr_name] = attr_value
-            mapped_fields, field_errors = map_dom_threshold_attribute_to_fields(attr_name, attr_value)
+            mapped_fields, field_errors = map_dom_attribute_to_fields(attr_name, attr_value, active_media_lanes=None)
             expected_fields.update(mapped_fields)
             errors.extend(field_errors)
 
@@ -320,9 +323,10 @@ def format_dom_port_failure(
     expected_fields,
     field_failures,
     field_label="expected field(s)",
+    include_lanes=True,
 ):
     """Prefix a port's failure block with its expected shape."""
-    lane_context = "" if active_lanes is None else ", media lanes {}".format(active_lanes or "none")
+    lane_context = ", lanes {}".format(active_lanes or "none") if include_lanes else ""
     return "{} [{} {}{}]:\n  {}".format(
         port,
         len(expected_fields),
@@ -492,7 +496,7 @@ def read_dom_sensor_data(duthost, ports):
     return _read_dom_table_data(duthost, ports, STATE_DB_SENSOR_TABLE)
 
 
-def read_dom_status_data(duthost, ports):
+def read_transceiver_status_data(duthost, ports):
     """Return ``({port: {field: value}}, errors)`` for current transceiver status data."""
     return _read_dom_table_data(duthost, ports, STATE_DB_STATUS_TABLE)
 

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -247,14 +247,13 @@ def build_dom_sensor_plan(port_attributes_dict, dom_primary_ports, lport_to_firs
 def build_dom_threshold_plan(port_attributes_dict, dom_primary_ports):
     """Return each port's expected threshold fields and paired operational ranges.
 
-    ``expected_fields`` is a ``{field: DomThresholdMappedField(...)}`` map for
-    ``TRANSCEIVER_DOM_THRESHOLD``. Threshold validation is transceiver-level, so
+    ``db_fields_by_threshold_attr`` groups ``TRANSCEIVER_DOM_THRESHOLD`` fields
+    by source threshold attribute. Threshold validation is transceiver-level, so
     no LANE_NUM expansion is applied here.
     """
     plan_by_port = {}
     for port in dom_primary_ports:
         dom_attrs = port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {})
-        expected_fields = {}
         configured_by_attr = {}
         db_fields_by_threshold_attr = defaultdict(dict)
         operational_range_by_threshold_attr = {}
@@ -266,7 +265,6 @@ def build_dom_threshold_plan(port_attributes_dict, dom_primary_ports):
 
             configured_by_attr[attr_name] = attr_value
             mapped_fields, field_errors = map_dom_attribute_to_fields(attr_name, attr_value, active_media_lanes=None)
-            expected_fields.update(mapped_fields)
             for field, mapped_field in mapped_fields.items():
                 db_fields_by_threshold_attr[attr_name][field] = mapped_field
             errors.extend(field_errors)
@@ -279,7 +277,6 @@ def build_dom_threshold_plan(port_attributes_dict, dom_primary_ports):
                 )
 
         plan_by_port[port] = {
-            "expected_fields": {field: expected_fields[field] for field in sorted(expected_fields)},
             "configured_by_attr": configured_by_attr,
             "db_fields_by_threshold_attr": {
                 attr_name: {
@@ -295,7 +292,7 @@ def build_dom_threshold_plan(port_attributes_dict, dom_primary_ports):
             "%s DOM threshold plan: %d expected field(s), %d threshold attr(s), "
             "%d paired operational range attr(s)",
             port,
-            len(expected_fields),
+            sum(len(fields) for fields in db_fields_by_threshold_attr.values()),
             len(configured_by_attr),
             len(operational_range_by_threshold_attr),
         )

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -23,6 +23,7 @@ from tests.transceiver.common.db_helpers import (
 logger = logging.getLogger(__name__)
 
 STATE_DB_SENSOR_TABLE = "TRANSCEIVER_DOM_SENSOR"
+STATE_DB_STATUS_TABLE = "TRANSCEIVER_STATUS"
 STATE_DB_THRESHOLD_TABLE = "TRANSCEIVER_DOM_THRESHOLD"
 
 OPERATIONAL_SUFFIX = "_operational_range"
@@ -489,6 +490,11 @@ def _read_dom_table_data(duthost, ports, table_name):
 def read_dom_sensor_data(duthost, ports):
     """Return ``({port: {field: value}}, errors)`` for current DOM sensor data."""
     return _read_dom_table_data(duthost, ports, STATE_DB_SENSOR_TABLE)
+
+
+def read_dom_status_data(duthost, ports):
+    """Return ``({port: {field: value}}, errors)`` for current transceiver status data."""
+    return _read_dom_table_data(duthost, ports, STATE_DB_STATUS_TABLE)
 
 
 def read_dom_threshold_data(duthost, ports):

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -178,7 +178,7 @@ def _operational_attr_for_threshold(attr_name):
     return THRESHOLD_TO_OPERATIONAL_ATTR.get(base_name)
 
 
-def build_dom_availability_plan(port_attributes_dict, dom_primary_ports, lport_to_first_subport_mapping):
+def build_dom_sensor_plan(port_attributes_dict, dom_primary_ports, lport_to_first_subport_mapping):
     """Return each port's expected DOM fields, active lanes, errors, and age limit.
 
     ``expected_fields`` is a ``{field: DomMappedField(source_attr, attr_value)}``
@@ -321,7 +321,7 @@ def format_dom_port_failure(
     field_label="expected field(s)",
 ):
     """Prefix a port's failure block with its expected shape."""
-    lane_context = "" if active_lanes is None else ", lanes {}".format(active_lanes or "none")
+    lane_context = "" if active_lanes is None else ", media lanes {}".format(active_lanes or "none")
     return "{} [{} {}{}]:\n  {}".format(
         port,
         len(expected_fields),
@@ -396,7 +396,7 @@ def validate_dom_plan_fields(
             continue
 
         freshness_age_min = None
-        if max_age_min is not None and (has_field_checks or include_freshness_only):
+        if max_age_min is not None:
             if now_utc is None:
                 now_utc = duthost.get_now_time(utc_timezone=True)
             freshness_result = check_dom_sensor_freshness(sensor_data, max_age_min, now_utc)

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -23,11 +23,33 @@ from tests.transceiver.common.db_helpers import (
 logger = logging.getLogger(__name__)
 
 STATE_DB_SENSOR_TABLE = "TRANSCEIVER_DOM_SENSOR"
+STATE_DB_THRESHOLD_TABLE = "TRANSCEIVER_DOM_THRESHOLD"
 
 OPERATIONAL_SUFFIX = "_operational_range"
+THRESHOLD_SUFFIX = "_threshold_range"
 LANE_NUM_PLACEHOLDER = "LANE_NUM"
 MEDIA_LANE_MASK_KEY = "media_lane_mask"
 DomMappedField = namedtuple("DomMappedField", ("source_attr", "attr_value"))
+DomThresholdMappedField = namedtuple("DomThresholdMappedField", ("source_attr", "attr_value", "threshold_key"))
+
+THRESHOLD_FIELD_SUFFIXES = ("lowalarm", "lowwarning", "highwarning", "highalarm")
+THRESHOLD_FIELD_PREFIXES = {
+    "temperature": "temp",
+    "voltage": "vcc",
+    "laser_temperature": "lasertemp",
+    "tx_bias": "txbias",
+    "tx_power": "txpower",
+    "rx_power": "rxpower",
+}
+THRESHOLD_TO_OPERATIONAL_ATTR = {
+    "temperature": "temperature_operational_range",
+    "voltage": "voltage_operational_range",
+    "laser_temperature": "laser_temperature_operational_range",
+    "tx_bias": "txLANE_NUMbias_operational_range",
+    "tx_power": "txLANE_NUMpower_operational_range",
+    "rx_power": "rxLANE_NUMpower_operational_range",
+}
+THRESHOLD_VALUE_TOLERANCE = 0.01
 
 DOM_POLLING_ENABLED_VALUES = ("", "enabled")
 DOM_POLLING_DISABLED_VALUE = "disabled"
@@ -117,15 +139,43 @@ DOM_FIELD_MAPPERS = (
 def map_dom_attribute_to_fields(attr_name, attr_value, active_media_lanes):
     """Map one DOM attribute to current STATE_DB field metadata.
 
-    The suffix dispatch is DOM-local: TC1/TC2 use the operational mapper today,
-    and future threshold/consistency families can add their own mapper here
-    without duplicating the LANE_NUM expansion path.
+    The suffix dispatch is DOM-local. TC1/TC2 use this operational mapper for
+    ``TRANSCEIVER_DOM_SENSOR``; TC3 uses separate threshold helpers because
+    ``TRANSCEIVER_DOM_THRESHOLD`` is transceiver-level and does not expand
+    LANE_NUM.
     """
     for suffix, mapper in DOM_FIELD_MAPPERS:
         if attr_name.endswith(suffix):
             return mapper(attr_name, attr_value, active_media_lanes)
     logger.debug("DOM attribute %s matched no field mapper; skipped", attr_name)
     return {}, []
+
+
+def map_dom_threshold_attribute_to_fields(attr_name, attr_value):
+    """Return ``({field: DomThresholdMappedField(source_attr, attr_value, threshold_key)}, errors)``."""
+    if not attr_name.endswith(THRESHOLD_SUFFIX):
+        logger.debug("DOM attribute %s is not a threshold range; skipped", attr_name)
+        return {}, []
+
+    base_name = attr_name[:-len(THRESHOLD_SUFFIX)]
+    prefix = THRESHOLD_FIELD_PREFIXES.get(base_name)
+    if prefix is None:
+        return {}, ["{} has no DOM threshold field mapping".format(attr_name)]
+
+    return {
+        "{}{}".format(prefix, suffix): DomThresholdMappedField(
+            attr_name,
+            attr_value,
+            suffix,
+        )
+        for suffix in THRESHOLD_FIELD_SUFFIXES
+    }, []
+
+
+def _operational_attr_for_threshold(attr_name):
+    """Return the configured operational-range attribute paired with a threshold attribute."""
+    base_name = attr_name[:-len(THRESHOLD_SUFFIX)]
+    return THRESHOLD_TO_OPERATIONAL_ATTR.get(base_name)
 
 
 def build_dom_availability_plan(port_attributes_dict, dom_primary_ports, lport_to_first_subport_mapping):
@@ -167,6 +217,55 @@ def build_dom_availability_plan(port_attributes_dict, dom_primary_ports, lport_t
             len(expected_fields),
             active_media_lanes or "none",
             dom_attrs.get("data_max_age_min"),
+        )
+
+    return plan_by_port
+
+
+def build_dom_threshold_plan(port_attributes_dict, dom_primary_ports):
+    """Return each port's expected threshold fields and paired operational ranges.
+
+    ``expected_fields`` is a ``{field: DomThresholdMappedField(...)}`` map for
+    ``TRANSCEIVER_DOM_THRESHOLD``. Threshold validation is transceiver-level, so
+    no LANE_NUM expansion is applied here.
+    """
+    plan_by_port = {}
+    for port in dom_primary_ports:
+        dom_attrs = port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {})
+        expected_fields = {}
+        threshold_attrs = {}
+        operational_ranges = {}
+        errors = []
+
+        for attr_name, attr_value in sorted(dom_attrs.items()):
+            if not attr_name.endswith(THRESHOLD_SUFFIX):
+                continue
+
+            threshold_attrs[attr_name] = attr_value
+            mapped_fields, field_errors = map_dom_threshold_attribute_to_fields(attr_name, attr_value)
+            expected_fields.update(mapped_fields)
+            errors.extend(field_errors)
+
+            operational_attr = _operational_attr_for_threshold(attr_name)
+            if operational_attr in dom_attrs:
+                operational_ranges[attr_name] = DomMappedField(
+                    operational_attr,
+                    dom_attrs[operational_attr],
+                )
+
+        plan_by_port[port] = {
+            "expected_fields": {field: expected_fields[field] for field in sorted(expected_fields)},
+            "threshold_attrs": threshold_attrs,
+            "operational_ranges": operational_ranges,
+            "errors": errors,
+        }
+        logger.debug(
+            "%s DOM threshold plan: %d expected field(s), %d threshold attr(s), "
+            "%d paired operational range attr(s)",
+            port,
+            len(expected_fields),
+            len(threshold_attrs),
+            len(operational_ranges),
         )
 
     return plan_by_port
@@ -214,12 +313,20 @@ def format_optional_float(value):
     return "{:.2f}".format(value) if value is not None else "not-available"
 
 
-def format_dom_port_failure(port, active_lanes, expected_fields, field_failures):
+def format_dom_port_failure(
+    port,
+    active_lanes,
+    expected_fields,
+    field_failures,
+    field_label="expected field(s)",
+):
     """Prefix a port's failure block with its expected shape."""
-    return "{} [{} expected field(s), lanes {}]:\n  {}".format(
+    lane_context = "" if active_lanes is None else ", lanes {}".format(active_lanes or "none")
+    return "{} [{} {}{}]:\n  {}".format(
         port,
         len(expected_fields),
-        active_lanes or "none",
+        field_label,
+        lane_context,
         "\n  ".join(field_failures),
     )
 
@@ -337,10 +444,10 @@ def validate_dom_plan_fields(
     return failures, checked_field_count, checked_port_count
 
 
-def read_dom_sensor_data(duthost, ports):
-    """Return ``({port: {field: value}}, errors)`` for current DOM sensor data."""
+def _read_dom_table_data(duthost, ports, table_name):
+    """Return ``({port: {field: value}}, errors)`` for a current DOM STATE_DB table."""
     ports = list(ports)
-    sensor_data = {port: {} for port in ports}
+    table_data_by_port = {port: {} for port in ports}
     errors = []
     ports_by_namespace = defaultdict(list)
 
@@ -349,15 +456,15 @@ def read_dom_sensor_data(duthost, ports):
         ports_by_namespace[namespace].append(port)
 
     for namespace, namespace_ports in ports_by_namespace.items():
-        sensor_table, err = get_state_db_table(
+        dom_table, err = get_state_db_table(
             duthost,
-            STATE_DB_SENSOR_TABLE,
+            table_name,
             namespace=namespace,
         )
         if err:
             errors.append(
                 "{} namespace {}: {}".format(
-                    STATE_DB_SENSOR_TABLE,
+                    table_name,
                     namespace or "default",
                     err,
                 )
@@ -365,17 +472,28 @@ def read_dom_sensor_data(duthost, ports):
             continue
 
         for port in namespace_ports:
-            sensor_data[port] = sensor_table.get(port, {}) or {}
+            table_data_by_port[port] = dom_table.get(port, {}) or {}
 
     logger.debug(
-        "Read DOM sensor data for %d port(s) across %d namespace(s); "
+        "Read %s data for %d port(s) across %d namespace(s); "
         "%d port(s) returned data",
+        table_name,
         len(ports),
         len(ports_by_namespace),
-        sum(1 for port_data in sensor_data.values() if port_data),
+        sum(1 for port_data in table_data_by_port.values() if port_data),
     )
 
-    return sensor_data, errors
+    return table_data_by_port, errors
+
+
+def read_dom_sensor_data(duthost, ports):
+    """Return ``({port: {field: value}}, errors)`` for current DOM sensor data."""
+    return _read_dom_table_data(duthost, ports, STATE_DB_SENSOR_TABLE)
+
+
+def read_dom_threshold_data(duthost, ports):
+    """Return ``({port: {field: value}}, errors)`` for current DOM threshold data."""
+    return _read_dom_table_data(duthost, ports, STATE_DB_THRESHOLD_TABLE)
 
 
 def check_dom_sensor_freshness(sensor_data, max_age_min, now_utc):

--- a/tests/transceiver/dom/test_dom_availability.py
+++ b/tests/transceiver/dom/test_dom_availability.py
@@ -6,7 +6,7 @@ from natsort import natsorted
 
 from tests.transceiver.common.db_helpers import parse_numeric
 from tests.transceiver.dom.dom_helpers import (
-    build_dom_availability_plan,
+    build_dom_sensor_plan,
     read_dom_sensor_data,
     validate_dom_plan_fields,
 )
@@ -59,7 +59,7 @@ def test_dom_data_availability_verification(
     """Verify configured DOM sensor data is present and fresh in STATE_DB."""
     sensor_ports = natsorted(set(dom_primary_ports) | set(dom_non_primary_ports))
     sensor_by_port, sensor_read_errors = read_dom_sensor_data(duthost, sensor_ports)
-    availability_plan_by_port = build_dom_availability_plan(
+    sensor_plan_by_port = build_dom_sensor_plan(
         port_attributes_dict,
         dom_primary_ports,
         lport_to_first_subport_mapping,
@@ -70,7 +70,7 @@ def test_dom_data_availability_verification(
         duthost,
         dom_primary_ports,
         sensor_by_port,
-        availability_plan_by_port,
+        sensor_plan_by_port,
         _availability_field_check,
         include_freshness_only=True,
     )

--- a/tests/transceiver/dom/test_dom_consistency.py
+++ b/tests/transceiver/dom/test_dom_consistency.py
@@ -1,10 +1,15 @@
 import logging
 import math
 import time
+from collections import defaultdict
 
 import pytest
 
 from tests.transceiver.attribute_parser.attribute_keys import DOM_ATTRIBUTES_KEY
+from tests.transceiver.common.cmis_helper import (
+    STATE_DB_DP_STATE_ACTIVATED,
+    is_state_db_dp_state_activated,
+)
 from tests.transceiver.common.db_helpers import (
     STATE_DB_UPDATE_TIME_FIELD,
     parse_numeric,
@@ -14,60 +19,56 @@ from tests.transceiver.dom.dom_helpers import (
     STATE_DB_SENSOR_TABLE,
     build_dom_sensor_plan,
     format_dom_port_failure,
+    format_optional_float,
     read_dom_sensor_data,
-    read_dom_status_data,
+    read_transceiver_status_data,
 )
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONSISTENCY_CHECK_POLL_COUNT = 3
 DEFAULT_MAX_UPDATE_TIME_SEC = 60
+UPDATE_ADVANCE_MARGIN_SEC = 5
 TX_BIAS_THRESHOLD_ATTR = "tx_bias_threshold_range"
-DP_ACTIVATED_VALUES = ("DPActivated", "DataPathActivated")
+TX_BIAS_CONSISTENCY_ATTR = "tx_bias_consistency_variation_threshold"
+MODE_ABSOLUTE = "absolute"
+MODE_PERCENT = "percent"
 
-ABSOLUTE_CONSISTENCY_FIELDS = {
-    "temperature_consistency_variation_threshold": ("temperature", "C"),
-    "voltage_consistency_variation_threshold": ("voltage", "V"),
-    "laser_temperature_consistency_variation_threshold": ("laser_temperature", "C"),
-}
-LANE_CONSISTENCY_FIELDS = {
-    "tx_power_consistency_variation_threshold": ("tx{}power", "dB", "absolute"),
-    "rx_power_consistency_variation_threshold": ("rx{}power", "dB", "absolute"),
-    "tx_bias_consistency_variation_threshold": ("tx{}bias", "percent", "percent"),
-}
+CONSISTENCY_FIELD_DEFINITIONS = (
+    ("temperature_consistency_variation_threshold", "temperature", "C", MODE_ABSOLUTE, False),
+    ("voltage_consistency_variation_threshold", "voltage", "V", MODE_ABSOLUTE, False),
+    ("laser_temperature_consistency_variation_threshold", "laser_temperature", "C", MODE_ABSOLUTE, False),
+    ("tx_power_consistency_variation_threshold", "tx{}power", "dB", MODE_ABSOLUTE, True),
+    ("rx_power_consistency_variation_threshold", "rx{}power", "dB", MODE_ABSOLUTE, True),
+    (TX_BIAS_CONSISTENCY_ATTR, "tx{}bias", "percent", MODE_PERCENT, True),
+)
 
 
 def _parse_positive_int(attr_name, raw_value, default_value, minimum):
-    """Return ``(value, error)`` for positive integer DOM timing attributes."""
     if raw_value is None:
         return default_value, None
 
     value = parse_numeric(raw_value)
     if value is None or not math.isfinite(value) or int(value) != value or value < minimum:
         return None, "{} must be an integer >= {} in DOM_ATTRIBUTES (got {!r})".format(
-            attr_name,
-            minimum,
-            raw_value,
+            attr_name, minimum, raw_value
         )
     return int(value), None
 
 
 def _parse_non_negative_threshold(attr_name, raw_value):
-    """Return ``(threshold, error)`` for configured consistency thresholds."""
     value = parse_numeric(raw_value)
     if value is None or not math.isfinite(value) or value < 0:
         return None, "{} must be a finite non-negative number in DOM_ATTRIBUTES (got {!r})".format(
-            attr_name,
-            raw_value,
+            attr_name, raw_value
         )
     return value, None
 
 
 def _parse_tx_bias_warning_range(dom_attrs):
-    """Return ``(lowwarning, highwarning, reason)`` for Tx-bias percentage gating."""
     attr_value = dom_attrs.get(TX_BIAS_THRESHOLD_ATTR)
     if not isinstance(attr_value, dict):
-        return None, None, "{} not configured as a dict".format(TX_BIAS_THRESHOLD_ATTR)
+        return {"low": None, "high": None, "error": "{} not configured as a dict".format(TX_BIAS_THRESHOLD_ATTR)}
 
     lowwarning = parse_numeric(attr_value.get("lowwarning"))
     highwarning = parse_numeric(attr_value.get("highwarning"))
@@ -78,13 +79,16 @@ def _parse_tx_bias_warning_range(dom_attrs):
         or not math.isfinite(highwarning)
         or lowwarning > highwarning
     ):
-        return None, None, "{} has no valid lowwarning/highwarning range".format(TX_BIAS_THRESHOLD_ATTR)
-
-    return lowwarning, highwarning, None
+        return {
+            "low": None,
+            "high": None,
+            "error": "{} has no valid lowwarning/highwarning range".format(TX_BIAS_THRESHOLD_ATTR),
+        }
+    return {"low": lowwarning, "high": highwarning, "error": None}
 
 
 def _build_dom_consistency_plan(port_attributes_dict, dom_primary_ports, sensor_plan_by_port):
-    """Build per-port TC4 timing and field-variation checks from DOM attributes."""
+    """Build per-port update-count and variation checks from DOM attributes."""
     plan_by_port = {}
     for port in dom_primary_ports:
         dom_attrs = port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {})
@@ -93,69 +97,45 @@ def _build_dom_consistency_plan(port_attributes_dict, dom_primary_ports, sensor_
         errors = []
         field_checks = {}
 
-        poll_count, poll_count_error = _parse_positive_int(
+        poll_count, poll_error = _parse_positive_int(
             "consistency_check_poll_count",
             dom_attrs.get("consistency_check_poll_count"),
             DEFAULT_CONSISTENCY_CHECK_POLL_COUNT,
             minimum=2,
         )
-        if poll_count_error:
-            errors.append(poll_count_error)
+        if poll_error:
+            errors.append(poll_error)
             poll_count = DEFAULT_CONSISTENCY_CHECK_POLL_COUNT
 
-        update_interval_sec, update_interval_error = _parse_positive_int(
-            "max_update_time_sec",
-            dom_attrs.get("max_update_time_sec"),
-            DEFAULT_MAX_UPDATE_TIME_SEC,
-            minimum=1,
+        has_lane_check = any(
+            attr_name in dom_attrs and lane_expanded
+            for attr_name, _field_template, _unit, _mode, lane_expanded in CONSISTENCY_FIELD_DEFINITIONS
         )
-        if update_interval_error:
-            errors.append(update_interval_error)
-            update_interval_sec = DEFAULT_MAX_UPDATE_TIME_SEC
+        if has_lane_check and sensor_plan.get("errors"):
+            errors.extend(sensor_plan["errors"])
 
-        for attr_name, (field, unit) in sorted(ABSOLUTE_CONSISTENCY_FIELDS.items()):
+        for attr_name, field_template, unit, mode, lane_expanded in CONSISTENCY_FIELD_DEFINITIONS:
             if attr_name not in dom_attrs:
                 continue
+
             threshold, threshold_error = _parse_non_negative_threshold(attr_name, dom_attrs[attr_name])
             if threshold_error:
                 errors.append(threshold_error)
                 continue
-            field_checks[field] = {
-                "source_attr": attr_name,
-                "threshold": threshold,
-                "mode": "absolute",
-                "unit": unit,
-            }
 
-        has_lane_checks = any(attr_name in dom_attrs for attr_name in LANE_CONSISTENCY_FIELDS)
-        if has_lane_checks and sensor_plan.get("errors"):
-            errors.extend(sensor_plan.get("errors", []))
-
-        for attr_name, (field_template, unit, mode) in sorted(LANE_CONSISTENCY_FIELDS.items()):
-            if attr_name not in dom_attrs:
-                continue
-            threshold, threshold_error = _parse_non_negative_threshold(attr_name, dom_attrs[attr_name])
-            if threshold_error:
-                errors.append(threshold_error)
-                continue
-            if not active_lanes:
+            if lane_expanded and not active_lanes:
                 errors.append("{} configured but no active media lanes resolved".format(attr_name))
                 continue
 
-            lowwarning = highwarning = warning_range_error = None
-            if mode == "percent":
-                lowwarning, highwarning, warning_range_error = _parse_tx_bias_warning_range(dom_attrs)
-
-            for lane in active_lanes:
-                field_checks[field_template.format(lane)] = {
+            lanes = active_lanes if lane_expanded else [None]
+            for lane in lanes:
+                field = field_template.format(lane) if lane is not None else field_template
+                field_checks[field] = {
                     "source_attr": attr_name,
                     "threshold": threshold,
                     "mode": mode,
                     "unit": unit,
                     "lane": lane,
-                    "warning_low": lowwarning,
-                    "warning_high": highwarning,
-                    "warning_range_error": warning_range_error,
                 }
 
         plan_by_port[port] = {
@@ -163,340 +143,198 @@ def _build_dom_consistency_plan(port_attributes_dict, dom_primary_ports, sensor_
             "errors": errors,
             "field_checks": {field: field_checks[field] for field in sorted(field_checks)},
             "poll_count": poll_count,
-            "update_interval_sec": update_interval_sec,
+            "tx_bias_warning_range": (
+                _parse_tx_bias_warning_range(dom_attrs)
+                if TX_BIAS_CONSISTENCY_ATTR in dom_attrs
+                else {"low": None, "high": None, "error": None}
+            ),
         }
-        logger.debug(
-            "%s DOM consistency plan: poll_count=%s update_interval_sec=%s "
-            "field_checks=%s active_media_lanes=%s",
-            port,
-            poll_count,
-            update_interval_sec,
-            sorted(field_checks),
-            active_lanes or "none",
-        )
-
     return plan_by_port
 
 
 def _collect_dom_samples(duthost, dom_primary_ports, sample_count, interval_sec, read_status):
-    """Read DOM sensor/status samples with a fixed interval between samples."""
-    samples = []
-    for sample_index in range(sample_count):
+    samples_by_port = {port: [] for port in dom_primary_ports}
+    read_failures = []
+    sleep_sec = interval_sec + UPDATE_ADVANCE_MARGIN_SEC
+
+    for sample_index in range(1, sample_count + 1):
         sensor_by_port, sensor_errors = read_dom_sensor_data(duthost, dom_primary_ports)
-        status_by_port = {}
-        status_errors = []
+        status_by_port, status_errors = ({}, [])
         if read_status:
-            status_by_port, status_errors = read_dom_status_data(duthost, dom_primary_ports)
-        samples.append(
-            {
-                "sensor_by_port": sensor_by_port,
-                "status_by_port": status_by_port,
-                "sensor_errors": sensor_errors,
-                "status_errors": status_errors,
-            }
+            status_by_port, status_errors = read_transceiver_status_data(duthost, dom_primary_ports)
+
+        read_failures.extend(
+            "STATE_DB sample {} sensor read:\n  {}".format(sample_index, error)
+            for error in sensor_errors
         )
-        logger.debug("Collected DOM consistency sample %d/%d", sample_index + 1, sample_count)
-        if sample_index + 1 < sample_count:
-            time.sleep(interval_sec)
-    return samples
+        read_failures.extend(
+            "STATE_DB sample {} status read:\n  {}".format(sample_index, error)
+            for error in status_errors
+        )
+        for port in dom_primary_ports:
+            samples_by_port[port].append({
+                "sensor": sensor_by_port.get(port, {}) or {},
+                "status": status_by_port.get(port, {}) or {},
+            })
 
+        logger.debug("Collected DOM consistency sample %d/%d", sample_index, sample_count)
+        if sample_index < sample_count:
+            time.sleep(sleep_sec)
 
-def _sensor_sample_for_port(samples, sample_index, port):
-    return samples[sample_index]["sensor_by_port"].get(port, {}) or {}
-
-
-def _status_sample_for_port(samples, sample_index, port):
-    return samples[sample_index]["status_by_port"].get(port, {}) or {}
-
-
-def _validate_last_update_time(port, samples, poll_count):
-    """Validate last_update_time exists and advances between TC4 samples."""
-    failures = []
-    parsed_times = []
-
-    for sample_index in range(poll_count):
-        sensor_data = _sensor_sample_for_port(samples, sample_index, port)
-        if not sensor_data:
-            failures.append(
-                "sample {}: no {} entry published for port".format(
-                    sample_index + 1,
-                    STATE_DB_SENSOR_TABLE,
-                )
-            )
-            parsed_times.append(None)
-            continue
-
-        raw_update_time = sensor_data.get(STATE_DB_UPDATE_TIME_FIELD)
-        parsed_time = parse_update_time(raw_update_time)
-        if parsed_time is None:
-            failures.append(
-                "sample {}: {} missing or unparsable (raw={!r})".format(
-                    sample_index + 1,
-                    STATE_DB_UPDATE_TIME_FIELD,
-                    raw_update_time,
-                )
-            )
-        parsed_times.append(parsed_time)
-
-    for sample_index in range(1, poll_count):
-        previous_time = parsed_times[sample_index - 1]
-        current_time = parsed_times[sample_index]
-        if previous_time is None or current_time is None:
-            continue
-        if current_time <= previous_time:
-            failures.append(
-                "{} did not advance between sample {} and {} (prev={!r}, curr={!r})".format(
-                    STATE_DB_UPDATE_TIME_FIELD,
-                    sample_index,
-                    sample_index + 1,
-                    _sensor_sample_for_port(samples, sample_index - 1, port).get(STATE_DB_UPDATE_TIME_FIELD),
-                    _sensor_sample_for_port(samples, sample_index, port).get(STATE_DB_UPDATE_TIME_FIELD),
-                )
-            )
-
-    return failures
+    return samples_by_port, read_failures
 
 
 def _numeric_sensor_value(sensor_data, field):
     value = parse_numeric(sensor_data.get(field))
-    if value is None or not math.isfinite(value):
-        return None
-    return value
+    return value if value is not None and math.isfinite(value) else None
 
 
-def _dp_state_activated(status_data, lane):
-    return status_data.get("DP{}State".format(lane)) in DP_ACTIVATED_VALUES
-
-
-def _validate_absolute_delta(port, field, check, previous_sensor, current_sensor, sample_index):
-    previous_value = _numeric_sensor_value(previous_sensor, field)
-    current_value = _numeric_sensor_value(current_sensor, field)
-    if previous_value is None or current_value is None:
-        return (
-            "{} sample {}->{}: missing/non-finite value (prev={!r}, curr={!r})".format(
-                field,
-                sample_index,
-                sample_index + 1,
-                previous_sensor.get(field),
-                current_sensor.get(field),
-            )
-        )
-
-    delta = abs(current_value - previous_value)
-    if delta > check["threshold"]:
-        return (
-            "{} sample {}->{} delta {}{} exceeds {}{} "
-            "(prev={}, curr={})".format(
-                field,
-                sample_index,
-                sample_index + 1,
-                delta,
-                check["unit"],
-                check["threshold"],
-                check["unit"],
-                previous_value,
-                current_value,
-            )
-        )
-
-    logger.debug(
-        "DOM consistency PASS %s %s sample %d->%d: delta=%s%s limit=%s%s",
-        port,
+def _format_delta_failure(field, sample_index, delta, threshold, unit, previous_value, current_value):
+    return "{} sample {}->{} delta {}{} exceeds {}{} (prev={}, curr={})".format(
         field,
         sample_index,
         sample_index + 1,
-        delta,
-        check["unit"],
-        check["threshold"],
-        check["unit"],
+        format_optional_float(delta),
+        unit,
+        format_optional_float(threshold),
+        unit,
+        format_optional_float(previous_value),
+        format_optional_float(current_value),
     )
-    return None
 
 
-def _tx_bias_skip_reason(field, check, previous_sensor, current_sensor, previous_status, current_status):
-    if check.get("warning_range_error"):
-        return check["warning_range_error"]
+def _validate_pair(port, field, check, previous_sample, current_sample, sample_index, plan):
+    previous_sensor = previous_sample["sensor"]
+    current_sensor = current_sample["sensor"]
+    previous_value = _numeric_sensor_value(previous_sensor, field)
+    current_value = _numeric_sensor_value(current_sensor, field)
 
+    if check["mode"] == MODE_ABSOLUTE:
+        if previous_value is None or current_value is None:
+            return "{} sample {}->{}: missing/non-finite value (prev={!r}, curr={!r})".format(
+                field, sample_index, sample_index + 1, previous_sensor.get(field), current_sensor.get(field)
+            ), False, None
+        delta = abs(current_value - previous_value)
+        if delta > check["threshold"]:
+            return _format_delta_failure(
+                field, sample_index, delta, check["threshold"], check["unit"], previous_value, current_value
+            ), True, None
+        logger.debug("DOM consistency PASS %s %s sample %d->%d: delta=%s%s limit=%s%s",
+                     port, field, sample_index, sample_index + 1, format_optional_float(delta),
+                     check["unit"], format_optional_float(check["threshold"]), check["unit"])
+        return None, True, None
+
+    warning_range = plan["tx_bias_warning_range"]
     lane = check["lane"]
-    previous_state = previous_status.get("DP{}State".format(lane))
-    current_state = current_status.get("DP{}State".format(lane))
-    if not (_dp_state_activated(previous_status, lane) and _dp_state_activated(current_status, lane)):
-        return "DP{}State not activated (prev={!r}, curr={!r})".format(
-            lane,
-            previous_state,
-            current_state,
+    previous_status = previous_sample["status"]
+    current_status = current_sample["status"]
+    if warning_range["error"]:
+        skip_reason = warning_range["error"]
+    elif not (
+        is_state_db_dp_state_activated(previous_status, lane)
+        and is_state_db_dp_state_activated(current_status, lane)
+    ):
+        skip_reason = "DP{}State not {} (prev={!r}, curr={!r})".format(
+            lane, STATE_DB_DP_STATE_ACTIVATED, previous_status.get("DP{}State".format(lane)),
+            current_status.get("DP{}State".format(lane))
         )
-
-    previous_value = _numeric_sensor_value(previous_sensor, field)
-    current_value = _numeric_sensor_value(current_sensor, field)
-    if previous_value is None or current_value is None:
-        return "missing/non-finite value (prev={!r}, curr={!r})".format(
-            previous_sensor.get(field),
-            current_sensor.get(field),
+    elif previous_value is None or current_value is None:
+        skip_reason = "missing/non-finite value (prev={!r}, curr={!r})".format(
+            previous_sensor.get(field), current_sensor.get(field)
         )
-
-    lowwarning = check["warning_low"]
-    highwarning = check["warning_high"]
-    if not (lowwarning <= previous_value <= highwarning and lowwarning <= current_value <= highwarning):
-        return "value outside tx_bias warning range [{}, {}] (prev={}, curr={})".format(
-            lowwarning,
-            highwarning,
-            previous_value,
-            current_value,
+    elif not (warning_range["low"] <= previous_value <= warning_range["high"]
+              and warning_range["low"] <= current_value <= warning_range["high"]):
+        # Tx-bias percent stability is meaningful only in the normal warning range;
+        # threshold/alarm tests own values that are already outside this envelope.
+        skip_reason = "value outside tx_bias warning range [{}, {}] (prev={}, curr={})".format(
+            format_optional_float(warning_range["low"]),
+            format_optional_float(warning_range["high"]),
+            format_optional_float(previous_value),
+            format_optional_float(current_value),
         )
+    elif previous_value == 0:
+        skip_reason = "previous value is zero; percent change is undefined"
+    else:
+        skip_reason = None
 
-    if previous_value == 0:
-        return "previous value is zero; percent change is undefined"
-
-    return None
-
-
-def _validate_tx_bias_percent_delta(
-    port,
-    field,
-    check,
-    previous_sensor,
-    current_sensor,
-    previous_status,
-    current_status,
-    sample_index,
-):
-    skip_reason = _tx_bias_skip_reason(field, check, previous_sensor, current_sensor, previous_status, current_status)
     if skip_reason:
-        logger.info(
-            "DOM consistency SKIP %s %s sample %d->%d: %s",
-            port,
-            field,
-            sample_index,
-            sample_index + 1,
-            skip_reason,
-        )
-        return None, False
+        logger.info("DOM consistency SKIP %s %s sample %d->%d: %s",
+                    port, field, sample_index, sample_index + 1, skip_reason)
+        return None, False, skip_reason
 
-    previous_value = _numeric_sensor_value(previous_sensor, field)
-    current_value = _numeric_sensor_value(current_sensor, field)
     delta_percent = abs(current_value - previous_value) / abs(previous_value) * 100
     if delta_percent > check["threshold"]:
-        return (
-            "{} sample {}->{} delta {:.2f}% exceeds {}% "
-            "(prev={}, curr={})".format(
-                field,
-                sample_index,
-                sample_index + 1,
-                delta_percent,
-                check["threshold"],
-                previous_value,
-                current_value,
-            ),
-            True,
-        )
-
-    logger.debug(
-        "DOM consistency PASS %s %s sample %d->%d: delta=%.2f%% limit=%s%%",
-        port,
-        field,
-        sample_index,
-        sample_index + 1,
-        delta_percent,
-        check["threshold"],
-    )
-    return None, True
+        return _format_delta_failure(
+            field, sample_index, delta_percent, check["threshold"], "%", previous_value, current_value
+        ), True, None
+    logger.debug("DOM consistency PASS %s %s sample %d->%d: delta=%.2f%% limit=%s%%",
+                 port, field, sample_index, sample_index + 1, delta_percent,
+                 format_optional_float(check["threshold"]))
+    return None, True, None
 
 
-def _validate_variation_checks(port, samples, plan):
-    """Validate configured variation checks for one port across samples."""
+def _validate_port_samples(port, port_samples, plan):
     failures = []
     checked_pair_count = 0
-    field_checks = plan.get("field_checks", {})
-    poll_count = plan["poll_count"]
+    checked_by_attr = defaultdict(int)
+    skipped_by_attr = defaultdict(list)
 
-    for sample_index in range(1, poll_count):
-        previous_sensor = _sensor_sample_for_port(samples, sample_index - 1, port)
-        current_sensor = _sensor_sample_for_port(samples, sample_index, port)
-        previous_status = _status_sample_for_port(samples, sample_index - 1, port)
-        current_status = _status_sample_for_port(samples, sample_index, port)
+    parsed_times = []
+    for sample_index in range(plan["poll_count"]):
+        sensor_data = port_samples[sample_index]["sensor"]
+        if not sensor_data:
+            failures.append("sample {}: no {} entry published for port".format(
+                sample_index + 1, STATE_DB_SENSOR_TABLE
+            ))
+            parsed_times.append(None)
+            continue
+        raw_update_time = sensor_data.get(STATE_DB_UPDATE_TIME_FIELD)
+        parsed_time = parse_update_time(raw_update_time)
+        if parsed_time is None:
+            failures.append("sample {}: {} missing or unparsable (raw={!r})".format(
+                sample_index + 1, STATE_DB_UPDATE_TIME_FIELD, raw_update_time
+            ))
+        parsed_times.append(parsed_time)
 
-        for field, check in field_checks.items():
-            if check["mode"] == "percent":
-                error, checked = _validate_tx_bias_percent_delta(
-                    port,
-                    field,
-                    check,
-                    previous_sensor,
-                    current_sensor,
-                    previous_status,
-                    current_status,
-                    sample_index,
-                )
-                if checked:
-                    checked_pair_count += 1
-            else:
-                error = _validate_absolute_delta(
-                    port,
-                    field,
-                    check,
-                    previous_sensor,
-                    current_sensor,
-                    sample_index,
-                )
+    for sample_index in range(1, plan["poll_count"]):
+        previous_time = parsed_times[sample_index - 1]
+        current_time = parsed_times[sample_index]
+        if previous_time is not None and current_time is not None and current_time <= previous_time:
+            failures.append("{} did not advance between sample {} and {} (prev={!r}, curr={!r})".format(
+                STATE_DB_UPDATE_TIME_FIELD, sample_index, sample_index + 1,
+                port_samples[sample_index - 1]["sensor"].get(STATE_DB_UPDATE_TIME_FIELD),
+                port_samples[sample_index]["sensor"].get(STATE_DB_UPDATE_TIME_FIELD),
+            ))
+
+    for sample_index in range(1, plan["poll_count"]):
+        previous_sample = port_samples[sample_index - 1]
+        current_sample = port_samples[sample_index]
+        for field, check in plan["field_checks"].items():
+            error, checked, skip_reason = _validate_pair(
+                port, field, check, previous_sample, current_sample, sample_index, plan
+            )
+            if checked:
                 checked_pair_count += 1
-
+                checked_by_attr[check["source_attr"]] += 1
+            if skip_reason:
+                skipped_by_attr[check["source_attr"]].append(
+                    "{} sample {}->{}: {}".format(field, sample_index, sample_index + 1, skip_reason)
+                )
             if error:
                 failures.append(error)
 
-    return failures, checked_pair_count
-
-
-def _validate_dom_consistency(dom_primary_ports, samples, consistency_plan_by_port):
-    failures = []
-    checked_pair_count = 0
-    checked_port_count = 0
-
-    for port in dom_primary_ports:
-        plan = consistency_plan_by_port.get(port, {})
-        expected_fields = plan.get("field_checks", {})
-        field_failures = list(plan.get("errors", []))
-        active_lanes = plan.get("active_media_lanes", [])
-
-        last_update_failures = _validate_last_update_time(port, samples, plan["poll_count"])
-        variation_failures, port_checked_pair_count = _validate_variation_checks(port, samples, plan)
-        field_failures.extend(last_update_failures)
-        field_failures.extend(variation_failures)
-
-        checked_port_count += 1
-        checked_pair_count += port_checked_pair_count
-
-        if field_failures:
-            failures.append(
-                format_dom_port_failure(
-                    port,
-                    active_lanes,
-                    expected_fields,
-                    field_failures,
-                    field_label="configured consistency field(s)",
-                )
-            )
-
-    return failures, checked_pair_count, checked_port_count
-
-
-def _format_consistency_plan_failures(dom_primary_ports, consistency_plan_by_port):
-    failures = []
-    for port in dom_primary_ports:
-        plan = consistency_plan_by_port.get(port, {})
-        field_failures = list(plan.get("errors", []))
-        if not field_failures:
+    percent_attrs = {
+        check["source_attr"] for check in plan["field_checks"].values() if check["mode"] == MODE_PERCENT
+    }
+    for attr_name in sorted(percent_attrs):
+        if checked_by_attr[attr_name]:
             continue
-        failures.append(
-            format_dom_port_failure(
-                port,
-                plan.get("active_media_lanes", []),
-                plan.get("field_checks", {}),
-                field_failures,
-                field_label="configured consistency field(s)",
-            )
-        )
-    return failures
+        skip_details = "; ".join(sorted(set(skipped_by_attr[attr_name]))) or "no eligible sample pairs"
+        failures.append("{} configured but no Tx-bias sample pair was checked ({})".format(
+            attr_name, skip_details
+        ))
+
+    return failures, checked_pair_count
 
 
 def test_dom_data_consistency_verification(
@@ -505,59 +343,82 @@ def test_dom_data_consistency_verification(
     port_attributes_dict,
     lport_to_first_subport_mapping,
 ):
-    """Verify DOM sensor update cadence and configured variation thresholds."""
+    """Verify DOM sensor update cadence and any configured variation thresholds."""
     sensor_plan_by_port = build_dom_sensor_plan(
-        port_attributes_dict,
-        dom_primary_ports,
-        lport_to_first_subport_mapping,
+        port_attributes_dict, dom_primary_ports, lport_to_first_subport_mapping
     )
     consistency_plan_by_port = _build_dom_consistency_plan(
-        port_attributes_dict,
-        dom_primary_ports,
-        sensor_plan_by_port,
+        port_attributes_dict, dom_primary_ports, sensor_plan_by_port
     )
-    plan_failures = _format_consistency_plan_failures(dom_primary_ports, consistency_plan_by_port)
-    if plan_failures:
-        pytest.fail("DOM consistency validation failures:\n" + "\n".join(plan_failures))
+
+    raw_update_interval = next(
+        (
+            port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {}).get("max_update_time_sec")
+            for port in dom_primary_ports
+            if "max_update_time_sec" in port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {})
+        ),
+        None,
+    )
+    update_interval_sec, update_interval_error = _parse_positive_int(
+        "max_update_time_sec", raw_update_interval, DEFAULT_MAX_UPDATE_TIME_SEC, minimum=1
+    )
+
+    config_failures = [update_interval_error] if update_interval_error else []
+    for port in dom_primary_ports:
+        plan = consistency_plan_by_port[port]
+        if plan["errors"]:
+            config_failures.append(format_dom_port_failure(
+                port,
+                plan["active_media_lanes"],
+                plan["field_checks"],
+                plan["errors"],
+                field_label="configured consistency field(s)",
+            ))
+    if config_failures:
+        pytest.fail("DOM consistency configuration failures:\n" + "\n".join(config_failures))
 
     sample_count = max(plan["poll_count"] for plan in consistency_plan_by_port.values())
-    interval_sec = max(plan["update_interval_sec"] for plan in consistency_plan_by_port.values())
     read_status = any(
-        check["mode"] == "percent"
+        check["mode"] == MODE_PERCENT
         for plan in consistency_plan_by_port.values()
-        for check in plan.get("field_checks", {}).values()
+        for check in plan["field_checks"].values()
     )
+    if not any(plan["field_checks"] for plan in consistency_plan_by_port.values()):
+        logger.info("No DOM consistency variation thresholds configured; validating last_update_time cadence only")
     logger.info(
-        "DOM consistency sampling: %d sample(s), %d second interval, status_table=%s",
+        "DOM consistency sampling: %d sample(s), %d second interval, %d second margin, status_table=%s",
         sample_count,
-        interval_sec,
+        update_interval_sec,
+        UPDATE_ADVANCE_MARGIN_SEC,
         read_status,
     )
 
-    samples = _collect_dom_samples(
-        duthost,
-        dom_primary_ports,
-        sample_count,
-        interval_sec,
-        read_status,
+    samples_by_port, all_failures = _collect_dom_samples(
+        duthost, dom_primary_ports, sample_count, update_interval_sec, read_status
     )
-    all_failures = []
-    for sample_index, sample in enumerate(samples, start=1):
-        all_failures.extend(
-            "STATE_DB sample {} sensor read:\n  {}".format(sample_index, error)
-            for error in sample["sensor_errors"]
-        )
-        all_failures.extend(
-            "STATE_DB sample {} status read:\n  {}".format(sample_index, error)
-            for error in sample["status_errors"]
-        )
+    checked_pair_count = 0
+    checked_port_count = 0
+    for port in dom_primary_ports:
+        plan = consistency_plan_by_port[port]
+        port_samples = samples_by_port.get(port, [])
+        if len(port_samples) < plan["poll_count"]:
+            port_failures = ["only {} sample(s) collected, expected {}".format(
+                len(port_samples), plan["poll_count"]
+            )]
+            port_checked_pair_count = 0
+        else:
+            port_failures, port_checked_pair_count = _validate_port_samples(port, port_samples, plan)
 
-    consistency_failures, checked_pair_count, checked_port_count = _validate_dom_consistency(
-        dom_primary_ports,
-        samples,
-        consistency_plan_by_port,
-    )
-    all_failures.extend(consistency_failures)
+        checked_port_count += 1
+        checked_pair_count += port_checked_pair_count
+        if port_failures:
+            all_failures.append(format_dom_port_failure(
+                port,
+                plan["active_media_lanes"],
+                plan["field_checks"],
+                port_failures,
+                field_label="configured consistency field(s)",
+            ))
 
     if all_failures:
         pytest.fail("DOM consistency validation failures:\n" + "\n".join(all_failures))

--- a/tests/transceiver/dom/test_dom_consistency.py
+++ b/tests/transceiver/dom/test_dom_consistency.py
@@ -254,6 +254,9 @@ def _validate_pair(port, field, check, previous_sample, current_sample, sample_i
     elif previous_status is None or current_status is None:
         skip_reason = "{} namespace read failed".format(STATE_DB_STATUS_TABLE)
     elif not (
+        # Current TC4 scope covers optics where media lanes map 1:1 to host/datapath
+        # lanes, so the media lane used for tx{lane}bias also selects DP{lane}State.
+        # Gearbox and inverse-gearbox lane translation should be added in a follow-up.
         is_state_db_dp_state_activated(previous_status, lane)
         and is_state_db_dp_state_activated(current_status, lane)
     ):

--- a/tests/transceiver/dom/test_dom_consistency.py
+++ b/tests/transceiver/dom/test_dom_consistency.py
@@ -388,9 +388,12 @@ def _validate_port_samples(port, port_samples, plan):
         if checked_by_attr[attr_name]:
             continue
         skip_details = "; ".join(sorted(set(skipped_by_attr[attr_name]))) or "no eligible sample pairs"
-        failures.append("{} configured but no Tx-bias sample pair was checked ({})".format(
-            attr_name, skip_details
-        ))
+        logger.warning(
+            "DOM consistency SKIP %s %s: no Tx-bias sample pair was checked (%s)",
+            port,
+            attr_name,
+            skip_details,
+        )
 
     return failures, checked_pair_count
 

--- a/tests/transceiver/dom/test_dom_consistency.py
+++ b/tests/transceiver/dom/test_dom_consistency.py
@@ -6,10 +6,6 @@ from collections import defaultdict
 import pytest
 
 from tests.transceiver.attribute_parser.attribute_keys import DOM_ATTRIBUTES_KEY
-from tests.transceiver.common.cmis_helper import (
-    STATE_DB_DP_STATE_ACTIVATED,
-    is_state_db_dp_state_activated,
-)
 from tests.transceiver.common.db_helpers import (
     STATE_DB_UPDATE_TIME_FIELD,
     parse_numeric,
@@ -17,14 +13,12 @@ from tests.transceiver.common.db_helpers import (
 )
 from tests.transceiver.dom.dom_helpers import (
     STATE_DB_SENSOR_TABLE,
-    STATE_DB_STATUS_TABLE,
     build_dom_sensor_plan,
     consistency_field_template_for_attr,
     field_template_is_lane_expanded,
     format_dom_port_failure,
     format_optional_float,
     read_dom_sensor_data,
-    read_transceiver_status_data,
 )
 
 logger = logging.getLogger(__name__)
@@ -145,7 +139,6 @@ def _build_dom_consistency_plan(port_attributes_dict, dom_primary_ports, sensor_
                     "threshold": threshold,
                     "mode": mode,
                     "unit": unit,
-                    "lane": lane,
                 }
 
         plan_by_port[port] = {
@@ -162,7 +155,7 @@ def _build_dom_consistency_plan(port_attributes_dict, dom_primary_ports, sensor_
     return plan_by_port
 
 
-def _collect_dom_samples(duthost, dom_primary_ports, sample_count, interval_sec, read_status):
+def _collect_dom_samples(duthost, dom_primary_ports, sample_count, interval_sec):
     """Return ``(samples_by_port, read_failures)`` for interval-based DOM samples."""
     samples_by_port = {port: [] for port in dom_primary_ports}
     read_failures = []
@@ -170,22 +163,14 @@ def _collect_dom_samples(duthost, dom_primary_ports, sample_count, interval_sec,
 
     for sample_index in range(1, sample_count + 1):
         sensor_by_port, sensor_errors = read_dom_sensor_data(duthost, dom_primary_ports)
-        status_by_port, status_errors = ({}, [])
-        if read_status:
-            status_by_port, status_errors = read_transceiver_status_data(duthost, dom_primary_ports)
 
         read_failures.extend(
             "STATE_DB sample {} sensor read:\n  {}".format(sample_index, error)
             for error in sensor_errors
         )
-        read_failures.extend(
-            "STATE_DB sample {} status read:\n  {}".format(sample_index, error)
-            for error in status_errors
-        )
         for port in dom_primary_ports:
             samples_by_port[port].append({
                 "sensor": sensor_by_port.get(port, {}),
-                "status": status_by_port.get(port, {}) if read_status else {},
             })
 
         logger.debug("Collected DOM consistency sample %d/%d", sample_index, sample_count)
@@ -236,24 +221,11 @@ def _validate_absolute_pair(port, field, check, previous_sensor, current_sensor,
     return None, True, None
 
 
-def _tx_bias_percent_skip_reason(field, lane, warning_range, previous_value, current_value,
-                                 previous_sensor, current_sensor, previous_status, current_status):
+def _tx_bias_percent_skip_reason(field, warning_range, previous_value, current_value,
+                                 previous_sensor, current_sensor):
     """Return the Tx-bias percent-check skip reason, or ``None`` when checkable."""
     if warning_range["error"]:
         return warning_range["error"]
-    if previous_status is None or current_status is None:
-        return "{} namespace read failed".format(STATE_DB_STATUS_TABLE)
-    if not (
-        # Current TC4 scope covers optics where media lanes map 1:1 to host/datapath
-        # lanes, so the media lane used for tx{lane}bias also selects DP{lane}State.
-        # Gearbox and inverse-gearbox lane translation should be added in a follow-up.
-        is_state_db_dp_state_activated(previous_status, lane)
-        and is_state_db_dp_state_activated(current_status, lane)
-    ):
-        return "DP{}State not {} (prev={!r}, curr={!r})".format(
-            lane, STATE_DB_DP_STATE_ACTIVATED, previous_status.get("DP{}State".format(lane)),
-            current_status.get("DP{}State".format(lane))
-        )
     if previous_value is None or current_value is None:
         return "missing/non-finite value (prev={!r}, curr={!r})".format(
             previous_sensor.get(field), current_sensor.get(field)
@@ -276,17 +248,13 @@ def _tx_bias_percent_skip_reason(field, lane, warning_range, previous_value, cur
 def _validate_tx_bias_percent_pair(port, field, check, previous_sample, current_sample,
                                    previous_value, current_value, sample_index, plan):
     """Return ``(error, checked, skip_reason)`` for one Tx-bias percent check."""
-    lane = check["lane"]
     skip_reason = _tx_bias_percent_skip_reason(
         field,
-        lane,
         plan["tx_bias_warning_range"],
         previous_value,
         current_value,
         previous_sample["sensor"],
         current_sample["sensor"],
-        previous_sample["status"],
-        current_sample["status"],
     )
     if skip_reason:
         logger.info("DOM consistency SKIP %s %s sample %d->%d: %s",
@@ -439,23 +407,17 @@ def test_dom_data_consistency_verification(
         pytest.fail("DOM consistency configuration failures:\n" + "\n".join(config_failures))
 
     sample_count = max(plan["poll_count"] for plan in consistency_plan_by_port.values())
-    read_status = any(
-        check["mode"] == MODE_PERCENT
-        for plan in consistency_plan_by_port.values()
-        for check in plan["field_checks"].values()
-    )
     if not any(plan["field_checks"] for plan in consistency_plan_by_port.values()):
         logger.info("No DOM consistency variation thresholds configured; validating last_update_time cadence only")
     logger.info(
-        "DOM consistency sampling: %d sample(s), %d second interval, %d second margin, status_table=%s",
+        "DOM consistency sampling: %d sample(s), %d second interval, %d second margin",
         sample_count,
         update_interval_sec,
         UPDATE_ADVANCE_MARGIN_SEC,
-        read_status,
     )
 
     samples_by_port, all_failures = _collect_dom_samples(
-        duthost, dom_primary_ports, sample_count, update_interval_sec, read_status
+        duthost, dom_primary_ports, sample_count, update_interval_sec
     )
     checked_pair_count = 0
     checked_port_count = 0

--- a/tests/transceiver/dom/test_dom_consistency.py
+++ b/tests/transceiver/dom/test_dom_consistency.py
@@ -218,71 +218,76 @@ def _format_delta_failure(field, sample_index, delta, threshold, unit, previous_
     )
 
 
-def _validate_pair(port, field, check, previous_sample, current_sample, sample_index, plan):
-    """Return ``(error, checked, skip_reason)`` for one sample pair and field."""
-    previous_sensor = previous_sample["sensor"]
-    current_sensor = current_sample["sensor"]
-    if previous_sensor is None or current_sensor is None:
-        return None, False, "{} namespace read failed".format(STATE_DB_SENSOR_TABLE)
-    if not previous_sensor or not current_sensor:
-        return None, False, "{} entry missing for one or both samples".format(STATE_DB_SENSOR_TABLE)
+def _validate_absolute_pair(port, field, check, previous_sensor, current_sensor,
+                            previous_value, current_value, sample_index):
+    """Return ``(error, checked, skip_reason)`` for one absolute-delta check."""
+    if previous_value is None or current_value is None:
+        return "{} sample {}->{}: missing/non-finite value (prev={!r}, curr={!r})".format(
+            field, sample_index, sample_index + 1, previous_sensor.get(field), current_sensor.get(field)
+        ), False, None
+    delta = abs(current_value - previous_value)
+    if delta > check["threshold"]:
+        return _format_delta_failure(
+            field, sample_index, delta, check["threshold"], check["unit"], previous_value, current_value
+        ), True, None
+    logger.debug("DOM consistency PASS %s %s sample %d->%d: delta=%s%s limit=%s%s",
+                 port, field, sample_index, sample_index + 1, format_optional_float(delta),
+                 check["unit"], format_optional_float(check["threshold"]), check["unit"])
+    return None, True, None
 
-    previous_value = _numeric_sensor_value(previous_sensor, field)
-    current_value = _numeric_sensor_value(current_sensor, field)
 
-    if check["mode"] == MODE_ABSOLUTE:
-        if previous_value is None or current_value is None:
-            return "{} sample {}->{}: missing/non-finite value (prev={!r}, curr={!r})".format(
-                field, sample_index, sample_index + 1, previous_sensor.get(field), current_sensor.get(field)
-            ), False, None
-        delta = abs(current_value - previous_value)
-        if delta > check["threshold"]:
-            return _format_delta_failure(
-                field, sample_index, delta, check["threshold"], check["unit"], previous_value, current_value
-            ), True, None
-        logger.debug("DOM consistency PASS %s %s sample %d->%d: delta=%s%s limit=%s%s",
-                     port, field, sample_index, sample_index + 1, format_optional_float(delta),
-                     check["unit"], format_optional_float(check["threshold"]), check["unit"])
-        return None, True, None
-
-    warning_range = plan["tx_bias_warning_range"]
-    lane = check["lane"]
-    previous_status = previous_sample["status"]
-    current_status = current_sample["status"]
+def _tx_bias_percent_skip_reason(field, lane, warning_range, previous_value, current_value,
+                                 previous_sensor, current_sensor, previous_status, current_status):
+    """Return the Tx-bias percent-check skip reason, or ``None`` when checkable."""
     if warning_range["error"]:
-        skip_reason = warning_range["error"]
-    elif previous_status is None or current_status is None:
-        skip_reason = "{} namespace read failed".format(STATE_DB_STATUS_TABLE)
-    elif not (
+        return warning_range["error"]
+    if previous_status is None or current_status is None:
+        return "{} namespace read failed".format(STATE_DB_STATUS_TABLE)
+    if not (
         # Current TC4 scope covers optics where media lanes map 1:1 to host/datapath
         # lanes, so the media lane used for tx{lane}bias also selects DP{lane}State.
         # Gearbox and inverse-gearbox lane translation should be added in a follow-up.
         is_state_db_dp_state_activated(previous_status, lane)
         and is_state_db_dp_state_activated(current_status, lane)
     ):
-        skip_reason = "DP{}State not {} (prev={!r}, curr={!r})".format(
+        return "DP{}State not {} (prev={!r}, curr={!r})".format(
             lane, STATE_DB_DP_STATE_ACTIVATED, previous_status.get("DP{}State".format(lane)),
             current_status.get("DP{}State".format(lane))
         )
-    elif previous_value is None or current_value is None:
-        skip_reason = "missing/non-finite value (prev={!r}, curr={!r})".format(
+    if previous_value is None or current_value is None:
+        return "missing/non-finite value (prev={!r}, curr={!r})".format(
             previous_sensor.get(field), current_sensor.get(field)
         )
-    elif not (warning_range["low"] <= previous_value <= warning_range["high"]
-              and warning_range["low"] <= current_value <= warning_range["high"]):
+    if not (warning_range["low"] <= previous_value <= warning_range["high"]
+            and warning_range["low"] <= current_value <= warning_range["high"]):
         # Tx-bias percent stability is meaningful only in the normal warning range;
         # threshold/alarm tests own values that are already outside this envelope.
-        skip_reason = "value outside tx_bias warning range [{}, {}] (prev={}, curr={})".format(
+        return "value outside tx_bias warning range [{}, {}] (prev={}, curr={})".format(
             format_optional_float(warning_range["low"]),
             format_optional_float(warning_range["high"]),
             format_optional_float(previous_value),
             format_optional_float(current_value),
         )
-    elif previous_value == 0:
-        skip_reason = "previous value is zero; percent change is undefined"
-    else:
-        skip_reason = None
+    if previous_value == 0:
+        return "previous value is zero; percent change is undefined"
+    return None
 
+
+def _validate_tx_bias_percent_pair(port, field, check, previous_sample, current_sample,
+                                   previous_value, current_value, sample_index, plan):
+    """Return ``(error, checked, skip_reason)`` for one Tx-bias percent check."""
+    lane = check["lane"]
+    skip_reason = _tx_bias_percent_skip_reason(
+        field,
+        lane,
+        plan["tx_bias_warning_range"],
+        previous_value,
+        current_value,
+        previous_sample["sensor"],
+        current_sample["sensor"],
+        previous_sample["status"],
+        current_sample["status"],
+    )
     if skip_reason:
         logger.info("DOM consistency SKIP %s %s sample %d->%d: %s",
                     port, field, sample_index, sample_index + 1, skip_reason)
@@ -297,6 +302,26 @@ def _validate_pair(port, field, check, previous_sample, current_sample, sample_i
                  port, field, sample_index, sample_index + 1, delta_percent,
                  format_optional_float(check["threshold"]))
     return None, True, None
+
+
+def _validate_pair(port, field, check, previous_sample, current_sample, sample_index, plan):
+    """Return ``(error, checked, skip_reason)`` for one sample pair and field."""
+    previous_sensor = previous_sample["sensor"]
+    current_sensor = current_sample["sensor"]
+    if previous_sensor is None or current_sensor is None:
+        return None, False, "{} namespace read failed".format(STATE_DB_SENSOR_TABLE)
+    if not previous_sensor or not current_sensor:
+        return None, False, "{} entry missing for one or both samples".format(STATE_DB_SENSOR_TABLE)
+
+    previous_value = _numeric_sensor_value(previous_sensor, field)
+    current_value = _numeric_sensor_value(current_sensor, field)
+    if check["mode"] == MODE_ABSOLUTE:
+        return _validate_absolute_pair(
+            port, field, check, previous_sensor, current_sensor, previous_value, current_value, sample_index
+        )
+    return _validate_tx_bias_percent_pair(
+        port, field, check, previous_sample, current_sample, previous_value, current_value, sample_index, plan
+    )
 
 
 def _validate_port_samples(port, port_samples, plan):

--- a/tests/transceiver/dom/test_dom_consistency.py
+++ b/tests/transceiver/dom/test_dom_consistency.py
@@ -17,7 +17,10 @@ from tests.transceiver.common.db_helpers import (
 )
 from tests.transceiver.dom.dom_helpers import (
     STATE_DB_SENSOR_TABLE,
+    STATE_DB_STATUS_TABLE,
     build_dom_sensor_plan,
+    consistency_field_template_for_attr,
+    field_template_is_lane_expanded,
     format_dom_port_failure,
     format_optional_float,
     read_dom_sensor_data,
@@ -26,27 +29,26 @@ from tests.transceiver.dom.dom_helpers import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_CONSISTENCY_CHECK_POLL_COUNT = 3
-DEFAULT_MAX_UPDATE_TIME_SEC = 60
 UPDATE_ADVANCE_MARGIN_SEC = 5
 TX_BIAS_THRESHOLD_ATTR = "tx_bias_threshold_range"
 TX_BIAS_CONSISTENCY_ATTR = "tx_bias_consistency_variation_threshold"
 MODE_ABSOLUTE = "absolute"
 MODE_PERCENT = "percent"
 
-CONSISTENCY_FIELD_DEFINITIONS = (
-    ("temperature_consistency_variation_threshold", "temperature", "C", MODE_ABSOLUTE, False),
-    ("voltage_consistency_variation_threshold", "voltage", "V", MODE_ABSOLUTE, False),
-    ("laser_temperature_consistency_variation_threshold", "laser_temperature", "C", MODE_ABSOLUTE, False),
-    ("tx_power_consistency_variation_threshold", "tx{}power", "dB", MODE_ABSOLUTE, True),
-    ("rx_power_consistency_variation_threshold", "rx{}power", "dB", MODE_ABSOLUTE, True),
-    (TX_BIAS_CONSISTENCY_ATTR, "tx{}bias", "percent", MODE_PERCENT, True),
+CONSISTENCY_CHECK_DEFINITIONS = (
+    ("temperature_consistency_variation_threshold", "C", MODE_ABSOLUTE),
+    ("voltage_consistency_variation_threshold", "V", MODE_ABSOLUTE),
+    ("laser_temperature_consistency_variation_threshold", "C", MODE_ABSOLUTE),
+    ("tx_power_consistency_variation_threshold", "dB", MODE_ABSOLUTE),
+    ("rx_power_consistency_variation_threshold", "dB", MODE_ABSOLUTE),
+    (TX_BIAS_CONSISTENCY_ATTR, "percent", MODE_PERCENT),
 )
 
 
-def _parse_positive_int(attr_name, raw_value, default_value, minimum):
+def _parse_positive_int(attr_name, raw_value, minimum):
+    """Return ``(value, error)`` for configured positive integer DOM attributes."""
     if raw_value is None:
-        return default_value, None
+        return None, "{} missing in DOM_ATTRIBUTES".format(attr_name)
 
     value = parse_numeric(raw_value)
     if value is None or not math.isfinite(value) or int(value) != value or value < minimum:
@@ -57,6 +59,7 @@ def _parse_positive_int(attr_name, raw_value, default_value, minimum):
 
 
 def _parse_non_negative_threshold(attr_name, raw_value):
+    """Return ``(threshold, error)`` for configured consistency thresholds."""
     value = parse_numeric(raw_value)
     if value is None or not math.isfinite(value) or value < 0:
         return None, "{} must be a finite non-negative number in DOM_ATTRIBUTES (got {!r})".format(
@@ -66,6 +69,7 @@ def _parse_non_negative_threshold(attr_name, raw_value):
 
 
 def _parse_tx_bias_warning_range(dom_attrs):
+    """Return ``{"low": value, "high": value, "error": reason}`` for Tx-bias gating."""
     attr_value = dom_attrs.get(TX_BIAS_THRESHOLD_ATTR)
     if not isinstance(attr_value, dict):
         return {"low": None, "high": None, "error": "{} not configured as a dict".format(TX_BIAS_THRESHOLD_ATTR)}
@@ -100,23 +104,29 @@ def _build_dom_consistency_plan(port_attributes_dict, dom_primary_ports, sensor_
         poll_count, poll_error = _parse_positive_int(
             "consistency_check_poll_count",
             dom_attrs.get("consistency_check_poll_count"),
-            DEFAULT_CONSISTENCY_CHECK_POLL_COUNT,
             minimum=2,
         )
         if poll_error:
             errors.append(poll_error)
-            poll_count = DEFAULT_CONSISTENCY_CHECK_POLL_COUNT
 
         has_lane_check = any(
-            attr_name in dom_attrs and lane_expanded
-            for attr_name, _field_template, _unit, _mode, lane_expanded in CONSISTENCY_FIELD_DEFINITIONS
+            attr_name in dom_attrs
+            and consistency_field_template_for_attr(attr_name)
+            and field_template_is_lane_expanded(consistency_field_template_for_attr(attr_name))
+            for attr_name, _unit, _mode in CONSISTENCY_CHECK_DEFINITIONS
         )
         if has_lane_check and sensor_plan.get("errors"):
             errors.extend(sensor_plan["errors"])
 
-        for attr_name, field_template, unit, mode, lane_expanded in CONSISTENCY_FIELD_DEFINITIONS:
+        for attr_name, unit, mode in CONSISTENCY_CHECK_DEFINITIONS:
             if attr_name not in dom_attrs:
                 continue
+
+            field_template = consistency_field_template_for_attr(attr_name)
+            if field_template is None:
+                errors.append("{} has no DOM consistency field mapping".format(attr_name))
+                continue
+            lane_expanded = field_template_is_lane_expanded(field_template)
 
             threshold, threshold_error = _parse_non_negative_threshold(attr_name, dom_attrs[attr_name])
             if threshold_error:
@@ -153,6 +163,7 @@ def _build_dom_consistency_plan(port_attributes_dict, dom_primary_ports, sensor_
 
 
 def _collect_dom_samples(duthost, dom_primary_ports, sample_count, interval_sec, read_status):
+    """Return ``(samples_by_port, read_failures)`` for interval-based DOM samples."""
     samples_by_port = {port: [] for port in dom_primary_ports}
     read_failures = []
     sleep_sec = interval_sec + UPDATE_ADVANCE_MARGIN_SEC
@@ -173,8 +184,8 @@ def _collect_dom_samples(duthost, dom_primary_ports, sample_count, interval_sec,
         )
         for port in dom_primary_ports:
             samples_by_port[port].append({
-                "sensor": sensor_by_port.get(port, {}) or {},
-                "status": status_by_port.get(port, {}) or {},
+                "sensor": sensor_by_port.get(port, {}),
+                "status": status_by_port.get(port, {}) if read_status else {},
             })
 
         logger.debug("Collected DOM consistency sample %d/%d", sample_index, sample_count)
@@ -185,11 +196,15 @@ def _collect_dom_samples(duthost, dom_primary_ports, sample_count, interval_sec,
 
 
 def _numeric_sensor_value(sensor_data, field):
+    """Return a finite numeric sensor value, or ``None`` when absent/unparseable."""
+    if not isinstance(sensor_data, dict):
+        return None
     value = parse_numeric(sensor_data.get(field))
     return value if value is not None and math.isfinite(value) else None
 
 
 def _format_delta_failure(field, sample_index, delta, threshold, unit, previous_value, current_value):
+    """Return a formatted sensor-delta threshold failure message."""
     return "{} sample {}->{} delta {}{} exceeds {}{} (prev={}, curr={})".format(
         field,
         sample_index,
@@ -204,8 +219,14 @@ def _format_delta_failure(field, sample_index, delta, threshold, unit, previous_
 
 
 def _validate_pair(port, field, check, previous_sample, current_sample, sample_index, plan):
+    """Return ``(error, checked, skip_reason)`` for one sample pair and field."""
     previous_sensor = previous_sample["sensor"]
     current_sensor = current_sample["sensor"]
+    if previous_sensor is None or current_sensor is None:
+        return None, False, "{} namespace read failed".format(STATE_DB_SENSOR_TABLE)
+    if not previous_sensor or not current_sensor:
+        return None, False, "{} entry missing for one or both samples".format(STATE_DB_SENSOR_TABLE)
+
     previous_value = _numeric_sensor_value(previous_sensor, field)
     current_value = _numeric_sensor_value(current_sensor, field)
 
@@ -230,6 +251,8 @@ def _validate_pair(port, field, check, previous_sample, current_sample, sample_i
     current_status = current_sample["status"]
     if warning_range["error"]:
         skip_reason = warning_range["error"]
+    elif previous_status is None or current_status is None:
+        skip_reason = "{} namespace read failed".format(STATE_DB_STATUS_TABLE)
     elif not (
         is_state_db_dp_state_activated(previous_status, lane)
         and is_state_db_dp_state_activated(current_status, lane)
@@ -274,6 +297,7 @@ def _validate_pair(port, field, check, previous_sample, current_sample, sample_i
 
 
 def _validate_port_samples(port, port_samples, plan):
+    """Return ``(failures, checked_pair_count)`` for one port's collected samples."""
     failures = []
     checked_pair_count = 0
     checked_by_attr = defaultdict(int)
@@ -282,6 +306,12 @@ def _validate_port_samples(port, port_samples, plan):
     parsed_times = []
     for sample_index in range(plan["poll_count"]):
         sensor_data = port_samples[sample_index]["sensor"]
+        if sensor_data is None:
+            failures.append("sample {}: could not read {} for port (namespace read failed)".format(
+                sample_index + 1, STATE_DB_SENSOR_TABLE
+            ))
+            parsed_times.append(None)
+            continue
         if not sensor_data:
             failures.append("sample {}: no {} entry published for port".format(
                 sample_index + 1, STATE_DB_SENSOR_TABLE
@@ -360,7 +390,7 @@ def test_dom_data_consistency_verification(
         None,
     )
     update_interval_sec, update_interval_error = _parse_positive_int(
-        "max_update_time_sec", raw_update_interval, DEFAULT_MAX_UPDATE_TIME_SEC, minimum=1
+        "max_update_time_sec", raw_update_interval, minimum=1
     )
 
     config_failures = [update_interval_error] if update_interval_error else []

--- a/tests/transceiver/dom/test_dom_consistency.py
+++ b/tests/transceiver/dom/test_dom_consistency.py
@@ -1,0 +1,570 @@
+import logging
+import math
+import time
+
+import pytest
+
+from tests.transceiver.attribute_parser.attribute_keys import DOM_ATTRIBUTES_KEY
+from tests.transceiver.common.db_helpers import (
+    STATE_DB_UPDATE_TIME_FIELD,
+    parse_numeric,
+    parse_update_time,
+)
+from tests.transceiver.dom.dom_helpers import (
+    STATE_DB_SENSOR_TABLE,
+    build_dom_sensor_plan,
+    format_dom_port_failure,
+    read_dom_sensor_data,
+    read_dom_status_data,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONSISTENCY_CHECK_POLL_COUNT = 3
+DEFAULT_MAX_UPDATE_TIME_SEC = 60
+TX_BIAS_THRESHOLD_ATTR = "tx_bias_threshold_range"
+DP_ACTIVATED_VALUES = ("DPActivated", "DataPathActivated")
+
+ABSOLUTE_CONSISTENCY_FIELDS = {
+    "temperature_consistency_variation_threshold": ("temperature", "C"),
+    "voltage_consistency_variation_threshold": ("voltage", "V"),
+    "laser_temperature_consistency_variation_threshold": ("laser_temperature", "C"),
+}
+LANE_CONSISTENCY_FIELDS = {
+    "tx_power_consistency_variation_threshold": ("tx{}power", "dB", "absolute"),
+    "rx_power_consistency_variation_threshold": ("rx{}power", "dB", "absolute"),
+    "tx_bias_consistency_variation_threshold": ("tx{}bias", "percent", "percent"),
+}
+
+
+def _parse_positive_int(attr_name, raw_value, default_value, minimum):
+    """Return ``(value, error)`` for positive integer DOM timing attributes."""
+    if raw_value is None:
+        return default_value, None
+
+    value = parse_numeric(raw_value)
+    if value is None or not math.isfinite(value) or int(value) != value or value < minimum:
+        return None, "{} must be an integer >= {} in DOM_ATTRIBUTES (got {!r})".format(
+            attr_name,
+            minimum,
+            raw_value,
+        )
+    return int(value), None
+
+
+def _parse_non_negative_threshold(attr_name, raw_value):
+    """Return ``(threshold, error)`` for configured consistency thresholds."""
+    value = parse_numeric(raw_value)
+    if value is None or not math.isfinite(value) or value < 0:
+        return None, "{} must be a finite non-negative number in DOM_ATTRIBUTES (got {!r})".format(
+            attr_name,
+            raw_value,
+        )
+    return value, None
+
+
+def _parse_tx_bias_warning_range(dom_attrs):
+    """Return ``(lowwarning, highwarning, reason)`` for Tx-bias percentage gating."""
+    attr_value = dom_attrs.get(TX_BIAS_THRESHOLD_ATTR)
+    if not isinstance(attr_value, dict):
+        return None, None, "{} not configured as a dict".format(TX_BIAS_THRESHOLD_ATTR)
+
+    lowwarning = parse_numeric(attr_value.get("lowwarning"))
+    highwarning = parse_numeric(attr_value.get("highwarning"))
+    if (
+        lowwarning is None
+        or highwarning is None
+        or not math.isfinite(lowwarning)
+        or not math.isfinite(highwarning)
+        or lowwarning > highwarning
+    ):
+        return None, None, "{} has no valid lowwarning/highwarning range".format(TX_BIAS_THRESHOLD_ATTR)
+
+    return lowwarning, highwarning, None
+
+
+def _build_dom_consistency_plan(port_attributes_dict, dom_primary_ports, sensor_plan_by_port):
+    """Build per-port TC4 timing and field-variation checks from DOM attributes."""
+    plan_by_port = {}
+    for port in dom_primary_ports:
+        dom_attrs = port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {})
+        sensor_plan = sensor_plan_by_port.get(port, {})
+        active_lanes = sensor_plan.get("active_media_lanes", [])
+        errors = []
+        field_checks = {}
+
+        poll_count, poll_count_error = _parse_positive_int(
+            "consistency_check_poll_count",
+            dom_attrs.get("consistency_check_poll_count"),
+            DEFAULT_CONSISTENCY_CHECK_POLL_COUNT,
+            minimum=2,
+        )
+        if poll_count_error:
+            errors.append(poll_count_error)
+            poll_count = DEFAULT_CONSISTENCY_CHECK_POLL_COUNT
+
+        update_interval_sec, update_interval_error = _parse_positive_int(
+            "max_update_time_sec",
+            dom_attrs.get("max_update_time_sec"),
+            DEFAULT_MAX_UPDATE_TIME_SEC,
+            minimum=1,
+        )
+        if update_interval_error:
+            errors.append(update_interval_error)
+            update_interval_sec = DEFAULT_MAX_UPDATE_TIME_SEC
+
+        for attr_name, (field, unit) in sorted(ABSOLUTE_CONSISTENCY_FIELDS.items()):
+            if attr_name not in dom_attrs:
+                continue
+            threshold, threshold_error = _parse_non_negative_threshold(attr_name, dom_attrs[attr_name])
+            if threshold_error:
+                errors.append(threshold_error)
+                continue
+            field_checks[field] = {
+                "source_attr": attr_name,
+                "threshold": threshold,
+                "mode": "absolute",
+                "unit": unit,
+            }
+
+        has_lane_checks = any(attr_name in dom_attrs for attr_name in LANE_CONSISTENCY_FIELDS)
+        if has_lane_checks and sensor_plan.get("errors"):
+            errors.extend(sensor_plan.get("errors", []))
+
+        for attr_name, (field_template, unit, mode) in sorted(LANE_CONSISTENCY_FIELDS.items()):
+            if attr_name not in dom_attrs:
+                continue
+            threshold, threshold_error = _parse_non_negative_threshold(attr_name, dom_attrs[attr_name])
+            if threshold_error:
+                errors.append(threshold_error)
+                continue
+            if not active_lanes:
+                errors.append("{} configured but no active media lanes resolved".format(attr_name))
+                continue
+
+            lowwarning = highwarning = warning_range_error = None
+            if mode == "percent":
+                lowwarning, highwarning, warning_range_error = _parse_tx_bias_warning_range(dom_attrs)
+
+            for lane in active_lanes:
+                field_checks[field_template.format(lane)] = {
+                    "source_attr": attr_name,
+                    "threshold": threshold,
+                    "mode": mode,
+                    "unit": unit,
+                    "lane": lane,
+                    "warning_low": lowwarning,
+                    "warning_high": highwarning,
+                    "warning_range_error": warning_range_error,
+                }
+
+        plan_by_port[port] = {
+            "active_media_lanes": active_lanes,
+            "errors": errors,
+            "field_checks": {field: field_checks[field] for field in sorted(field_checks)},
+            "poll_count": poll_count,
+            "update_interval_sec": update_interval_sec,
+        }
+        logger.debug(
+            "%s DOM consistency plan: poll_count=%s update_interval_sec=%s "
+            "field_checks=%s active_media_lanes=%s",
+            port,
+            poll_count,
+            update_interval_sec,
+            sorted(field_checks),
+            active_lanes or "none",
+        )
+
+    return plan_by_port
+
+
+def _collect_dom_samples(duthost, dom_primary_ports, sample_count, interval_sec, read_status):
+    """Read DOM sensor/status samples with a fixed interval between samples."""
+    samples = []
+    for sample_index in range(sample_count):
+        sensor_by_port, sensor_errors = read_dom_sensor_data(duthost, dom_primary_ports)
+        status_by_port = {}
+        status_errors = []
+        if read_status:
+            status_by_port, status_errors = read_dom_status_data(duthost, dom_primary_ports)
+        samples.append(
+            {
+                "sensor_by_port": sensor_by_port,
+                "status_by_port": status_by_port,
+                "sensor_errors": sensor_errors,
+                "status_errors": status_errors,
+            }
+        )
+        logger.debug("Collected DOM consistency sample %d/%d", sample_index + 1, sample_count)
+        if sample_index + 1 < sample_count:
+            time.sleep(interval_sec)
+    return samples
+
+
+def _sensor_sample_for_port(samples, sample_index, port):
+    return samples[sample_index]["sensor_by_port"].get(port, {}) or {}
+
+
+def _status_sample_for_port(samples, sample_index, port):
+    return samples[sample_index]["status_by_port"].get(port, {}) or {}
+
+
+def _validate_last_update_time(port, samples, poll_count):
+    """Validate last_update_time exists and advances between TC4 samples."""
+    failures = []
+    parsed_times = []
+
+    for sample_index in range(poll_count):
+        sensor_data = _sensor_sample_for_port(samples, sample_index, port)
+        if not sensor_data:
+            failures.append(
+                "sample {}: no {} entry published for port".format(
+                    sample_index + 1,
+                    STATE_DB_SENSOR_TABLE,
+                )
+            )
+            parsed_times.append(None)
+            continue
+
+        raw_update_time = sensor_data.get(STATE_DB_UPDATE_TIME_FIELD)
+        parsed_time = parse_update_time(raw_update_time)
+        if parsed_time is None:
+            failures.append(
+                "sample {}: {} missing or unparsable (raw={!r})".format(
+                    sample_index + 1,
+                    STATE_DB_UPDATE_TIME_FIELD,
+                    raw_update_time,
+                )
+            )
+        parsed_times.append(parsed_time)
+
+    for sample_index in range(1, poll_count):
+        previous_time = parsed_times[sample_index - 1]
+        current_time = parsed_times[sample_index]
+        if previous_time is None or current_time is None:
+            continue
+        if current_time <= previous_time:
+            failures.append(
+                "{} did not advance between sample {} and {} (prev={!r}, curr={!r})".format(
+                    STATE_DB_UPDATE_TIME_FIELD,
+                    sample_index,
+                    sample_index + 1,
+                    _sensor_sample_for_port(samples, sample_index - 1, port).get(STATE_DB_UPDATE_TIME_FIELD),
+                    _sensor_sample_for_port(samples, sample_index, port).get(STATE_DB_UPDATE_TIME_FIELD),
+                )
+            )
+
+    return failures
+
+
+def _numeric_sensor_value(sensor_data, field):
+    value = parse_numeric(sensor_data.get(field))
+    if value is None or not math.isfinite(value):
+        return None
+    return value
+
+
+def _dp_state_activated(status_data, lane):
+    return status_data.get("DP{}State".format(lane)) in DP_ACTIVATED_VALUES
+
+
+def _validate_absolute_delta(port, field, check, previous_sensor, current_sensor, sample_index):
+    previous_value = _numeric_sensor_value(previous_sensor, field)
+    current_value = _numeric_sensor_value(current_sensor, field)
+    if previous_value is None or current_value is None:
+        return (
+            "{} sample {}->{}: missing/non-finite value (prev={!r}, curr={!r})".format(
+                field,
+                sample_index,
+                sample_index + 1,
+                previous_sensor.get(field),
+                current_sensor.get(field),
+            )
+        )
+
+    delta = abs(current_value - previous_value)
+    if delta > check["threshold"]:
+        return (
+            "{} sample {}->{} delta {}{} exceeds {}{} "
+            "(prev={}, curr={})".format(
+                field,
+                sample_index,
+                sample_index + 1,
+                delta,
+                check["unit"],
+                check["threshold"],
+                check["unit"],
+                previous_value,
+                current_value,
+            )
+        )
+
+    logger.debug(
+        "DOM consistency PASS %s %s sample %d->%d: delta=%s%s limit=%s%s",
+        port,
+        field,
+        sample_index,
+        sample_index + 1,
+        delta,
+        check["unit"],
+        check["threshold"],
+        check["unit"],
+    )
+    return None
+
+
+def _tx_bias_skip_reason(field, check, previous_sensor, current_sensor, previous_status, current_status):
+    if check.get("warning_range_error"):
+        return check["warning_range_error"]
+
+    lane = check["lane"]
+    previous_state = previous_status.get("DP{}State".format(lane))
+    current_state = current_status.get("DP{}State".format(lane))
+    if not (_dp_state_activated(previous_status, lane) and _dp_state_activated(current_status, lane)):
+        return "DP{}State not activated (prev={!r}, curr={!r})".format(
+            lane,
+            previous_state,
+            current_state,
+        )
+
+    previous_value = _numeric_sensor_value(previous_sensor, field)
+    current_value = _numeric_sensor_value(current_sensor, field)
+    if previous_value is None or current_value is None:
+        return "missing/non-finite value (prev={!r}, curr={!r})".format(
+            previous_sensor.get(field),
+            current_sensor.get(field),
+        )
+
+    lowwarning = check["warning_low"]
+    highwarning = check["warning_high"]
+    if not (lowwarning <= previous_value <= highwarning and lowwarning <= current_value <= highwarning):
+        return "value outside tx_bias warning range [{}, {}] (prev={}, curr={})".format(
+            lowwarning,
+            highwarning,
+            previous_value,
+            current_value,
+        )
+
+    if previous_value == 0:
+        return "previous value is zero; percent change is undefined"
+
+    return None
+
+
+def _validate_tx_bias_percent_delta(
+    port,
+    field,
+    check,
+    previous_sensor,
+    current_sensor,
+    previous_status,
+    current_status,
+    sample_index,
+):
+    skip_reason = _tx_bias_skip_reason(field, check, previous_sensor, current_sensor, previous_status, current_status)
+    if skip_reason:
+        logger.info(
+            "DOM consistency SKIP %s %s sample %d->%d: %s",
+            port,
+            field,
+            sample_index,
+            sample_index + 1,
+            skip_reason,
+        )
+        return None, False
+
+    previous_value = _numeric_sensor_value(previous_sensor, field)
+    current_value = _numeric_sensor_value(current_sensor, field)
+    delta_percent = abs(current_value - previous_value) / abs(previous_value) * 100
+    if delta_percent > check["threshold"]:
+        return (
+            "{} sample {}->{} delta {:.2f}% exceeds {}% "
+            "(prev={}, curr={})".format(
+                field,
+                sample_index,
+                sample_index + 1,
+                delta_percent,
+                check["threshold"],
+                previous_value,
+                current_value,
+            ),
+            True,
+        )
+
+    logger.debug(
+        "DOM consistency PASS %s %s sample %d->%d: delta=%.2f%% limit=%s%%",
+        port,
+        field,
+        sample_index,
+        sample_index + 1,
+        delta_percent,
+        check["threshold"],
+    )
+    return None, True
+
+
+def _validate_variation_checks(port, samples, plan):
+    """Validate configured variation checks for one port across samples."""
+    failures = []
+    checked_pair_count = 0
+    field_checks = plan.get("field_checks", {})
+    poll_count = plan["poll_count"]
+
+    for sample_index in range(1, poll_count):
+        previous_sensor = _sensor_sample_for_port(samples, sample_index - 1, port)
+        current_sensor = _sensor_sample_for_port(samples, sample_index, port)
+        previous_status = _status_sample_for_port(samples, sample_index - 1, port)
+        current_status = _status_sample_for_port(samples, sample_index, port)
+
+        for field, check in field_checks.items():
+            if check["mode"] == "percent":
+                error, checked = _validate_tx_bias_percent_delta(
+                    port,
+                    field,
+                    check,
+                    previous_sensor,
+                    current_sensor,
+                    previous_status,
+                    current_status,
+                    sample_index,
+                )
+                if checked:
+                    checked_pair_count += 1
+            else:
+                error = _validate_absolute_delta(
+                    port,
+                    field,
+                    check,
+                    previous_sensor,
+                    current_sensor,
+                    sample_index,
+                )
+                checked_pair_count += 1
+
+            if error:
+                failures.append(error)
+
+    return failures, checked_pair_count
+
+
+def _validate_dom_consistency(dom_primary_ports, samples, consistency_plan_by_port):
+    failures = []
+    checked_pair_count = 0
+    checked_port_count = 0
+
+    for port in dom_primary_ports:
+        plan = consistency_plan_by_port.get(port, {})
+        expected_fields = plan.get("field_checks", {})
+        field_failures = list(plan.get("errors", []))
+        active_lanes = plan.get("active_media_lanes", [])
+
+        last_update_failures = _validate_last_update_time(port, samples, plan["poll_count"])
+        variation_failures, port_checked_pair_count = _validate_variation_checks(port, samples, plan)
+        field_failures.extend(last_update_failures)
+        field_failures.extend(variation_failures)
+
+        checked_port_count += 1
+        checked_pair_count += port_checked_pair_count
+
+        if field_failures:
+            failures.append(
+                format_dom_port_failure(
+                    port,
+                    active_lanes,
+                    expected_fields,
+                    field_failures,
+                    field_label="configured consistency field(s)",
+                )
+            )
+
+    return failures, checked_pair_count, checked_port_count
+
+
+def _format_consistency_plan_failures(dom_primary_ports, consistency_plan_by_port):
+    failures = []
+    for port in dom_primary_ports:
+        plan = consistency_plan_by_port.get(port, {})
+        field_failures = list(plan.get("errors", []))
+        if not field_failures:
+            continue
+        failures.append(
+            format_dom_port_failure(
+                port,
+                plan.get("active_media_lanes", []),
+                plan.get("field_checks", {}),
+                field_failures,
+                field_label="configured consistency field(s)",
+            )
+        )
+    return failures
+
+
+def test_dom_data_consistency_verification(
+    duthost,
+    dom_primary_ports,
+    port_attributes_dict,
+    lport_to_first_subport_mapping,
+):
+    """Verify DOM sensor update cadence and configured variation thresholds."""
+    sensor_plan_by_port = build_dom_sensor_plan(
+        port_attributes_dict,
+        dom_primary_ports,
+        lport_to_first_subport_mapping,
+    )
+    consistency_plan_by_port = _build_dom_consistency_plan(
+        port_attributes_dict,
+        dom_primary_ports,
+        sensor_plan_by_port,
+    )
+    plan_failures = _format_consistency_plan_failures(dom_primary_ports, consistency_plan_by_port)
+    if plan_failures:
+        pytest.fail("DOM consistency validation failures:\n" + "\n".join(plan_failures))
+
+    sample_count = max(plan["poll_count"] for plan in consistency_plan_by_port.values())
+    interval_sec = max(plan["update_interval_sec"] for plan in consistency_plan_by_port.values())
+    read_status = any(
+        check["mode"] == "percent"
+        for plan in consistency_plan_by_port.values()
+        for check in plan.get("field_checks", {}).values()
+    )
+    logger.info(
+        "DOM consistency sampling: %d sample(s), %d second interval, status_table=%s",
+        sample_count,
+        interval_sec,
+        read_status,
+    )
+
+    samples = _collect_dom_samples(
+        duthost,
+        dom_primary_ports,
+        sample_count,
+        interval_sec,
+        read_status,
+    )
+    all_failures = []
+    for sample_index, sample in enumerate(samples, start=1):
+        all_failures.extend(
+            "STATE_DB sample {} sensor read:\n  {}".format(sample_index, error)
+            for error in sample["sensor_errors"]
+        )
+        all_failures.extend(
+            "STATE_DB sample {} status read:\n  {}".format(sample_index, error)
+            for error in sample["status_errors"]
+        )
+
+    consistency_failures, checked_pair_count, checked_port_count = _validate_dom_consistency(
+        dom_primary_ports,
+        samples,
+        consistency_plan_by_port,
+    )
+    all_failures.extend(consistency_failures)
+
+    if all_failures:
+        pytest.fail("DOM consistency validation failures:\n" + "\n".join(all_failures))
+
+    logger.info(
+        "DOM consistency validation passed: %d variation pair(s), %d port(s), %d sample(s)",
+        checked_pair_count,
+        checked_port_count,
+        sample_count,
+    )

--- a/tests/transceiver/dom/test_dom_operational_range.py
+++ b/tests/transceiver/dom/test_dom_operational_range.py
@@ -7,7 +7,7 @@ from tests.transceiver.attribute_parser.attribute_keys import DOM_ATTRIBUTES_KEY
 from tests.transceiver.common.db_helpers import parse_numeric
 from tests.transceiver.dom.dom_helpers import (
     OPERATIONAL_SUFFIX,
-    build_dom_availability_plan,
+    build_dom_sensor_plan,
     parse_min_max_range,
     read_dom_sensor_data,
     validate_dom_plan_fields,
@@ -55,22 +55,22 @@ def test_dom_sensor_operational_range_validation(
     port_attributes_dict,
     lport_to_first_subport_mapping,
 ):
-    """Verify configured DOM sensor values are fresh and within operational ranges."""
-    availability_plan_by_port = build_dom_availability_plan(
+    """Validate configured DOM operational ranges; freshness is checked with range fields."""
+    if not _has_operational_range_attributes(port_attributes_dict, dom_primary_ports):
+        pytest.skip("No *_operational_range attributes configured for DOM operational range validation")
+
+    sensor_plan_by_port = build_dom_sensor_plan(
         port_attributes_dict,
         dom_primary_ports,
         lport_to_first_subport_mapping,
     )
-    if not _has_operational_range_attributes(port_attributes_dict, dom_primary_ports):
-        pytest.skip("No *_operational_range attributes configured for DOM operational range validation")
-
     sensor_by_port, sensor_read_errors = read_dom_sensor_data(duthost, dom_primary_ports)
     all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in sensor_read_errors]
     range_failures, checked_field_count, checked_port_count = validate_dom_plan_fields(
         duthost,
         dom_primary_ports,
         sensor_by_port,
-        availability_plan_by_port,
+        sensor_plan_by_port,
         _operational_range_field_check,
     )
     all_failures.extend(range_failures)

--- a/tests/transceiver/dom/test_dom_threshold.py
+++ b/tests/transceiver/dom/test_dom_threshold.py
@@ -132,32 +132,40 @@ def _compare_thresholds(attr_name, configured_values, db_values):
     return errors
 
 
+def _expected_fields_from_threshold_plan(db_fields_by_threshold_attr):
+    """Return a flat ``{db_field: mapped_field}`` view for failure headers."""
+    return {
+        field: db_fields_by_threshold_attr[attr_name][field]
+        for attr_name in sorted(db_fields_by_threshold_attr)
+        for field in sorted(db_fields_by_threshold_attr[attr_name])
+    }
+
+
 def _validate_threshold_attr(attr_name, attr_value, threshold_table_data, db_fields_by_name, operational_mapped_field):
-    """Return ``(errors, checked_fields, skipped_checks)`` for one threshold attribute."""
+    """Return ``(errors, checked_fields, skipped_checks, skip_reasons)`` for one threshold attribute."""
     attr_errors = []
     skipped_checks = 0
+    skip_reasons = []
 
     configured_values, threshold_errors = _parse_threshold_range(attr_name, attr_value)
     attr_errors.extend(threshold_errors)
     if threshold_errors:
-        return attr_errors, 0, skipped_checks
+        return attr_errors, 0, skipped_checks, skip_reasons
 
     if not db_fields_by_name:
-        return ["{} has no expected STATE_DB threshold fields".format(attr_name)], 0, skipped_checks
+        return ["{} has no expected STATE_DB threshold fields".format(attr_name)], 0, skipped_checks, skip_reasons
 
     db_values, db_value_errors = _db_values_for_attr(attr_name, threshold_table_data, db_fields_by_name)
     attr_errors.extend(db_value_errors)
     if len(db_values) != len(THRESHOLD_FIELD_SUFFIXES):
         skipped_checks += 1
+        skip_reasons.append("STATE_DB hierarchy skipped because STATE_DB threshold data is incomplete")
         if operational_mapped_field:
             skipped_checks += 1
-        attr_errors.append(
-            "{} skipped STATE_DB hierarchy{} check(s) because STATE_DB threshold data is incomplete".format(
-                attr_name,
-                " and operational-range-within-warning" if operational_mapped_field else "",
+            skip_reasons.append(
+                "operational-range-within-warning skipped because STATE_DB threshold data is incomplete"
             )
-        )
-        return attr_errors, 0, skipped_checks
+        return attr_errors, 0, skipped_checks, skip_reasons
 
     attr_errors.extend(_compare_thresholds(attr_name, configured_values, db_values))
 
@@ -175,8 +183,9 @@ def _validate_threshold_attr(attr_name, attr_value, threshold_table_data, db_fie
         )
     else:
         skipped_checks += 1
+        skip_reasons.append("no paired operational range configured")
 
-    return attr_errors, len(db_fields_by_name) if not attr_errors else 0, skipped_checks
+    return attr_errors, len(db_fields_by_name) if not attr_errors else 0, skipped_checks, skip_reasons
 
 
 def _validate_dom_threshold_ranges(dom_primary_ports, threshold_table_by_port, threshold_plan_by_port):
@@ -188,14 +197,14 @@ def _validate_dom_threshold_ranges(dom_primary_ports, threshold_table_by_port, t
     skipped_check_count = 0
 
     for port in dom_primary_ports:
-        threshold_table_data = threshold_table_by_port.get(port, {})
+        threshold_table_data = threshold_table_by_port.get(port)
         threshold_plan = threshold_plan_by_port.get(port, {})
-        expected_fields = threshold_plan.get("expected_fields", {})
         configured_by_attr = threshold_plan.get("configured_by_attr", {})
         db_fields_by_threshold_attr = threshold_plan.get("db_fields_by_threshold_attr", {})
+        expected_fields = _expected_fields_from_threshold_plan(db_fields_by_threshold_attr)
         operational_range_by_threshold_attr = threshold_plan.get("operational_range_by_threshold_attr", {})
         field_failures = list(threshold_plan.get("errors", []))
-        has_threshold_checks = bool(expected_fields or configured_by_attr or field_failures)
+        has_threshold_checks = bool(configured_by_attr or field_failures)
 
         if has_threshold_checks:
             checked_port_count += 1
@@ -235,7 +244,7 @@ def _validate_dom_threshold_ranges(dom_primary_ports, threshold_table_by_port, t
         for attr_name, attr_value in sorted(configured_by_attr.items()):
             db_fields_by_name = db_fields_by_threshold_attr.get(attr_name, {})
             operational_mapped_field = operational_range_by_threshold_attr.get(attr_name)
-            attr_errors, checked_fields, skipped_checks = _validate_threshold_attr(
+            attr_errors, checked_fields, skipped_checks, skip_reasons = _validate_threshold_attr(
                 attr_name,
                 attr_value,
                 threshold_table_data,
@@ -244,17 +253,12 @@ def _validate_dom_threshold_ranges(dom_primary_ports, threshold_table_by_port, t
             )
             skipped_check_count += skipped_checks
             if skipped_checks:
-                logger.warning(
-                    "DOM threshold reduced coverage %s %s: %d check(s) skipped",
+                logger.debug(
+                    "DOM threshold reduced coverage %s %s: %d check(s) skipped (%s)",
                     port,
                     attr_name,
                     skipped_checks,
-                )
-            if not operational_mapped_field:
-                logger.warning(
-                    "DOM threshold reduced coverage %s %s: no paired operational range configured",
-                    port,
-                    attr_name,
+                    "; ".join(skip_reasons),
                 )
 
             if attr_errors:

--- a/tests/transceiver/dom/test_dom_threshold.py
+++ b/tests/transceiver/dom/test_dom_threshold.py
@@ -89,31 +89,134 @@ def _validate_operational_range_within_warning(threshold_attr, thresholds, opera
 def _has_threshold_range_attributes(threshold_plan_by_port):
     """Return True when any primary port has configured threshold-range checks."""
     return any(
-        plan.get("threshold_attrs") or plan.get("errors")
+        plan.get("configured_by_attr") or plan.get("errors")
         for plan in threshold_plan_by_port.values()
     )
 
 
-def _validate_dom_threshold_ranges(dom_primary_ports, threshold_by_port, threshold_plan_by_port):
+def _db_values_for_attr(attr_name, threshold_table_data, db_fields_by_name):
+    """Return ``(db_values, errors)`` for one configured threshold attribute."""
+    db_values = {}
+    errors = []
+    for field, mapped_field in db_fields_by_name.items():
+        raw_value = threshold_table_data.get(field)
+        actual_value = parse_numeric(raw_value)
+        if actual_value is None or not math.isfinite(actual_value):
+            errors.append(
+                "{} threshold field {} missing/non-finite in STATE_DB (raw={!r})".format(
+                    attr_name,
+                    field,
+                    raw_value,
+                )
+            )
+            continue
+        db_values[mapped_field.threshold_key] = actual_value
+    return db_values, errors
+
+
+def _compare_thresholds(attr_name, configured_values, db_values):
+    """Return threshold value mismatch errors between configured and STATE_DB values."""
+    errors = []
+    for threshold_key in THRESHOLD_FIELD_SUFFIXES:
+        expected_value = configured_values[threshold_key]
+        actual_value = db_values[threshold_key]
+        if abs(actual_value - expected_value) > THRESHOLD_VALUE_TOLERANCE:
+            errors.append(
+                "{} expected {}={}, got {} from STATE_DB".format(
+                    attr_name,
+                    threshold_key,
+                    expected_value,
+                    actual_value,
+                )
+            )
+    return errors
+
+
+def _validate_threshold_attr(attr_name, attr_value, threshold_table_data, db_fields_by_name, operational_mapped_field):
+    """Return ``(errors, checked_fields, skipped_checks)`` for one threshold attribute."""
+    attr_errors = []
+    skipped_checks = 0
+
+    configured_values, threshold_errors = _parse_threshold_range(attr_name, attr_value)
+    attr_errors.extend(threshold_errors)
+    if threshold_errors:
+        return attr_errors, 0, skipped_checks
+
+    if not db_fields_by_name:
+        return ["{} has no expected STATE_DB threshold fields".format(attr_name)], 0, skipped_checks
+
+    db_values, db_value_errors = _db_values_for_attr(attr_name, threshold_table_data, db_fields_by_name)
+    attr_errors.extend(db_value_errors)
+    if len(db_values) != len(THRESHOLD_FIELD_SUFFIXES):
+        skipped_checks += 1
+        if operational_mapped_field:
+            skipped_checks += 1
+        attr_errors.append(
+            "{} skipped STATE_DB hierarchy{} check(s) because STATE_DB threshold data is incomplete".format(
+                attr_name,
+                " and operational-range-within-warning" if operational_mapped_field else "",
+            )
+        )
+        return attr_errors, 0, skipped_checks
+
+    attr_errors.extend(_compare_thresholds(attr_name, configured_values, db_values))
+
+    hierarchy_error = _threshold_hierarchy_error(attr_name, db_values, "STATE_DB")
+    if hierarchy_error:
+        attr_errors.append(hierarchy_error)
+
+    if operational_mapped_field:
+        attr_errors.extend(
+            _validate_operational_range_within_warning(
+                attr_name,
+                db_values,
+                operational_mapped_field,
+            )
+        )
+    else:
+        skipped_checks += 1
+
+    return attr_errors, len(db_fields_by_name) if not attr_errors else 0, skipped_checks
+
+
+def _validate_dom_threshold_ranges(dom_primary_ports, threshold_table_by_port, threshold_plan_by_port):
     """Validate configured DOM threshold fields against STATE_DB threshold data."""
     failures = []
     checked_attr_count = 0
     checked_field_count = 0
     checked_port_count = 0
+    skipped_check_count = 0
 
     for port in dom_primary_ports:
-        threshold_data = threshold_by_port.get(port, {})
+        threshold_table_data = threshold_table_by_port.get(port, {})
         threshold_plan = threshold_plan_by_port.get(port, {})
         expected_fields = threshold_plan.get("expected_fields", {})
-        threshold_attrs = threshold_plan.get("threshold_attrs", {})
-        operational_ranges = threshold_plan.get("operational_ranges", {})
+        configured_by_attr = threshold_plan.get("configured_by_attr", {})
+        db_fields_by_threshold_attr = threshold_plan.get("db_fields_by_threshold_attr", {})
+        operational_range_by_threshold_attr = threshold_plan.get("operational_range_by_threshold_attr", {})
         field_failures = list(threshold_plan.get("errors", []))
-        has_threshold_checks = bool(expected_fields or threshold_attrs or field_failures)
+        has_threshold_checks = bool(expected_fields or configured_by_attr or field_failures)
 
         if has_threshold_checks:
             checked_port_count += 1
 
-        if has_threshold_checks and not threshold_data:
+        if has_threshold_checks and threshold_table_data is None:
+            field_failures.append(
+                "could not read {} for port (namespace read failed)".format(STATE_DB_THRESHOLD_TABLE)
+            )
+            failures.append(
+                format_dom_port_failure(
+                    port,
+                    [],
+                    expected_fields,
+                    field_failures,
+                    field_label="expected threshold field(s)",
+                    include_lanes=False,
+                )
+            )
+            continue
+
+        if has_threshold_checks and not threshold_table_data:
             field_failures.append(
                 "no {} entry published for port".format(STATE_DB_THRESHOLD_TABLE)
             )
@@ -129,76 +232,41 @@ def _validate_dom_threshold_ranges(dom_primary_ports, threshold_by_port, thresho
             )
             continue
 
-        for attr_name, attr_value in sorted(threshold_attrs.items()):
-            attr_failure_count = len(field_failures)
-            attr_expected_fields = {
-                field: mapped_field
-                for field, mapped_field in expected_fields.items()
-                if mapped_field.source_attr == attr_name
-            }
-
-            expected_thresholds, threshold_errors = _parse_threshold_range(attr_name, attr_value)
-            field_failures.extend(threshold_errors)
-            if threshold_errors:
-                continue
-
-            if not attr_expected_fields:
-                field_failures.append("{} has no expected STATE_DB threshold fields".format(attr_name))
-                continue
-
-            actual_thresholds = {}
-            for field, mapped_field in attr_expected_fields.items():
-                raw_value = threshold_data.get(field)
-                actual_value = parse_numeric(raw_value)
-                if actual_value is None or not math.isfinite(actual_value):
-                    field_failures.append(
-                        "{} threshold field {} missing/non-finite in STATE_DB (raw={!r})".format(
-                            attr_name,
-                            field,
-                            raw_value,
-                        )
-                    )
-                    continue
-                actual_thresholds[mapped_field.threshold_key] = actual_value
-
-            if len(actual_thresholds) != len(THRESHOLD_FIELD_SUFFIXES):
-                continue
-
-            for threshold_key in THRESHOLD_FIELD_SUFFIXES:
-                expected_value = expected_thresholds[threshold_key]
-                actual_value = actual_thresholds[threshold_key]
-                if abs(actual_value - expected_value) > THRESHOLD_VALUE_TOLERANCE:
-                    field_failures.append(
-                        "{} expected {}={}, got {} from STATE_DB".format(
-                            attr_name,
-                            threshold_key,
-                            expected_value,
-                            actual_value,
-                        )
-                    )
-
-            hierarchy_error = _threshold_hierarchy_error(attr_name, actual_thresholds, "STATE_DB")
-            if hierarchy_error:
-                field_failures.append(hierarchy_error)
-
-            operational_mapped_field = operational_ranges.get(attr_name)
-            if operational_mapped_field:
-                field_failures.extend(
-                    _validate_operational_range_within_warning(
-                        attr_name,
-                        actual_thresholds,
-                        operational_mapped_field,
-                    )
+        for attr_name, attr_value in sorted(configured_by_attr.items()):
+            db_fields_by_name = db_fields_by_threshold_attr.get(attr_name, {})
+            operational_mapped_field = operational_range_by_threshold_attr.get(attr_name)
+            attr_errors, checked_fields, skipped_checks = _validate_threshold_attr(
+                attr_name,
+                attr_value,
+                threshold_table_data,
+                db_fields_by_name,
+                operational_mapped_field,
+            )
+            skipped_check_count += skipped_checks
+            if skipped_checks:
+                logger.warning(
+                    "DOM threshold reduced coverage %s %s: %d check(s) skipped",
+                    port,
+                    attr_name,
+                    skipped_checks,
+                )
+            if not operational_mapped_field:
+                logger.warning(
+                    "DOM threshold reduced coverage %s %s: no paired operational range configured",
+                    port,
+                    attr_name,
                 )
 
-            if len(field_failures) == attr_failure_count:
+            if attr_errors:
+                field_failures.extend(attr_errors)
+            else:
                 checked_attr_count += 1
-                checked_field_count += len(attr_expected_fields)
+                checked_field_count += checked_fields
                 logger.debug(
                     "DOM threshold PASS %s %s fields=%s operational_attr=%s",
                     port,
                     attr_name,
-                    sorted(attr_expected_fields),
+                    sorted(db_fields_by_name),
                     operational_mapped_field.source_attr if operational_mapped_field else "not-configured",
                 )
 
@@ -214,7 +282,7 @@ def _validate_dom_threshold_ranges(dom_primary_ports, threshold_by_port, thresho
                 )
             )
 
-    return failures, checked_attr_count, checked_field_count, checked_port_count
+    return failures, checked_attr_count, checked_field_count, checked_port_count, skipped_check_count
 
 
 def test_dom_threshold_validation(
@@ -227,12 +295,12 @@ def test_dom_threshold_validation(
     if not _has_threshold_range_attributes(threshold_plan_by_port):
         pytest.skip("No *_threshold_range attributes configured for DOM threshold validation")
 
-    threshold_by_port, threshold_read_errors = read_dom_threshold_data(duthost, dom_primary_ports)
+    threshold_table_by_port, threshold_read_errors = read_dom_threshold_data(duthost, dom_primary_ports)
     all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in threshold_read_errors]
-    threshold_failures, checked_attr_count, checked_field_count, checked_port_count = (
+    threshold_failures, checked_attr_count, checked_field_count, checked_port_count, skipped_check_count = (
         _validate_dom_threshold_ranges(
             dom_primary_ports,
-            threshold_by_port,
+            threshold_table_by_port,
             threshold_plan_by_port,
         )
     )
@@ -241,9 +309,13 @@ def test_dom_threshold_validation(
     if all_failures:
         pytest.fail("DOM threshold validation failures:\n" + "\n".join(all_failures))
 
+    if skipped_check_count:
+        logger.warning("DOM threshold validation completed with %d skipped check(s)", skipped_check_count)
     logger.info(
-        "DOM threshold validation passed: %d threshold attribute(s), %d field(s) across %d port(s)",
+        "DOM threshold validation passed: %d threshold attribute(s), %d field(s) across %d port(s), "
+        "%d skipped check(s)",
         checked_attr_count,
         checked_field_count,
         checked_port_count,
+        skipped_check_count,
     )

--- a/tests/transceiver/dom/test_dom_threshold.py
+++ b/tests/transceiver/dom/test_dom_threshold.py
@@ -120,10 +120,11 @@ def _validate_dom_threshold_ranges(dom_primary_ports, threshold_by_port, thresho
             failures.append(
                 format_dom_port_failure(
                     port,
-                    None,
+                    [],
                     expected_fields,
                     field_failures,
                     field_label="expected threshold field(s)",
+                    include_lanes=False,
                 )
             )
             continue
@@ -205,10 +206,11 @@ def _validate_dom_threshold_ranges(dom_primary_ports, threshold_by_port, thresho
             failures.append(
                 format_dom_port_failure(
                     port,
-                    None,
+                    [],
                     expected_fields,
                     field_failures,
                     field_label="expected threshold field(s)",
+                    include_lanes=False,
                 )
             )
 

--- a/tests/transceiver/dom/test_dom_threshold.py
+++ b/tests/transceiver/dom/test_dom_threshold.py
@@ -1,0 +1,247 @@
+import logging
+import math
+
+import pytest
+
+from tests.transceiver.common.db_helpers import parse_numeric
+from tests.transceiver.dom.dom_helpers import (
+    STATE_DB_THRESHOLD_TABLE,
+    THRESHOLD_FIELD_SUFFIXES,
+    THRESHOLD_VALUE_TOLERANCE,
+    build_dom_threshold_plan,
+    format_dom_port_failure,
+    parse_min_max_range,
+    read_dom_threshold_data,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_threshold_range(attr_name, attr_value):
+    """Return ``(thresholds, errors)`` for one configured threshold attribute."""
+    if not isinstance(attr_value, dict):
+        return {}, [
+            "{} must be a dict with {} in DOM_ATTRIBUTES".format(
+                attr_name,
+                THRESHOLD_FIELD_SUFFIXES,
+            )
+        ]
+
+    thresholds = {}
+    errors = []
+    for threshold_key in THRESHOLD_FIELD_SUFFIXES:
+        value = parse_numeric(attr_value.get(threshold_key))
+        if value is None or not math.isfinite(value):
+            errors.append(
+                "{} missing/non-finite numeric {} in DOM_ATTRIBUTES".format(
+                    attr_name,
+                    threshold_key,
+                )
+            )
+            continue
+        thresholds[threshold_key] = value
+
+    if errors:
+        return {}, errors
+
+    hierarchy_error = _threshold_hierarchy_error(attr_name, thresholds, "configured")
+    if hierarchy_error:
+        return {}, [hierarchy_error]
+
+    return thresholds, []
+
+
+def _threshold_hierarchy_error(attr_name, thresholds, source):
+    if (
+        thresholds["lowalarm"]
+        < thresholds["lowwarning"]
+        < thresholds["highwarning"]
+        < thresholds["highalarm"]
+    ):
+        return None
+    return (
+        "{} {} hierarchy lowalarm < lowwarning < highwarning < highalarm "
+        "is violated".format(attr_name, source)
+    )
+
+
+def _validate_operational_range_within_warning(threshold_attr, thresholds, operational_mapped_field):
+    """Validate a paired operational range sits inside threshold warning bounds."""
+    op_min, op_max, range_error = parse_min_max_range(operational_mapped_field)
+    if range_error:
+        return [range_error]
+
+    if thresholds["lowwarning"] < op_min and op_max < thresholds["highwarning"]:
+        return []
+
+    return [
+        "{} operational range [{}, {}] is not within {} warning bounds ({}, {})".format(
+            operational_mapped_field.source_attr,
+            op_min,
+            op_max,
+            threshold_attr,
+            thresholds["lowwarning"],
+            thresholds["highwarning"],
+        )
+    ]
+
+
+def _has_threshold_range_attributes(threshold_plan_by_port):
+    """Return True when any primary port has configured threshold-range checks."""
+    return any(
+        plan.get("threshold_attrs") or plan.get("errors")
+        for plan in threshold_plan_by_port.values()
+    )
+
+
+def _validate_dom_threshold_ranges(dom_primary_ports, threshold_by_port, threshold_plan_by_port):
+    """Validate configured DOM threshold fields against STATE_DB threshold data."""
+    failures = []
+    checked_attr_count = 0
+    checked_field_count = 0
+    checked_port_count = 0
+
+    for port in dom_primary_ports:
+        threshold_data = threshold_by_port.get(port, {})
+        threshold_plan = threshold_plan_by_port.get(port, {})
+        expected_fields = threshold_plan.get("expected_fields", {})
+        threshold_attrs = threshold_plan.get("threshold_attrs", {})
+        operational_ranges = threshold_plan.get("operational_ranges", {})
+        field_failures = list(threshold_plan.get("errors", []))
+        has_threshold_checks = bool(expected_fields or threshold_attrs or field_failures)
+
+        if has_threshold_checks:
+            checked_port_count += 1
+
+        if has_threshold_checks and not threshold_data:
+            field_failures.append(
+                "no {} entry published for port".format(STATE_DB_THRESHOLD_TABLE)
+            )
+            failures.append(
+                format_dom_port_failure(
+                    port,
+                    None,
+                    expected_fields,
+                    field_failures,
+                    field_label="expected threshold field(s)",
+                )
+            )
+            continue
+
+        for attr_name, attr_value in sorted(threshold_attrs.items()):
+            attr_failure_count = len(field_failures)
+            attr_expected_fields = {
+                field: mapped_field
+                for field, mapped_field in expected_fields.items()
+                if mapped_field.source_attr == attr_name
+            }
+
+            expected_thresholds, threshold_errors = _parse_threshold_range(attr_name, attr_value)
+            field_failures.extend(threshold_errors)
+            if threshold_errors:
+                continue
+
+            if not attr_expected_fields:
+                field_failures.append("{} has no expected STATE_DB threshold fields".format(attr_name))
+                continue
+
+            actual_thresholds = {}
+            for field, mapped_field in attr_expected_fields.items():
+                raw_value = threshold_data.get(field)
+                actual_value = parse_numeric(raw_value)
+                if actual_value is None or not math.isfinite(actual_value):
+                    field_failures.append(
+                        "{} threshold field {} missing/non-finite in STATE_DB (raw={!r})".format(
+                            attr_name,
+                            field,
+                            raw_value,
+                        )
+                    )
+                    continue
+                actual_thresholds[mapped_field.threshold_key] = actual_value
+
+            if len(actual_thresholds) != len(THRESHOLD_FIELD_SUFFIXES):
+                continue
+
+            for threshold_key in THRESHOLD_FIELD_SUFFIXES:
+                expected_value = expected_thresholds[threshold_key]
+                actual_value = actual_thresholds[threshold_key]
+                if abs(actual_value - expected_value) > THRESHOLD_VALUE_TOLERANCE:
+                    field_failures.append(
+                        "{} expected {}={}, got {} from STATE_DB".format(
+                            attr_name,
+                            threshold_key,
+                            expected_value,
+                            actual_value,
+                        )
+                    )
+
+            hierarchy_error = _threshold_hierarchy_error(attr_name, actual_thresholds, "STATE_DB")
+            if hierarchy_error:
+                field_failures.append(hierarchy_error)
+
+            operational_mapped_field = operational_ranges.get(attr_name)
+            if operational_mapped_field:
+                field_failures.extend(
+                    _validate_operational_range_within_warning(
+                        attr_name,
+                        actual_thresholds,
+                        operational_mapped_field,
+                    )
+                )
+
+            if len(field_failures) == attr_failure_count:
+                checked_attr_count += 1
+                checked_field_count += len(attr_expected_fields)
+                logger.debug(
+                    "DOM threshold PASS %s %s fields=%s operational_attr=%s",
+                    port,
+                    attr_name,
+                    sorted(attr_expected_fields),
+                    operational_mapped_field.source_attr if operational_mapped_field else "not-configured",
+                )
+
+        if field_failures:
+            failures.append(
+                format_dom_port_failure(
+                    port,
+                    None,
+                    expected_fields,
+                    field_failures,
+                    field_label="expected threshold field(s)",
+                )
+            )
+
+    return failures, checked_attr_count, checked_field_count, checked_port_count
+
+
+def test_dom_threshold_validation(
+    duthost,
+    dom_primary_ports,
+    port_attributes_dict,
+):
+    """Verify configured DOM threshold ranges against STATE_DB threshold data."""
+    threshold_plan_by_port = build_dom_threshold_plan(port_attributes_dict, dom_primary_ports)
+    if not _has_threshold_range_attributes(threshold_plan_by_port):
+        pytest.skip("No *_threshold_range attributes configured for DOM threshold validation")
+
+    threshold_by_port, threshold_read_errors = read_dom_threshold_data(duthost, dom_primary_ports)
+    all_failures = ["STATE_DB read:\n  {}".format(read_error) for read_error in threshold_read_errors]
+    threshold_failures, checked_attr_count, checked_field_count, checked_port_count = (
+        _validate_dom_threshold_ranges(
+            dom_primary_ports,
+            threshold_by_port,
+            threshold_plan_by_port,
+        )
+    )
+    all_failures.extend(threshold_failures)
+
+    if all_failures:
+        pytest.fail("DOM threshold validation failures:\n" + "\n".join(all_failures))
+
+    logger.info(
+        "DOM threshold validation passed: %d threshold attribute(s), %d field(s) across %d port(s)",
+        checked_attr_count,
+        checked_field_count,
+        checked_port_count,
+    )


### PR DESCRIPTION
### Description of PR

  Summary:
  Add DOM basic TC3 threshold validation and TC4 consistency validation for transceiver DOM data.

  Fixes # N/A

  This PR includes DOM basic TC3 and TC4 validation.

  TC3 validates configured DOM threshold data from `TRANSCEIVER_DOM_THRESHOLD`.
  TC4 validates DOM sensor update consistency over multiple samples using `TRANSCEIVER_DOM_SENSOR` and, when Tx-bias consistency checks are
  configured, `TRANSCEIVER_STATUS`.

  TC1 availability validation, TC2 operational range validation, and the shared DOM helper infrastructure are already available from
  master. This PR extends that architecture with TC3 threshold validation and TC4 consistency validation.

  ### Type of change

  - [ ] Bug fix
  - [x] Testbed and Framework(new/improvement)
  - [x] New Test case
      - [x] Skipped for non-supported platforms
  - [ ] Test case improvement

  ### Back port request

  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511
  - [ ] 202512
  - [ ] 202605

  Tracking issue/work item for backport/cherry-pick request: N/A
  Failure type: N/A

  ### Tested branch

  - [x] master
  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511
  - [ ] 202512
  - [ ] 202605
  - [ ] N/A

  ### Test result

  Validated on `verify/dom-basic-tc4` using `single-dut-mgmt61` and DUT `str-nexthop_4010-01`.

  TC1 availability regression:
  `tests/transceiver/dom/test_dom_availability.py::test_dom_data_availability_verification`
  Result: `1 passed in 23.70s`

  TC2 operational range regression:
  `tests/transceiver/dom/test_dom_operational_range.py::test_dom_sensor_operational_range_validation`
  Result: `1 passed in 23.38s`

  TC3 threshold validation:
  `tests/transceiver/dom/test_dom_threshold.py::test_dom_threshold_validation`
  Result: `1 passed in 23.16s`

  TC4 consistency validation:
  `tests/transceiver/dom/test_dom_consistency.py::test_dom_data_consistency_verification`
  Result: `1 passed in 335.85s`

  Generated pytest-html reports:
  - `dom_test_tc1.html`
  - `dom_test_tc2.html`
  - `dom_test_tc3.html`
  - `dom_test_tc4.html`

  Example TC3 command:

  ```bash
  ./tests/run_tests.sh \
    -c "tests/transceiver/dom/test_dom_threshold.py" \
    -n single-dut-mgmt61 \
    -d str-nexthop_4010-01 \
    -i "ansible/my_inventory/lab" \
    -f "ansible/testbed.yaml" \
    -u \
    -e "-rs -n 0 -p no:tests.common.plugins.memory_utilization --ignore-conditional-mark --skip_sanity --skip_yang --disable-warnings
    --skip_transceiver_template_validation --html=dom_test_tc3.html --self-contained-html"

  Example TC4 command:

  ./tests/run_tests.sh \
    -c "tests/transceiver/dom/test_dom_consistency.py" \
    -n single-dut-mgmt61 \
    -d str-nexthop_4010-01 \
    -i "ansible/my_inventory/lab" \
    -f "ansible/testbed.yaml" \
    -u \
    -e "-rs -n 0 -p no:tests.common.plugins.memory_utilization --ignore-conditional-mark --skip_sanity --skip_yang --disable-warnings
    --skip_transceiver_template_validation --html=dom_test_tc4.html --self-contained-html"

  ### Approach

  #### What is the motivation for this PR?

  This PR continues splitting DOM basic validation into smaller, reviewable test cases while reusing the shared DOM helper architecture.

  TC3 verifies that configured DOM threshold ranges match the threshold values published in STATE_DB.

  TC4 verifies that DOM sensor data keeps updating and that configured DOM values remain stable within expected variation thresholds across
  multiple samples.

  #### How did you do it?

  Added TC3 threshold validation in:

  - tests/transceiver/dom/test_dom_threshold.py

  TC3:

  - Reads DOM threshold data from TRANSCEIVER_DOM_THRESHOLD in STATE_DB.
  - Uses resolved DOM attributes from port_attributes_dict.
  - Dynamically selects configured *_threshold_range attributes.
  - Maps configured threshold attributes to STATE_DB threshold fields.
  - Validates required threshold keys: lowalarm, lowwarning, highwarning, and highalarm.
  - Validates configured threshold values are numeric and finite.
  - Compares configured threshold values against STATE_DB values with tolerance.
  - Validates threshold hierarchy: lowalarm < lowwarning < highwarning < highalarm.
  - Validates paired operational {min, max} ranges are within warning threshold bounds when both attributes are configured.
  - Skips before reading STATE_DB when no DOM *_threshold_range attributes are configured.
  - Aggregates per-port failures and reports reduced coverage via skipped-check summary.

  Added TC4 consistency validation in:

  - tests/transceiver/dom/test_dom_consistency.py

  TC4:

  - Reuses build_dom_sensor_plan() to resolve DOM-capable primary ports and active media lanes.
  - Builds per-port consistency plans from DOM_ATTRIBUTES.
  - Samples TRANSCEIVER_DOM_SENSOR multiple times using configured timing.
  - Verifies last_update_time exists and advances between samples.
  - Validates absolute variation thresholds for temperature, voltage, laser temperature, TX power, and RX power.
  - Reads TRANSCEIVER_STATUS when Tx-bias consistency validation is configured.
  - Validates Tx-bias percentage variation only when the datapath is activated and values are within the configured Tx-bias warning range.
  - Current Tx-bias datapath gating assumes media lanes map 1:1 to host/datapath lanes. Gearbox and inverse-gearbox lane translation can be
    added in a follow-up PR.

  Extended shared DOM helpers with:

  - Threshold table read support.
  - Transceiver status table read support.
  - Shared STATE_DB read handling with namespace-read failure sentinel behavior.
  - Shared threshold and consistency field mapping helpers.
  - Consistent per-port failure formatting.

  #### How did you verify/test it?

  Validated in the lab using single-dut-mgmt61 and DUT str-nexthop_4010-01.

  The following tests passed:

  - TC1 availability: 1 passed in 23.70s
  - TC2 operational range: 1 passed in 23.38s
  - TC3 threshold validation: 1 passed in 23.16s
  - TC4 consistency validation: 1 passed in 335.85s

  #### Any platform specific information?

  Validated with Accelight AGP80SC0CW41002 transceivers on str-nexthop_4010-01.

  The tests are configuration-driven and depend on DOM attributes being configured for the transceiver under test. Unsupported or
  unconfigured DOM attributes are skipped according to the DOM test behavior.

  #### Supported testbed topology if it's a new test case?

  PTP topology / real transceiver hardware testbed.

  Validated on mgmt-only single DUT testbed:

  single-dut-mgmt61

  ### Documentation

  The DOM basic TC3 and TC4 behavior follows:

  docs/testplan/transceiver/dom_test_plan.md
