### PR TITLE
Revert "[conditional_mark][bgp] Skip test_traffic_shift_lc on non-chassis platforms"

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -769,12 +769,6 @@ bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away:
       - "asic_type in ['vs']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6471
 
-bgp/test_traffic_shift_lc.py:
-  skip:
-    reason: "test_traffic_shift_lc is only applicable to modular chassis platforms"
-    conditions:
-      - "is_chassis==False"
-
 bgp/test_traffic_shift_sup.py:
   skip:
     reason: "Not supported on T2 single node topology"


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#25235

This is the only file that tests TSA/TSB on UT2 platform today. Removing skip