### PR TITLE
[cacl]: xfail test_multiasic_cacl_application on multi-ASIC KVM t2 testbed

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -816,6 +816,10 @@ cacl/test_cacl_application.py::test_multiasic_cacl_application:
     conditions_logical_operator: or
     conditions:
       - "not is_multi_asic"
+  xfail:
+    reason: "xfail for multi-ASIC KVM t2 testbed, issue https://github.com/sonic-net/sonic-mgmt/issues/27182"
+    conditions:
+      - "asic_type in ['vs'] and is_multi_asic and topo_type in ['t2']"
 
 cacl/test_cacl_function.py:
   xfail:


### PR DESCRIPTION
### Description of PR

Summary:
Mark `test_multiasic_cacl_application` as `xfail` on multi-ASIC KVM (VS) t2 topology testbeds where the test is still failing.

Fixes #27182

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`test_multiasic_cacl_application` is failing on multi-ASIC KVM t2 testbeds. This PR marks it as `xfail` to unblock CI while the root cause is investigated in issue #27182.

Reference: similar pattern used in https://github.com/sonic-net/sonic-mgmt/pull/26935 (which removed a previous xfail once the underlying fix landed).

#### How did you do it?

Added `xfail` condition to `tests_mark_conditions.yaml` for `test_multiasic_cacl_application`:
```yaml
xfail:
  reason: "xfail for multi-ASIC KVM t2 testbed, issue https://github.com/sonic-net/sonic-mgmt/issues/27182"
  conditions:
    - "asic_type in ['vs'] and is_multi_asic and topo_type in ['t2']"
```

#### How did you verify/test it?

Verified the YAML syntax and condition logic.

#### Any platform specific information?

Only affects multi-ASIC KVM (VS) t2 topology.

#### Supported testbed topology if it is a new test case?

N/A — existing test, adding xfail marker.

### Documentation
N/A