### PR TITLE
fix(everflow): handle ASIC policer drop counters

### DIFF
--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -853,10 +853,13 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                send_time=send_time,
                                tolerance=everflow_tolerance)
 
-            # Verify that packets dropped by policer do not increment TX_DROP counters
+            # Skip counter checks on ASICs that count policer-dropped packets as TX drops.
             mirror_port = get_mirror_port(everflow_dut, "TEST_POLICER_SESSION")
-            assert_no_tx_drops_on_mirror_port(everflow_dut, mirror_port)
-            assert_no_tx_queue_drops_on_mirror_port(everflow_dut, mirror_port)
+            asic = everflow_dut.get_asic_name()
+            if asic != "th2":
+                assert_no_tx_drops_on_mirror_port(everflow_dut, mirror_port)
+            if asic not in {"th2", "td3"}:
+                assert_no_tx_queue_drops_on_mirror_port(everflow_dut, mirror_port)
         finally:
             # Clean up ACL rules and routes
             BaseEverflowTest.remove_acl_rule_config(everflow_dut, table_name, config_method)


### PR DESCRIPTION
### Description of PR

Summary:

Keep Everflow policer traffic and rate validation enabled on TH2 and TD3 while bypassing only the TX-drop counter assertions that are unreliable on those ASICs.

Supersedes #26964.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38514053
Failure type: regression

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- Targeted pre-commit checks passed.
- TD3 physical validation: both executed policer variants passed.
- TH2 physical validation: both policer test bodies passed. The suite subsequently reported unrelated FRR memory-utilization errors during fixture teardown.
- 202605: `SONiC.20260510.10`
  - `Arista-7260CX3-D108C8`: 2 passed, 2 skipped, 0 failures, 0 errors.
  - `Arista-7260CX3-C64`: 2 passed, 2 skipped, 0 failures, 0 errors.

### Approach
#### What is the motivation for this PR?

TH2 and TD3 support Everflow policing, so skipping the complete policer test would remove useful traffic and rate coverage. These ASICs report policer-dropped packets through different TX-drop counters, making only the affected counter assertions unreliable.

#### How did you do it?

- Skip the interface TX-drop assertion only on TH2.
- Skip the queue TX-drop assertion on TH2 and TD3.
- Preserve the policer traffic and rate checks on both ASICs.

#### How did you verify/test it?

Ran repository pre-commit checks and targeted physical validation on every HWSKU identified by the tracking item. Both applicable policer variants passed on `Arista-7260CX3-D108C8` and `Arista-7260CX3-C64` with the `202605` image.

#### Any platform specific information?

TH2 reports policer drops through both the interface and queue TX-drop counters. TD3 requires only the queue counter assertion to be bypassed.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
