### PR TITLE
Allow link down duplications on MLNX/Cisco for A/S setup

### DIFF
--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -84,10 +84,13 @@ def test_active_link_down_downstream_active(
     Send traffic from T1 to active ToR and shutdown the active ToR link.
     Verify switchover and disruption lasts < 1 second
     """
+    allowed_duplication, merge_duplications = link_down_downstream_active_duplication_setting
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
+            allowed_disruption=3, allowed_duplication=allowed_duplication,
+            action=shutdown_fanout_upper_tor_intfs,
+            merge_duplications_into_disruptions=merge_duplications
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -96,7 +99,6 @@ def test_active_link_down_downstream_active(
         )
 
     if cable_type == CableType.active_active:
-        allowed_duplication, merge_duplications = link_down_downstream_active_duplication_setting
         send_t1_to_server_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=1, allowed_duplication=allowed_duplication,
@@ -115,15 +117,19 @@ def test_active_link_down_downstream_active(
 def test_active_link_down_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa: F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa: F811
-    shutdown_fanout_upper_tor_intfs                                     # noqa: F811
+    shutdown_fanout_upper_tor_intfs,                                    # noqa: F811
+    link_down_downstream_active_duplication_setting                     # noqa: F811
 ):
     """
     Send traffic from T1 to standby ToR and shutdown the active ToR link.
     Verify switchover and disruption lasts < 1 second
     """
+    allowed_duplication, merge_duplications = link_down_downstream_active_duplication_setting
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
+        allowed_disruption=3, allowed_duplication=allowed_duplication,
+        action=shutdown_fanout_upper_tor_intfs,
+        merge_duplications_into_disruptions=merge_duplications
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
There is already a fix for active-active setups .But same flooding issue can be found here for
active standby setup so same issue.

old fix ->
https://github.com/sonic-net/sonic-mgmt/pull/18287



Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
SONiC on Cisco will flood downstream packets if the link is down due to the fdb flush.
The following two test cases will report duplications or two disruptions when running on Cisco.

#### How did you do it?
Actually, the flooding is an expected behavior on those two platforms, so we need to adjust the dualtor I/O verification to allow this.

#### How did you verify/test it?
Ran it on local setup passed

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

generated xml file: /run_logs/harjosin/dualtor_io/test_link_failure.py::test_active_link_down_downstream_standby_2026-08-15-02-51-21.xml -
=========================== short test summary info ============================
SKIPPED [20] dualtor_io/test_link_failure.py:115: Skip cable type 'active-active'
========== 20 passed, 20 skipped, 3056 warnings in 7540.12s (2:05:40) ==========
dualtor_io/test_link_failure.py::test_active_link_down_downstream_active[active-standby-1-6]
/data/tests/conftest.py:1589: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
record_testsuite_property("timestamp", datetime.utcnow())

dualtor_io/test_link_failure.py::test_active_link_down_downstream_active[active-standby-1-6]
dualtor_io/test_link_failure.py::test_active_link_down_downstream_active[active-standby-2-6]
dualtor_io/test_link_failure.py::test_active_link_down_downstream_active[active-standby-3-6]
dualtor_io/test_link_failure.py::test_active_link_down_downstream_active[active-standby-4-6]
dualtor_io/test_link_failure.py::test_active_link_down_downstream_active[active-standby-5-6]
dualtor_io/test_link_failure.py::test_active_link_down_downstream_active[active-standby-6-6]
/data/tests/common/dualtor/mux_simulator_control.py:527: DeprecationWarning: Deprecated toggle fixture, please use setup_dualtor_mux_ports (docs/tests/setup.dualtor.mux.ports.md).
warnings.warn("Deprecated toggle fixture, please use setup_dualtor_mux_ports "

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

generated xml file: /run_logs/harjosin/dualtor_io/test_link_failure.py::test_active_link_down_downstream_active_2026-08-15-00-27-14.xml -
=========================== short test summary info ============================
SKIPPED [6] dualtor_io/test_link_failure.py:75: Skip as no mux ports of 'active-active' cable type
=========== 6 passed, 6 skipped, 739 warnings in 1905.99s (0:31:45) ============
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
