### PR TITLE
[dualtor] Add route scale properties to 32-port topologies

### DIFF
--- a/ansible/vars/topo_dualtor-aa.yml
+++ b/ansible/vars/topo_dualtor-aa.yml
@@ -175,6 +175,9 @@ configuration_properties:
     swrole: leaf
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
 
 configuration:
   ARISTA01T1:

--- a/ansible/vars/topo_dualtor.yml
+++ b/ansible/vars/topo_dualtor.yml
@@ -150,6 +150,9 @@ configuration_properties:
     swrole: leaf
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
 
 configuration:
   ARISTA01T1:


### PR DESCRIPTION
### Description of PR

Summary:
Add the missing route-scale properties to the 32-port active-standby and active-active dual-ToR topologies. The 56-port and 64-port variants already define podset_number, tor_number, and tor_subnet_number, but topo_dualtor.yml and topo_dualtor-aa.yml do not. `tests/bgp/test_bgp_vnet.py` requires these properties and accesses them directly when calculating `route_count`, so the 32-port topologies fail with `KeyError` before test execution can proceed.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: day-one issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: `tests/bgp/test_bgp_vnet.py::test_dynamic_peer_vnet` passed on `dualtor-aa` testbed `tor-dualtor3`, platform `Cisco-8101-32FH-O-C01`, image `HEAD.46458-dirty-20260731.205654` (1229.720 seconds). Evidence: pytest XML and log from the 202605 rerun.

### Approach

#### What is the motivation for this PR?

Keep the 32-port active-standby and active-active dual-ToR topologies consistent with the 56-port and 64-port variants and prevent KeyError failures

`Failed: Vnet testing setup failed: KeyError('podset_number')
`
 in bgp/test_bgp_vnet.py test

#### How did you do it?

Added podset_number, tor_number, and tor_subnet_number to configuration_properties.common in topo_dualtor.yml and topo_dualtor-aa.yml, using the same values as the 56-port and 64-port variants.

#### How did you verify/test it?

Validated that the YAML parses successfully and that all three properties resolve to the expected integer values. On the 202605 image, `test_dynamic_peer_vnet` was rerun on the modified `dualtor-aa` topology and passed in 1229.720 seconds; the pytest XML and log were reviewed.

#### Any platform specific information?

The failure was observed on a 32-port active-active dual-ToR testbed; the active-standby topology had the same configuration gap.

#### Supported testbed topology if it is a new test case?

N/A

### Documentation

N/A