### PR TITLE
[bgp] fix vtysh usage in test/test_bgp_update_timer.py on multi-asic platforms

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -95,8 +95,8 @@ def _apply_outbound_route_filter(duthost, dut_asn, neighbor_ips, is_v6, namespac
     vtysh_cmds.append("exit")  # exit address-family
     vtysh_cmds.append("exit")  # exit router bgp
 
-    ns_option = "-n {}".format(namespace) if namespace != DEFAULT_NAMESPACE else ""
-    cmd = "vtysh {} {}".format(ns_option, " ".join("-c '{}'".format(c) for c in vtysh_cmds))
+    cmd = "vtysh {}".format(" ".join("-c '{}'".format(c) for c in vtysh_cmds))
+    cmd = duthost.get_vtysh_cmd_for_namespace(cmd, namespace)
     duthost.shell(cmd)
 
     # Soft-reset outbound so the filter takes effect immediately.
@@ -105,16 +105,14 @@ def _apply_outbound_route_filter(duthost, dut_asn, neighbor_ips, is_v6, namespac
     #   v6: clear bgp ipv6 <neighbor> soft out  (word order is 'bgp ipv6', not 'ipv6 bgp')
     clear_af = "bgp ipv6" if is_v6 else "ip bgp"
     for ip in neighbor_ips:
-        duthost.shell("vtysh {} -c 'clear {} {} soft out'".format(
-            ns_option, clear_af, ip
-        ))
+        cmd = "vtysh -c 'clear {} {} soft out'".format(clear_af, ip)
+        cmd = duthost.get_vtysh_cmd_for_namespace(cmd, namespace)
+        duthost.shell(cmd)
 
 
 def _remove_outbound_route_filter(duthost, dut_asn, neighbor_ips, is_v6, namespace=DEFAULT_NAMESPACE):
     """Remove the outbound route-map and prefix-list added by
     _apply_outbound_route_filter."""
-    ns_option = "-n {}".format(namespace) if namespace != DEFAULT_NAMESPACE else ""
-
     vtysh_cmds = [
         "configure terminal",
         "router bgp {}".format(dut_asn),
@@ -127,7 +125,8 @@ def _remove_outbound_route_filter(duthost, dut_asn, neighbor_ips, is_v6, namespa
     vtysh_cmds.append("no route-map {}".format(TEST_ROUTES_ROUTE_MAP))
     vtysh_cmds.append("no {} prefix-list {}".format("ipv6" if is_v6 else "ip", TEST_ROUTES_PREFIX_LIST))
 
-    cmd = "vtysh {} {}".format(ns_option, " ".join("-c '{}'".format(c) for c in vtysh_cmds))
+    cmd = "vtysh {}".format(" ".join("-c '{}'".format(c) for c in vtysh_cmds))
+    cmd = duthost.get_vtysh_cmd_for_namespace(cmd, namespace)
     duthost.shell(cmd, module_ignore_errors=True)
 
 
@@ -597,6 +596,7 @@ def test_bgp_update_timer_session_down(
                     "-c 'configure terminal' "
                     f"-c 'router bgp {dut_asn}' "
                     f"-c 'neighbor {neigh_ip} shutdown' ")
+                cmd = duthost.get_vtysh_cmd_for_namespace(cmd, n0.namespace)
             else:
                 cmd = "config bgp shutdown neighbor {}".format(n0.name)
 


### PR DESCRIPTION
https://github.com/sonic-net/sonic-mgmt/pull/22924 recently adds usage of FRR CLI shell commands. It passes namespace arg as `vtysh -n asic0` in various vtysh commands.

On multi-asic, correct usage of vtysh command to namespace (-n) is passing a numeric ASIC ID. eg. `vtysh -n 0 ...`

Fixes #27175

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

sonic-mgmt `test/test_bgp_update_timer.py` is currently failing on multi-asic platforms

#### How did you do it?

Fixed it by using `get_vtysh_cmd_for_namespace` helper function to correctly add the namespace argument for multi-asic

#### How did you verify/test it?

With this change, the test/test_bgp_update_timer.py passed on mutli-asic platfrom. Tested 202605 branch with this change.
```
bgp/test_bgp_update_timer.py::test_bgp_update_timer_single_route[qzd368-default] PASSED                                                                                                                       [ 50%]
bgp/test_bgp_update_timer.py::test_bgp_update_timer_session_down[qzd368-default] PASSED                                                                                                                       [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
