### PR TITLE
Refactor pinned bfd cases to match testplan.

### DIFF
--- a/tests/ha/ha_utils.py
+++ b/tests/ha/ha_utils.py
@@ -451,7 +451,13 @@ def wait_for_ha_scope_pmon_state(duthost, scope_key, expected_state,
     return success, last_state
 
 
-def bfd_pin_primary(localhost, ptfhost, duthosts):
+def set_vdpu_bfd_probe_states(localhost, ptfhost, duthosts, states):
+    """Set DASH_HA_SET_CONFIG_TABLE.pinned_vdpu_bfd_probe_states on both NPUs.
+
+    ``states`` is a two-element list, one entry per vDPU (index 0 = DPU1,
+    index 1 = DPU2), each "down" | "up" | "none". "none" removes the pin so the
+    probe reflects the real BFD session state.
+    """
     current_dir = os.path.dirname(os.path.abspath(__file__))
     base_dir = os.path.join(current_dir, "..", "common", "ha")
     ha_set_file = os.path.join(base_dir, "dash_ha_set_config_table.json")
@@ -460,10 +466,7 @@ def bfd_pin_primary(localhost, ptfhost, duthosts):
 
     for duthost in duthosts:
         for key, fields in ha_set_data.items():
-            if "pinned_vdpu_bfd_probe_states" not in fields:
-                fields["pinned_vdpu_bfd_probe_states"] = ["down", "up"]
-            else:
-                fields.update({"pinned_vdpu_bfd_probe_states": ["down", "up"]})
+            fields["pinned_vdpu_bfd_probe_states"] = list(states)
             ha_set_messages = ha_set_config(ha_set_id=key, **fields)
             apply_ha_messages(
                 localhost=localhost,
@@ -473,70 +476,53 @@ def bfd_pin_primary(localhost, ptfhost, duthosts):
             )
 
 
-def bfd_unpin_primary(localhost, ptfhost, duthosts):
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    base_dir = os.path.join(current_dir, "..", "common", "ha")
-    ha_set_file = os.path.join(base_dir, "dash_ha_set_config_table.json")
-    with open(ha_set_file) as f:
-        ha_set_data = json.load(f)["DASH_HA_SET_CONFIG_TABLE"]
-
-    for duthost in duthosts:
-        for key, fields in ha_set_data.items():
-            if "pinned_vdpu_bfd_probe_states" in fields:
-                fields["pinned_vdpu_bfd_probe_states"] = ["up", "up"]
-            else:
-                fields.update({"pinned_vdpu_bfd_probe_states": ["up", "up"]})
-            ha_set_messages = ha_set_config(ha_set_id=key, **fields)
-            apply_ha_messages(
-                localhost=localhost,
-                duthost=duthost,
-                ptfhost=ptfhost,
-                messages=ha_set_messages,
-            )
+def _dpu_multihop_bfd_peers(dpuhost):
+    """Return [(peer, local_addr), ...] for multihop BFD peers in FRR on the DPU."""
+    out = dpuhost.shell('vtysh -c "show bfd peers json"')["stdout"]
+    peers = []
+    for sess in json.loads(out):
+        if sess.get("multihop") and sess.get("peer") and sess.get("local"):
+            peers.append((sess["peer"], sess["local"]))
+    return peers
 
 
-def bfd_pin_both_sides(localhost, ptfhost, duthosts):
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    base_dir = os.path.join(current_dir, "..", "common", "ha")
-    ha_set_file = os.path.join(base_dir, "dash_ha_set_config_table.json")
-    with open(ha_set_file) as f:
-        ha_set_data = json.load(f)["DASH_HA_SET_CONFIG_TABLE"]
+def set_dpu_bfd_admin_down(dpuhost, shutdown):
+    """Admin-shut (or restore) every multihop BFD peer in FRR on ``dpuhost`` to
+    force its software BFD probe DOWN/UP.
 
-    for duthost in duthosts:
-        for key, fields in ha_set_data.items():
-            if "pinned_vdpu_bfd_probe_states" not in fields:
-                fields["pinned_vdpu_bfd_probe_states"] = ["down", "down"]
-            else:
-                fields.update({"pinned_vdpu_bfd_probe_states": ["down", "down"]})
-            ha_set_messages = ha_set_config(ha_set_id=key, **fields)
-            apply_ha_messages(
-                localhost=localhost,
-                duthost=duthost,
-                ptfhost=ptfhost,
-                messages=ha_set_messages,
-            )
+    This is out-of-band from hamgrd; bgpcfgd's BfdMgr dedupes on unchanged fields,
+    so a hamgrd re-write of the session table will not revert the shutdown.
+    """
+    peers = _dpu_multihop_bfd_peers(dpuhost)
+    if not peers:
+        return
+    cmds = ["configure terminal", "bfd"]
+    for peer, local in peers:
+        cmds.append(f"peer {peer} multihop local-address {local}")
+        cmds.append("shutdown" if shutdown else "no shutdown")
+        cmds.append("exit")
+    cmds.append("end")
+    dpuhost.shell("vtysh " + " ".join('-c "{}"'.format(c) for c in cmds))
 
 
-def bfd_unpin_both_sides(localhost, ptfhost, duthosts):
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    base_dir = os.path.join(current_dir, "..", "common", "ha")
-    ha_set_file = os.path.join(base_dir, "dash_ha_set_config_table.json")
-    with open(ha_set_file) as f:
-        ha_set_data = json.load(f)["DASH_HA_SET_CONFIG_TABLE"]
+def wait_dpu_bfd_peers_down(dpuhost, timeout=60, interval=5):
+    """Wait until no multihop BFD peer on ``dpuhost`` reports status 'up'."""
+    def _check():
+        out = dpuhost.shell('vtysh -c "show bfd peers json"')["stdout"]
+        return all(
+            not sess.get("multihop") or sess.get("status") != "up"
+            for sess in json.loads(out)
+        )
+    return wait_until(timeout, interval, 0, _check)
 
-    for duthost in duthosts:
-        for key, fields in ha_set_data.items():
-            if "pinned_vdpu_bfd_probe_states" in fields:
-                fields["pinned_vdpu_bfd_probe_states"] = ["up", "up"]
-            else:
-                fields.update({"pinned_vdpu_bfd_probe_states": ["up", "up"]})
-            ha_set_messages = ha_set_config(ha_set_id=key, **fields)
-            apply_ha_messages(
-                localhost=localhost,
-                duthost=duthost,
-                ptfhost=ptfhost,
-                messages=ha_set_messages,
-            )
+
+def wait_dpu_bfd_peers_up(dpuhost, timeout=120, interval=5):
+    """Wait until every multihop BFD peer on ``dpuhost`` reports status 'up'."""
+    def _check():
+        out = dpuhost.shell('vtysh -c "show bfd peers json"')["stdout"]
+        sessions = [s for s in json.loads(out) if s.get("multihop")]
+        return bool(sessions) and all(s.get("status") == "up" for s in sessions)
+    return wait_until(timeout, interval, 0, _check)
 
 
 def program_eni_pl_on_dpu(localhost, ptfhost, duthost, dpuhost):

--- a/tests/ha/test_ha_bfd_pin.py
+++ b/tests/ha/test_ha_bfd_pin.py
@@ -3,8 +3,6 @@ import logging
 import ptf.testutils as testutils
 import pytest
 import time
-import threading
-import queue
 from constants import (
     LOCAL_PTF_INTF,
     REMOTE_PTF_RECV_INTF
@@ -12,12 +10,12 @@ from constants import (
 from ha_packets import outbound_pl_packets, bootstrap_pl_tcp_flow_outbound
 from tests.ha.conftest import apply_dash_pl_pipeline_config
 from tests.common.helpers.assertions import pytest_assert
-from ha_dash_flow_utils import compare_flow_tables
 from ha_utils import (
-    bfd_pin_primary,
-    bfd_unpin_primary,
-    bfd_pin_both_sides,
-    bfd_unpin_both_sides,
+    set_vdpu_bfd_probe_states,
+    set_dpu_bfd_admin_down,
+    wait_dpu_bfd_peers_down,
+    wait_dpu_bfd_peers_up,
+    verify_ha_state,
     parallel_config_reload_dpuhosts,
 )
 
@@ -28,7 +26,18 @@ pytestmark = [
     pytest.mark.skip_check_dut_health
 ]
 
-TRAFFIC_LOSS_THRESHOLD_PERCENTAGE = 1.0
+ENCAP_PROTO = "vxlan"
+RATE_PPS = 20
+SEND_COUNT = 100
+# Bounded so a lost packet costs ~0.2s instead of ptf's 2s default, keeping the
+# loss count meaningful.
+VERIFY_TIMEOUT = 0.2
+
+# pinned_vdpu_bfd_probe_states vectors. Index 0 = DPU1 (active/primary),
+# index 1 = DPU2 (standby); "none" removes the pin.
+PIN_DPU1_DOWN = ["down", "none"]
+PIN_DPU1_UP = ["up", "none"]
+UNPIN = ["none", "none"]
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -55,27 +64,54 @@ def common_setup_teardown(
 
 
 """
-We are testing 4 scenarios:
-1. BFD state UP pinned as DOWN(Pin DPU1 BFD probe state as DOWN) - traffic to active side
-   Verify: DPU1 remains active, DPU2 remains standby and T2 receives packets without disruption.
-2. BFD state UP pinned as DOWN(Pin DPU1 BFD probe state as DOWN) - traffic to standby side
-   Verify: DPU1 remains active, DPU2 remains standby and T2 receives packets without disruption.
-3. Both side pinned as DOWN (Pin DPU1 and DPU2 BFD probe state as DOWN) - traffic to active side
-   Verify: DPU1 remains active, DPU2 remains standby. T2 receives packets without disruption.
-4. Both side pinned as DOWN (Pin DPU1 and DPU2 BFD probe state as DOWN) - traffic to standby side
-   Verify: DPU1 remains active, DPU2 remains standby. T2 receives packets without disruption.
+Test plan: DASH HA "pinned BFD probe state". Two scenarios, each with traffic
+sent to the active or the standby side:
+
+1. BFD state UP pinned as DOWN: pin DPU1's (active) probe DOWN over a healthy
+   session. Traffic must egress via DUT2 while pinned and return to DUT1 after
+   the pin is removed. DPU1 stays active, DPU2 stays standby.
+2. BFD state DOWN pinned as UP: force DPU1's software BFD DOWN (admin-shut the
+   FRR peers on the DPU), then pin its probe UP. Traffic must egress via DUT1
+   while pinned and move to DUT2 after the pin is removed.
 """
 
 
-@pytest.mark.parametrize(
-    "both_sides_pinned", [True, False],
-    ids=["Both Sides Pinned", "Single Side Pinned"]
-)
+def _bfd_pin_scope_keys(dpuhosts):
+    return (
+        f"vdpu0_{dpuhosts[0].dpu_index}:haset0_0",
+        f"vdpu1_{dpuhosts[1].dpu_index}:haset0_0",
+    )
+
+
+def _send_outbound_pl_loss(ptfadapter, tx_intf, vm_to_dpu_pkt, exp_pkt, recv_ports, count=SEND_COUNT):
+    """Send ``count`` outbound PL packets; return how many were not received
+    (transformed) on ``recv_ports``."""
+    lost = 0
+    ptfadapter.dataplane.flush()
+    for _ in range(count):
+        testutils.send(ptfadapter, tx_intf, vm_to_dpu_pkt, 1)
+        try:
+            testutils.verify_packet_any_port(ptfadapter, exp_pkt, recv_ports, timeout=VERIFY_TIMEOUT)
+        except Exception:
+            lost += 1
+        time.sleep(1.0 / RATE_PPS)
+    return lost
+
+
+def _wait_bfd_pin_steady(duthosts, dpuhosts, active_key):
+    """Wait for DPU1 to be active with its software BFD up before probing the data
+    plane; a prior test can leave BFD/HA briefly re-converging after config reload."""
+    pytest_assert(wait_dpu_bfd_peers_up(dpuhosts[0]),
+                  "DPU1 software BFD did not reach 'up' at steady state")
+    pytest_assert(verify_ha_state(duthosts[0], active_key, "active"),
+                  "DPU1 did not reach 'active' at steady state")
+
+
 @pytest.mark.parametrize(
     "traffic_to_standby", [True, False],
     ids=["Standby Traffic", "Primary Traffic"]
 )
-def test_ha_bfd_pin(
+def test_ha_bfd_pin_up_as_down(
     localhost,
     ptfadapter,
     ptfhost,
@@ -83,97 +119,94 @@ def test_ha_bfd_pin(
     dpuhosts,
     activate_dash_ha_from_json,
     dash_pl_config,
-    both_sides_pinned,
     traffic_to_standby
 ):
-    traffic = "traffic to standby" if traffic_to_standby else "traffic to primary"
-    bfd_pin_type = "Both sides pinned" if both_sides_pinned else "Primary side pinned"
-    encap_proto = "vxlan"
-    rate_pps = 20  # packets per second
-    initial_send_count = 100
-    delay = 1.0 / rate_pps
-    rcv_outbound_pl_ports = dash_pl_config[0][REMOTE_PTF_RECV_INTF] + dash_pl_config[1][REMOTE_PTF_RECV_INTF]
+    """BFD state UP pinned as DOWN: pinning DPU1 down moves traffic to DUT2;
+    removing the pin returns it to DUT1, with no disruption and no failover."""
+    cfg = dash_pl_config[1] if traffic_to_standby else dash_pl_config[0]
+    vm_to_dpu_pkt, exp_pkt = outbound_pl_packets(cfg, ENCAP_PROTO)
+    tx_intf = cfg[LOCAL_PTF_INTF]
+    dut1_recv = dash_pl_config[0][REMOTE_PTF_RECV_INTF]
+    dut2_recv = dash_pl_config[1][REMOTE_PTF_RECV_INTF]
+    active_key, _ = _bfd_pin_scope_keys(dpuhosts)
 
-    if traffic_to_standby:
-        vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(dash_pl_config[1], encap_proto)
-    else:
-        vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(dash_pl_config[0], encap_proto)
+    # Wait for steady state (a prior test may have churned BFD/HA) before probing.
+    _wait_bfd_pin_steady(duthosts, dpuhosts, active_key)
 
-    # Bootstrap stateful TCP flow on the DPU so subsequent ACK packets match the established flow.
-    bootstrap_pl_tcp_flow_outbound(
-        ptfadapter, dash_pl_config[1] if traffic_to_standby else dash_pl_config[0], encap_proto,
-        recv_ports=rcv_outbound_pl_ports,
-    )
+    # Establish the stateful TCP flow (syncs to the standby) before pinning.
+    bootstrap_pl_tcp_flow_outbound(ptfadapter, cfg, ENCAP_PROTO, recv_ports=dut1_recv + dut2_recv)
 
-    packet_sending_flag = queue.Queue(1)
+    try:
+        # Pin DPU1 (active) probe DOWN -> traffic honors the pin, egresses via DUT2.
+        set_vdpu_bfd_probe_states(localhost, ptfhost, duthosts, PIN_DPU1_DOWN)
+        pytest_assert(verify_ha_state(duthosts[0], active_key, "active"),
+                      "DPU1 must remain active while its probe is pinned down")
+        lost = _send_outbound_pl_loss(ptfadapter, tx_intf, vm_to_dpu_pkt, exp_pkt, dut2_recv)
+        pytest_assert(lost == 0,
+                      f"UP-pinned-as-DOWN: {lost}/{SEND_COUNT} lost while pinned (expected egress on DUT2)")
 
-    send_count = 0
-    failed_count = 0
+        # Remove the pin -> probe follows the real (up) state, egress returns to DUT1.
+        set_vdpu_bfd_probe_states(localhost, ptfhost, duthosts, UNPIN)
+        pytest_assert(verify_ha_state(duthosts[0], active_key, "active"),
+                      "DPU1 must remain active after the pin is removed")
+        lost = _send_outbound_pl_loss(ptfadapter, tx_intf, vm_to_dpu_pkt, exp_pkt, dut1_recv)
+        pytest_assert(lost == 0,
+                      f"UP-pinned-as-DOWN: {lost}/{SEND_COUNT} lost after unpin (expected egress on DUT1)")
+    finally:
+        set_vdpu_bfd_probe_states(localhost, ptfhost, duthosts, UNPIN)
 
-    def pinning_ha_action():
-        # wait for packets sending started, then pin BFD state as DOWN
-        while packet_sending_flag.empty() or (not packet_sending_flag.get()):
-            time.sleep(0.2)
-        if both_sides_pinned:
-            logger.info(f"{bfd_pin_type}, pkt sent {send_count}")
-            bfd_pin_both_sides(localhost, ptfhost, duthosts)
-        else:
-            logger.info(f"{bfd_pin_type}, pkt sent {send_count}")
-            bfd_pin_primary(localhost, ptfhost, duthosts)
-        logger.info(f"After BFD pinning, pkt sent {send_count}")
 
-    t = threading.Thread(target=pinning_ha_action, name="pinning_ha_action_thread")
-    t.start()
-    t_max = time.time() + 60
-    reached_max_time = False
-    ptfadapter.dataplane.flush()
-    time.sleep(1)
-    while not reached_max_time:
-        # After we send initial_send_count packets, awake pinning_ha_action thread
-        if send_count == initial_send_count:
-            logger.info("Awake pinning HA action thread")
-            packet_sending_flag.put(True)
+@pytest.mark.parametrize(
+    "traffic_to_standby", [True, False],
+    ids=["Standby Traffic", "Primary Traffic"]
+)
+def test_ha_bfd_pin_down_as_up(
+    localhost,
+    ptfadapter,
+    ptfhost,
+    duthosts,
+    dpuhosts,
+    activate_dash_ha_from_json,
+    dash_pl_config,
+    traffic_to_standby
+):
+    """BFD state DOWN pinned as UP: with DPU1's software BFD forced down, pinning
+    its probe UP keeps traffic on DUT1; removing the pin lets the real down state
+    move traffic to DUT2."""
+    cfg = dash_pl_config[1] if traffic_to_standby else dash_pl_config[0]
+    vm_to_dpu_pkt, exp_pkt = outbound_pl_packets(cfg, ENCAP_PROTO)
+    tx_intf = cfg[LOCAL_PTF_INTF]
+    dut1_recv = dash_pl_config[0][REMOTE_PTF_RECV_INTF]
+    dut2_recv = dash_pl_config[1][REMOTE_PTF_RECV_INTF]
+    active_key, _ = _bfd_pin_scope_keys(dpuhosts)
 
-        try:
-            if traffic_to_standby:
-                if send_count == 0:
-                    logger.info("Send first packet to standby")
-                testutils.send(ptfadapter, dash_pl_config[1][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
-                testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
-                if send_count == 0:
-                    logger.info("First packet verified on standby - compare flows")
-                    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
-                    pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
+    # Wait for steady state (a prior test may have churned BFD/HA) before probing.
+    _wait_bfd_pin_steady(duthosts, dpuhosts, active_key)
 
-            else:
-                if send_count == 0:
-                    logger.info("Send first packet to primary")
-                testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
-                testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, rcv_outbound_pl_ports)
-                if send_count == 0:
-                    logger.info("First packet verified on primary - compare flows")
-                    flow_op = compare_flow_tables(dpuhosts[0], dpuhosts[1])
-                    pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
-        except Exception as e:
-            if failed_count == 0:
-                logger.info(f"pkt dropped after {send_count} pkts, exception {e}")
-                if send_count == 0:
-                    logger.error(f"pkt dropped exception {e}")
-                    pytest.fail(f"{bfd_pin_type} with {traffic} test error: no packets received")
-            failed_count += 1
+    bootstrap_pl_tcp_flow_outbound(ptfadapter, cfg, ENCAP_PROTO, recv_ports=dut1_recv + dut2_recv)
 
-        send_count += 1
-        time.sleep(delay)
-        reached_max_time = time.time() > t_max
+    try:
+        # Force DPU1's real software BFD DOWN by admin-shutting its FRR peers.
+        # BfdMgr dedupes, so hamgrd re-writes will not revert this.
+        set_dpu_bfd_admin_down(dpuhosts[0], shutdown=True)
+        pytest_assert(wait_dpu_bfd_peers_down(dpuhosts[0]),
+                      "DPU1 software BFD did not go down after admin shutdown")
 
-    t.join()
-    time.sleep(2)
-    if failed_count > 0:
-        pytest.fail(f"{bfd_pin_type} with {traffic} test failed: "
-                    f"sent: {send_count}, lost {failed_count}")
-    else:
-        logger.info(f"{bfd_pin_type} with {traffic} test passed. All {send_count} packets received.")
-    if both_sides_pinned:
-        bfd_unpin_both_sides(localhost, ptfhost, duthosts)
-    else:
-        bfd_unpin_primary(localhost, ptfhost, duthosts)
+        # Pin DPU1 probe UP -> masks the real down; traffic stays on DUT1.
+        set_vdpu_bfd_probe_states(localhost, ptfhost, duthosts, PIN_DPU1_UP)
+        pytest_assert(verify_ha_state(duthosts[0], active_key, "active"),
+                      "DPU1 must remain active while its probe is pinned up")
+        lost = _send_outbound_pl_loss(ptfadapter, tx_intf, vm_to_dpu_pkt, exp_pkt, dut1_recv)
+        pytest_assert(lost == 0,
+                      f"DOWN-pinned-as-UP: {lost}/{SEND_COUNT} lost while pinned (expected egress on DUT1)")
+
+        # Remove the pin -> the real (down) state governs; traffic moves to DUT2.
+        set_vdpu_bfd_probe_states(localhost, ptfhost, duthosts, UNPIN)
+        lost = _send_outbound_pl_loss(ptfadapter, tx_intf, vm_to_dpu_pkt, exp_pkt, dut2_recv)
+        pytest_assert(lost == 0,
+                      f"DOWN-pinned-as-UP: {lost}/{SEND_COUNT} lost after unpin (expected egress on DUT2)")
+    finally:
+        # Restore BFD before removing the pin so HA never sees a real-down and
+        # unpinned window (which would churn the active role).
+        set_dpu_bfd_admin_down(dpuhosts[0], shutdown=False)
+        set_vdpu_bfd_probe_states(localhost, ptfhost, duthosts, UNPIN)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
Rework test_ha_bfd_pin so it matches the DASH HA "pinned BFD probe state" test plan. The previous test exercised a "both sides pinned DOWN" case that is not in the plan (with both vDPU probes forced down there is no BFD‑up path, so traffic is legitimately dropped), yet asserted zero loss over the combined receive ports; it also never removed the pin in‑test and relied on a fragile blocking‑verify loss metric. In run evidence this produced false failures (test_ha_bfd_pin[Both Sides Pinned]).

This replaces the single test with the plan's two scenarios, each run with traffic to the active and to the standby side:

BFD UP pinned as DOWN — pin DPU1's (active) probe DOWN over a healthy session; traffic must egress via DUT2 while pinned and return to DUT1 after unpin.

BFD DOWN pinned as UP — force DPU1's software BFD DOWN, pin its probe UP; traffic must stay on DUT1 while pinned and move to DUT2 after unpin.

Each follows the plan's pin → send → unpin → send sequence with directional receive checks, verifies DPU1 stays active, and waits for steady state before probing. The four hardcoded pin/unpin helpers are replaced by a generic set_vdpu_bfd_probe_states() (with the correct "none" unpin), plus DPU‑side FRR BFD admin‑down helpers for the down‑pinned‑as‑up precondition.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
The pinned‑BFD tests did not reflect the test plan and produced false failures. The both_sides_pinned=True (down/down) parametrization is not a planned scenario — forcing both vDPU probes down leaves no BFD‑up path, so the DPU drops the private‑link traffic, but the test asserted zero loss. The test also never exercised the plan's unpin‑and‑resend step or the directional receive expectations, and did not verify the control‑plane invariant (DPU1 stays active / DPU2 stays standby).

#### How did you do it?

- Removed the invalid both_sides_pinned case and the now‑unused bfd_pin_primary / bfd_unpin_primary / bfd_pin_both_sides / bfd_unpin_both_sides helpers.

- Added set_vdpu_bfd_probe_states(localhost, ptfhost, duthosts, states) — a two‑element down/up/none vector per vDPU; ["none","none"] is the real unpin (the old helpers incorrectly wrote ["up","up"]).

- Implemented the plan's two scenarios × two traffic directions with directional receive checks and verify_ha_state that DPU1 stays active.

- For "DOWN pinned as UP", the real software BFD is forced down by admin‑shutting the DPU's multihop FRR peers via vtysh (set_dpu_bfd_admin_down) and confirmed with wait_dpu_bfd_peers_down (show bfd peers json); restored in cleanup.


#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Tested on Smartswitch HA testbed using 202605 images:
```
--------------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/logs/ha/test_ha_bfd_pin.xml ---------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
--------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------
19/08/2026 18:17:17 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
===================================================================== 4 passed, 1408 warnings in 2169.06s (0:36:09) 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
