### PR TITLE
ci: replace 'python' with 'python3' in impacted-area pipeline scripts

### DIFF
--- a/.azure-pipelines/cancel-previous-elastictest-testplan.yml
+++ b/.azure-pipelines/cancel-previous-elastictest-testplan.yml
@@ -82,7 +82,7 @@ steps:
       # Enable verbose debugging output for the creation call in test_plan.py
       set -x
 
-      python ./.azure-pipelines/test_plan.py cancel_pr
+      python3 ./.azure-pipelines/test_plan.py cancel_pr
 
       echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
 

--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -73,7 +73,7 @@ steps:
 
     sudo uv pip install --system azure-kusto-data azure-identity
 
-    INSTANCE_NUMBER=$(python ./.azure-pipelines/impacted_area_testing/calculate_instance_number.py --scripts $(SCRIPTS) --topology ${{ parameters.TOPOLOGY }} --branch ${{ parameters.BUILD_BRANCH }} --prepare_time ${{ parameters.PREPARE_TIME }} --target_pr_test_time $(TARGET_PR_TEST_TIME))
+    INSTANCE_NUMBER=$(python3 ./.azure-pipelines/impacted_area_testing/calculate_instance_number.py --scripts $(SCRIPTS) --topology ${{ parameters.TOPOLOGY }} --branch ${{ parameters.BUILD_BRANCH }} --prepare_time ${{ parameters.PREPARE_TIME }} --target_pr_test_time $(TARGET_PR_TEST_TIME))
 
     if [[ $? -ne 0 ]]; then
       echo "##vso[task.complete result=Failed;]Get instances number fails."

--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -112,7 +112,7 @@ steps:
     while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
       echo "Attempt $((RETRY_COUNT + 1)): Generating test scripts..."
 
-      TEST_SCRIPTS=$(python ./.azure-pipelines/impacted_area_testing/get_test_scripts.py --features ${FINAL_FEATURES} --location tests)
+      TEST_SCRIPTS=$(python3 ./.azure-pipelines/impacted_area_testing/get_test_scripts.py --features ${FINAL_FEATURES} --location tests)
 
       if [[ $? -ne 0 ]]; then
         echo "Get test scripts command failed on attempt $((RETRY_COUNT + 1))"

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -285,7 +285,7 @@ steps:
       # Enable verbose debugging output for the creation call in test_plan.py
       set -x
 
-      python ./.azure-pipelines/test_plan.py create \
+      python3 ./.azure-pipelines/test_plan.py create \
       -t ${{ parameters.TOPOLOGY }} \
       -o new_test_plan_id.txt \
       --min-worker ${{ parameters.MIN_WORKER }} \
@@ -371,7 +371,7 @@ steps:
           echo -e "\033[33mfor detailed test plan progress \033[0m"
           # When "LOCK_TESTBED" finish, it changes into "PREPARE_TESTBED"
           echo "[test_plan.py] poll LOCK_TESTBED status"
-          python ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state LOCK_TESTBED
+          python3 ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state LOCK_TESTBED
           RET=$?
           if [ $RET -ne 0 ]; then
               ((failure_count++))
@@ -405,7 +405,7 @@ steps:
           echo -e "\033[33mfor detailed test plan progress \033[0m"
           # When "PREPARE_TESTBED" finish, it changes into "EXECUTING"
           echo "[test_plan.py] poll PREPARE_TESTBED status"
-          python ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state PREPARE_TESTBED
+          python3 ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state PREPARE_TESTBED
           RET=$?
           if [ $RET -ne 0 ]; then
               ((failure_count++))
@@ -438,7 +438,7 @@ steps:
           echo -e "\033[33mfor detailed test plan progress \033[0m"
           # When "EXECUTING" finish, it changes into "KVMDUMP", "FAILED", "CANCELLED" or "FINISHED"
           echo "[test_plan.py] poll EXECUTING status"
-          python ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state EXECUTING --expected-result ${{ parameters.EXPECTED_RESULT }}
+          python3 ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state EXECUTING --expected-result ${{ parameters.EXPECTED_RESULT }}
           RET=$?
           if [ $RET -ne 0 ]; then
               ((failure_count++))
@@ -462,7 +462,7 @@ steps:
       IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
       for TEST_PLAN_ID in "${TEST_PLAN_ID_LIST[@]}"
       do
-          python ./.azure-pipelines/test_plan.py cancel -i $TEST_PLAN_ID
+          python3 ./.azure-pipelines/test_plan.py cancel -i $TEST_PLAN_ID
       done
     condition: always()
     displayName: "Finalize Running Test Plan"


### PR DESCRIPTION
**What:** Replace `python` with `python3` in two impacted-area pipeline scripts.

**Why:** AZP agent pools (including `sonic-ubuntu-1c`) only ship `python3`; there is no `python` symlink. Any PR whose changed files map to a feature path routed through these scripts hits:
```
python: command not found
```
causing `Test Get impacted area` to fail with exit code 1. The issue was observed on PRs touching `tests/process_monitoring/` (maps to the `autorestart` feature).

**Files changed:**
- `.azure-pipelines/impacted_area_testing/get-impacted-area.yml:115` — `get_test_scripts.py` invocation
- `.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml:76` — `calculate_instance_number.py` invocation

**How to verify:** After merging, PRs touching `tests/autorestart/` or `tests/process_monitoring/` should pass `Test Get impacted area` without `python: command not found` errors.
