### PR TITLE
[autorestart] Don't fail when a FEATURE has no systemd service

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -406,7 +406,20 @@ def is_hiting_start_limit(duthost, service_name):
     @summary: Determine whether the service can not be restarted is due to
               start-limit-hit or not
     """
-    service_status = duthost.shell("sudo systemctl status {}.service | grep 'Active'".format(service_name))
+    # Not every FEATURE row has a systemd service behind it. SONiC has features
+    # that are pure config flags with no container (for example mpls), and for
+    # those `systemctl status <name>.service` exits non-zero with
+    # "Unit <name>.service could not be found". Asking whether such a service
+    # hit its start limit is a legitimate question with the answer "no", so
+    # tolerate the failure instead of raising and failing the calling test.
+    service_status = duthost.shell(
+        "sudo systemctl status {}.service | grep 'Active'".format(service_name),
+        module_ignore_errors=True)
+    if service_status["rc"] != 0:
+        logger.debug("Skipping start-limit check for '{}': no active systemd service ({})"
+                     .format(service_name, service_status.get("stderr", "").strip()))
+        return False
+
     for line in service_status["stdout_lines"]:
         if "start-limit-hit" in line:
             return True


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)

`autorestart/test_container_autorestart.py` fails a container's test case when the
DUT has a FEATURE row that has no systemd service behind it. The failure is
attributed to whichever container happened to be under test, which makes it
confusing to diagnose.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A - no backport requested.
Failure type: other (test robustness fix, not a product regression)

### Tested branch

- [x] master
- [ ] N/A

### Test result

- **master**: reproduced and diagnosed on `t0-vpp` (Elastictest plan `6a7e524179a16f6b66031c52`). See below.

### Approach
#### What is the motivation for this PR?

`postcheck_critical_processes_status()` walks every row returned by
`show feature autorestart` and calls `is_hiting_start_limit()` on each, which runs:

```
sudo systemctl status <feature>.service | grep 'Active'
```

Not every FEATURE row has a systemd service behind it - SONiC has features that are
pure config flags with no container. For those the command exits non-zero with
`Unit <feature>.service could not be found`, and `duthost.shell()` raises on a
non-zero return code. The exception propagates out of the post-check and fails the
container case that was running at the time:

```
RunAnsibleModuleFail: run module shell failed
cmd = sudo systemctl status mpls.service | grep 'Active'
rc = 1
stderr = Unit mpls.service could not be found.

FAILED autorestart/test_container_autorestart.py::test_containers_autorestart[...-bgp]
```

Note the reported failure is `bgp`, which has nothing to do with the cause. The loop
in `postcheck_critical_processes_status()` has no disabled- or skip-list filter,
unlike the per-container check in `run_test_on_single_container()` - so any such
feature trips it regardless of whether that feature's own case would be skipped.

#### How did you do it?

Made `is_hiting_start_limit()` tolerant of a service that does not exist. A service
that is not present has not hit its start limit, so the honest answer is `False`
rather than an exception.

Uses the `module_ignore_errors=True` + `rc` check pattern already used elsewhere in
this same module (lines 151, 332, 358). Fixing it here also covers the other
`is_hiting_start_limit()` call site in `verify_autorestart_with_critical_process()`.

#### How did you verify/test it?

Reproduced on a `t0-vpp` testbed where a containerless `mpls` FEATURE was present:
`autorestart/test_container_autorestart.py` failed its `bgp` case with the traceback
above, while the `mpls` case itself was correctly skipped by
`run_test_on_single_container()` - which is what made the failure misleading.

`py_compile` and `flake8` clean.

#### Any platform specific information?

None. The change is platform-agnostic; it just stops a shell command from raising
when the unit is absent. Behaviour is unchanged whenever the service does exist -
the same `stdout_lines` are parsed for `start-limit-hit` exactly as before.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change needed.
