### PR TITLE
[tests/bgp] Set VNET VXLAN ttl_mode=pipe for Cisco-8000 platforms

### DIFF
--- a/tests/bgp/templates/vnet_config_db.j2
+++ b/tests/bgp/templates/vnet_config_db.j2
@@ -121,7 +121,8 @@
     },
     "VXLAN_TUNNEL": {
         "vtep_v4": {
-            "src_ip": "10.1.0.32"
+            "src_ip": "10.1.0.32"{% if asic_type == 'cisco-8000' %},
+            "ttl_mode": "pipe"{% endif %}
         }
     }
 }

--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -94,7 +94,8 @@ def setup_vnet_cfg(duthost, localhost, cfg_facts):
                   'Vlan2000': ports[len(ports)//2:]}
 
     extra_vars = {'cfg_t0': cfg_t0,
-                  'vlan_ports': vlan_ports}
+                  'vlan_ports': vlan_ports,
+                  'asic_type': duthost.facts.get('asic_type')}
 
     duthost.host.options['variable_manager'].extra_vars.update(extra_vars)
 


### PR DESCRIPTION
### Description of PR

Summary:
This PR follows the same approach as [sonic-net/sonic-mgmt#26084](https://github.com/sonic-net/sonic-mgmt/pull/26084), applying the Cisco-8000 VXLAN `ttl_mode: pipe` handling to the BGP VNET setup.
The BGP VNET setup creates a VXLAN tunnel without an explicit decapsulation TTL mode. On dual-ToR platforms, the base IP-in-IP MUX tunnel uses pipe TTL mode. Leaving the VXLAN mode implicit can produce a TTL-mode mismatch and prevent `MuxTunnel0` creation.

This change passes the DUT ASIC type to `vnet_config_db.j2` and sets `ttl_mode: pipe` for the VNET VXLAN tunnel only on Cisco-8000. This matches the platform-specific handling already used by the other VXLAN tests.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: The affected BGP VNET cases passed on a Cisco 8101-32FH dualtor-aa testbed. 

### Approach

#### What is the motivation for this PR?

Keep VXLAN and IP-in-IP tunnel decapsulation TTL modes consistent on Cisco-8000 so the BGP VNET setup does not leave the dual-ToR MUX state unprogrammed.

#### How did you do it?

Added `asic_type` to the template variables and conditionally rendered `ttl_mode: pipe` in the VNET VXLAN tunnel configuration for Cisco-8000 only.

#### How did you verify/test it?

- The affected BGP VNET cases passed on the Cisco-8000 dualtor-aa testbed.
- `python3 -m py_compile tests/bgp/test_bgp_vnet.py`
- `git diff --check`

#### Any platform specific information?

The conditional change applies only when `asic_type` is `cisco-8000`; other platforms keep the existing configuration.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
