### PR TITLE
[202512][process_monitoring]: Fix BGP recovery wait

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -31,13 +31,21 @@ CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_RESTART_THRESHOLD_SECS = 180
 POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 600
+# config_reload adds 120 seconds to these values for its BGP convergence check.
+CONFIG_RELOAD_WAIT_SECS = 120
+LT2_CONFIG_RELOAD_WAIT_SECS = 480
+
+
+def get_config_reload_wait(tbinfo):
+    return LT2_CONFIG_RELOAD_WAIT_SECS if tbinfo["topo"]["type"] == "lt2" else CONFIG_RELOAD_WAIT_SECS
 
 
 @pytest.fixture(autouse=True, scope='module')
-def config_reload_after_tests(duthosts, rand_one_dut_hostname):
+def config_reload_after_tests(duthosts, rand_one_dut_hostname, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     yield
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True,
+                  wait=get_config_reload_wait(tbinfo), wait_for_bgp=True)
 
 
 @pytest.fixture(autouse=True, scope='module')
@@ -548,7 +556,8 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
     yield
 
     logger.info("Executing the config reload...")
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True,
+                  wait=get_config_reload_wait(tbinfo), wait_for_bgp=True)
     logger.info("Executing the config reload was done!")
 
     ensure_all_critical_processes_running(duthost, containers_in_namespaces)


### PR DESCRIPTION
### Description of PR

Summary:
Backport #26933 to allow additional time for LT2 BGP neighbors to converge after configuration reload without changing the timeout for other topologies.

Fixes #26933

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] N/A

### Test result

- 202512: `SONiC.20251210.10` - `process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes` passed on `vms13-lt2-nh4210-1` (`1 passed, 1 deselected` in 14m35s).

### Approach
#### What is the motivation for this PR?

The process-monitoring test body passes, but cleanup can fail on LT2 testbeds because the default `config_reload` BGP convergence timeout expires before all neighbors recover.

#### How did you do it?

Added a topology-scoped helper that uses `wait=480` for LT2 and preserves `wait=120` for other topologies. Since `config_reload` adds 120 seconds to this value for its BGP check, LT2 receives up to 600 seconds for convergence while other topologies retain the existing 240-second window.

The cherry-pick conflict was resolved by retaining the `202512` recovery flow and applying only the timeout changes from #26933.

#### How did you verify/test it?

- `internal-202512`, `SONiC.20251210.10`: `process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes` passed on `vms13-lt2-nh4210-1` (`1 passed, 1 deselected` in 14m35s).
- `python3 -m py_compile tests/process_monitoring/test_critical_process_monitoring.py`
- `git diff --check`

#### Any platform specific information?

The failure was observed on the Nexthop NH-4210 LT2 testbed, where BGP convergence after config reload can exceed the generic timeout.

#### Supported testbed topology if it's a new test case?

Not applicable.

### Documentation

Not applicable.