### PR TITLE
[HFT] Restart OTEL through systemd

### DIFF
--- a/tests/high_frequency_telemetry/conftest.py
+++ b/tests/high_frequency_telemetry/conftest.py
@@ -48,16 +48,18 @@ def suppress_otel_debug_logging(duthosts, enum_rand_one_per_hwsku_hostname):
         f"sed -i 's/verbosity: detailed/verbosity: basic/' {OTEL_CONFIG_PATH}",
         module_ignore_errors=False
     )
-    duthost.shell('docker restart otel', module_ignore_errors=True)
-    wait_until(60, 2, 0, duthost.is_service_fully_started, "otel")
+    duthost.shell('sudo systemctl restart otel', module_ignore_errors=False)
+    if not wait_until(60, 2, 10, duthost.is_service_fully_started, "otel"):
+        pytest.fail("OTEL container failed to start after restarting otel.service")
 
     yield
 
     # Restore original config
     logger.info("Restoring original OTEL collector config")
     duthost.copy(content=original_config, dest=OTEL_CONFIG_PATH)
-    duthost.shell('docker restart otel', module_ignore_errors=True)
-    wait_until(60, 2, 0, duthost.is_service_fully_started, "otel")
+    duthost.shell('sudo systemctl restart otel', module_ignore_errors=False)
+    if not wait_until(60, 2, 10, duthost.is_service_fully_started, "otel"):
+        pytest.fail("OTEL container failed to start after restarting otel.service")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Description of PR

Summary:

Restart the OTEL container through its systemd service when the HFT fixture
changes or restores the collector configuration. A direct `docker restart`
releases the `otel.service` container waiter, after which systemd can stop the
newly restarted container. Also fail explicitly if OTEL is not running after a
10-second stabilization delay.

Fixes #27080

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #27080
Failure type: regression

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: static validation on the identical fixture code passed (`py_compile`, `pre-commit`, and `git diff --check`).
- 202511: `SONiC.20251110.43`, `Mellanox-SN5640-C512S2`, `t0-isolated-d32u32s2`; full `high_frequency_telemetry/test_high_frequency_telemetry.py` run passed with LogAnalyzer enabled: `9 passed, 7 skipped`, `0 failures`, `0 errors`. All 7 executed HFT cases completed LogAnalyzer analysis without `Expected containers not running: otel`.

### Approach
#### What is the motivation for this PR?

The HFT fixture temporarily reduces OTEL debug exporter verbosity. Directly
restarting the systemd-managed container through Docker can leave it stopped,
which makes otherwise-passing HFT cases fail during LogAnalyzer teardown.

#### How did you do it?

Replace both direct Docker restarts with `systemctl restart otel` and verify the
container is running after a 10-second stabilization delay. Restart and
readiness failures are no longer ignored.

#### How did you verify/test it?

Ran the complete HFT module on physical testbed `vms95-t0-sn5640-3` after
disabling container autorestart, matching nightly behavior. LogAnalyzer stayed
enabled for all HFT cases. The test restored the original OTEL configuration
and container autorestart state afterward; OTEL remained running.

#### Any platform specific information?

Validated on Mellanox SN5640 (`Mellanox-SN5640-C512S2`, SPC5).

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
