### PR TITLE
[crm] Make threshold log verification reliable

### DIFF
--- a/tests/common/helpers/crm.py
+++ b/tests/common/helpers/crm.py
@@ -7,8 +7,8 @@ EXPECT_EXCEEDED = ".* THRESHOLD_EXCEEDED .*"
 EXPECT_CLEAR = ".* THRESHOLD_CLEAR .*"
 
 THR_VERIFY_CMDS = OrderedDict([
-    ("exceeded_used", "bash -c \"crm config thresholds {{crm_cli_res}}  type used; \
-         crm config thresholds {{crm_cli_res}} low {{crm_used|int - 1}}; \
+    ("exceeded_used", "bash -c \"crm config thresholds {{crm_cli_res}} type used && \
+         crm config thresholds {{crm_cli_res}} low {{crm_used|int - 1}} && \
          crm config thresholds {{crm_cli_res}} high {{crm_used|int}}\""),
     ("clear_used", "bash -c \"crm config thresholds {{crm_cli_res}} type used && \
          crm config thresholds {{crm_cli_res}} low {{crm_used|int}} && \

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -26,9 +26,10 @@ def pytest_runtest_teardown(item, nextitem):
     """
     failures = []
     crm_threshold_name = RESTORE_CMDS.get("crm_threshold_name")
-    restore_cmd = "bash -c \"sonic-db-cli CONFIG_DB hset 'CRM|Config' {threshold_name}_threshold_type percentage \
-    && sonic-db-cli CONFIG_DB hset 'CRM|Config' {threshold_name}_high_threshold {high} \
-    && sonic-db-cli CONFIG_DB hset 'CRM|Config' {threshold_name}_low_threshold {low}\""
+    restore_cmd = "sonic-db-cli CONFIG_DB hmset 'CRM|Config' \
+    {threshold_name}_high_threshold {high} \
+    {threshold_name}_low_threshold {low} \
+    {threshold_name}_threshold_type percentage"
     if item.rep_setup.passed and not item.rep_call.skipped:
         test_name = item.function.__name__
         duthosts = item.funcargs['duthosts']

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -339,7 +339,7 @@ def wait_for_threshold_log(loganalyzer, duthost, asichost, cmd):
     with DisableLogrotateCronContext(duthost):
         marker = loganalyzer.init()
         result = duthost.shell(
-            "sudo wc -l < /var/log/syslog",
+            "sudo wc -l /var/log/syslog | awk '{print $1}'",
             module_ignore_errors=True
         )
         pytest_assert(

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -6,12 +6,13 @@ import netaddr
 import copy
 import logging
 import os
-import shlex
+import re
 import tempfile
 
+from contextlib import contextmanager
 from jinja2 import Template
 from tests.common.cisco_data import is_cisco_device
-from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
+from tests.common.plugins.loganalyzer.loganalyzer import DisableLogrotateCronContext, LogAnalyzer
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.crm import get_used_percent, CRM_UPDATE_TIME, CRM_POLLING_INTERVAL, EXPECT_EXCEEDED, \
      EXPECT_CLEAR, THR_VERIFY_CMDS
@@ -257,25 +258,110 @@ def get_acl_tbl_key(asichost):
     return "CRM:ACL_TABLE_STATS:{0}".format(oid.replace("oid:", ""))
 
 
+@contextmanager
+def disable_swss_syslog_rate_limit(duthost, asichost):
+    """Prevent SWSS threshold messages from being dropped during CRM verification."""
+    swss_container = asichost.get_docker_name("swss")
+    config_file = "/etc/rsyslog.conf"
+
+    def restart_rsyslog():
+        duthost.shell(
+            "docker exec {} supervisorctl restart rsyslogd".format(swss_container)
+        )
+
+        def is_rsyslog_running():
+            status = duthost.shell(
+                "docker exec {} supervisorctl status rsyslogd".format(swss_container),
+                module_ignore_errors=True
+            )
+            return status.get("rc") == 0 and "RUNNING" in status.get("stdout", "")
+
+        pytest_assert(
+            wait_until(10, 1, 0, is_rsyslog_running),
+            "SWSS rsyslogd did not return to RUNNING state"
+        )
+
+    check_cmd = (
+        r"docker exec {} grep -oE "
+        r"'SysSock\.RateLimit\.Interval=\"[0-9]+\"' {} | head -1"
+        .format(swss_container, config_file)
+    )
+    result = duthost.shell(check_cmd, module_ignore_errors=True)
+    interval_match = re.fullmatch(
+        r'SysSock\.RateLimit\.Interval="([0-9]+)"',
+        result.get("stdout", "").strip()
+    )
+    pytest_assert(
+        result.get("rc") == 0 and interval_match is not None,
+        "Failed to determine SWSS syslog rate-limit state"
+    )
+    original_interval = int(interval_match.group(1))
+    rate_limit_enabled = original_interval != 0
+    logger.info(
+        "SWSS syslog rate-limit interval is {} in container {}"
+        .format(original_interval, swss_container)
+    )
+
+    try:
+        if rate_limit_enabled:
+            disable_cmd = (
+                r"docker exec {} sed -i "
+                r"'s/SysSock\.RateLimit\.Interval=\"{}\"/"
+                r"SysSock.RateLimit.Interval=\"0\"/g' {}"
+                .format(swss_container, original_interval, config_file)
+            )
+            duthost.shell(disable_cmd)
+            restart_rsyslog()
+
+        yield
+    finally:
+        if rate_limit_enabled:
+            restore_cmd = (
+                r"docker exec {} sed -i "
+                r"'s/SysSock\.RateLimit\.Interval=\"0\"/"
+                r"SysSock.RateLimit.Interval=\"{}\"/g' {}"
+                .format(swss_container, original_interval, config_file)
+            )
+            duthost.shell(restore_cmd)
+            restart_rsyslog()
+
+
 def wait_for_threshold_log(loganalyzer, duthost, asichost, cmd):
     """Apply CRM thresholds and wait for the expected syslog message."""
-    marker = loganalyzer.init()
     expect_regex = loganalyzer.expect_regex[0]
 
-    def count_matches():
+    def has_expected_log(first_line):
         result = duthost.shell(
-            "sudo grep -c -E -- {} /var/log/syslog".format(shlex.quote(expect_regex)),
+            "sudo tail -n +{} /var/log/syslog".format(first_line),
             module_ignore_errors=True)
-        return int(result.get("stdout", "").strip() or 0)
+        return re.search(expect_regex, result.get("stdout", "")) is not None
 
-    matches_before = count_matches()
-    asichost.command(cmd)
+    with DisableLogrotateCronContext(duthost):
+        marker = loganalyzer.init()
+        result = duthost.shell(
+            "sudo wc -l < /var/log/syslog",
+            module_ignore_errors=True
+        )
+        pytest_assert(
+            result.get("rc", 1) == 0 and result.get("stdout", "").strip().isdigit(),
+            "Failed to determine the current syslog position"
+        )
+        first_line = int(result["stdout"].strip()) + 1
+        asichost.command(cmd)
+        observed = wait_until(
+            CRM_THRESHOLD_LOG_TIMEOUT,
+            CRM_POLLING_INTERVAL,
+            CRM_POLLING_INTERVAL,
+            has_expected_log,
+            first_line
+        )
 
-    if not wait_until(CRM_THRESHOLD_LOG_TIMEOUT, CRM_POLLING_INTERVAL,
-                      CRM_POLLING_INTERVAL, lambda: count_matches() > matches_before):
-        logger.warning("CRM threshold message was not observed within {} seconds"
-                       .format(CRM_THRESHOLD_LOG_TIMEOUT))
-    loganalyzer.analyze(marker, fail=True)
+        if not observed:
+            logger.warning(
+                "CRM threshold message was not observed within {} seconds"
+                .format(CRM_THRESHOLD_LOG_TIMEOUT)
+            )
+        loganalyzer.analyze(marker, fail=True)
 
 
 def verify_thresholds(duthost, asichost, **kwargs):
@@ -1201,7 +1287,8 @@ def test_crm_nexthop_group(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
 
         RESTORE_CMDS["wait"] = SONIC_RES_CLEANUP_UPDATE_TIME
 
-    verify_thresholds(duthost, asichost, crm_cli_res=redis_threshold, crm_cmd=get_nexthop_group_stats)
+    with disable_swss_syslog_rate_limit(duthost, asichost):
+        verify_thresholds(duthost, asichost, crm_cli_res=redis_threshold, crm_cmd=get_nexthop_group_stats)
 
 
 def recreate_acl_table(duthost, ports):

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -6,6 +6,7 @@ import netaddr
 import copy
 import logging
 import os
+import shlex
 import tempfile
 
 from jinja2 import Template
@@ -34,6 +35,7 @@ FDB_CLEAR_TIMEOUT = 20
 ROUTE_COUNTER_POLL_TIMEOUT = 15
 CRM_COUNTER_TOLERANCE = 2
 ACL_TABLE_NAME = "DATAACL"
+CRM_THRESHOLD_LOG_TIMEOUT = CRM_UPDATE_TIME * 3
 
 RESTORE_CMDS = {"test_crm_route": [],
                 "test_crm_nexthop": [],
@@ -255,6 +257,27 @@ def get_acl_tbl_key(asichost):
     return "CRM:ACL_TABLE_STATS:{0}".format(oid.replace("oid:", ""))
 
 
+def wait_for_threshold_log(loganalyzer, duthost, asichost, cmd):
+    """Apply CRM thresholds and wait for the expected syslog message."""
+    marker = loganalyzer.init()
+    expect_regex = loganalyzer.expect_regex[0]
+
+    def count_matches():
+        result = duthost.shell(
+            "sudo grep -c -E -- {} /var/log/syslog".format(shlex.quote(expect_regex)),
+            module_ignore_errors=True)
+        return int(result.get("stdout", "").strip() or 0)
+
+    matches_before = count_matches()
+    asichost.command(cmd)
+
+    if not wait_until(CRM_THRESHOLD_LOG_TIMEOUT, CRM_POLLING_INTERVAL,
+                      CRM_POLLING_INTERVAL, lambda: count_matches() > matches_before):
+        logger.warning("CRM threshold message was not observed within {} seconds"
+                       .format(CRM_THRESHOLD_LOG_TIMEOUT))
+    loganalyzer.analyze(marker, fail=True)
+
+
 def verify_thresholds(duthost, asichost, **kwargs):
     """
     Verifies that WARNING message logged if there are any resources that exceeds a pre-defined threshold value.
@@ -309,10 +332,7 @@ def verify_thresholds(duthost, asichost, **kwargs):
         kwargs['crm_used'], kwargs['crm_avail'] = get_crm_stats(kwargs['crm_cmd'], duthost)
         cmd = template.render(**kwargs)
 
-        with loganalyzer:
-            asichost.command(cmd)
-            # Make sure CRM counters updated
-            wait_until(CRM_UPDATE_TIME, CRM_POLLING_INTERVAL, 0, lambda: True)
+        wait_for_threshold_log(loganalyzer, duthost, asichost, cmd)
 
 
 def get_crm_stats(cmd, duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Improve CRM threshold-log verification reliability and prevent failed threshold checks from leaving invalid CRM configuration on the DUT.

The change waits for the expected threshold message instead of using a no-op delay, prevents log rotation while polling, searches only newly written syslog lines, and protects nexthop-group verification from SWSS rsyslog rate limiting. It also makes threshold updates and restoration failure-safe.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
https://elastictest.org/scheduler/testplan/6a86329da4d1c39d04745d9b?testcase=crm%2Ftest_crm.py&type=console
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
CRM threshold tests can fail intermittently because CRM processing and syslog delivery are asynchronous. The previous  wait_until(..., lambda: True)  returned immediately, allowing LogAnalyzer to run before the expected  THRESHOLD_EXCEEDED  or  THRESHOLD_CLEAR  message was generated.

Whole-file message counts were also unsafe because log rotation could reset the count. Additionally, SWSS rsyslog rate limiting could discard threshold messages during resource-intensive nexthop-group tests.

A failed threshold command could continue executing subsequent commands and leave incompatible CRM settings, such as a  percentage  threshold type with resource-count limits. This caused misleading missing-log failures and post-test YANG validation errors.

#### How did you do it?
• Added bounded polling for the expected CRM threshold message.
• Disabled scheduled log rotation during the polling window.
• Recorded the current syslog position and searched only newly written lines.
• Kept LogAnalyzer as the final validation of the marker-bounded log section.
• Temporarily disabled SWSS rsyslog rate limiting during nexthop-group threshold verification.
• Restored the original SWSS rsyslog configuration after verification.
• Read the syslog line count using a privileged command.
• Changed the threshold command sequence to use  && , stopping immediately if an individual command fails.
• Restored threshold type, high threshold, and low threshold in one Config DB operation to avoid partially restored state.

#### How did you verify/test it?
Ran the complete existing  crm/test_crm.py  suite using the  internal-202511  Mellanox image.

The final run passed after including the threshold-log reliability changes, privileged syslog access fix, SWSS rate-limit handling, and failure-safe threshold configuration.

Test result: https://elastictest.org/scheduler/testplan/6a9b451d3ec361ab864b5ccf

#### Any platform specific information?
No. The change is platform-independent and preserves the existing platform-specific skips and conditions.

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
