### PR TITLE
[radius] skip RADIUS tests on BMC topologies

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4685,6 +4685,16 @@ qos/test_voq_watchdog.py:
       - "asic_type not in ['cisco-8000']"
 
 #######################################
+#####          radius            #####
+#######################################
+
+radius/:
+  skip:
+    reason: 'RADIUS tests require routing and switch CLI, not available on BMC'
+    conditions:
+      - "'bmc' in topo_type"
+
+#######################################
 #####           radv             #####
 #######################################
 


### PR DESCRIPTION
### Why i did it ?
The RADIUS suite ran on BMC by accident. It is marked topology("any") and was never opted into the BMC topologies, but the test runner passes --topology bmc-shared-mgmt,any and check_topology does a literal membership test, so the "any" element matches.

### how i did it?
Two of the six cases depend on a routing stack that a BMC does not have by design (no bgp container, no /usr/bin/rvtysh):

  - test_radius_command_auth asserts "show ip route" is authorized; as a RADIUS RO user the sudo escalation is rejected first, surfacing a misleading "not authorized" failure
  - test_radius_source_ip needs a routed interface and "show ip route <ip> json", its existing skip guard never fires because routed_interfaces accepts the management interface
  - tests/radius/ is not in the BMC-compatible suite list in docs/testplan/bmc/BMC-high-level-test-plan.md
  - Add a directory-level conditional_mark entry, matching the adjacent precedent, so both current and future radius tests are skipped on BMC.

### How to verify?
  - run sonic mgmt test for bmc 
  

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
