### PR TITLE
Prevent LogAnalyzer failures when /var/log is full

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -7,6 +7,56 @@ from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
 from .bug_handler_helper import get_bughandler_instance
 
 
+VAR_LOG_CLEANUP_THRESHOLD = 85
+VAR_LOG_FAILURE_THRESHOLD = 90
+VAR_LOG_MAINTENANCE_FAILURE_RC = 90
+VAR_LOG_USAGE_CHECK_FAILURE_RC = 91
+
+LOGROTATE_AND_CLEANUP_CMD = f"""
+logrotate_failed=0
+if ! /usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1; then
+    logrotate_failed=1
+fi
+
+get_var_log_usage() {{
+    df -P /var/log 2>/dev/null | awk 'END {{gsub(/%/, "", $5); print $5}}'
+}}
+
+usage=$(get_var_log_usage)
+case "$usage" in
+    ''|*[!0-9]*)
+        echo "Failed to determine /var/log usage" >&2
+        exit {VAR_LOG_USAGE_CHECK_FAILURE_RC}
+        ;;
+esac
+
+if [ "$usage" -ge {VAR_LOG_CLEANUP_THRESHOLD} ]; then
+    echo "/var/log usage is ${{usage}}%; deleting compressed rotated logs"
+    if ! find /var/log -xdev -type f -name '*.gz' -delete; then
+        echo "Failed to delete compressed rotated logs under /var/log" >&2
+        exit {VAR_LOG_MAINTENANCE_FAILURE_RC}
+    fi
+
+    usage=$(get_var_log_usage)
+    case "$usage" in
+        ''|*[!0-9]*)
+            echo "Failed to determine /var/log usage after cleanup" >&2
+            exit {VAR_LOG_USAGE_CHECK_FAILURE_RC}
+            ;;
+    esac
+    echo "/var/log usage after cleanup is ${{usage}}%"
+
+    if [ "$usage" -ge {VAR_LOG_FAILURE_THRESHOLD} ]; then
+        echo "/var/log usage remains above the safe limit after cleanup" >&2
+        du -kx /var/log 2>/dev/null | sort -nr | head -20 >&2
+        exit {VAR_LOG_MAINTENANCE_FAILURE_RC}
+    fi
+fi
+
+exit "$logrotate_failed"
+"""
+
+
 def _cleanup_orphaned_ansible_processes(timed_out_duts):
     """Kill orphaned ansible processes on DUTs whose analyze_logs did not complete.
 
@@ -59,12 +109,35 @@ def analyzer_logrotate(node=None, results=None):
     with DisableLogrotateCronContext(node):
         logging.info("logrotate called on {}".format(node.hostname))
         try:
-            node.shell("/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1")
+            result = node.shell(LOGROTATE_AND_CLEANUP_CMD)
+            if result.get("stdout"):
+                logging.info(
+                    "Log maintenance on %s:\n%s",
+                    node.hostname,
+                    result["stdout"]
+                )
         except RunAnsibleModuleFail as e:
+            result = getattr(e, "results", {}) or {}
+            if result.get("rc") in [
+                VAR_LOG_MAINTENANCE_FAILURE_RC,
+                VAR_LOG_USAGE_CHECK_FAILURE_RC
+            ]:
+                raise RuntimeError(
+                    "Unable to ensure safe /var/log usage on {}:\n"
+                    "Stdout: {}\nStderr: {}".format(
+                        node.hostname,
+                        result.get("stdout", ""),
+                        result.get("stderr", "")
+                    )
+                )
             logging.warning("logrotate is failed. Command returned:\n"
                             "Stdout: {}\n"
                             "Stderr: {}\n"
-                            "Return code: {}".format(e.results["stdout"], e.results["stderr"], e.results["rc"]))
+                            "Return code: {}".format(
+                                result.get("stdout", ""),
+                                result.get("stderr", ""),
+                                result.get("rc", "")
+                            ))
 
 
 @reset_ansible_local_tmp

--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -8,7 +8,8 @@ from .bug_handler_helper import get_bughandler_instance
 
 
 VAR_LOG_CLEANUP_THRESHOLD = 85
-VAR_LOG_FAILURE_THRESHOLD = 90
+# Preserve enough room for the observed ~44 MiB per-test log growth on small filesystems.
+VAR_LOG_MIN_FREE_KB = 64 * 1024
 VAR_LOG_MAINTENANCE_FAILURE_RC = 90
 VAR_LOG_USAGE_CHECK_FAILURE_RC = 91
 
@@ -18,36 +19,48 @@ if ! /usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1; then
     logrotate_failed=1
 fi
 
-get_var_log_usage() {{
-    df -P /var/log 2>/dev/null | awk 'END {{gsub(/%/, "", $5); print $5}}'
+refresh_var_log_stats() {{
+    stats=$(df -Pk /var/log 2>/dev/null | awk 'END {{gsub(/%/, "", $5); print $5, $4}}')
+    set -- $stats
+    usage=$1
+    available_kb=$2
+
+    case "$usage" in
+        ''|*[!0-9]*)
+            return 1
+            ;;
+    esac
+    case "$available_kb" in
+        ''|*[!0-9]*)
+            return 1
+            ;;
+    esac
 }}
 
-usage=$(get_var_log_usage)
-case "$usage" in
-    ''|*[!0-9]*)
-        echo "Failed to determine /var/log usage" >&2
-        exit {VAR_LOG_USAGE_CHECK_FAILURE_RC}
-        ;;
-esac
+var_log_is_unsafe() {{
+    [ "$usage" -ge {VAR_LOG_CLEANUP_THRESHOLD} ] || [ "$available_kb" -lt {VAR_LOG_MIN_FREE_KB} ]
+}}
 
-if [ "$usage" -ge {VAR_LOG_CLEANUP_THRESHOLD} ]; then
-    echo "/var/log usage is ${{usage}}%; deleting compressed rotated logs"
-    if ! find /var/log -xdev -type f -name '*.gz' -delete; then
+if ! refresh_var_log_stats; then
+    echo "Failed to determine /var/log usage and available space" >&2
+    exit {VAR_LOG_USAGE_CHECK_FAILURE_RC}
+fi
+
+if var_log_is_unsafe; then
+    echo "/var/log usage is ${{usage}}% with ${{available_kb}} KB available; deleting numbered rotated logs"
+    if ! find /var/log -xdev -regextype posix-extended -type f -regex '.*\\.[0-9]+\\.gz$' -delete; then
         echo "Failed to delete compressed rotated logs under /var/log" >&2
         exit {VAR_LOG_MAINTENANCE_FAILURE_RC}
     fi
 
-    usage=$(get_var_log_usage)
-    case "$usage" in
-        ''|*[!0-9]*)
-            echo "Failed to determine /var/log usage after cleanup" >&2
-            exit {VAR_LOG_USAGE_CHECK_FAILURE_RC}
-            ;;
-    esac
-    echo "/var/log usage after cleanup is ${{usage}}%"
+    if ! refresh_var_log_stats; then
+        echo "Failed to determine /var/log usage and available space after cleanup" >&2
+        exit {VAR_LOG_USAGE_CHECK_FAILURE_RC}
+    fi
+    echo "/var/log usage after cleanup is ${{usage}}% with ${{available_kb}} KB available"
 
-    if [ "$usage" -ge {VAR_LOG_FAILURE_THRESHOLD} ]; then
-        echo "/var/log usage remains above the safe limit after cleanup" >&2
+    if var_log_is_unsafe; then
+        echo "/var/log remains above the safe limits after cleanup" >&2
         du -kx /var/log 2>/dev/null | sort -nr | head -20 >&2
         exit {VAR_LOG_MAINTENANCE_FAILURE_RC}
     fi

--- a/tests/common/unit_tests/unit_test_loganalyzer_plugin.py
+++ b/tests/common/unit_tests/unit_test_loganalyzer_plugin.py
@@ -1,0 +1,151 @@
+"""Unit tests for the LogAnalyzer log maintenance setup."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+COMMON_TESTS_PATH = Path(__file__).resolve().parents[1]
+MODULE_PATH = COMMON_TESTS_PATH / "plugins" / "loganalyzer" / "__init__.py"
+
+
+def _load_target_module():
+    package_name = "unit_target_loganalyzer"
+
+    package_stub = types.ModuleType(package_name)
+    package_stub.__path__ = [str(MODULE_PATH.parent)]
+
+    loganalyzer_stub = types.ModuleType(
+        "{}.loganalyzer".format(package_name)
+    )
+    loganalyzer_stub.LogAnalyzer = object
+
+    class DisableLogrotateCronContext:
+        def __init__(self, node):
+            self.node = node
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+    loganalyzer_stub.DisableLogrotateCronContext = (
+        DisableLogrotateCronContext
+    )
+
+    bug_handler_stub = types.ModuleType(
+        "{}.bug_handler_helper".format(package_name)
+    )
+    bug_handler_stub.get_bughandler_instance = mock.Mock()
+
+    tests_stub = types.ModuleType("tests")
+    tests_stub.__path__ = []
+    common_stub = types.ModuleType("tests.common")
+    common_stub.__path__ = []
+    helpers_stub = types.ModuleType("tests.common.helpers")
+    helpers_stub.__path__ = []
+
+    errors_stub = types.ModuleType("tests.common.errors")
+
+    class RunAnsibleModuleFail(Exception):
+        def __init__(self, message, results=None):
+            super().__init__(message)
+            self.results = results
+
+    errors_stub.RunAnsibleModuleFail = RunAnsibleModuleFail
+
+    parallel_stub = types.ModuleType("tests.common.helpers.parallel")
+    parallel_stub.parallel_run = mock.Mock()
+    parallel_stub.reset_ansible_local_tmp = lambda target: target
+
+    stubs = {
+        package_name: package_stub,
+        "{}.loganalyzer".format(package_name): loganalyzer_stub,
+        "{}.bug_handler_helper".format(package_name): bug_handler_stub,
+        "tests": tests_stub,
+        "tests.common": common_stub,
+        "tests.common.errors": errors_stub,
+        "tests.common.helpers": helpers_stub,
+        "tests.common.helpers.parallel": parallel_stub,
+    }
+
+    spec = importlib.util.spec_from_file_location(
+        package_name,
+        MODULE_PATH,
+        submodule_search_locations=[str(MODULE_PATH.parent)]
+    )
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(sys.modules, stubs):
+        spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def loganalyzer_plugin():
+    return _load_target_module()
+
+
+def test_logrotate_and_cleanup_use_one_remote_call(loganalyzer_plugin):
+    node = mock.Mock(hostname="dut")
+    node.shell.return_value = {"rc": 0, "stdout": "", "stderr": ""}
+
+    loganalyzer_plugin.analyzer_logrotate(node=node)
+
+    node.shell.assert_called_once_with(
+        loganalyzer_plugin.LOGROTATE_AND_CLEANUP_CMD
+    )
+    command = node.shell.call_args.args[0]
+    assert "/usr/sbin/logrotate -f /etc/logrotate.conf" in command
+    assert "logrotate_failed=1" in command
+    assert "df -P /var/log" in command
+    assert "find /var/log -xdev -type f -name '*.gz' -delete" in command
+    assert (
+        '"$usage" -ge {}'.format(
+            loganalyzer_plugin.VAR_LOG_CLEANUP_THRESHOLD
+        )
+        in command
+    )
+
+
+@pytest.mark.parametrize("return_code", [90, 91])
+def test_log_maintenance_failure_stops_test_setup(
+    loganalyzer_plugin,
+    return_code
+):
+    node = mock.Mock(hostname="dut")
+    node.shell.side_effect = loganalyzer_plugin.RunAnsibleModuleFail(
+        "maintenance failed",
+        {
+            "rc": return_code,
+            "stdout": "/var/log usage is 95%",
+            "stderr": "/var/log usage remains above the safe limit",
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="safe /var/log usage") as error:
+        loganalyzer_plugin.analyzer_logrotate(node=node)
+
+    assert "/var/log usage is 95%" in str(error.value)
+    assert "remains above the safe limit" in str(error.value)
+
+
+def test_regular_logrotate_failure_remains_nonfatal(
+    loganalyzer_plugin,
+    monkeypatch
+):
+    node = mock.Mock(hostname="dut")
+    node.shell.side_effect = loganalyzer_plugin.RunAnsibleModuleFail(
+        "logrotate failed",
+        {"rc": 1}
+    )
+    warning = mock.Mock()
+    monkeypatch.setattr(loganalyzer_plugin.logging, "warning", warning)
+
+    loganalyzer_plugin.analyzer_logrotate(node=node)
+
+    warning.assert_called_once()

--- a/tests/common/unit_tests/unit_test_loganalyzer_plugin.py
+++ b/tests/common/unit_tests/unit_test_loganalyzer_plugin.py
@@ -102,14 +102,25 @@ def test_logrotate_and_cleanup_use_one_remote_call(loganalyzer_plugin):
     command = node.shell.call_args.args[0]
     assert "/usr/sbin/logrotate -f /etc/logrotate.conf" in command
     assert "logrotate_failed=1" in command
-    assert "df -P /var/log" in command
-    assert "find /var/log -xdev -type f -name '*.gz' -delete" in command
+    assert "df -Pk /var/log" in command
+    assert (
+        "find /var/log -xdev -regextype posix-extended -type f "
+        "-regex '.*\\.[0-9]+\\.gz$' -delete"
+        in command
+    )
     assert (
         '"$usage" -ge {}'.format(
             loganalyzer_plugin.VAR_LOG_CLEANUP_THRESHOLD
         )
         in command
     )
+    assert (
+        '"$available_kb" -lt {}'.format(
+            loganalyzer_plugin.VAR_LOG_MIN_FREE_KB
+        )
+        in command
+    )
+    assert command.count("if var_log_is_unsafe; then") == 2
 
 
 @pytest.mark.parametrize("return_code", [90, 91])


### PR DESCRIPTION
### Description of PR

Summary:

Prevent LogAnalyzer teardown failures caused by `/var/log` exhaustion by performing threshold-gated cleanup before the test marker. The normal path adds only a `df` check to the existing remote logrotate call; cleanup is limited to numbered compressed rotated logs and runs only when usage or available-space safety limits are reached.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38688394

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38688394

Failure type: other - test infrastructure resource exhaustion

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master (PR head `9cd3d91`): 4 isolated LogAnalyzer unit cases passed; Python compilation, flake8, `git diff --check`, and generated-shell syntax validation passed.
- 202511 (`20251110.37`): pre-fix failure evidence is tracked by ADO 38688394 and Elastictest plan `6a45e2d8b44d875a05262f2b`. The functional test passed, but LogAnalyzer teardown failed after `/var/log` increased from 95% to 100%.
- 202605 (`SONiC.20260510.10`): [Elastictest plan 6a8268eb79a16f6b66032101](https://elastictest.org/scheduler/testplan/6a8268eb79a16f6b66032101) passed `log_fidelity/test_bgp_shutdown.py` 1/1 on Mellanox SN2700. The initial combined rotation/usage-check implementation completed with `rc=0`, LogAnalyzer teardown passed, and the post-test disk-usage sanity check passed. The follow-up review refinement in `9cd3d91` passed the targeted unit, compilation, lint, diff, and shell-syntax checks.

### Approach

#### What is the motivation for this PR?

ADO 38688394 failed in LogAnalyzer teardown because `monit` correctly reported that `/var/log` had no free space. The DUT started the test with the 789 MB `/var/log` tmpfs already 95% full (45 MB available), and the test generated about 44 MB of additional logs. The existing forced logrotate completed but did not reclaim enough space.

The cleanup must run before the LogAnalyzer start marker so maintenance messages and deletion of old archives cannot affect the current test's analyzed log window. It also must avoid adding a separate remote command to every test.

#### How did you do it?

Extended `analyzer_logrotate` to perform rotation, filesystem measurement, and conditional cleanup in one remote shell call:

- Check `/var/log` usage and available space after forced rotation.
- At 85% or higher, or when less than 64 MiB is free, delete only numbered compressed logrotate archives under `/var/log` and remain on the same filesystem.
- Recheck both values and stop setup with diagnostics if usage remains at 85% or higher, less than 64 MiB remains free, or filesystem statistics cannot be determined.
- Keep ordinary logrotate failures warning-only to preserve existing behavior, while still attempting the safety check and cleanup.
- Run the expensive `find` only on the unsafe-space path and `du` only on the fatal diagnostic path.

Added isolated unit coverage for the single remote call, percentage/free-space cleanup gates, the numbered logrotate archive filter, fatal maintenance return codes, diagnostics, and legacy nonfatal logrotate behavior.

#### How did you verify/test it?

- Ran 4 isolated LogAnalyzer unit test cases.
- Compiled both changed Python files with `py_compile`.
- Ran flake8 against both changed files with the repository's 120-character line limit.
- Ran `git diff --check`.
- Validated the generated shell command with `bash -n`.
- Cherry-picked the initial PR commit onto `internal-202605` and passed the same targeted local checks.
- Ran `log_fidelity/test_bgp_shutdown.py` on 202605 Mellanox SN2700 hardware; 1 test passed with no LogAnalyzer or disk-usage teardown failure.

#### Any platform specific information?

Universal. Cleanup is skipped unless `/var/log` reaches either safety limit, and only numbered compressed logrotate archives are removed.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
