### PR TITLE
[Dualtor] Fix the skip condition of advanced reboot test for dualtor

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1332,11 +1332,11 @@ platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
 #######################################
 platform_tests/test_advanced_reboot.py:
   skip:
-    reason: "Unsupported platform / Skip in PR testing as taking too much time. / Warm reboot is not required for 202412 and this test is not run on this topology currently"
+    reason: "Unsupported platform / Skip in PR testing as taking too much time. / Advanced reboot is not supported on dualtor topology."
     conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-arista_7050_qx32s']"
-      - "'dualtor' in topo_name and release in ['202012']"
+      - "'dualtor' in topo_name"
       - "asic_type in ['vs']"
       - "'isolated' in topo_name"
       - "'f2' in topo_name"


### PR DESCRIPTION
### Description of PR

Summary:
Advanced reboot test(warm and fast reboot) is not supported on dualtor.
The test is skipped only in 202012 branch but actually it should be skipped in all branches for now.
We already have other similar skips, for example:
https://github.com/sonic-net/sonic-mgmt/blob/bf17d3da22330319602fcc8f1c5b8570b99f19b6/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml#L4932-L4946

https://github.com/sonic-net/sonic-mgmt/blob/bf17d3da22330319602fcc8f1c5b8570b99f19b6/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml#L4994-L5012


### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
Test is skipped on dualtor-aa-64-breakout topo.

### Approach
#### What is the motivation for this PR?
Fix the skip condition of advanced reboot test for dualtor
#### How did you do it?
Remove the release condition in the original skip.
#### How did you verify/test it?
Run the advanced reboot test on dualtor-aa-64-breakout topo.

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A