### PR TITLE
[dhcp_relay]: Wait for IPv6 relay readiness with uplinks down

### DIFF
--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -647,29 +647,21 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
 
     try:
         for dhcp_relay in dut_dhcp_relay_data:
-            # Bring all uplink interfaces down
-            for iface in dhcp_relay['uplink_interfaces']:
-                duthost.shell('ifconfig {} down'.format(iface))
+            uplink_interfaces = dhcp_relay['uplink_interfaces']
 
-            # Sleep a bit to ensure uplinks are down
-            time.sleep(20)
+            try:
+                # Bring all uplink interfaces down
+                for iface in uplink_interfaces:
+                    duthost.shell('ifconfig {} down'.format(iface))
 
-            # Restart DHCP relay service on DUT
-            # dhcp_relay service has 3 times restart limit in 20 mins, for 4 vlans config it will hit the maximum limit
-            # reset-failed before restart service
-            cmds = ['systemctl reset-failed dhcp_relay', 'systemctl restart dhcp_relay']
-            duthost.shell_cmds(cmds=cmds)
+                # Sleep a bit to ensure uplinks are down
+                time.sleep(20)
 
-            # Sleep to give the DHCP relay container time to start up and
-            # allow the relay agent to begin listening on the down interfaces
-            time.sleep(40)
-
-            # Bring all uplink interfaces back up
-            for iface in dhcp_relay['uplink_interfaces']:
-                duthost.shell('ifconfig {} up'.format(iface))
-
-            # Sleep a bit to ensure uplinks are up
-            wait_all_bgp_up(duthost)
+                restart_dhcp_service(duthost, ['v6'])
+            finally:
+                for iface in uplink_interfaces:
+                    duthost.shell('ifconfig {} up'.format(iface), module_ignore_errors=True)
+                wait_all_bgp_up(duthost)
 
             dhcp_server_num = len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'])
             restart_dhcpmon_in_debug(duthost)


### PR DESCRIPTION
### Description of PR

Summary:
Use shared DHCPv6 restart/readiness when the relay starts with uplinks down, and guarantee every tested uplink is restored when shutdown or readiness fails.

ADO Task: https://msazure.visualstudio.com/One/_workitems/edit/39300953
Parent PBI: https://msazure.visualstudio.com/One/_workitems/edit/38699914

Affected test:
`tests/dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down`.

This PR is independent of #26531. Both merge orders were applied locally and
produced the same tree without conflicts.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39300953
Failure type: other

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master, `SONiC.internal.173569967-e2b6c23f55` on
  `testbed-bjw2-can-7215a1-4`: the IPv6 uplinks-down case passed as part of the
  previously validated combined DHCPv6 selection (2 passed).
- 202605, `SONiC.20260510.07` (`1df5b92630`) on
  `testbed-bjw2-can-7215a1-4`: the same uplinks-down case passed as part of the
  combined DHCPv6 selection (2 passed).

The current head `22c0e1a617bd17685d75d16889c8693f2032f7d0` passed diff check, Python compilation, and targeted pre-commit checks. Existing master/202605 successful-path hardware evidence is reused because the added cleanup affects failure paths.

### Approach
#### What is the motivation for this PR?

The test used a manual reset/restart and fixed 40-second sleep, which did not
prove the IPv6 relay was ready.

#### How did you do it?

Replace the manual restart and fixed sleep with `restart_dhcp_service(duthost, ['v6'])`. Wrap the shutdown/restart path in `try/finally`, restore every uplink with `module_ignore_errors=True`, and retain `wait_all_bgp_up(duthost)` as the recovery assertion.

#### How did you verify/test it?

Reused the branch-specific successful-path hardware evidence above and ran exact-head diff, Python compilation, targeted pre-commit, composition, and merge-order checks.

#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

N/A; existing t0/m0 coverage.

### Documentation

No documentation change is required.

