### PR TITLE
Fix service warm restart DUT selection on dual-ToR

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -456,14 +456,20 @@ def verify_yang(duthost):
         raise RebootHealthError("Yang validation failed")
 
 
-@pytest.fixture
-def verify_dut_health(request, duthosts, rand_one_dut_hostname, tbinfo):
+def _verify_dut_health_for_host(request, duthost, tbinfo):
     """
-    Performs health check on single DUT defined by rand_one_dut_hostname before and after a test
+    Perform health checks on a DUT before and after a test.
+
+    Args:
+        request: Pytest request object.
+        duthost: DUT host to check.
+        tbinfo: Testbed information.
+
+    Returns:
+        Iterator that performs post-test checks during fixture teardown.
     """
     global test_report
     test_report = {}
-    duthost = duthosts[rand_one_dut_hostname]
     check_services(duthost)
     check_interfaces_and_transceivers(duthost, request)
     check_neighbors(duthost, tbinfo)
@@ -486,6 +492,46 @@ def verify_dut_health(request, duthosts, rand_one_dut_hostname, tbinfo):
     check_all = all([check is True for check in list(test_report.values())])
     pytest_assert(check_all, "Health check failed after reboot: {}"
                   .format(test_report))
+
+
+@pytest.fixture
+def verify_dut_health(request, duthosts, rand_one_dut_hostname, tbinfo):
+    """
+    Perform health checks on the randomly selected DUT.
+
+    Args:
+        request: Pytest request object.
+        duthosts: Available DUT hosts.
+        rand_one_dut_hostname: Randomly selected DUT hostname.
+        tbinfo: Testbed information.
+
+    Returns:
+        Iterator that performs post-test checks during fixture teardown.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    yield from _verify_dut_health_for_host(request, duthost, tbinfo)
+
+
+@pytest.fixture
+def verify_dut_health_enum_frontend(
+        request, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+        tbinfo, setup_dualtor_mux_ports):
+    """
+    Perform health checks on the enumerated frontend DUT.
+
+    Args:
+        request: Pytest request object.
+        duthosts: Available DUT hosts.
+        enum_rand_one_per_hwsku_frontend_hostname: Enumerated frontend DUT hostname.
+        tbinfo: Testbed information.
+        setup_dualtor_mux_ports: Keeps the dual-ToR mux setup active
+            throughout the health checks.
+
+    Returns:
+        Iterator that performs post-test checks during fixture teardown.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    yield from _verify_dut_health_for_host(request, duthost, tbinfo)
 
 
 @pytest.fixture

--- a/tests/platform_tests/test_service_warm_restart.py
+++ b/tests/platform_tests/test_service_warm_restart.py
@@ -4,13 +4,14 @@ import logging
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot       # noqa: F401
 from tests.common.helpers.assertions import pytest_require
 from tests.common.utilities import skip_release
-from tests.common.platform.device_utils import verify_dut_health         # noqa: F401
+from tests.common.platform.device_utils import verify_dut_health_enum_frontend  # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
 from tests.common.platform.device_utils import advanceboot_loganalyzer  # noqa: F401
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0'),
+    pytest.mark.dualtor_active_standby_toggle_to_enum_tor_manual_mode
 ]
 
 
@@ -92,11 +93,11 @@ def select_services_to_warmrestart(duthost, request):
     return [service for service in all_services if passes_all_checks(service)]
 
 
-def test_service_warm_restart(request, duthosts, rand_one_dut_hostname,
-                              verify_dut_health, get_advanced_reboot,       # noqa: F811
+def test_service_warm_restart(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                              verify_dut_health_enum_frontend, get_advanced_reboot,  # noqa: F811
                               advanceboot_loganalyzer,  # noqa: F811
                               capture_interface_counters):
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     candidate_service_list = select_services_to_warmrestart(duthost, request)
     pytest_require(candidate_service_list, 'Skip service warm restart test because candidate_service_list is empty')


### PR DESCRIPTION

### Description of PR

Summary:

Fix test_service_warm_restart flaky failure on dual-ToR testbeds where the test timed out with `IO didn't come up within warm up timeout. Control plane: init, Data plane: down before any service warm restart was executed`

Two root causes fixed:

DUT mismatch: The test selected its DUT via rand_one_dut_hostname while get_advanced_reboot internally uses enum_rand_one_per_hwsku_frontend_hostname. These could resolve to different switches, causing PTF to probe a DUT the test was not inspecting.
Mux never toggled: The deprecated toggle_all_simulator_ports_to_rand_selected_tor_m fixture was present in request.fixturenames. This caused the modern autouse setup_dualtor_mux_ports fixture (conftest.py) to exit immediately without touching the mux, leaving the selected DUT in standby which ultimately did not forward traffic.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Approach
#### What is the motivation for this PR?

test_service_warm_restart is ~50% flaky on dual-ToR testbeds. When rand_one_dut_hostname randomly selects the standby ToR, the PTF advanced-reboot pre-test warm-up immediately fails because a standby ToR does not forward the
server/T1 probe traffic the test expects. The test never reaches the actual service warm restart phase, wasting 300s per run and producing a misleading failure that looks like a platform warm-restart regression.

#### How did you do it?

Two changes in test_service_warm_restart.py:

Replaced rand_one_dut_hostname with enum_rand_one_per_hwsku_frontend_hostname in the test signature and DUT selection. This aligns with how get_advanced_reboot selects its DUT internally (advanced_reboot.py:1108), eliminating the DUT mismatch.

Removed the deprecated toggle_all_simulator_ports_to_rand_selected_tor_m fixture import and parameter. Added pytest.mark.dualtor_active_standby_toggle_to_enum_tor_manual_mode to pytestmark. This marker correctly activates setup_dualtor_mux_ports to toggle the mux to the enum-selected DUT in manual mode.

Reference pattern followed: test_advanced_reboot.py::test_warm_reboot.

#### How did you verify/test it?
Ran the script on dualtor testbed, below are the results
```
HW validation: tornado-dualtor, Cisco-8101-32FH-O-C01

15:52:49 dualtor mux port setup config:
         DUALTOR_ACTIVE_STANDBY_TOGGLE_TO_ENUM_TOR_MANUAL_MODE
15:52:49 Toggle mux ports to the target DUT tor-dut-0
15:52:49 Toggling mux cable to tor-dut-0
15:52:54 Set all mux ports to manual mode on all ToRs
15:52:58 verify_dut_health_enum_frontend setup
15:53:38 test_service_warm_restart[tor-dut-0] call
15:54:41 Data plane state transition from init to up (500)
15:54:42 Control plane state transition from init to up
15:54:44 Check that device is alive and pinging
15:55:19 Schedule to reboot the remote switch in 10 sec
15:55:34 return code from service-warm-restart bmp: 0
15:55:38 return code from service-warm-restart eventd: 0
15:55:43 return code from service-warm-restart gnmi: 0
15:55:50 return code from service-warm-restart lldp: 0
15:56:35 return code from service-warm-restart swss: 0
15:56:38 return code from service-warm-restart teamd: 0
15:56:42 Service has restarted
15:57:09 Data plane state transition from down to up (500)
16:15:56 Send 100 Received 100 servers->t1
16:15:57 Send 500 Received 500 t1->servers
```


202605: Test Result 

```
test_service_warm_restart[dtor3-dut0]
1 test, 0 failures, 0 errors, 0 skipped
Duration: 544.692 seconds
```

#### Any platform specific information?
No platform-specific changes. The fix applies to all platforms running on dual-ToR (dualtor) topology. Non-dualtor t0 runs are unaffected — the marker and enum fixture are no-ops on single-ToR testbeds.

#### Supported testbed topology if it's a new test case?
Existing test. Supported topologies: t0, dualtor

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
