### PR TITLE
Accept bcmcmd timeout option without space

### DIFF
--- a/tests/show_techsupport/tech_support_cmds.py
+++ b/tests/show_techsupport/tech_support_cmds.py
@@ -250,8 +250,8 @@ copy_config_cmds_no_qos = [
 ]
 
 broadcom_cmd_bcmcmd_xgs = [
-    'bcmcmd{} -t 5 version',
-    'bcmcmd{} -t 5 ps',
+    re.compile(r'bcmcmd{} -t\s?5 version'),
+    re.compile(r'bcmcmd{} -t\s?5 ps'),
     'bcmcmd{} "ipmc table show"',
     'bcmcmd{} "multicast show"',
     'bcmcmd{} "fp show"',
@@ -267,7 +267,7 @@ broadcom_cmd_bcmcmd_xgs = [
 ]
 
 broadcom_cmd_bcmcmd_xgs_soc = [
-    'bcmcmd{} -t 5 soc',
+    re.compile(r'bcmcmd{} -t\s?5 soc'),
     'bcmcmd{} "conf show"',
     'bcmcmd{} "l3 defip show"',
     'bcmcmd{} "l3 l3table show"',


### PR DESCRIPTION
### Description of PR
Fix `test_techsupport_commands` to accept both `bcmcmd -t 5 ...` and `bcmcmd -t5 ...` timeout option formatting in `generate_dump --noop` output.

Nightly 202511 image on Arista-7060CX-32S-C32 emits `bcmcmd -t5 version/ps/soc`, while the test expected only `bcmcmd -t 5 ...`. Both forms are equivalent for bcmcmd, so the command-list check should not fail only because of the spacing.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
Nightly PBI 39326156 fails with: `Commands not found for 'broadcom_cmd_bcmcmd': bcmcmd -t 5 version; bcmcmd -t 5 ps; bcmcmd -t 5 soc` because `generate_dump -n` outputs the equivalent compact form `-t5`.

#### How did you do it?
Changed the affected expected commands to regex patterns that match either `-t 5` or `-t5`.

#### How did you verify/test it?
Ran a local Python validation that imports `tech_support_cmds.py` and confirms the new regexes match both spaced and compact bcmcmd timeout-option forms.

#### Any platform specific information?
Observed on Arista-7060CX-32S-C32, t0 topology, 20251110 branch.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A