### PR TITLE
[HFT] Fix InfluxDB database setup and OTEL restart

### DIFF
--- a/tests/high_frequency_telemetry/conftest.py
+++ b/tests/high_frequency_telemetry/conftest.py
@@ -1,7 +1,8 @@
 import pytest
 import logging
 import time
-from tests.common.utilities import wait_until
+
+from tests.high_frequency_telemetry.utilities import restart_otel_collector
 
 logger = logging.getLogger(__name__)
 
@@ -48,18 +49,14 @@ def suppress_otel_debug_logging(duthosts, enum_rand_one_per_hwsku_hostname):
         f"sed -i 's/verbosity: detailed/verbosity: basic/' {OTEL_CONFIG_PATH}",
         module_ignore_errors=False
     )
-    duthost.shell('sudo systemctl restart otel', module_ignore_errors=False)
-    if not wait_until(60, 2, 10, duthost.is_service_fully_started, "otel"):
-        pytest.fail("OTEL container failed to start after restarting otel.service")
+    restart_otel_collector(duthost)
 
     yield
 
     # Restore original config
     logger.info("Restoring original OTEL collector config")
     duthost.copy(content=original_config, dest=OTEL_CONFIG_PATH)
-    duthost.shell('sudo systemctl restart otel', module_ignore_errors=False)
-    if not wait_until(60, 2, 10, duthost.is_service_fully_started, "otel"):
-        pytest.fail("OTEL container failed to start after restarting otel.service")
+    restart_otel_collector(duthost)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/high_frequency_telemetry/test_hft_end_to_end.py
+++ b/tests/high_frequency_telemetry/test_hft_end_to_end.py
@@ -13,6 +13,7 @@ from tests.high_frequency_telemetry.utilities import (
     stop_countersyncd_otel,
     render_otel_collector_config,
     install_otel_collector_config,
+    restart_otel_collector,
     enable_otel_collector,
     start_influxdb,
     setup_influxdb,
@@ -72,8 +73,7 @@ def test_hft_end_to_end_influxdb(duthosts, enum_rand_one_per_hwsku_hostname,
             influxdb_bucket=INFLUXDB_BUCKET,
         )
         install_otel_collector_config(duthost, rendered_config)
-        duthost.shell("docker restart otel", module_ignore_errors=False)
-        time.sleep(5)
+        restart_otel_collector(duthost)
 
         # --- Step 4: Discover ports and configure HFT ---
         test_ports = get_available_ports(

--- a/tests/high_frequency_telemetry/utilities.py
+++ b/tests/high_frequency_telemetry/utilities.py
@@ -1531,23 +1531,42 @@ def install_otel_collector_config(duthost, rendered_config,
 
 
 def _is_otel_collector_ready(duthost):
-    """Return whether the OTEL container and its critical processes are running."""
-    return (
-        duthost.is_service_fully_started("otel")
-        and duthost.critical_processes_running("otel")
+    if (
+        not duthost.is_service_fully_started("otel")
+        or not duthost.critical_processes_running("otel")
+    ):
+        return False
+
+    result = duthost.shell(
+        "sudo ss -lnt | grep -Eq ':4317[[:space:]]'",
+        module_ignore_errors=True,
     )
+    return result.get("rc") == 0
 
 
 def restart_otel_collector(duthost, timeout=60):
-    """Restart otel.service and wait for the collector to become ready."""
+    """Restart otel.service and wait for the collector's OTLP listener."""
     duthost.shell(
-        "sudo systemctl restart otel",
+        "sudo systemctl reset-failed otel && sudo systemctl restart otel",
         module_ignore_errors=False,
     )
+    ready = wait_until(timeout, 2, 10, _is_otel_collector_ready, duthost)
+    diagnostics = ""
+    if not ready:
+        status = duthost.shell(
+            "systemctl status otel --no-pager",
+            module_ignore_errors=True,
+        )
+        logs = duthost.shell(
+            "docker logs --tail 200 otel",
+            module_ignore_errors=True,
+        )
+        diagnostics = f"; service status: {status}; container logs: {logs}"
+
     pytest_assert(
-        wait_until(timeout, 2, 10, _is_otel_collector_ready, duthost),
-        "OTEL container or a critical collector process failed to start "
-        "after restarting otel.service",
+        ready,
+        "OTEL container, critical process, or OTLP listener did not become "
+        f"ready after restarting otel.service{diagnostics}",
     )
 
 

--- a/tests/high_frequency_telemetry/utilities.py
+++ b/tests/high_frequency_telemetry/utilities.py
@@ -8,6 +8,7 @@ high frequency telemetry test cases.
 import itertools
 import logging
 import re
+import shlex
 import threading
 import time
 from datetime import datetime, timedelta, timezone
@@ -1528,6 +1529,33 @@ def install_otel_collector_config(duthost, rendered_config,
     logger.info(f"Installed otel collector config to {dest_path}")
 
 
+def restart_otel_collector(duthost, timeout=30):
+    """Reload the OTEL configuration without restarting its container."""
+    duthost.shell(
+        "docker exec otel supervisorctl stop otel",
+        module_ignore_errors=True,
+    )
+    result = duthost.shell(
+        "docker exec otel supervisorctl start otel",
+        module_ignore_errors=True,
+    )
+    pytest_assert(
+        result.get("rc") == 0,
+        f"Failed to restart the OTEL collector process: {result}",
+    )
+
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        status = duthost.shell(
+            "docker exec otel supervisorctl status otel",
+            module_ignore_errors=True,
+        )
+        if status.get("rc") == 0 and "RUNNING" in status.get("stdout", ""):
+            return True
+        time.sleep(1)
+    pytest_assert(False, "OTEL collector process did not become ready")
+
+
 def enable_otel_collector(duthost, timeout=60):
     """
     Enable the OpenTelemetry collector feature on the DUT and wait
@@ -1624,24 +1652,27 @@ def start_influxdb(ptfhost, port=8181, timeout=30):
 
 
 def setup_influxdb(ptfhost, port=8181, bucket="home"):
-    """
-    Ensure the InfluxDB 3 database exists.
-
-    InfluxDB 3 Core is schema-on-write and auto-creates databases on first
-    write, so explicit creation is optional. We attempt to pre-create the
-    database via the CLI for clarity; failure is non-fatal.
-    """
-    result = ptfhost.shell(
-        f"influxdb3 create database {bucket} --port {port}",
-        module_ignore_errors=True,
+    """Create the InfluxDB 3 database used by the test."""
+    modern = (
+        f"influxdb3 create database --host http://127.0.0.1:{int(port)} "
+        f"{shlex.quote(bucket)}"
     )
-    if result["rc"] == 0:
-        logger.info(f"InfluxDB 3 database '{bucket}' created")
-    else:
-        logger.info(
-            f"InfluxDB 3 database '{bucket}' may already exist or will "
-            "auto-create on first write (rc=%d)", result["rc"],
-        )
+    legacy = (
+        f"influxdb3 create database {shlex.quote(bucket)} --port {int(port)}"
+    )
+    result = ptfhost.shell(modern, module_ignore_errors=True)
+    stderr = result.get("stderr", "").lower()
+    if result.get("rc") != 0 and (
+        "unexpected argument '--host'" in stderr
+        or "unrecognized option '--host'" in stderr
+    ):
+        result = ptfhost.shell(legacy, module_ignore_errors=True)
+
+    pytest_assert(
+        result.get("rc") == 0,
+        f"Failed to create InfluxDB database '{bucket}': {result}",
+    )
+    logger.info(f"InfluxDB 3 database '{bucket}' created")
 
 
 def query_influxdb(ptfhost, influxql_query, port=8181, db="home"):

--- a/tests/high_frequency_telemetry/utilities.py
+++ b/tests/high_frequency_telemetry/utilities.py
@@ -8,6 +8,7 @@ high frequency telemetry test cases.
 import itertools
 import logging
 import re
+import shlex
 import threading
 import time
 from datetime import datetime, timedelta, timezone
@@ -18,6 +19,7 @@ import ptf.testutils as testutils
 from natsort import natsorted
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -1528,6 +1530,27 @@ def install_otel_collector_config(duthost, rendered_config,
     logger.info(f"Installed otel collector config to {dest_path}")
 
 
+def _is_otel_collector_ready(duthost):
+    """Return whether the OTEL container and its critical processes are running."""
+    return (
+        duthost.is_service_fully_started("otel")
+        and duthost.critical_processes_running("otel")
+    )
+
+
+def restart_otel_collector(duthost, timeout=60):
+    """Restart otel.service and wait for the collector to become ready."""
+    duthost.shell(
+        "sudo systemctl restart otel",
+        module_ignore_errors=False,
+    )
+    pytest_assert(
+        wait_until(timeout, 2, 10, _is_otel_collector_ready, duthost),
+        "OTEL container or a critical collector process failed to start "
+        "after restarting otel.service",
+    )
+
+
 def enable_otel_collector(duthost, timeout=60):
     """
     Enable the OpenTelemetry collector feature on the DUT and wait
@@ -1624,24 +1647,27 @@ def start_influxdb(ptfhost, port=8181, timeout=30):
 
 
 def setup_influxdb(ptfhost, port=8181, bucket="home"):
-    """
-    Ensure the InfluxDB 3 database exists.
-
-    InfluxDB 3 Core is schema-on-write and auto-creates databases on first
-    write, so explicit creation is optional. We attempt to pre-create the
-    database via the CLI for clarity; failure is non-fatal.
-    """
-    result = ptfhost.shell(
-        f"influxdb3 create database {bucket} --port {port}",
-        module_ignore_errors=True,
+    """Create the InfluxDB 3 database used by the test."""
+    modern = (
+        f"influxdb3 create database --host http://127.0.0.1:{int(port)} "
+        f"{shlex.quote(bucket)}"
     )
-    if result["rc"] == 0:
-        logger.info(f"InfluxDB 3 database '{bucket}' created")
-    else:
-        logger.info(
-            f"InfluxDB 3 database '{bucket}' may already exist or will "
-            "auto-create on first write (rc=%d)", result["rc"],
-        )
+    legacy = (
+        f"influxdb3 create database {shlex.quote(bucket)} --port {int(port)}"
+    )
+    result = ptfhost.shell(modern, module_ignore_errors=True)
+    stderr = result.get("stderr", "").lower()
+    if result.get("rc") != 0 and (
+        "unexpected argument '--host'" in stderr
+        or "unrecognized option '--host'" in stderr
+    ):
+        result = ptfhost.shell(legacy, module_ignore_errors=True)
+
+    pytest_assert(
+        result.get("rc") == 0,
+        f"Failed to create InfluxDB database '{bucket}': {result}",
+    )
+    logger.info(f"InfluxDB 3 database '{bucket}' created")
 
 
 def query_influxdb(ptfhost, influxql_query, port=8181, db="home"):


### PR DESCRIPTION
Use the supported InfluxDB 3 --host option and fail explicitly when database creation fails. Reload the OTEL collector.

Extracted from:
https://github.com/sonic-net/sonic-mgmt/pull/26582

Depends on:
https://github.com/sonic-net/sonic-mgmt/pull/24926

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the HFT end-to-end test by using the supported InfluxDB 3 database-creation syntax and reloading the OTEL collector.

Extracted from #26582 and depends on #24926.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
https://elastictest.org/scheduler/testplan/6a8c9a8122e697e2cbed9d0d?testcase=high_frequency_telemetry%2Ftest_hft_end_to_end.py&type=console&leftSideViewMode=detail
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
The HFT end-to-end test could not create its InfluxDB 3 database because it used the unsupported  --port  CLI option and silently ignored the failure. Restarting the entire OTEL container also generated a  memory_checker  error detected by LogAnalyzer.

This follows the lifecycle approach from #26582 and depends on the InfluxDB launch fix in #24926.

#### How did you do it?

• Create the database using the supported  --host http://127.0.0.1:<port>  option.
• Retain fallback compatibility with older InfluxDB CLI syntax.
• Fail immediately with command details if database creation fails.
• Reload only the OTEL collector.
• Wait until the OTEL process reports  RUNNING .

#### How did you verify/test it?
<img width="930" height="549" alt="image" src="https://github.com/user-attachments/assets/8616ed54-4115-4773-8158-f334707b497e" />

<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
Validated with an NVIDIA SN5640 running SONiC  20251110.43 .

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
