### PR TITLE
[smartswitch]: Revalidate cached DPU NAT state

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -880,7 +880,12 @@ def extract_techsupport_tarball_file(duthost, tarball_name):
 
 
 def is_enabled_nat_for_dpu(duthost, request):
-    if request.config.cache.get(NAT_ENABLE_KEY.format(duthost.hostname), False):
+    cache_key = NAT_ENABLE_KEY.format(duthost.hostname)
+    if request.config.cache.get(cache_key, False):
+        if not is_nat_rule_present(duthost):
+            logger.warning("Cached NAT state is stale on %s; live DNAT rules are missing", duthost.hostname)
+            request.config.cache.set(cache_key, False)
+            return False
         logger.info("NAT is enabled")
         return True
     else:
@@ -915,11 +920,15 @@ def get_dpu_names_and_ssh_ports(duthost, dpuhost_names, ansible_adhoc):
     return dpu_name_ssh_port_dict
 
 
-def check_nat_is_enabled_and_set_cache(duthost, request):
+def is_nat_rule_present(duthost):
     get_nat_iptable_output = 'sudo iptables -t nat -L'
     nat_iptable_output = duthost.shell(get_nat_iptable_output)['stdout']
     pattern_nat_result = '.*DNAT.*tcp.*anywhere.*anywhere.*tcp dpt:.* to:169.254.200.*22.*'
-    if re.search(pattern_nat_result, nat_iptable_output):
+    return re.search(pattern_nat_result, nat_iptable_output) is not None
+
+
+def check_nat_is_enabled_and_set_cache(duthost, request):
+    if is_nat_rule_present(duthost):
         logger.info('NAT is enabled successfully')
         request.config.cache.set(NAT_ENABLE_KEY.format(duthost.hostname), True)
         return True

--- a/tests/common/unit_tests/helpers/unit_test_dut_utils.py
+++ b/tests/common/unit_tests/helpers/unit_test_dut_utils.py
@@ -1,0 +1,182 @@
+"""Unit tests for DPU NAT cache validation in dut_utils."""
+
+import contextlib
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "helpers" / "dut_utils.py"
+NAT_RULE = (
+    "DNAT tcp -- anywhere anywhere tcp dpt:5021 "
+    "to:169.254.200.1:22"
+)
+
+
+def _load_target_module():
+    allure_stub = types.ModuleType("allure")
+    allure_stub.step = lambda *args, **kwargs: contextlib.nullcontext()
+    allure_stub.attach = types.SimpleNamespace(file=mock.Mock())
+
+    pytest_stub = types.ModuleType("pytest")
+    pytest_stub.skip = mock.Mock()
+
+    tests_stub = types.ModuleType("tests")
+    tests_stub.__path__ = []
+    common_stub = types.ModuleType("tests.common")
+    common_stub.__path__ = []
+    helpers_stub = types.ModuleType("tests.common.helpers")
+    helpers_stub.__path__ = []
+    connections_stub = types.ModuleType("tests.common.connections")
+    connections_stub.__path__ = []
+
+    assertions_stub = types.ModuleType("tests.common.helpers.assertions")
+    assertions_stub.pytest_assert = mock.Mock()
+
+    utilities_stub = types.ModuleType("tests.common.utilities")
+    utilities_stub.get_host_visible_vars = mock.Mock()
+    utilities_stub.wait_until = mock.Mock()
+    utilities_stub.get_dut_current_passwd = mock.Mock()
+    utilities_stub.update_console_creds = mock.Mock()
+
+    errors_stub = types.ModuleType("tests.common.errors")
+    errors_stub.RunAnsibleModuleFail = type(
+        "RunAnsibleModuleFail", (Exception,), {}
+    )
+
+    console_host_stub = types.ModuleType(
+        "tests.common.connections.console_host"
+    )
+    console_host_stub.ConsoleHost = type("ConsoleHost", (), {})
+    console_host_stub.CONSOLE_LINECARD = "linecard"
+
+    linecard_stub = types.ModuleType(
+        "tests.common.connections.linecard_console_conn"
+    )
+    linecard_stub.UnsupportedPlatformError = type(
+        "UnsupportedPlatformError", (Exception,), {}
+    )
+
+    base_console_stub = types.ModuleType(
+        "tests.common.connections.base_console_conn"
+    )
+    base_console_stub.CONSOLE_SSH_CISCO_CONFIG = {}
+    base_console_stub.CONSOLE_SSH_DIGI_CONFIG = {}
+    base_console_stub.CONSOLE_SSH_SONIC_CONFIG = {}
+
+    mellanox_stub = types.ModuleType("tests.common.mellanox_data")
+    mellanox_stub.is_mellanox_device = mock.Mock()
+    mellanox_stub.is_issu_enabled = mock.Mock()
+
+    stubs = {
+        "allure": allure_stub,
+        "pytest": pytest_stub,
+        "tests": tests_stub,
+        "tests.common": common_stub,
+        "tests.common.helpers": helpers_stub,
+        "tests.common.helpers.assertions": assertions_stub,
+        "tests.common.utilities": utilities_stub,
+        "tests.common.errors": errors_stub,
+        "tests.common.connections": connections_stub,
+        "tests.common.connections.console_host": console_host_stub,
+        "tests.common.connections.linecard_console_conn": linecard_stub,
+        "tests.common.connections.base_console_conn": base_console_stub,
+        "tests.common.mellanox_data": mellanox_stub,
+    }
+
+    spec = importlib.util.spec_from_file_location(
+        "unit_target_dut_utils", MODULE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(sys.modules, stubs):
+        spec.loader.exec_module(module)
+    return module
+
+
+class TestDpuNatCacheValidation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.dut_utils = _load_target_module()
+
+    def setUp(self):
+        self.duthost = mock.Mock(hostname="npu-01")
+        self.cache = mock.Mock()
+        self.request = mock.Mock()
+        self.request.config.cache = self.cache
+
+    def test_cache_miss_does_not_probe_live_rules(self):
+        """Do not add an iptables probe when the cache already requests setup."""
+        self.cache.get.return_value = False
+
+        self.assertFalse(
+            self.dut_utils.is_enabled_nat_for_dpu(
+                self.duthost, self.request
+            )
+        )
+
+        self.duthost.shell.assert_not_called()
+
+    def test_cached_nat_is_accepted_when_live_rule_exists(self):
+        """Keep cached NAT state only when a matching live DNAT rule exists."""
+        self.cache.get.return_value = True
+        self.duthost.shell.return_value = {"stdout": NAT_RULE}
+
+        self.assertTrue(
+            self.dut_utils.is_enabled_nat_for_dpu(
+                self.duthost, self.request
+            )
+        )
+
+        self.duthost.shell.assert_called_once_with(
+            "sudo iptables -t nat -L"
+        )
+        self.cache.set.assert_not_called()
+
+    def test_stale_cache_is_cleared_when_live_rule_is_missing(self):
+        """Clear stale cached NAT state so the fixture re-enables forwarding."""
+        self.cache.get.return_value = True
+        self.duthost.shell.return_value = {"stdout": ""}
+
+        self.assertFalse(
+            self.dut_utils.is_enabled_nat_for_dpu(
+                self.duthost, self.request
+            )
+        )
+
+        self.cache.set.assert_called_once_with(
+            "nat_enabled_on_npu-01", False
+        )
+
+    def test_successful_nat_check_sets_cache(self):
+        """Cache NAT state after post-configuration verification succeeds."""
+        self.duthost.shell.return_value = {"stdout": NAT_RULE}
+
+        self.assertTrue(
+            self.dut_utils.check_nat_is_enabled_and_set_cache(
+                self.duthost, self.request
+            )
+        )
+
+        self.cache.set.assert_called_once_with(
+            "nat_enabled_on_npu-01", True
+        )
+
+    def test_failed_nat_check_does_not_set_cache(self):
+        """Reject and avoid caching a NAT configuration with no DNAT rule."""
+        self.duthost.shell.return_value = {"stdout": ""}
+
+        with self.assertRaisesRegex(
+            Exception, "NAT is not enabled successfully"
+        ):
+            self.dut_utils.check_nat_is_enabled_and_set_cache(
+                self.duthost, self.request
+            )
+
+        self.cache.set.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description of PR

Summary:
Revalidate cached SmartSwitch DPU NAT state against the live iptables rules. When a retained pytest cache entry is stale after an NPU reboot or iptables reset, clear it so the existing session fixture recreates DPU SSH forwarding instead of allowing unrelated tests to fail with unreachable DPU hosts.

Fixes #27130

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #27130
Failure type: other - stale framework state after NPU reboot

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: 5 DPU NAT cache unit tests passed; changed-file flake8 and pre-commit checks passed.
- 202605 non-regression: [plan 6a84380b5585d0b8ab0a7979](https://elastictest.org/scheduler/testplan/6a84380b5585d0b8ab0a7979) passed on `SONiC.20260510.11` (18 passed, 5 skipped, 0 failed), including two cold-reboot variants and the originally tracked auto-techsupport sanity test.
- 202605 stale-state recovery: [plan 6a84dbdb24f9645a147a495c](https://elastictest.org/scheduler/testplan/6a84dbdb24f9645a147a495c) passed on `SONiC.20260510.11`. The first pytest session removed the four DPU DNAT/SNAT rule pairs while retaining the `true` cache entry. The next session detected the missing live rule, cleared the stale cache, reran `sonic-dpu-mgmt-traffic.sh`, verified NAT, and passed the originally tracked test.

### Approach
#### What is the motivation for this PR?

The session-scoped DPU NAT fixture treated the persistent pytest cache as authoritative. NPU reboots or other iptables resets can remove the live DNAT rules, but later pytest sessions can retain `nat_enabled_on_<hostname> = true`, skip NAT setup, and fail every DPU connection before the affected test bodies execute.

This defect was identified while triaging a plan-wide SmartSwitch DPU connectivity failure where the cache reported NAT enabled immediately before all four DPU hosts became unreachable. The failed run did not capture the live iptables state, so this PR does not claim that missing rules were proven as the sole cause of that run.

#### How did you do it?

When the cache says NAT is enabled, query the live NAT table using the same rule signature already used after configuration. If the rule is missing, log the stale state, clear the cache entry, and return `False` so the existing fixture runs `sonic-dpu-mgmt-traffic.sh` and verifies the recreated rule.

The post-configuration check now reuses the same live-rule helper to keep both decisions consistent.

#### How did you verify/test it?

Added unit coverage for cache misses, valid cached state, stale cached state, successful post-configuration verification, and failed verification.

For 202605, first ran an ordered SmartSwitch non-regression suite containing cold-reboot coverage and the originally affected DPU-aware test.

A second controlled validation primes the persistent cache, removes only the live DPU NAT rules, and runs the affected test in a separate pytest session. This directly exercises stale-cache detection, NAT recreation, and restored DPU access.

#### Any platform specific information?

This affects SmartSwitch topologies where DPU SSH access is forwarded through NPU DNAT rules.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
