### PR TITLE
Unskip log_fidelity/test_bgp_shutdown.py on vms-kvm-t2

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
@@ -425,11 +425,6 @@ lldp/test_lldp_syncd.py:
     conditions:
     - asic_type in ['vs'] and 't2' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
-log_fidelity/test_bgp_shutdown.py:
-  skip:
-    conditions:
-    - asic_type in ['vs'] and 't2' in topo_name
-    reason: This test case either cannot pass or should be skipped on virtual chassis
 macsec/test_controlplane.py:
   skip:
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: log_fidelity/test_bgp_shutdown.py now can pass on vms-kvm-t2 consistently so there is no need to skip it anymore. 
Fixes # (issue)

ADO: 39290823

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

Result

┌─────┬───────────────┬──────────┐
│ Run │ Outcome       │ Duration │
├─────┼───────────────┼──────────┤
│ 1   │ ✅  1 passed  │ 3m44s    │
├─────┼───────────────┼──────────┤
│ 2   │ ✅  1 passed  │ 3m48s    │
└─────┴───────────────┴──────────┘

Ran on  vlab-t2-1-1  (the test uses  enum_rand_one_per_hwsku_frontend_hostname , so one LC is selected — both LCs share a hwsku, and the supervisor is excluded as non-frontend). LogAnalyzer was left enabled since this test asserts on syslog content.

Why the skip was wrong

The test is trivially portable — nothing in it is chassis-sensitive:

 BGP_DOWN_COMMAND = "config bgp shutdown all"
 BGP_DOWN_EXPECTED_LOG_MESSAGE = "admin state is set to 'down'"
 BGP_UP_COMMAND = "config bgp startup all"

It just runs  config bgp shutdown all , greps syslog for the admin-state message via LogAnalyzer, and restores with  config bgp startup all  in a  finally  block. It's marked  topology('any') , has no ASIC/platform dependencies, and needs no dataplane. The generic reason "This test case either cannot pass or should be skipped on virtual chassis" doesn't apply.

Cleanup verified

BGP fully re-established on both line cards after the run — LC1 sessions back up with all 4 T3 peers and prefixes intact (50819 from ARISTA01T3), LC2 untouched. The test restores state correctly, no leakage.

I also confirmed the  post_sanity_check_failed  /  core_dump_check_failed  cache warnings in the log are just  pytest_sessionstart  resetting stale keys ( tests/conftest.py:718-726 ), not real failures.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
