### PR TITLE
[qos] Use 1200B packets for Mellanox SPC6 lossy queue test

### DIFF
--- a/tests/qos/files/mellanox/special_qos_config.yml
+++ b/tests/qos/files/mellanox/special_qos_config.yml
@@ -72,3 +72,6 @@ qos_params:
             pkts_num_margin: 8
         wm_q_shared_lossy:
             packet_size: 1200
+    spc6:
+        lossy_queue_1:
+            packet_size: 1200


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
testQosSaiLossyQueue on Mellanox SPC6 still used the default 300B packet size from qos_params.mellanox.yaml. On SPC6 (256B cell + descriptor overhead) that size exhausts descriptors before data cells, so pkts_num_trig_egr_drp over-injects on high queue draws and the test flakes on legitimate OutDiscard.

SPC4 and SPC5 already override lossy_queue_1 to 1200B in special_qos_config.yml. This PR adds the same SPC6 override so occupancy matches real pool capacity.

Fixes flaky qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue on SPC6 (e.g. SN6600_LD).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
Added an SPC6 lossy_queue_1 packet-size override in tests/qos/files/mellanox/special_qos_config.yml. QosParamMellanox.update_special_qos_config() already merges this file per ASIC, so no generator change is needed.
#### How did you do it?

#### How did you verify/test it?
tested few times, the test passed

#### Any platform specific information?
Platform: SN6600_LD
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
