### PR TITLE
[copp] Skip IP-in-IP neighbor miss test when decap is disabled

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -184,6 +184,14 @@ class TestCOPP(object):
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
+        if packet_type == "VlanSubnetIPinIP":
+            ip_decap_status = duthost.shell(
+                "sonic-cfggen -d -v 'SYSTEM_DEFAULTS.ip_decap.status'",
+                module_ignore_errors=True
+            )["stdout"].strip()
+            if ip_decap_status == "disabled":
+                pytest.skip("IP-in-IP decapsulation is disabled on this DUT")
+
         # Access test_params from the class-level variable
         test_params = self.test_params
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip the CoPP  VlanSubnetIPinIP  neighbor-miss test when IP-in-IP decapsulation is explicitly disabled through  SYSTEM_DEFAULTS.ip_decap.status .

The plain  VlanSubnet  neighbor-miss cases continue to run, preserving coverage on platforms that support neighbor-miss policing without IP-in-IP decapsulation.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
Some platforms intentionally disable IP-in-IP decapsulation. For example, NVIDIA/Mellanox non-storage backend devices set:

SYSTEM_DEFAULTS|ip_decap status=disabled

On these devices, no IP-in-IP tunnel is created. The test packet is therefore processed using its outer loopback destination and trapped as  ip2me , rather than being decapsulated and trapped as  neighbor_miss .

This caused  VlanSubnetIPinIP  to expect the 200-PPS neighbor-miss policer while observing approximately 600 PPS from the test-configured  ip2me  policer. The resulting failure did not indicate a CoPP defect because IP-in-IP decapsulation is unsupported by design.

#### How did you do it?
Before running a  VlanSubnetIPinIP  test, query the system default with:

sonic-cfggen -d -v 'SYSTEM_DEFAULTS.ip_decap.status'

If the returned status is  disabled , skip that parameterized test case.

The check is limited to  VlanSubnetIPinIP . Plain  VlanSubnet  cases still validate the  neighbor_miss  trap and policer. Images that do not define this system default also continue running the test, maintaining backward compatibility.

#### How did you verify/test it?
Validated the original failure on an NVIDIA SN5640 non-storage backend DUT:

DEVICE_METADATA.type: BackEndToRRouter
storage_device: absent
SYSTEM_DEFAULTS.ip_decap.status: disabled
IP-in-IP configuration: []
APPL_DB IP-in-IP tunnel entries: absent

Before the change:

IPv4 VlanSubnetIPinIP: 590 PPS, expected 180–260 PPS
IPv6 VlanSubnetIPinIP: 604 PPS, expected 180–260 PPS

The approximately 600-PPS result confirms that the non-decapsulated packet was handled by the test-configured  ip2me  policer instead of the 200-PPS  neighbor_miss  policer.

Targeted runtime verification:

copp/test_copp.py::TestCOPP::test_trap_neighbor_miss

Expected results:

• IPv4  VlanSubnet : pass
• IPv6  VlanSubnet : pass
• IPv4  VlanSubnetIPinIP : skip when  ip_decap  is disabled
• IPv6  VlanSubnetIPinIP : skip when  ip_decap  is disabled

<img width="1384" height="1016" alt="image" src="https://github.com/user-attachments/assets/cf4005f4-c29d-449c-88c2-3e4f9de106e2" />

<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
The issue was reproduced on:

Platform: x86_64-nvidia_sn5640-r0
HwSKU: Mellanox-SN5640-C512S2
ASIC: NVIDIA/Mellanox SPC5
Device type: BackEndToRRouter
Storage device: false/absent

IP-in-IP decapsulation is intentionally disabled for NVIDIA/Mellanox non-storage backend devices. The change is capability-based rather than hard-coding a platform or HwSKU, so it also applies correctly to any other DUT that explicitly reports  SYSTEM_DEFAULTS.ip_decap.status=disabled.

#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
