### PR TITLE
[dhcp_relay]: Restore IPv6 relay test state after failures

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -448,20 +448,20 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
     testing_mode, duthost = testing_config
 
     for dhcp_relay in dut_dhcp_relay_data:
-        # Bring all uplink interfaces down
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('config interface shutdown {}'.format(iface))
+        uplink_interfaces = dhcp_relay['uplink_interfaces']
 
-        pytest_assert(wait_until(50, 5, 0, check_link_status, duthost, dhcp_relay['uplink_interfaces'], "down"),
-                      "Not all uplinks go down")
+        try:
+            # Bring all uplink interfaces down
+            for iface in uplink_interfaces:
+                duthost.shell('config interface shutdown {}'.format(iface))
 
-        # Bring all uplink interfaces back up
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('config interface startup {}'.format(iface))
-
-        # Wait until uplinks are up and routes are recovered
-        pytest_assert(wait_until(50, 5, 0, check_routes_to_dhcp_server, duthost, dut_dhcp_relay_data),
-                      "Not all DHCP servers are routed")
+            pytest_assert(wait_until(50, 5, 0, check_link_status, duthost, uplink_interfaces, "down"),
+                          "Not all uplinks go down")
+        finally:
+            for iface in uplink_interfaces:
+                duthost.shell('config interface startup {}'.format(iface), module_ignore_errors=True)
+            pytest_assert(wait_until(50, 5, 0, check_routes_to_dhcp_server, duthost, dut_dhcp_relay_data),
+                          "Not all DHCP servers are routed")
 
         # Run the DHCP relay test on the PTF host
         ptf_runner(ptfhost,

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -649,29 +649,21 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
 
     try:
         for dhcp_relay in dut_dhcp_relay_data:
-            # Bring all uplink interfaces down
-            for iface in dhcp_relay['uplink_interfaces']:
-                duthost.shell('ifconfig {} down'.format(iface))
+            uplink_interfaces = dhcp_relay['uplink_interfaces']
 
-            # Sleep a bit to ensure uplinks are down
-            time.sleep(20)
+            try:
+                # Bring all uplink interfaces down
+                for iface in uplink_interfaces:
+                    duthost.shell('ifconfig {} down'.format(iface))
 
-            # Restart DHCP relay service on DUT
-            # dhcp_relay service has 3 times restart limit in 20 mins, for 4 vlans config it will hit the maximum limit
-            # reset-failed before restart service
-            cmds = ['systemctl reset-failed dhcp_relay', 'systemctl restart dhcp_relay']
-            duthost.shell_cmds(cmds=cmds)
+                # Sleep a bit to ensure uplinks are down
+                time.sleep(20)
 
-            # Sleep to give the DHCP relay container time to start up and
-            # allow the relay agent to begin listening on the down interfaces
-            time.sleep(40)
-
-            # Bring all uplink interfaces back up
-            for iface in dhcp_relay['uplink_interfaces']:
-                duthost.shell('ifconfig {} up'.format(iface))
-
-            # Sleep a bit to ensure uplinks are up
-            wait_all_bgp_up(duthost)
+                restart_dhcp_service(duthost, ['v6'])
+            finally:
+                for iface in uplink_interfaces:
+                    duthost.shell('ifconfig {} up'.format(iface), module_ignore_errors=True)
+                wait_all_bgp_up(duthost)
 
             dhcp_server_num = len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'])
             restart_dhcpmon_in_debug(duthost)

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -580,19 +580,19 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
 
     try:
         for dhcp_relay in dut_dhcp_relay_data:
-            # Bring all uplink interfaces down
-            for iface in dhcp_relay['uplink_interfaces']:
-                duthost.shell('ifconfig {} down'.format(iface))
+            uplink_interfaces = dhcp_relay['uplink_interfaces']
 
-            # Sleep a bit to ensure uplinks are down
-            time.sleep(20)
+            try:
+                # Bring all uplink interfaces down
+                for iface in uplink_interfaces:
+                    duthost.shell('ifconfig {} down'.format(iface))
 
-            # Bring all uplink interfaces back up
-            for iface in dhcp_relay['uplink_interfaces']:
-                duthost.shell('ifconfig {} up'.format(iface))
-
-            # Sleep a bit to ensure uplinks are up
-            wait_all_bgp_up(duthost)
+                # Sleep a bit to ensure uplinks are down
+                time.sleep(20)
+            finally:
+                for iface in uplink_interfaces:
+                    duthost.shell('ifconfig {} up'.format(iface), module_ignore_errors=True)
+                wait_all_bgp_up(duthost)
 
             dhcp_server_num = len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'])
             restart_dhcpmon_in_debug(duthost)

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -246,13 +246,6 @@ def check_interface_status(duthost):
     return False
 
 
-def restart_dhcp_relay_and_check_dhcp6relay(duthost):
-    duthost.shell("sudo systemctl reset-failed dhcp_relay")
-    duthost.shell("sudo systemctl restart dhcp_relay")
-    wait_until(60, 3, 0, lambda: ("RUNNING" in duthost.shell("docker exec dhcp_relay supervisorctl status " +
-                                                             "dhcp-relay:dhcp6relay | awk '{print $2}'")["stdout"]))
-
-
 def ensure_client_reachability(duthost, vlan_name):
     """
     Ensure the DHCP client's link-local address is reachable from the relay agent.
@@ -272,15 +265,24 @@ def setup_and_teardown_no_servers_vlan(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     new_vlan_id = 4001
     new_vlan_ipv6 = "fc01:5000::1/64"
-    duthost.shell("sudo config vlan add {}".format(new_vlan_id))
-    duthost.shell("sudo config interface ip add Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
-    restart_dhcp_relay_and_check_dhcp6relay(duthost)
+    vlan_created = False
+    vlan_ipv6_assigned = False
 
-    yield new_vlan_id
+    try:
+        duthost.shell("sudo config vlan add {}".format(new_vlan_id))
+        vlan_created = True
+        duthost.shell("sudo config interface ip add Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
+        vlan_ipv6_assigned = True
+        restart_dhcp_service(duthost, ['v6'])
 
-    duthost.shell("sudo config interface ip remove Vlan{} {}".format(new_vlan_id, new_vlan_ipv6))
-    duthost.shell("sudo config vlan del {}".format(new_vlan_id))
-    restart_dhcp_relay_and_check_dhcp6relay(duthost)
+        yield new_vlan_id
+    finally:
+        if vlan_ipv6_assigned:
+            duthost.shell("sudo config interface ip remove Vlan{} {}".format(new_vlan_id, new_vlan_ipv6),
+                          module_ignore_errors=True)
+        if vlan_created:
+            duthost.shell("sudo config vlan del {}".format(new_vlan_id), module_ignore_errors=True)
+            restart_dhcp_service(duthost, ['v6'])
 
 
 def get_dhcptest_expected_counters(dhcp_server_num):


### PR DESCRIPTION
### Description of PR

Summary:
Restore temporary relay test state for the IPv4 and IPv6 link-flap cases. Cleanup for interface-binding and restart-with-uplinks-down remains in its owning prerequisite PR.

Dependencies:
- https://github.com/sonic-net/sonic-mgmt/pull/26531
- https://github.com/sonic-net/sonic-mgmt/pull/27115

ADO Task: https://msazure.visualstudio.com/One/_workitems/edit/39301793
Parent PBI: https://msazure.visualstudio.com/One/_workitems/edit/38699914

Affected tests:
- `tests/dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap`;
- `tests/dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap`.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39301793
Failure type: other

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- The prerequisite interface-binding and uplinks-down changes retain their existing master/202605 successful-path evidence.
- The unique head `d14fb890e0fbd45d57fde332f9ce6ce7d55d8398` changes only the IPv4 and IPv6 link-flap cleanup paths.
- The unique patch passed diff check, Python compilation, and targeted pre-commit checks.

### Approach
#### What is the motivation for this PR?

The IPv4 and IPv6 link-flap tests temporarily bring uplinks down. A failure before their existing restoration statements can leave the DUT modified.

#### How did you do it?

Wrap each link-flap shutdown sequence in direct `try/finally`, attempt every uplink restoration with `module_ignore_errors=True`, and retain the existing route/BGP recovery assertions.

#### How did you verify/test it?

Ran exact-stack diff, Python compilation, targeted pre-commit, and unique-commit checks. Prior successful-path hardware evidence is reused because the unique commit changes failure cleanup only.

#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

N/A; existing t0/m0 coverage.

### Documentation

No documentation change is required.

