### PR TITLE
Fix smartswitch DPU reboot cause log analysis

### DIFF
--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -460,6 +460,7 @@ def test_cold_reboot_switch(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname
                          pre_boot_times=pre_boot_times)
 
 
+@pytest.mark.disable_loganalyzer
 def test_reboot_cause(duthosts, dpuhosts,
                       enum_rand_one_per_hwsku_hostname,
                       platform_api_conn, num_dpu_modules):    # noqa: F811


### PR DESCRIPTION
### Description of PR

Summary:
Disable loganalyzer for smartswitch DPU `test_reboot_cause` because the test intentionally shuts down and starts DPUs. During the reboot window the DPUs can emit transient syslog errors (for example redis database config and feature stop messages), causing teardown loganalyzer to fail the test even when the test action is expected.

ADO: https://dev.azure.com/msazure/One/_workitems/edit/39326134

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/39326134
Failure type: regression / test issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Ran pre-commit on the changed file:
`python -m pre_commit run --files tests/smartswitch/platform_tests/test_reload_dpu.py`

Result: all applicable hooks passed (trailing whitespace, EOF fixer, large file check, python AST, flake8).

### Approach
#### What is the motivation for this PR?

Nightly PBI 39326134 shows `test_reboot_cause` failing in teardown because loganalyzer matched DPU syslog emitted while DPUs were being stopped/started. Other disruptive DPU reload tests in this file already disable loganalyzer for the same reason.

#### How did you do it?

Added `@pytest.mark.disable_loganalyzer` to `test_reboot_cause`.

#### How did you verify/test it?

Ran pre-commit on the changed file successfully.

#### Any platform specific information?

Observed on Mellanox-SN4280-O28 smartswitch DPU topology.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
