### PR TITLE
Fix repairing duthost missing args.

### DIFF
--- a/tests/ha/test_ha_repairing_dpu.py
+++ b/tests/ha/test_ha_repairing_dpu.py
@@ -17,6 +17,7 @@ from ha_packets import outbound_pl_packets
 from tests.common.devices.duthosts import DutHosts
 from tests.common.dash_utils import apply_swssconfig_file
 from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.smartswitch_util import get_data_port_on_dpu, get_dpu_dataplane_port
 from tests.common.utilities import InterruptableThread
 from tests.conftest import get_specified_dpus, get_target_hostname, is_parallel_leader
 from tests.ha.conftest import apply_dash_pl_pipeline_config
@@ -115,6 +116,32 @@ def _select_replacement_dpuhost(requested_dpuhosts, duthost_to_replace):
     )
 
 
+def _correlate_repair_dpuhosts(duthost, dpuhosts):
+    """Populate dpu_index/dpu_dataplane_port/... on each dpuhost, matching the
+    session-scoped correlate_dpu_info_with_dpuhost fixture. This module overrides
+    the `dpuhosts` fixture and so bypasses that autouse enrichment."""
+    npu_ip_intf_facts = duthost.show_ip_interface()['ansible_facts']['ip_interfaces']
+    npu_lldp_info = duthost.show_and_parse("show lldp table")
+    for dpuhost in dpuhosts:
+        dpu_ip_intf_facts = dpuhost.show_ip_interface()['ansible_facts']['ip_interfaces']
+        dpuhost_ip = dpu_ip_intf_facts['eth0-midplane']['ipv4']
+        dpuhost.dpu_index = int(dpuhost_ip.split(".")[-1]) - 1
+        dpuhost.dpu_mgmt_ip = dpuhost_ip
+
+        data_port_on_npu = get_dpu_dataplane_port(duthost, dpuhost.dpu_index)
+        data_port_on_dpu = get_data_port_on_dpu(npu_lldp_info, data_port_on_npu)
+        dpuhost.npu_data_port_ip = npu_ip_intf_facts[data_port_on_npu]['ipv4'] \
+            if data_port_on_npu in npu_ip_intf_facts else ''
+        dpuhost.dpu_data_port_ip = dpu_ip_intf_facts[data_port_on_dpu]['ipv4'] \
+            if data_port_on_dpu in dpu_ip_intf_facts else ''
+        dpuhost.npu_dataplane_port = data_port_on_npu
+        dpuhost.dpu_dataplane_port = data_port_on_dpu
+        dpuhost.npu_dataplane_mac = duthost.get_dut_iface_mac(data_port_on_npu)
+        dpuhost.dpu_dataplane_mac = dpuhost.get_dut_iface_mac(data_port_on_dpu)
+        dpuhost.dataplane_mask_length = 31
+        dpuhost.name = f"dpu{dpuhost.dpu_index}"
+
+
 @pytest.fixture(scope="session")
 def dpuhosts(
     enhance_inventory,
@@ -123,6 +150,7 @@ def dpuhosts(
     request,
     enable_nat_for_dpuhosts,
     duthosts,
+    duthost,
 ):
     """Return all requested DPU hosts in CLI order for the repair test module."""
     del enhance_inventory, enable_nat_for_dpuhosts
@@ -148,6 +176,7 @@ def dpuhosts(
         _dpuhost_matches_duthost(requested_dpuhosts[1], duthosts[1]),
         "The second requested DPU host must belong to {}".format(duthosts[1].hostname),
     )
+    _correlate_repair_dpuhosts(duthost, requested_dpuhosts)
     return requested_dpuhosts
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

test_ha_repairing_dpu is missing the dpu_dataplane_port attribute for its dpu hosts:
AttributeError: '<class 'tests.common.devices.sonic.SonicHost'>' object has no attribute 'dpu_dataplane_port'.

The repairing module defines its own session‑scoped dpuhosts fixture (it needs 3–4 requested DPU hosts: the HA pair plus replacement candidates), built from a fresh DutHosts(...). Those host objects never pass through the session‑scoped, autouse correlate_dpu_info_with_dpuhost fixture (which had already run once against the conftest dpuhosts), so the dynamically‑set attributes dpu_index, dpu_dataplane_port, dpu_data_port_ip, dpu_dataplane_mac and their NPU counterparts are never populated. The shared dash_pl_config fixture reads dpuhost.dpu_dataplane_port (and the test itself reads replacement_dpuhost.dpu_index via _replacement_vdpu_id), which raises the AttributeError.

This adds a local _correlate_repair_dpuhosts() that performs the same enrichment on the override's requested DPU hosts, reusing the existing get_dpu_dataplane_port / get_data_port_on_dpu helpers, and calls it from the dpuhosts override. 

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
test_ha_repairing_dpu is missing the dpu_dataplane_port attribute for its dpu hosts, causing the testcase to error out.

#### How did you do it?
The repairing module overrides the session‑scoped dpuhosts fixture to return its own requested DPU hosts (HA pair + replacement candidates). Because that override creates fresh objects, they never receive the attributes set by the session/autouse correlate_dpu_info_with_dpuhost fixture, which had already executed against the conftest dpuhosts. Downstream consumers (dash_pl_config, _replacement_vdpu_id) then read dpu_dataplane_port / dpu_index and fail.

The fix adds a module‑local _correlate_repair_dpuhosts(duthost, dpuhosts) that populates dpu_index, dpu_mgmt_ip, npu/dpu_dataplane_port, npu/dpu_data_port_ip, npu/dpu_dataplane_mac, dataplane_mask_length and name on every requested DPU host — identical to what the shared fixture sets — reusing the existing get_dpu_dataplane_port / get_data_port_on_dpu helpers. It is invoked from the dpuhosts override, which now also takes the duthost fixture as the correlation source (mirroring the shared fixture). 

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran on Smartswitch HA testbed with 202605 images:
```
- generated xml file: /data/sonic-mgmt/tests/logs/ha/test_ha_repairing_dpu.xml -
---------------------------- live log sessionfinish ----------------------------
19/08/2026 16:34:14 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
INFO:root:[Parallel Fixture] Terminating parallel fixture manager
INFO:root:Can not get Allure report URL. Please check logs
================ 2 passed, 1351 warnings in 1660.07s (0:27:40) =================
```

#### Any platform specific information?
Requires 3–4 requested DPU hosts (the HA pair plus one or two replacement DPU candidates), per the existing pytest_require checks in the fixture.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
