### PR TITLE
Fix router_mac fact losing lowercase normalization

### DIFF
--- a/ansible/library/sonic_basic_facts.py
+++ b/ansible/library/sonic_basic_facts.py
@@ -435,7 +435,7 @@ def gather_config_db_facts(config_db, basic_facts):
 
     # Update basic facts with metadata
     basic_facts['num_asic'] = basic_facts.get('asic_count', 1)
-    basic_facts['router_mac'] = localhost_metadata.get('mac', '')
+    basic_facts['router_mac'] = localhost_metadata.get('mac', '').lower()
     basic_facts['modular_chassis'] = is_chassis(basic_facts.get('asic_type', ''))
     basic_facts['switch_type'] = localhost_metadata.get('switch_type', '')
     basic_facts['router_type'] = localhost_metadata.get('type', '')


### PR DESCRIPTION
### Description of PR

Summary: Restore lowercase normalization of the `router_mac` fact, which was lost when fact gathering moved to the `sonic_basic_facts` Ansible module. Without it, PTF tests that compare MAC addresses as raw strings fail on any DUT whose hardware MAC is stored uppercase.


#### Symptom

`advanced-reboot` based tests (for example `test_upgrade_path`) fail on affected devices with:

```
AssertionError: [] is not true : Sniffer failed to capture any traffic
```

even though traffic is clearly flowing. In a representative run the sender transmitted 82,028 packets and the sniffer captured 165,055, yet the post-capture analysis produced zero packets. The reboot itself succeeded, with no control-plane or protocol flaps.

#### Root cause

`router_mac` is populated from CONFIG_DB `DEVICE_METADATA.localhost.mac`. That value is hardware-derived: `sonic_py_common.device_info.get_system_mac()` returns the ONIE base MAC from `/host/machine.conf`, or EEPROM TLV 0x24 via `decode-syseeprom -m`, with no case normalization on any return path. `_valid_mac_address()` matches `[0-9A-Fa-f]`, so an uppercase value passes validation and is carried through unchanged.

On a device that stores the MAC uppercase, that raw value flows:

```
CONFIG_DB DEVICE_METADATA.localhost.mac
  -> ansible/library/sonic_basic_facts.py        basic_facts['router_mac']
  -> tests/common/fixtures/advanced_reboot.py    rebootData['dut_mac'] / rebootData['vlan_mac']
  -> ptftests/py3/advanced-reboot.py             self.dut_mac / self.vlan_mac
```

`no_flood()` compares those against packet fields as raw strings:

```python
packet[scapyall.Ether].src == self.dut_mac
packet[scapyall.Ether].dst == self.dut_mac
```

Scapy always renders MAC addresses lowercase when parsing a packet, but accepts uppercase when building one. Traffic is therefore generated and forwarded correctly while every comparison in the analysis path evaluates False. `filtered_packets` ends up empty and `examine_flow()` asserts.

#### Why this is a regression

Fact gathering previously went through `SonicHost._get_router_mac()`, which ended in `.lower()`. When it was replaced by the `sonic_basic_facts` module, that normalization was dropped.

The sibling accessor `sonic_asic.get_router_mac()` in `tests/common/devices/sonic_asic.py` still applies `.lower()` today, so the two accessors for the same CONFIG_DB value currently disagree. Several call sites already work around this by calling `.lower()` themselves. This change realigns them.

#### Impact

The failure is deterministic and per-device rather than flaky: a DUT whose hardware MAC is stored uppercase fails every run, and one stored lowercase passes every run. This was observed as a Mellanox SN2700 T0 testbed sitting at 0% pass while other SKUs running the same image were at 100%.

Virtual testbeds are unaffected: `generate_mac_for_vs()` formats each byte with `'{:02x}'`, so KVM/VS platforms are lowercase by construction. That is why VS-based CI does not catch this.

Worth noting that the assertion fires before any disruption measurement is taken, so on affected testbeds this failure would also mask a genuine dataplane regression.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38951215/
Failure type: regression

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

To be transparent: **this change has not yet been validated on affected hardware.** No "Tested branch" box is checked deliberately, and I am happy for the PR to be held until evidence is attached.

What has been verified so far:

- The full data path was traced in source, from `get_system_mac()` through to the failing comparison in `no_flood()`.
- The scapy behaviour was confirmed directly: building `Ether(dst='AA:BB:CC:DD:EE:FF')` and re-parsing it yields `'aa:bb:cc:dd:ee:ff'`, so an uppercase comparison operand can never match.
- `flake8` is clean on the changed file (the repo enforces `--max-line-length=120` via the pre-commit hook).
- The observed pass/fail pattern matches the prediction: one physical SKU consistently at 0% while other SKUs on the same image are at 100%, and all virtual testbeds unaffected.

Requested validation: re-run an `advanced-reboot` test such as `test_upgrade_path` on a physical DUT whose `sonic-cfggen -d -v DEVICE_METADATA.localhost.mac` returns uppercase hex. Expected result is that flow examination completes and reports a real disruption figure instead of asserting.

`.lower()` is a no-op on values that are already lowercase, so testbeds passing today cannot regress.

### Approach

#### What is the motivation for this PR?

Any DUT whose hardware MAC is stored uppercase currently fails every `advanced-reboot` based test at the traffic-analysis stage, regardless of whether the dataplane behaved correctly. The failure looks like a total traffic loss but is purely a string comparison artifact, so it both wastes triage effort and hides real regressions behind a misleading assertion.

#### How did you do it?

Applied `.lower()` where the fact is populated, restoring the behaviour that existed before fact gathering moved to `sonic_basic_facts`:

```python
basic_facts['router_mac'] = localhost_metadata.get('mac', '').lower()
```

Fixing it at the fact source repairs every consumer at once and makes `duthost.facts['router_mac']` agree with `sonic_asic.get_router_mac()`. No test-case logic is changed.

An alternative would be to make the PTF comparisons case-insensitive, but that leaves the inconsistency between the two accessors in place and would need repeating at each comparison site.

#### How did you verify/test it?

See the Test result section above. Static and source-level verification is complete; hardware validation is outstanding and I would welcome help running it on an affected testbed.

#### Any platform specific information?

Affects physical platforms whose ONIE base MAC or EEPROM TLV 0x24 is stored uppercase; this was observed on Mellanox SN2700. It is a property of the individual device's stored value rather than of the vendor or SKU, so the affected set is best identified by checking `sonic-cfggen -d -v DEVICE_METADATA.localhost.mac` on each DUT. KVM/VS platforms are not affected.

#### Supported testbed topology if it's a new test case?

N/A, not a new test case.

### Documentation

N/A, no documentation change required.
