### PR TITLE
[autorestart] Fix systemd start-limit handling in container autorestart test

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -577,6 +577,11 @@ def is_process_running(duthost, container_name, program_name):
 
 
 def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
+    # Reset systemd's restart counter for all services so that cascade restarts
+    # from previous test cases don't cause start-limit-hit
+    # when testing dependent services like teamd.
+    duthost.shell("sudo systemctl reset-failed", module_ignore_errors=True)
+
     feature_autorestart_states = duthost.get_container_autorestart_states()
     disabled_containers = get_disabled_container_list(duthost)
 


### PR DESCRIPTION
### Description of PR

Summary:
 Cascade restarts from earlier container restart cases create enough service activations that a dependent container can exceed systemd's restart rate limit and get stuck in a failed state. Once that happens, later test cases fail too. This was seen when the syncd case failed and the failure trickled down into the teamd case. The fix resets systemd's start-limit counters at the start of each test case so that restarts accumulated by previous cases don't poison later ones.

Fixes # (issue): N/A

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: day-one issue — the test never accounted for syncd's dependency on swss, and never
reset start-limit counters accumulated by earlier cases.

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] N/A

### Test result

`tests/autorestart/test_container_autorestart.py` was run on NH-4210-F. Before the change, the
syncd case failed because `swss` was sitting at its start limit, and the resulting start-limit
state carried forward and failed the teamd case as well. Now the `syncd` failure does not carry through to the `teamd` failure.

### Approach

#### What is the motivation for this PR?

#### How did you do it?

Added `systemctl reset-failed` at the start of `run_test_on_single_container()` so each case begins with clean start-limit counters. It is run with `module_ignore_errors=True` so it cannot itself fail the case.

#### How did you verify/test it?

Ran the module on hardware as described in Test result; the syncd case recovers instead of
failing, and the teamd case is no longer affected by the preceding cases.

#### Any platform specific information?

None — this is generic systemd start-limit behavior. It was observed on NH-4210.

#### Supported testbed topology if it's a new test case?

N/A — existing test.

### Documentation

N/A
