### PR TITLE
Fix ICMP orchagent fixture registration

### DIFF
--- a/tests/snappi_tests/test_orchagent_icmp_hw_offload.py
+++ b/tests/snappi_tests/test_orchagent_icmp_hw_offload.py
@@ -97,9 +97,21 @@ def check_snappi_versions():
 _skip_required, _skip_reason = check_snappi_versions()
 
 # Import dualtor mock fixtures for proper orchagent mocking
-from tests.common.dualtor.dual_tor_mock import apply_mock_dual_tor_tables  # noqa: F401, E402
-from tests.common.dualtor.dual_tor_mock import apply_mock_dual_tor_kernel_configs  # noqa: F401, E402
-from tests.common.dualtor.dual_tor_mock import apply_active_state_to_orchagent  # noqa: F401, E402
+from tests.common.dualtor.dual_tor_mock import (  # noqa: F401, E402
+    apply_active_state_to_orchagent,
+    apply_dual_tor_neigh_entries,
+    apply_dual_tor_peer_switch_route,
+    apply_mock_dual_tor_kernel_configs,
+    apply_mock_dual_tor_tables,
+    apply_mux_cable_table_to_dut,
+    apply_peer_switch_table_to_dut,
+    apply_tunnel_table_to_dut,
+    cleanup_mocked_configs,
+    mock_peer_switch_loopback_ip,
+    mock_server_base_ip_addr,
+    mock_server_ip_mac_map,
+    mock_server_ipv6_mac_map,
+)
 from tests.common.dualtor.dual_tor_utils import tor_mux_intfs  # noqa: F401, E402
 
 # Import Snappi/IXIA fixtures and utilities


### PR DESCRIPTION
### Description of PR

Summary:
Register all dual ToR mock helper fixtures used by `test_orchagent_icmp_hw_offload.py` so pytest can resolve fixtures requested dynamically by `apply_mock_dual_tor_tables` and `apply_mock_dual_tor_kernel_configs`.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/39291371

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: regression

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
- Local validation: `python -m py_compile tests/snappi_tests/test_orchagent_icmp_hw_offload.py`
- Local validation: `python -m pre_commit run --files tests/snappi_tests/test_orchagent_icmp_hw_offload.py`

### Approach
#### What is the motivation for this PR?

Nightly runs fail during setup because `apply_mock_dual_tor_tables` dynamically requests `apply_mux_cable_table_to_dut`, but the snappi test module only imported the wrapper fixtures. Pytest did not register the dynamically requested helper fixtures in this module, so setup failed before any ICMP orchagent validation ran.

#### How did you do it?

Import the dual ToR helper fixtures that are dynamically requested by the wrapper fixtures, including their fixture dependencies, from `tests.common.dualtor.dual_tor_mock`.

#### How did you verify/test it?

Ran Python compilation and pre-commit checks for the changed test file locally.

#### Any platform specific information?

Observed on Arista-7060CX-32S-C32 T0 internal nightly testbeds, but the fix is test fixture registration and is platform-independent.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
