### PR TITLE
Wait for arp_responder readiness before static route traffic checks

### DIFF
--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -19,6 +19,14 @@ ERSPAN_GRE_TYPE = 0x8949
 # so the canonical value lives in one place.
 ARP_RESPONDER_DEFAULT_CONFIG = "/tmp/from_t1.json"
 
+# Readiness flag written by tests/scripts/arp_responder.py once it has bound every
+# capture socket. Starting the responder is not the same as it being able to answer:
+# it spends 10-15 seconds reinitializing scapy for libpcap first, and `supervisorctl
+# restart` returns long before that finishes. Tests that send traffic depending on a
+# responder-backed neighbor must wait for this file to appear, otherwise the neighbor
+# never resolves and traffic silently follows a less specific route instead.
+ARP_RESPONDER_READY_FLAG = "/tmp/arp_responder.ready"
+
 # Per-suffix variant used by the advanced-reboot family of tests when a logfile suffix
 # differentiates one run's responder config from another (e.g. preboot/inboot operations).
 # The format takes a single %s placeholder for the suffix and is consumed both inside the

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -20,7 +20,7 @@ from tests.common.utilities import wait_until, get_intf_by_sub_intf, is_ipv6_onl
 from tests.common.utilities import get_neighbor_ptf_port_list
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
-from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG, UPSTREAM_NEIGHBOR_MAP
+from tests.common.helpers.constants import ARP_RESPONDER_DEFAULT_CONFIG, ARP_RESPONDER_READY_FLAG, UPSTREAM_NEIGHBOR_MAP
 from tests.common import config_reload
 from tests.common.reboot import reboot
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
@@ -92,7 +92,28 @@ def add_ipaddr(ptfadapter, ptfhost, nexthop_addrs, prefix_len, nexthop_interface
         ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
 
         ptfhost.shell('supervisorctl reread && supervisorctl update')
+        ptfhost.file(path=ARP_RESPONDER_READY_FLAG, state="absent")
         ptfhost.shell('supervisorctl restart arp_responder')
+        wait_for_arp_responder_ready(ptfhost)
+
+
+def wait_for_arp_responder_ready(ptfhost, timeout=60):
+    """Wait until arp_responder is able to answer, not merely running.
+
+    supervisorctl returns as soon as the process exists, but the responder first
+    spends 10-15s reinitializing scapy for libpcap. It touches
+    ARP_RESPONDER_READY_FLAG once every capture socket is bound.
+    """
+    def _ready():
+        return ptfhost.shell(
+            "test -f {}".format(ARP_RESPONDER_READY_FLAG), module_ignore_errors=True
+        )["rc"] == 0
+
+    pytest_assert(
+        wait_until(timeout, 2, 0, _ready),
+        "arp_responder did not become ready within {}s, check /tmp/arp_responder.out.log and "
+        "/tmp/arp_responder.err.log on the PTF".format(timeout)
+    )
 
 
 def del_ipaddr(ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv6=False):
@@ -110,6 +131,10 @@ def del_ipaddr(ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv6=False):
         # cannot be picked up by a later test invoking arp_responder with its
         # default config path.
         ptfhost.file(path=ARP_RESPONDER_DEFAULT_CONFIG, state="absent")
+        # SIGTERM from supervisorctl stop skips the responder's own cleanup, so
+        # drop the readiness flag here as well; a stale one would let the next
+        # caller proceed before the responder can answer.
+        ptfhost.file(path=ARP_RESPONDER_READY_FLAG, state="absent")
 
 
 def clear_arp_ndp(duthost, ipv6=False):

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -1,6 +1,7 @@
 import binascii
 import json
 import argparse
+import os
 import os.path
 from collections import defaultdict
 import logging
@@ -17,6 +18,12 @@ logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 # import that here because this script is distributed to and executed inside
 # the PTF container, where the sonic-mgmt test tree is not on sys.path.
 DEFAULT_CONFIG_PATH = '/tmp/from_t1.json'
+
+# Created only once every capture socket is bound, i.e. once ARP requests can
+# actually be answered. Callers must wait for this rather than treating process
+# start as readiness: the scapy import above costs 10-15 seconds, and requests
+# arriving in that window go unanswered, leaving neighbors unresolved on the DUT.
+READY_FLAG_PATH = '/tmp/arp_responder.ready'
 
 
 class ARPResponder(object):
@@ -96,6 +103,17 @@ class ARPResponder(object):
         return neigh_adv_pkt
 
 
+def set_ready_flag():
+    with open(READY_FLAG_PATH, 'w') as ready_flag:
+        ready_flag.write(str(os.getpid()))
+    print("arp_responder ready", flush=True)
+
+
+def clear_ready_flag():
+    if os.path.exists(READY_FLAG_PATH):
+        os.remove(READY_FLAG_PATH)
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description='ARP autoresponder')
     parser.add_argument('--conf', '-c', type=str, dest='conf',
@@ -109,6 +127,8 @@ def parse_args():
 
 def main():
     args = parse_args()
+
+    clear_ready_flag()
 
     if not os.path.exists(args.conf):
         print(("Can't find file %s" % args.conf))
@@ -169,7 +189,11 @@ def main():
     ARPResponder.ip_sets = ip_sets
     ARPResponder.sockets = sockets
 
-    scapy.sniff(prn=ARPResponder.action, opened_socket=inverse_sockets, store=False)
+    set_ready_flag()
+    try:
+        scapy.sniff(prn=ARPResponder.action, opened_socket=inverse_sockets, store=False)
+    finally:
+        clear_ready_flag()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
test_static_route intermittently failed with traffic egressing the default BGP route instead of the configured static route.
The reason is that arp_responder (service on ptf) needs 10-15s to reinitialize scapy for libpcap, but `supervisorctl restart arp_responder` returns immediately, so the single ping that followed raced its startup. Then the nexthop stayed unresolved, which keeps the static route out of the hardware FIB, while it remains visible in the RIB, so traffic silently follows a less specific route instead of failing in an obvious way.

That 10-15s startup cost came from "Improve arp_responder.py performance" (https://github.com/sonic-net/sonic-mgmt/pull/17280, commit 3f31542da7).
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
test failed because arp_responder on ptf restart but still was not ready when get arp request

#### How did you do it?
add readiness mechanism 
#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
rerun the test and make sure it passed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
