### PR TITLE
[ci]: Restrict t0-vpp PR checks to master

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -527,7 +527,7 @@ jobs:
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       RUN_BY_INCLUDE_JOBS: ${{ or(eq(parameters.INCLUDE_JOBS, 'all'), contains(parameters.INCLUDE_JOBS, 't0_vpp_job')) }}
-    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-vpp_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
+    condition: and(not(canceled()), succeeded(), eq(variables['BUILD_BRANCH'], 'master'), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-vpp_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: ${{ parameters.RUN_TEST_AGENT_POOL }}


### PR DESCRIPTION
### Description of PR

Summary:
- Restrict the impacted-area `t0-vpp` PR test job to the `master` branch.
- Prevent release-branch sonic-buildimage PRs from scheduling this master-only checker when they consume the sonic-mgmt template from `master`.

Fixes # (issue) N/A

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: Regression

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: Static validation confirmed that the `t0_vpp_elastictest` job contains exactly one `BUILD_BRANCH == master` predicate. `git diff --check` passed.

### Approach
#### What is the motivation for this PR?

The sonic-buildimage pipeline imports the sonic-mgmt PR test template from `master`, including for release-branch PRs. The `t0-vpp` job added by #27024 had no branch condition, so `202605` sonic-buildimage PRs could schedule a checker that was intended and validated only for `master`.

#### How did you do it?

Added a `BUILD_BRANCH == master` predicate to the existing `t0_vpp_elastictest` job condition. No checker selection, test allowlist, or other VPP job behavior was changed.

#### How did you verify/test it?

Validated that the predicate appears exactly once within the `t0_vpp_elastictest` job and ran `git diff --check`.

#### Any platform specific information?

This change affects only the `t0-vpp` impacted-area PR checker.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
