### PR TITLE
[crm] Fix cEOS interface name in test_crm_nexthop

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -864,7 +864,10 @@ def _get_interface_neighbor_and_port(duthost, tbinfo, dut_interface, nbrhosts):
     neighbor_name, neighbor_interface = neighbor_name['name'], neighbor_name['port']
     neighbor = nbrhosts[neighbor_name]
     lacp_num = neighbor['conf']['interfaces'][neighbor_interface].get('lacp')
-    neighbor_interface = f'po{lacp_num}' if lacp_num else neighbor_interface
+    if lacp_num:
+        neighbor_interface = f'po{lacp_num}'
+    elif neighbor_interface.startswith('Ethernet'):
+        neighbor_interface = f"eth{neighbor_interface.removeprefix('Ethernet')}"
     return neighbor['host'], neighbor_interface
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix test_crm_nexthop  to translate EOS physical interface names such as  Ethernet1  to their cEOS Linux names such as  eth1 . Preserve existing PortChannel handling by continuing to use  po<lacp_num>  for LACP interfaces.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
On a Mellanox SN5640 running  t0-isolated-d32u32s2 , both IPv4 and IPv6  test_crm_nexthop  cases failed with:

ip addr add 2.2.2.2/24 dev Ethernet1
Cannot find device "Ethernet1"

The test executes Linux  ip  commands on the cEOS neighbor. Topology data uses the EOS interface name  Ethernet1 , while the cEOS Linux namespace exposes it as  eth1 .

Failure: https://elastictest.org/scheduler/testplan/6a7bd4ce749c94fa50d6a8e6?searchTestCase=crm&testcase=crm%2Ftest_crm.py%7C%7C%7C1&type=console

#### How did you do it?
Keep the existing LACP conversion for PortChannel interfaces. For non-LACP physical interfaces, translate the EOS  Ethernet<N>  name to Linux  eth<N>  before executing  ip addr  and  ip link  commands.

#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/6a83a566f6996a5358f9f6c6?testcase=crm%2Ftest_crm.py%3A%3Atest_crm_nexthop&type=console
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
Observed with a cEOS neighbor on:

• DUT: Mellanox SN5640
• HW SKU:  Mellanox-SN5640-C512S2 
• ASIC: Mellanox
• Image:  SONiC.20251110.43 

The change only affects non-LACP EOS physical interface names used by Linux shell commands.

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
