### PR TITLE
Ignore transient thermalctld JSONDecodeError after reboot in packet_t…

### DIFF
--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -300,9 +300,13 @@ class BasePacketTrimming:
         if loganalyzer and duthost.hostname in loganalyzer:
             # thermalctld can throw a transient JSONDecodeError while state-db is being
             # repopulated right after boot. This is expected and unrelated to packet trimming
-            # (see sonic-buildimage#8984); tacacs transport errors are already ignored globally.
+            # (see sonic-buildimage#8984). The exception is caught internally by thermalctld
+            # (the daemon keeps running, per `supervisorctl status`) and it successfully
+            # re-initializes the thermal manager on its next polling cycle once state-db is
+            # repopulated, so this is safe to ignore here.
             loganalyzer[duthost.hostname].ignore_regex.extend([
-                r".*ERR pmon#thermalctld.*Caught exception while initializing thermal manager.*",
+                r".*ERR pmon#thermalctld.*Caught exception while initializing thermal manager"
+                r".*JSONDecodeError.*",
             ])
 
         with allure.step(f"Configure packet trimming in global level for {self.trimming_mode} mode"):

--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -305,8 +305,7 @@ class BasePacketTrimming:
             # re-initializes the thermal manager on its next polling cycle once state-db is
             # repopulated, so this is safe to ignore here.
             loganalyzer[duthost.hostname].ignore_regex.extend([
-                r".*ERR pmon#thermalctld.*Caught exception while initializing thermal manager"
-                r".*JSONDecodeError.*",
+                r".*ERR pmon#thermalctld.*Caught exception while initializing thermal manager - JSONDecodeError.*",
             ])
 
         with allure.step(f"Configure packet trimming in global level for {self.trimming_mode} mode"):

--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -288,7 +288,8 @@ class BasePacketTrimming:
                                   f"port level trim counters are zero for {port}")
                     verify_queue_and_port_trim_counter_consistency(duthost, port)
 
-    def test_trimming_with_reload_and_reboot(self, duthost, ptfadapter, test_params, localhost, request):
+    def test_trimming_with_reload_and_reboot(self, duthost, ptfadapter, test_params, localhost, request,
+                                             loganalyzer):
         """
         Test Case: Verify Trimming Persistence After Reload and Reboot
 
@@ -296,6 +297,14 @@ class BasePacketTrimming:
         It ensures trimming functionality continues to work normally after the system recovers from
         a configuration reload or cold reboot.
         """
+        if loganalyzer and duthost.hostname in loganalyzer:
+            # thermalctld can throw a transient JSONDecodeError while state-db is being
+            # repopulated right after boot. This is expected and unrelated to packet trimming
+            # (see sonic-buildimage#8984); tacacs transport errors are already ignored globally.
+            loganalyzer[duthost.hostname].ignore_regex.extend([
+                r".*ERR pmon#thermalctld.*Caught exception while initializing thermal manager.*",
+            ])
+
         with allure.step(f"Configure packet trimming in global level for {self.trimming_mode} mode"):
             self.configure_trimming_global_by_mode(duthost)
 


### PR DESCRIPTION
 test_trimming_with_reload_and_reboot  performs a  config reload /cold reboot mid-test to verify packet trimming persists across reload/reboot. After boot,  thermalctld  can transiently throw a  JSONDecodeError  while state-db is still being repopulated — this is a known, benign, unrelated startup race (see  sonic-buildimage#8984 ), but LogAnalyzer flags it as a failure, causing an otherwise-passing packet trimming test to fail on an unrelated error.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
 test_trimming_with_reload_and_reboot  performs a  config reload/cold reboot mid-test to verify packet trimming persists across reload/reboot. After boot,  thermalctld  can transiently throw a  JSONDecodeError  while state-db is still being repopulated — this is a known, benign, unrelated startup race (see  sonic-buildimage#8984 ), but LogAnalyzer flags it as a failure, causing an otherwise-passing packet trimming test to fail on an unrelated error.

#### How did you do it?
Added a scoped LogAnalyzer ignore regex, applied only within this test (not globally), for the transient thermalctld error:

r".*ERR pmon#thermalctld.*Caught exception while initializing thermal manager.*"

This is added conditionally ( if loganalyzer and duthost.hostname in loganalyzer ) right before the reload/reboot step, so it only suppresses this specific benign message for this specific test's DUT, not repo-wide.

#### How did you verify/test it?
Ran  test_trimming_with_reload_and_reboot  after reload/cold-reboot; confirmed the test previously failed on the spurious thermalctld JSONDecodeError syslog line despite trimming behavior being correct, and passes cleanly with the ignore regex added.
https://elastictest.org/scheduler/testplan/6a81ebd7d8e164244320431a
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
