### PR TITLE
[dhcp_relay]: Skip VRF cases on 202605

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1211,11 +1211,11 @@ dhcp_relay/test_dhcpv4_relay.py:
       - "release < '202511'"
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/26645"
 
-dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_non_default_vrf:
+dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_option82_suboptions[server_id_override-sonic-relay-agent]:
   skip:
-    reason: "Skip on 202605 because the required sonic-swss RIF VRF fixes are not available in this release"
+    reason: "Test skipped: We are skipping this testcase for now"
     conditions:
-      - "release in ['202605']"
+      - "True"
 
 dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_different_non_default_vrf:
   skip:
@@ -1223,11 +1223,11 @@ dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_different_non_default_vrf:
     conditions:
       - "release in ['202605']"
 
-dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_option82_suboptions[server_id_override-sonic-relay-agent]:
+dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_non_default_vrf:
   skip:
-    reason: "Test skipped: We are skipping this testcase for now"
+    reason: "Skip on 202605 because the required sonic-swss RIF VRF fixes are not available in this release"
     conditions:
-      - "True"
+      - "release in ['202605']"
 
 dhcp_relay/test_dhcpv6_relay.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1211,6 +1211,18 @@ dhcp_relay/test_dhcpv4_relay.py:
       - "release < '202511'"
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/26645"
 
+dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_non_default_vrf:
+  skip:
+    reason: "Skip on 202605 because the required sonic-swss RIF VRF fixes are not available in this release"
+    conditions:
+      - "release in ['202605']"
+
+dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_different_non_default_vrf:
+  skip:
+    reason: "Skip on 202605 because the required sonic-swss RIF VRF fixes are not available in this release"
+    conditions:
+      - "release in ['202605']"
+
 dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_option82_suboptions[server_id_override-sonic-relay-agent]:
   skip:
     reason: "Test skipped: We are skipping this testcase for now"


### PR DESCRIPTION
### Description of PR

Summary:

Skip the four DHCPv4 non-default-VRF cases on the public `202605` branch because the required sonic-swss RIF VRF fixes will not merge into the release in time.

Affected cases:

- `tests/dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_non_default_vrf[vrf_selection]`
- `tests/dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_non_default_vrf[source_intf]`
- `tests/dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_non_default_vrf[server_id_override]`
- `tests/dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_with_different_non_default_vrf`

The product fixes remain under review:

- https://github.com/sonic-net/sonic-swss/pull/4746
- https://github.com/sonic-net/sonic-swss/pull/4766
- https://github.com/sonic-net/sonic-swss/pull/4764

Fixes # (tracked by Microsoft ADO 38514061)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach

#### What is the motivation for this PR?

The four cases depend on RIF dependency fencing, retryable dynamic loopback-action updates, and explicit RIF VRF rehome behavior that is not available on 202605. Leaving them enabled produces known failures that cannot be fixed in the release before cutoff.

The scope comes from recorded full-module hardware runs:

| Platform | Failed VRF cases | Other DHCPv4 cases |
|---|---|---|
| 7060 | `vrf_selection`, `server_id_override` | 11 passed, including `different_non_default_vrf` |
| 7260 | `source_intf`, `different_non_default_vrf` | 11 passed, including `vrf_selection` and `server_id_override` |
| 720DT | `source_intf`, `server_id_override`, `different_non_default_vrf` | 10 passed, including `vrf_selection` |

A focused 7060 confirmation also reproduced `vrf_selection` 6/6 times. Across the recorded platforms, these are the only four DHCPv4 cases with observed failures; no other DHCP tests are skipped.

#### How did you do it?

Added two centralized conditional-mark entries:

- one function-level entry for `test_dhcp_relay_with_non_default_vrf`, which covers all three parameterizations;
- one entry for `test_dhcp_relay_with_different_non_default_vrf`.

Both apply only when `release in ['202605']`. No test function or master-branch behavior is changed.

#### How did you verify/test it?

- Parsed `tests_mark_conditions.yaml` successfully.
- Verified the conditional-mark plugin uses prefix matching, so the function-level key covers all three parameterized node IDs.
- Verified exactly four intended node IDs match and an unrelated DHCPv4 test does not.
- Public PR CI provides the branch integration validation.

#### Any platform specific information?

The skip applies to every platform running these cases on release 202605.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change is required.

##### Work item tracking

- Microsoft ADO (number only): 38514061
