### PR TITLE
[platform_tests]: Skip interface validation on BMC in check_all_interface_information

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -184,6 +184,10 @@ def check_interface_status(dut, asic_index, interfaces, xcvr_skip_list):
 
 # This API to check the interface information actoss all front end ASIC's
 def check_all_interface_information(dut, interfaces, xcvr_skip_list):
+    # BMC SONiC images have no front-panel ports or transceivers to validate.
+    if dut.is_bmc():
+        return True
+
     for asic_index in dut.get_frontend_asic_ids():
         # Get the interfaces pertaining to that asic
         interface_list = get_port_map(dut, asic_index)


### PR DESCRIPTION
### Description of PR

Summary:
Skip front-panel interface and transceiver validation for BMC SONiC images.

BMC images have no front-panel ports or transceivers, but the generic reboot test invokes interface/transceiver validation (`check_all_interface_information`), which fails on BMC devices since there is no port config to inspect.

Fixes https://github.com/sonic-net/sonic-mgmt/issues/27105

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608


### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608
- [ ] N/A

### Approach

#### What is the motivation for this PR?

BMC images do not expose front-panel ports or transceivers, but the generic reboot test invokes `check_all_interface_information` (via `show interface transceiver presence`), which fails with `Failed to get port config` on BMC devices.

#### How did you do it?

- Added an early return in `check_all_interface_information` to skip validation when `dut.is_bmc()` is true.

#### How did you verify/test it?

- Validated the updated Python module with `py_compile`.
- Reviewed the BMC reboot failure logs to confirm transceiver validation failed because BMC images have no front-panel port configuration.
- Hardware validation is pending on a Nokia BMC testbed.

#### Any platform specific information?

Applies to SONiC BMC images. The initial issue was observed on the Nokia 7220 IXR-H6-128 BMC image.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A