### PR TITLE
Ensure teardown on reload failure for setup_po2vlan fixture

### DIFF
--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -74,7 +74,6 @@ def ptf_teardown(ptfhost, ptf_lag_map):
         ptfhost.set_dev_up_or_down(ptf_lag_member, True)
 
     ptfhost.shell("ip link del {}".format(PTF_LAG_NAME))
-    ptfhost.shell("teamd -t {} -k".format(PTF_LAG_NAME))
     ptfhost.ptf_nn_agent()
 
 

--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -74,6 +74,7 @@ def ptf_teardown(ptfhost, ptf_lag_map):
         ptfhost.set_dev_up_or_down(ptf_lag_member, True)
 
     ptfhost.shell("ip link del {}".format(PTF_LAG_NAME))
+    ptfhost.shell("teamd -t {} -k".format(PTF_LAG_NAME))
     ptfhost.ptf_nn_agent()
 
 
@@ -454,9 +455,11 @@ def setup_po2vlan(duthosts, ptfhost, rand_one_dut_hostname, rand_selected_dut, p
         yield
     # --------------------- Teardown -----------------------
     finally:
-        config_reload(duthost, safe_reload=True)
-        if ptf_lag_map is not None:
-            ptf_teardown(ptfhost, ptf_lag_map)
+        try:
+            config_reload(duthost, safe_reload=True)
+        finally:
+            if ptf_lag_map is not None:
+                ptf_teardown(ptfhost, ptf_lag_map)
 
 
 def has_portchannels(duthosts, rand_one_dut_hostname):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
- Wrap `config_reload` in an inner `try`/`finally` so `ptf_teardown` always runs even if DUT reload fails during module fixture cleanup.

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202605 - teardown was executed after mimic failure in internal block

### Approach
#### What is the motivation for this PR?
If `config_reload` fails during `setup_po2vlan` teardown, PTF LAG cleanup was skipped, leaving the bond/teamd state behind and affecting later tests.

#### How did you do it?
- Always call `ptf_teardown` from a `finally` block after `config_reload`
- 
#### How did you verify/test it?
internal regression (multiple tests using fixture)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
