### PR TITLE
Wait for chronyd to accept client command

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -1185,6 +1185,15 @@
             delay: 10
             until: chrony_start_result is succeeded
 
+          - name: Wait for chronyd to accept commands
+            become: true
+            command: chronyc tracking
+            register: chrony_ready_result
+            until: chrony_ready_result.rc == 0
+            retries: 12
+            delay: 5
+            changed_when: false
+
           - name: Force rapid NTP polling with chrony
             become: true
             command: chronyc burst 4/4


### PR DESCRIPTION
### Description of PR

The chrony service can report as started before its command interface is ready to accept chronyc requests. This race was observed on an IPv6-only management testbed, where the subsequent chronyc burst command failed with 506 Cannot talk to daemon. The added readiness check waits for chronyc tracking to succeed before continuing, ensuring chronyd is fully responsive and preventing intermittent testbed configuration failures.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

Manual runs on internal physical testbed

### Approach
#### What is the motivation for this PR?

The chrony service can report as started before its command interface is ready to accept chronyc requests. This race was observed on an IPv6-only management testbed, where the subsequent chronyc burst command failed with 506 Cannot talk to daemon. The added readiness check waits for chronyc tracking to succeed before continuing, ensuring chronyd is fully responsive and preventing intermittent testbed configuration failures.

#### How did you do it?

Add call to "chronyc tracking" expecting a valid response before the burst call.

#### How did you verify/test it?

Manual testing on physical testbed.

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA