### PR TITLE
Restore BMP golden config

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -345,8 +345,20 @@ class GenerateGoldenConfigDBModule(object):
         return json.dumps(golden_config_db, indent=4)
 
     def check_version_for_bmp(self):
-        # disable bmp feature table first
-        return False
+        output_version = device_info.get_sonic_version_info()
+        build_version = output_version['build_version']
+
+        if re.match(r'^(\d{6})', build_version):
+            version_number = int(re.findall(r'\d{6}', build_version)[0])
+            if version_number < 202411:
+                return False
+        elif re.match(r'^internal-(\d{6})', build_version):
+            internal_version_number = int(re.findall(r'\d{6}', build_version)[0])
+            if internal_version_number < 202411:
+                return False
+        else:
+            return True
+        return True
 
     def is_bmc_device(self):
         return device_info.get_localhost_info('type') == 'NetworkBmc'

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -778,9 +778,9 @@ bgp/test_traffic_shift_sup.py:
 
 bmp/:
   skip:
-    reason: "https://github.com/sonic-net/sonic-buildimage/issues/23777"
+    reason: 'BMP tests require BGP routing, not available on BMC'
     conditions:
-      - "release in ['master']"
+      - "'bmc' in topo_type"
 
 #######################################
 #####            cacl             #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Restore the version-gated BMP golden-config enablement path 

PR #24625 disabled BMP tests on master because of sonic-buildimage issue
#23777. That issue has since been fixed, so sonic-mgmt can again enable BMP
through golden config for supported images without enabling BMP by default in
production images.

Fixes #26162

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:  other 


### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202605: 
**Before Fix:** 
Imager : branch.202605-ars.f2e092bc-buildimage.17a11c3c9aa389a1e836d56151305c1e33c26d62-nightly-2026.06.24.14.40
[bmp_test_docker_restart_failure.log](https://github.com/user-attachments/files/31240401/bmp_test_docker_restart_failure.log)
[bmp_test_docker_restart_failure.xml](https://github.com/user-attachments/files/31240402/bmp_test_docker_restart_failure.xml)


**After Fix :**

Ran deploy-mg to apply golden config.
Result: BMP was enabled through golden config, and bmp tests passed.
Image : branch.202605-ars.159ac0ce-buildimage.0b2faef94668aef37278566e8d6277200de7a807-nightly-2026.08.12.14.39
[bmp_golden_config_pass.log](https://github.com/user-attachments/files/31240683/bmp_golden_config_pass.log)
[bmp_golden_config_pass.xml](https://github.com/user-attachments/files/31240684/bmp_golden_config_pass.xml)



### Approach
#### What is the motivation for this PR?

BMP was disabled in sonic-mgmt as a temporary gate for sonic-buildimage issue
#23777. That issue has been fixed, so the blanket master skip can be removed.

The fix keeps BMP disabled by default in production images, while allowing the
 sonic-mgmt golden-config flow to enable BMP for supported test images.

#### How did you do it?
Restored the version-gated `check_version_for_bmp()` logic in
  `generate_golden_config_db.py`.

Changed the `bmp/` conditional mark from a blanket master skip to a BMC-only
  skip.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
On 202605, verified after deploy-mg: BMP enabled through golden config and bmp tests passed.
 
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
