### PR TITLE
Fix YANG validation empty patch input

### DIFF
--- a/tests/common/helpers/yang_utils.py
+++ b/tests/common/helpers/yang_utils.py
@@ -16,10 +16,15 @@ def run_yang_validation(duthost, stage="validation"):
     """
     logger.info(f"Running YANG validation on {duthost.hostname} ({stage})")
     try:
-        result = duthost.shell(
-            'echo "[]" | sudo config apply-patch /dev/stdin',
-            module_ignore_errors=True
-        )
+        empty_patch_file = "/home/admin/yang_validation_empty_patch.json"
+        try:
+            duthost.copy(content="[]", dest=empty_patch_file)
+            result = duthost.shell(
+                f"sudo config apply-patch {empty_patch_file}",
+                module_ignore_errors=True
+            )
+        finally:
+            duthost.file(path=empty_patch_file, state="absent")
 
         if result['rc'] != 0:
             error = result.get('stderr', result.get('stdout', 'Unknown error'))


### PR DESCRIPTION
### Description of PR

Summary:
Fix YANG validation helper to pass the empty JSON patch through a real file instead of `/dev/stdin`. This avoids intermittent failures where `config apply-patch /dev/stdin` receives empty input and raises `Expecting value: line 1 column 1 (char 0)` during pre-test validation.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/39291361

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39291361
Failure type: regression

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

On master branch local validation:
- `python -m py_compile tests\common\helpers\yang_utils.py`
- `python -m pre_commit run --files tests/common/helpers/yang_utils.py`

202605 evidence: nightly failure on Cisco dualtor shows the original `/dev/stdin` path failing in pre-test YANG validation with `Expecting value: line 1 column 1 (char 0)`.

### Approach
#### What is the motivation for this PR?

Nightly tests can fail before the actual test body when the YANG validation helper runs `echo "[]" | sudo config apply-patch /dev/stdin`. In the tracked failure, all `closa/test_suppress_prefix_list_msft_internal.py` cases errored in setup because GCU received empty stdin.

#### How did you do it?

Write the empty JSON patch to `/home/admin/yang_validation_empty_patch.json`, call `sudo config apply-patch` with that filename, and remove the file in a `finally` block.

#### How did you verify/test it?

Ran Python compilation and sonic-mgmt pre-commit hooks on the changed file.

#### Any platform specific information?

Observed on Cisco-8101C01 dualtor 202605 nightly, but the helper is platform-independent.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.