### PR TITLE
[generic_config_updater] Ignore expected empty BGP prefix log

### DIFF
--- a/tests/generic_config_updater/test_bgp_prefix.py
+++ b/tests/generic_config_updater/test_bgp_prefix.py
@@ -30,6 +30,7 @@ def _ignore_allow_list_errlogs(duthosts, rand_one_dut_front_end_hostname, logana
     if loganalyzer:
         IgnoreRegex = [
             ".*ERR bgp[0-9]*#bgpcfgd: BGPAllowListMgr::Default action community value is not found.*",
+            ".*ERR bgp[0-9]*#bgpcfgd: BGPAllowListMgr::Received BGP ALLOWED .* message with no prefixes specified.*",
         ]
         duthost = duthosts[rand_one_dut_front_end_hostname]
         """Cisco 8111-O64 has different allow list config"""

--- a/tests/generic_config_updater/test_bgp_prefix.py
+++ b/tests/generic_config_updater/test_bgp_prefix.py
@@ -28,14 +28,17 @@ PREFIXES_V6_RE = r"ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_{}_V
 def _ignore_allow_list_errlogs(duthosts, rand_one_dut_front_end_hostname, loganalyzer):
     """Ignore expected failures logs during test execution."""
     if loganalyzer:
-        IgnoreRegex = [
-            ".*ERR bgp[0-9]*#bgpcfgd: BGPAllowListMgr::Default action community value is not found.*",
-            ".*ERR bgp[0-9]*#bgpcfgd: BGPAllowListMgr::Received BGP ALLOWED .* message with no prefixes specified.*",
+        ignore_regex = [
+            ".*ERR bgp[0-9]*#bgpcfgd: BGPAllowListMgr::Received BGP ALLOWED 'SET' "
+            "message with no prefixes specified.*",
         ]
         duthost = duthosts[rand_one_dut_front_end_hostname]
         """Cisco 8111-O64 has different allow list config"""
         if duthost.facts['hwsku'] in {'Cisco-8111-O64', 'Cisco-88-LC0-36FH-M-O36', 'Cisco-88-LC0-36FH-O36'}:
-            loganalyzer[rand_one_dut_front_end_hostname].ignore_regex.extend(IgnoreRegex)
+            ignore_regex.append(
+                ".*ERR bgp[0-9]*#bgpcfgd: BGPAllowListMgr::Default action community value is not found.*"
+            )
+        loganalyzer[rand_one_dut_front_end_hostname].ignore_regex.extend(ignore_regex)
     return
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes the nightly `generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite` teardown failure tracked by ADO 39294847. The suite intentionally exercises an empty BGP prefix leaf-list path, which can emit:

`BGPAllowListMgr::Received BGP ALLOWED 'SET' message with no prefixes specified`

The exact expected message is now registered with loganalyzer on every platform. The existing `Default action community value is not found` pattern remains limited to Cisco platforms where that configuration difference is expected.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A - no backport requested
Failure type: nightly test teardown failure

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master image version: N/A (test-only loganalyzer fixture change)
- `python -m pre_commit run --files tests/generic_config_updater/test_bgp_prefix.py`
- `python -m py_compile tests/generic_config_updater/test_bgp_prefix.py`
- Focused fixture behavior check: Arista registers the empty-prefix pattern; Cisco registers both the empty-prefix and Cisco-specific default-community patterns.

### Approach
#### What is the motivation for this PR?

The functional test passed on Arista-7060CX-32S-C32/t1 but loganalyzer failed teardown on an expected transient bgpcfgd message. The original change added the matching regex inside a Cisco-only registration path, so it could not affect the reported Arista run.

#### How did you do it?

Register the exact `BGP ALLOWED 'SET' ... no prefixes specified` regex for every DUT when loganalyzer is enabled. Append the historical default-community regex only for the existing Cisco HWSKU set.

#### How did you verify/test it?

Ran the changed file through the repository pre-commit hooks, Python compilation, and a focused behavior check covering the reported Arista HWSKU and an existing Cisco HWSKU.

#### Any platform specific information?

Observed on Arista-7060CX-32S-C32. The new expected message is not platform-specific; the pre-existing default-community message remains Cisco-specific.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A