### PR TITLE
[qos] Skip DPC backplane ports in traditional buffer test

### DIFF
--- a/tests/qos/test_buffer_traditional.py
+++ b/tests/qos/test_buffer_traditional.py
@@ -390,6 +390,11 @@ def test_buffer_pg(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
 
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     dut_asic = duthost.asic_instance(enum_frontend_asic_index)
+    config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
+    dpc_ports = {
+        port for port, attrs in config_facts.get("PORT", {}).items()
+        if attrs.get("role", "").lower() == "dpc"
+    }
 
     # Check whether the COUNTERS_PG_NAME_MAP exists. Skip ASIC_DB checking if it isn't
     pg_name_map = make_dict_from_output_lines(dut_asic.run_redis_cmd(
@@ -412,7 +417,7 @@ def test_buffer_pg(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
         should_check_buffer = False
         expected_profile = None
 
-        if is_port_up:
+        if is_port_up and port not in dpc_ports:
             # Always check buffer configuration for admin-up ports
             should_check_buffer = True
             # Filter out special ports (recirculation, inband, backplane) that don't have buffer profiles


### PR DESCRIPTION
### Description of PR

Summary:  
Skip DPC-role SmartSwitch backplane ports during traditional buffer validation. These ports do not require lossless `BUFFER_PG` entries, but were incorrectly validated as regular admin-up ports.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: N/A  
Failure type: N/A

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [x] N/A

### Test result

Before this change, `qos/test_buffer_traditional.py::test_buffer_pg` failed on SmartSwitch lit mode because `Ethernet240` had no lossless `BUFFER_PG`.

The targeted SmartSwitch test rerun after applying this change passed.

### Approach

#### What is the motivation for this PR?

SmartSwitch DPC backplane ports are not regular front-panel ports and do not require traditional lossless buffer profiles. The test incorrectly expected a lossless profile on these ports.

#### How did you do it?

Read persistent `config_facts` and identify ports with `role: dpc`, following the convention used by `test_neighbor_mac_noptf`. Exclude these ports from admin-up buffer validation.

#### How did you verify/test it?

Validated the modified Python file with the workspace error checker. The original failure was reproduced on SmartSwitch port `Ethernet240`.

#### Any platform specific information?

Applies to SmartSwitch platforms with DPC-role backplane ports, including MSN4280.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A