### PR TITLE
Fix advanced-reboot hang when the packet capture fails to start

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -98,6 +98,12 @@ PHYSICAL_PORT = "physical_port"
 ARP_RESPONDER_CONFIG_PATH = "/tmp/from_t1.json"
 ARP_RESPONDER_CONFIG_PATH_FMT = "/tmp/from_t1_%s.json"
 
+# Starting dumpcap has been observed to fail transiently, so retry before giving up.
+DUMPCAP_START_ATTEMPTS = 3
+DUMPCAP_START_RETRY_INTERVAL = 5
+# Upper bound on how long to wait for the IO sniffer/sender thread bodies to begin running.
+IO_THREAD_START_TIMEOUT = 120
+
 
 class StateMachine():
     def __init__(self, init_state='init'):
@@ -304,6 +310,13 @@ class ReloadTest(BaseTest):
 
         self.sender_thr = threading.Thread(target=self.send_in_background)
         self.sniff_thr = threading.Thread(target=self.sniff_in_background)
+        # Set as soon as the corresponding thread body starts running. Unlike Thread.is_alive(),
+        # these stay set after the thread exits, so a thread that started and then died cannot be
+        # mistaken for one that has not started yet.
+        self.sender_thr_started = threading.Event()
+        self.sniff_thr_started = threading.Event()
+        # Reason the packet capture could not be started, if it failed to start.
+        self.sniffer_error = None
         self.start_sender_delay = 60
 
         # Check if platform type is kvm
@@ -1182,6 +1195,33 @@ class ReloadTest(BaseTest):
         # TODO: add timestamp
         self.log("Service has restarted")
 
+    def wait_for_io_threads_to_start(self, timeout=IO_THREAD_START_TIMEOUT):
+        """
+        @summary: Block until both the sniffer and the sender thread bodies have begun running.
+
+        Thread.is_alive() cannot distinguish "has not started yet" from "already finished", so
+        polling it makes a thread that started and then died indistinguishable from one that is
+        still starting up. Waiting on explicit start events instead - and bounding that wait -
+        keeps a failed IO thread from stalling the test until the global PTF test-case timeout.
+        """
+        deadline = time.time() + timeout
+        for name, started in (('sniffer', self.sniff_thr_started),
+                              ('sender', self.sender_thr_started)):
+            if not started.wait(timeout=max(0, deadline - time.time())):
+                msg = 'IO {} thread failed to start within {}s'.format(name, timeout)
+                self.log(msg)
+                self.fails['dut'].add(msg)
+                raise Exception(msg)
+
+        # The threads are running, but the capture may still have failed to come up. Without a
+        # pcap there is nothing to examine, so fail now with the real reason rather than later
+        # with a generic one.
+        if self.sniffer_error:
+            msg = 'Packet capture failed to start: {}'.format(self.sniffer_error)
+            self.log(msg)
+            self.fails['dut'].add(msg)
+            raise Exception(msg)
+
     def handle_advanced_reboot_health_check(self):
         self.log("Check that device is still forwarding data plane traffic")
         self.fails['dut'].add(
@@ -1190,8 +1230,7 @@ class ReloadTest(BaseTest):
         self.fails['dut'].clear()
 
         # wait until sniffer and sender threads have started
-        while not (self.sniff_thr.is_alive() and self.sender_thr.is_alive()):
-            time.sleep(1)
+        self.wait_for_io_threads_to_start()
 
         self.log("IO sender and sniffer threads have started, wait until completion")
         self.sniff_thr.join()
@@ -1893,9 +1932,12 @@ class ReloadTest(BaseTest):
         """
         This method sends predefined list of packets with predefined interval.
         """
+        self.sender_thr_started.set()
         if not packets_list:
             packets_list = self.packets_list
-        self.sniffer_started.wait(timeout=self.start_sender_delay)
+        if not self.sniffer_started.wait(timeout=self.start_sender_delay):
+            self.log("Sender: gave up waiting for the sniffer to start after {}s".format(
+                self.start_sender_delay))
         with self.dataplane_io_lock:
             # While running fast data plane sender thread there are two reasons for filter to be applied
             #  1. filter out data plane traffic which is tcp to free up the load
@@ -1956,6 +1998,7 @@ class ReloadTest(BaseTest):
         Once found, all packets are dumped to local pcap file,
         and all packets are saved to self.packets as scapy type(pcap format).
         """
+        self.sniff_thr_started.set()
         if not wait:
             wait = self.time_to_listen + self.test_params['sniff_time_incr']
         sniffer_start = datetime.datetime.now()
@@ -1993,6 +2036,10 @@ class ReloadTest(BaseTest):
         except Exception:
             traceback_msg = traceback.format_exc()
             self.log("Error in tcpdump_sniff: {}".format(traceback_msg))
+            if not self.sniffer_error:
+                self.sniffer_error = traceback_msg.strip().splitlines()[-1]
+            # Never leave send_in_background() blocked on a capture that will never start.
+            self.sniffer_started.set()
 
     def start_sniffer_on_vmhost(self, pcap_path, tcpdump_filter, timeout):
         """
@@ -2032,6 +2079,18 @@ class ReloadTest(BaseTest):
         self.vmhost_connection.execCommand(f'sudo pkill -f "{cmd}"')
         self.log("Killed the tcpdump process")
 
+    def drain_dumpcap_stderr(self, process):
+        """
+        @summary: Wait for a dumpcap process to exit and return whatever it wrote to stderr.
+
+        Draining the pipe also keeps dumpcap from blocking on a full stderr buffer.
+        """
+        try:
+            _, stderr = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            return ''
+        return stderr.decode('utf-8', errors='replace').strip() if stderr else ''
+
     def start_sniffer_on_ptf(self, pcap_path, tcpdump_filter, timeout):
         """
         Start tcpdump sniffer on all data interfaces, and kill them after a specified timeout
@@ -2042,19 +2101,47 @@ class ReloadTest(BaseTest):
         for iface in self.tcpdump_data_ifaces:
             process_args += ['-i', iface]
 
-        process = subprocess.Popen(process_args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        self.log('Dumpcap sniffer process started')
-
+        # stderr is piped rather than discarded so that a failure to start (missing binary,
+        # missing capability, full disk, bad capture filter, ...) is reported instead of lost.
+        # Retries are budgeted so the capture always concludes - and so unblocks
+        # send_in_background() - before the sender gives up on its own after start_sender_delay.
+        start_deadline = time.time() + self.start_sender_delay
         pcap_existence_check_limit = 10
-        pcap_existence_check_count = 0
-        while not os.path.exists(pcap_path) and pcap_existence_check_count < pcap_existence_check_limit:
-            time.sleep(1)
-            pcap_existence_check_count += 1
 
-        if not os.path.exists(pcap_path):
-            self.log("Dumpcap did not create pcap file!")
+        process = None
+        for attempt in range(1, DUMPCAP_START_ATTEMPTS + 1):
+            process = subprocess.Popen(process_args, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+            self.log('Dumpcap sniffer process started')
+
+            pcap_existence_check_count = 0
+            while not os.path.exists(pcap_path) and pcap_existence_check_count < pcap_existence_check_limit:
+                time.sleep(1)
+                pcap_existence_check_count += 1
+
+            if os.path.exists(pcap_path):
+                break
+
             process.terminate()
-            process.kill()
+            stderr = self.drain_dumpcap_stderr(process)
+            # Return code here could be 0, so we need to explicitly check for None
+            if process.returncode is None:
+                process.kill()
+                stderr = self.drain_dumpcap_stderr(process) or stderr
+            self.log("Dumpcap did not create pcap file! (attempt {}/{}, rc={}, stderr={})".format(
+                attempt, DUMPCAP_START_ATTEMPTS, process.returncode, stderr or '<empty>'))
+            process = None
+
+            # Only retry while a further attempt can still finish within the budget.
+            next_attempt_cost = DUMPCAP_START_RETRY_INTERVAL + pcap_existence_check_limit
+            if attempt == DUMPCAP_START_ATTEMPTS or time.time() + next_attempt_cost >= start_deadline:
+                break
+            time.sleep(DUMPCAP_START_RETRY_INTERVAL)
+
+        if process is None:
+            self.sniffer_error = 'dumpcap failed to create {} after {} attempt(s)'.format(
+                pcap_path, DUMPCAP_START_ATTEMPTS)
+            # Unblock the sender, which would otherwise wait out the full start_sender_delay.
+            self.sniffer_started.set()
             return
 
         # Unblock waiter for the send_in_background.
@@ -2069,25 +2156,21 @@ class ReloadTest(BaseTest):
 
         self.log("Going to kill dumpcap process by SIGTERM")
         process.terminate()
-        try:
-            process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            pass
+        stderr = self.drain_dumpcap_stderr(process)
 
         # Return code here could be 0, so we need to explicitly check for None
         if process.returncode is not None:
             self.log("Dumpcap process terminated")
-            return
+        else:
+            self.log("Killing dumpcap process")
+            process.kill()
+            stderr = self.drain_dumpcap_stderr(process) or stderr
+            # Return code here could be 0, so we need to explicitly check for None
+            if process.returncode is not None:
+                self.log("Dumpcap process killed")
 
-        self.log("Killing dumpcap process")
-        process.kill()
-        try:
-            process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            pass
-        # Return code here could be 0, so we need to explicitly check for None
-        if process.returncode is not None:
-            self.log("Dumpcap process killed")
+        if stderr:
+            self.log("Dumpcap stderr: {}".format(stderr))
 
     def check_tcp_payload(self, packet):
         """


### PR DESCRIPTION
When dumpcap fails to create the pcap file, start_sniffer_on_ptf() returns early without setting self.sniffer_started, the sniffer thread then dies on a FileNotFoundError, and handle_advanced_reboot_health_check() spins forever in

    while not (self.sniff_thr.is_alive() and self.sender_thr.is_alive()):
        time.sleep(1)

Thread.is_alive() cannot tell "not started yet" apart from "already finished", so once either IO thread has exited this loop can never terminate. Observed on a warm upgrade: dumpcap failed at 11:38:13, the sender then wasted its full 60s start_sender_delay waiting on an event that was never set, and the test hung until the global PTF --test-case-timeout fired 35 minutes later. The DUT was healthy throughout - post-reboot loganalyzer reported no errors - so the run failed with a misleading data plane signal instead of the real cause.

Changes:

- Pipe dumpcap stderr instead of discarding it, and log the return code and stderr when the pcap is not created. Previously stderr went to DEVNULL, so the reason for the failure (missing binary, missing capability, full disk, bad capture filter, ...) was unrecoverable. Add drain_dumpcap_stderr() so the pipe is always drained and dumpcap never blocks on a full buffer.
- Retry dumpcap startup up to DUMPCAP_START_ATTEMPTS times, budgeted so the capture always concludes before the sender's start_sender_delay expires.
- Set self.sniffer_started on every sniffer failure path so send_in_background() is not left blocked, and record self.sniffer_error for reporting.
- Replace the unbounded is_alive() gate with explicit per-thread start events and a bounded wait. On timeout, or when the capture failed to start, fail immediately with an actionable message instead of hanging until the global test-case timeout.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
