### PR TITLE
[bgp] Cache EosHost.is_multiagent to avoid cEOS mgmt-SSH storm during BGP session flaps

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -549,9 +549,18 @@ class EosHost(AnsibleHostBase):
         return out
 
     def is_multiagent(self):
-        out = self.eos_command(commands=["show ip route summary | json"])
-        model = out["stdout"][0]["protoModelStatus"]["operatingProtoModel"]
-        return model == "multi-agent"
+        # Cache the result: a cEOS instance does not switch protocol model during
+        # a test run, so probe it only once per host instead of on every
+        # kill_bgpd()/start_bgpd() call. Each eos_command() opens a fresh SSH
+        # login, so re-probing on every flap iteration floods the cEOS
+        # management plane when many neighbors are flapped in parallel
+        # (e.g. test_bgp_session_flap.test_bgp_multiple_session_flaps on T2),
+        # which can lead to SSH "Authentication failed" errors.
+        if getattr(self, "_is_multiagent", None) is None:
+            out = self.eos_command(commands=["show ip route summary | json"])
+            model = out["stdout"][0]["protoModelStatus"]["operatingProtoModel"]
+            self._is_multiagent = (model == "multi-agent")
+        return self._is_multiagent
 
     def kill_bgpd(self):
         agent = 'Bgp' if self.is_multiagent() else 'Rib'


### PR DESCRIPTION
### Description of PR

`EosHost.is_multiagent()` runs a live `show ip route summary | json` over SSH on a cEOS neighbor to decide whether `kill_bgpd()`/`start_bgpd()` should restart the `Bgp` or the `Rib` agent (added in #18748). Every `eos_command()` opens a brand-new SSH login (`ansible_connection: network_cli`).

`bgp/test_bgp_session_flap.py::test_bgp_multiple_session_flaps` calls `kill_bgpd()`+`start_bgpd()` in a tight loop for **every neighbor in parallel**. With the per-call `is_multiagent()` probe, each flap iteration issues an extra SSH login on top of the config change, roughly doubling the management-SSH login rate. On large T2 topologies (many neighbors) this overwhelms the cEOS management SSH connection/auth rate limit, which starts rejecting logins as `Failed to authenticate: Authentication failed.` The failure surfaces at teardown, where the fixture calls `start_bgpd()` on all neighbors to restore BGP, so the test ERRORs even though the DUT/neighbors are healthy.

The protocol model of a given cEOS instance does not change during a test run, so it only needs to be probed once. This change caches the result per `EosHost` and reuses it on subsequent calls. The `Bgp`/`Rib` agent selection from #18748 is preserved.

### Type of change

- [x] Bug fix

### Approach

#### What is the fixed problem/issue?

`test_bgp_session_flap.py::test_bgp_multiple_session_flaps` fails at teardown with `eos_command failed ... Failed to authenticate: Authentication failed.` on large (64-neighbor) T2 topologies, because `is_multiagent()` is re-probed over SSH on every flap of every neighbor in parallel.

#### How did you do it?

Cache `is_multiagent()` per `EosHost` (`self._is_multiagent`, populated on first use), so the `show ip route summary | json` probe runs once per host instead of on every `kill_bgpd()`/`start_bgpd()` call. No behavior change to the `Bgp`/`Rib` agent selection.

#### How did you verify/test it?

Ran `bgp/test_bgp_session_flap.py` on a 64-neighbor T2 testbed:

- Before: `2 passed, 1 error` — `test_bgp_multiple_session_flaps` ERRORed at teardown with `Failed to authenticate`.
- After: `2 passed, 0 errors`; `is_multiagent()` probed exactly once per neighbor (instead of thousands of times), and 0 `Failed to authenticate` occurrences.

`py_compile` and `flake8` clean.
