### PR TITLE
[conditional_mark] Re-enable bgp/test_bgp_suppress_fib on master

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -170,7 +170,8 @@ def ignore_expected_loganalyzer_errors(duthosts, rand_one_dut_hostname, loganaly
             r".* ERR memory_checker: \[memory_checker\] Failed to get container ID of.*",
             r".* ERR memory_checker: \[memory_checker\] cgroup memory usage file.*",
             r".*ERR teamd#teamsyncd: :- readData: netlink reports an error=.*",
-            r".*ERR bgp#fpmsyncd: .*zmq send failed.*zmqerrno: 11:Resource temporarily unavailable.*"
+            r".*ERR bgp#fpmsyncd: .*zmq send failed.*zmqerrno: 11:Resource temporarily unavailable.*",
+            r".* ERR monit.*'chrony' process is not running.*"
         ]
         loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -638,23 +638,16 @@ bgp/test_bgp_suppress_fib.py:
              (2) suppress-fib dynamic-toggle offload/propagation race: the module toggles
              suppress-fib-pending dynamically at runtime, causing an orchagent/fpmsyncd/FRR race
              where routes are intermittently not offloaded in FRR / not propagated to the upstream VM.
-             The product fix that makes suppress-fib static (sonic-swss#4333 + sonic-mgmt#22916) is
-             merging to master only and is not backported. Therefore master auto-lifts once the fix
-             lands and the tracking issue is closed, while the release branches 202505/202511/202605
-             never receive the fix and stay skipped for the life of the branch.
-             Tracked by https://github.com/sonic-net/sonic-mgmt/issues/26175"
+             The fix that makes suppress-fib static (sonic-swss#4333) landed on master only and was
+             not backported, so release images remain skipped here."
     conditions_logical_operator: or
     conditions:
       - "release in ['201811', '201911', '202012', '202205', '202211', '202305', '202311', '202405']"
       - "release in ['202505', '202511', '202605']"
-      - "release in ['master'] and https://github.com/sonic-net/sonic-mgmt/issues/26175"
-      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/26175"
   xfail:
-    reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20756 or Mellanox platform due to https://github.com/sonic-net/sonic-buildimage/issues/24679"
-    conditions_logical_operator: or
+    reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20756"
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/20756 and '-v6-' in topo_name"
-      - "https://github.com/sonic-net/sonic-buildimage/issues/24679 and asic_type in ['mellanox', 'nvidia']"
 
 bgp/test_bgp_suppress_fib.py::test_bgp_route_with_suppress:
   skip:
@@ -673,12 +666,6 @@ bgp/test_bgp_suppress_fib.py::test_bgp_route_with_suppress_negative_operation:
              hold on VS. See https://github.com/sonic-net/sonic-mgmt/issues/14449"
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/14449"
-
-bgp/test_bgp_suppress_fib.py::test_bgp_route_without_suppress:
-  xfail:
-    reason: "Testcase ignored due to https://github.com/sonic-net/sonic-buildimage/issues/24679"
-    conditions:
-      - "https://github.com/sonic-net/sonic-buildimage/issues/24679 and asic_type in ['mellanox', 'nvidia']"
 
 bgp/test_bgp_suppress_fib.py::test_credit_loop:
   skip:


### PR DESCRIPTION
### Description of PR

Summary:
Re-enable `bgp/test_bgp_suppress_fib.py` on master, now that the product fix it was waiting on has merged, and drop two conditional-mark entries that reference an issue closed in March 2026.

The module was skipped on master and VS by [sonic-mgmt PR 26176](https://github.com/sonic-net/sonic-mgmt/pull/26176) because the test toggled `suppress-fib-pending` dynamically at runtime, racing orchagent/fpmsyncd/FRR — routes were intermittently not offloaded in FRR or not propagated upstream. The skip was gated on [sonic-mgmt issue 26175](https://github.com/sonic-net/sonic-mgmt/issues/26175) so it would lift once the fix landed. It has landed: [sonic-swss PR 4333](https://github.com/sonic-net/sonic-swss/pull/4333) makes suppress-fib static, and [sonic-mgmt PR 22916](https://github.com/sonic-net/sonic-mgmt/pull/22916) applies the required `config_reload` in the shared helper. Both are merged, and both are contained in the submodule pointers on sonic-buildimage master, so the fix is present in master images.

It also adds one LogAnalyzer ignore in `tests/bgp/test_bgp_suppress_fib.py`. Re-enabling the module surfaced a pre-existing teardown failure on t1-lag: disabling `suppress-fib-pending` config-reloads the DUT, chrony restarts with the other containers, and monit logs `'chrony' process is not running` before it is back up. The common ignore list already carries the identical pattern for `rsyslog`.

Related issue: https://github.com/sonic-net/sonic-mgmt/issues/26175 — intentionally referenced without a closing keyword. The 202605 branch still references this issue in its own conditional-mark file, so `skip_issue_close_guard` would reopen it on auto-close.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A — no backport requested.
Failure type: N/A

The fix that makes this module reliable landed on master only and was not backported, so the release branches must keep their skips. The release branches maintain their own conditional-mark files, and none of them is modified by this PR.

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

This PR changes conditional-mark metadata plus one LogAnalyzer ignore entry in the test module. It contains no product code and no change to test logic or assertions.

The chrony ignore is backed by CI evidence rather than static review: across two separate dates, every attempt of `test_bgp_route_without_suppress` on `impacted-area-kvmtest-t1-lag` errored on teardown with exactly this monit message (6/6 attempts; `failures_ignore_retries: 0`, i.e. no test actually failed — the module errored in teardown). The remaining re-enabled tests have not been run on a testbed as part of this PR.

Verified:
- The YAML parses, and the file still resolves to the expected 6 suppress-fib entries.
- Simulating `find_all_matches` mark resolution against the edited file gives the intended outcome: on physical, all 7 tests run; on VS, `test_bgp_route_without_suppress` and `test_bgp_update_relay_latency` run while the other 5 stay skipped under [sonic-mgmt issue 14449](https://github.com/sonic-net/sonic-mgmt/issues/14449) and the KVM performance skips.
- [sonic-buildimage issue 24679](https://github.com/sonic-net/sonic-buildimage/issues/24679) is closed (2026-03-05), so `update_issue_status` has been substituting `False` for it and both xfail conditions were already inert.
- The product fix commits are contained in the sonic-swss and sonic-utilities submodule pointers on sonic-buildimage master.
- The added regex was checked against the exact syslog lines captured in CI; it matches them and does not match the neighbouring `rsyslog` monit message or the `chronyd nss_tacplus` entry already ignored globally.
- Repo-wide, only this module and two internal suppress-fib/aggregate modules have ever tripped this message, consistent with it being specific to the suppress-fib config-reload path rather than to `config_reload` in general.

### Approach

#### What is the motivation for this PR?

The module-level skip was always meant to be temporary — it was gated on an issue URL specifically so master would re-enable the tests once the underlying race was fixed. That fix has merged, so the skip is now suppressing coverage of working functionality on master.

Separately, the `mellanox`/`nvidia` xfail conditions reference [sonic-buildimage issue 24679](https://github.com/sonic-net/sonic-buildimage/issues/24679) ("`config suppress-fib-pending` restarts BGP sessions"), which was closed in March 2026. That defect was in the runtime toggle path, which the static-config fix no longer exercises.

#### How did you do it?

In `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`:

1. Removed the two conditions gated on [sonic-mgmt issue 26175](https://github.com/sonic-net/sonic-mgmt/issues/26175) (`release in ['master']` and `asic_type in ['vs']`) from the module-level skip. This is the actual re-enable.
2. Updated the skip reason to describe the current state and dropped the stale tracking sentence.
3. Removed the [sonic-buildimage issue 24679](https://github.com/sonic-net/sonic-buildimage/issues/24679) condition from the module-level xfail, along with the now-redundant `conditions_logical_operator`.
4. Deleted the `::test_bgp_route_without_suppress` entry, whose only content was that same dead xfail.

In `tests/bgp/test_bgp_suppress_fib.py`:

5. Added `r".* ERR monit.*'chrony' process is not running.*"` to the module's existing `ignore_expected_loganalyzer_errors` list.

The `release in [...]` conditions are deliberately kept. They are dormant on master, but they follow the convention used by the other release-scoped entries in this file and they are what a future release branch inherits when its own entry is authored.

#### How did you verify/test it?

See the Test result section for the full list. In short: YAML parse, a simulation of the plugin's `find_all_matches` longest-prefix mark resolution against the edited file for both physical and VS fact sets, confirmation that the referenced closed issue already evaluated to `False`, and confirmation that the product fix commits are contained in sonic-buildimage master's submodule pointers.

#### Any platform specific information?

On VS this re-enables `test_bgp_route_without_suppress` and `test_bgp_update_relay_latency`. The remaining tests stay skipped on VS because the forwarding plane is the Linux kernel FIB rather than the ASIC, so `verify_no_packet` assertions cannot hold there ([sonic-mgmt issue 14449](https://github.com/sonic-net/sonic-mgmt/issues/14449)), and because the bulk route relay-timing and stress cases are too slow on KVM.

The mellanox/nvidia xfail removal restores normal pass/fail reporting for those platforms. The condition was already inert, so this does not change which tests execute.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case. The module's existing `pytest.mark.topology('t1', 't2', 'lrh', 'urh')` is unchanged.

### Documentation

N/A — no user-facing behavior or feature change.

