### PR TITLE
[memory_utilization]: Skip absent containers/daemons quietly instead of warning

### DIFF
--- a/tests/common/plugins/memory_utilization/README.md
+++ b/tests/common/plugins/memory_utilization/README.md
@@ -474,3 +474,15 @@ Common troubleshooting steps:
 2. Verify if the memory increase is expected due to test operations
 3. Analyze the DUT logs for potential memory leaks or resource issues
 4. For persistent issues, consider increasing the threshold or disabling the specific check
+
+### Absent containers / daemons (e.g. SmartSwitch DPUs)
+
+A monitored `docker` container or process may not run on every DUT. For example, a
+SmartSwitch DPU typically does not run the `snmp`, `lldp`, `radv`, or `teamd` containers,
+so `docker stats` never reports them. When a monitored item is missing from the collected
+output, the plugin treats it as "not present on this DUT" and skips it quietly (logged at
+`debug` level, not `warning`) — this is expected and does not affect the test result.
+
+A `WARNING| Skipping memory check for <name>-<item> due to zero value` is only emitted when
+the item **is** present in the command output but reports a value of `0`, which is worth
+investigating.

--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -162,8 +162,18 @@ class MemoryMonitor:
                 normalized_thresholds = self._normalize_thresholds(thresholds)
                 logger.debug("Normalized thresholds: {}".format(normalized_thresholds))
 
-                current_value = round(float(current_values.get(name, {}).get(mem_item, 0)), 1)
-                previous_value = round(float(previous_values.get(name, {}).get(mem_item, 0)), 1)
+                current_collected = current_values.get(name, {})
+                previous_collected = previous_values.get(name, {})
+
+                # A missing key means the container/daemon isn't running on this DUT
+                # (e.g. snmp/lldp/radv/teamd on a SmartSwitch DPU). That's expected, so skip
+                # quietly instead of emitting a warning for something that legitimately doesn't exist.
+                if mem_item not in current_collected or mem_item not in previous_collected:
+                    logger.debug("Skipping memory check for {}-{}: not present on this DUT".format(name, mem_item))
+                    continue
+
+                current_value = round(float(current_collected.get(mem_item, 0)), 1)
+                previous_value = round(float(previous_collected.get(mem_item, 0)), 1)
 
                 if current_value == 0 or previous_value == 0:
                     logger.warning("Skipping memory check for {}-{} due to zero value".format(name, mem_item))


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)

Related ADO work item (context where the noisy warnings were observed):
39059756

The `memory_utilization` plugin's `docker`/process monitors iterate a fixed list of
containers and daemons (`snmp`, `lldp`, `radv`, `teamd`, etc.). When one of them is not
running on a DUT — for example `snmp`/`lldp`/`radv`/`teamd` on a SmartSwitch DPU — the
parser never records a value for it, so `check_memory_thresholds()` defaulted it to `0`
and emitted a `WARNING` on every test:

```
memory_utilization.check_memory_threshol L0169 WARNING| Skipping memory check for docker-snmp due to zero value
memory_utilization.check_memory_threshol L0169 WARNING| Skipping memory check for docker-lldp due to zero value
memory_utilization.check_memory_threshol L0169 WARNING| Skipping memory check for docker-radv due to zero value
memory_utilization.check_memory_threshol L0169 WARNING| Skipping memory check for docker-teamd due to zero value
```

These warnings are expected on platforms where the container/daemon legitimately does not
run (SmartSwitch DPUs), and are pure log noise.

> Note: this PR only removes the expected/noisy warnings surfaced while investigating the
> ADO work item above. It does not change the underlying `test_pcie_link` DPU failure that
> the work item tracks.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
39059756
Failure type: other (expected log noise on SmartSwitch DPUs; not a functional failure)

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: validated locally (framework/plugin change, no image dependency)
  - `python3 -m py_compile` — pass
  - `flake8 --max-line-length=120` — clean
  - Focused logic test of `check_memory_thresholds()`:
    - absent container (key missing) → `DEBUG` "not present on this DUT", **no** WARNING
    - present-but-zero container → `WARNING` "due to zero value" (preserved)
    - present non-zero container → processed normally

### Approach
#### What is the motivation for this PR?

Remove misleading `WARNING` log noise for containers/daemons that legitimately do not run
on a DUT (e.g. `snmp`/`lldp`/`radv`/`teamd` on a SmartSwitch DPU), while keeping the
warning for containers that are actually present but report a zero memory value (a real
anomaly worth investigating).

#### How did you do it?

In `check_memory_thresholds()`, distinguish an **absent** monitored item (key missing from
the collected command output → the container/daemon does not exist on this DUT) from a
**genuinely zero** value (key present but `0`). Absent items are now skipped quietly at
`debug` level; the existing zero-value `WARNING` is preserved for items that are present.

Also documented the behavior in the plugin's `README.md` Troubleshooting section.

#### How did you verify/test it?

`py_compile` + `flake8` (max-line-length=120), plus a focused logic test exercising the
absent / present-zero / present-nonzero paths (see Test result). No functional behavior
changes for platforms where all monitored containers run.

#### Any platform specific information?

Primarily benefits SmartSwitch DPU testbeds (e.g. Mellanox-SN4280-O28), where the DPU does
not run the `snmp`/`lldp`/`radv`/`teamd` containers. Behavior is unchanged on platforms
where those containers are present.

#### Supported testbed topology if it's a new test case?

N/A — framework/plugin improvement, not a new test case.

### Documentation

Updated `tests/common/plugins/memory_utilization/README.md` with a Troubleshooting note
describing absent-container/daemon behavior on DUTs such as SmartSwitch DPUs.
