### PR TITLE
[conditional_mark]: Skip pcied/sensord/thermal/countersdb tests on BMC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2937,33 +2937,9 @@ gnmi/test_gnmi_configdb.py::test_gnmi_configdb_streaming_sample_01:
     conditions:
       - "'bmc' in topo_type"
 
-gnmi/test_gnmi_countersdb.py::test_gnmi_counterdb_polling_01:
+gnmi/test_gnmi_countersdb.py:
   skip:
-    reason: "Test relies on COUNTERS_PORT_NAME_MAP populated by syncd; not applicable on BMC"
-    conditions:
-      - "'bmc' in topo_type"
-
-gnmi/test_gnmi_countersdb.py::test_gnmi_counterdb_polling_02:
-  skip:
-    reason: "Test relies on COUNTERS_PORT_NAME_MAP populated by syncd; not applicable on BMC"
-    conditions:
-      - "'bmc' in topo_type"
-
-gnmi/test_gnmi_countersdb.py::test_gnmi_counterdb_streaming_sample_01:
-  skip:
-    reason: "not applicable on BMC (no COUNTERS_PORT_NAME_MAP)"
-    conditions:
-      - "'bmc' in topo_type"
-
-gnmi/test_gnmi_countersdb.py::test_gnmi_counterdb_streaming_sample_02:
-  skip:
-    reason: "not applicable on BMC (no COUNTERS_PORT_NAME_MAP)"
-    conditions:
-      - "'bmc' in topo_type"
-
-gnmi/test_gnmi_countersdb.py::test_gnmi_output:
-  skip:
-    reason: "not applicable on BMC (no COUNTERS_PORT_NAME_MAP)"
+    reason: "Not available in BMC"
     conditions:
       - "'bmc' in topo_type"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -858,6 +858,12 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_tx_disable_channel:
 #######################################
 #####     api/test_thermal.py     #####
 #######################################
+platform_tests/api/test_thermal.py:
+  skip:
+    reason: "Not available in BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_high_critical_threshold:
   skip:
     reason: "Unsupported platform API"
@@ -1197,6 +1203,12 @@ platform_tests/daemon/test_pcied.py:
 platform_tests/daemon/test_psud.py:
   skip:
     reason: "Not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
+platform_tests/daemon/test_sensord.py:
+  skip:
+    reason: "Not available in BMC"
     conditions:
       - "'bmc' in topo_type"
 


### PR DESCRIPTION
### Description of PR
Summary:
Skip the following tests on BMC topologies where they are not available:
- `platform_tests/daemon/test_pcied.py`
- `platform_tests/daemon/test_sensord.py`
- `gnmi/test_gnmi_countersdb.py`
- `platform_tests/api/test_thermal.py`

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202608

### Approach
#### What is the motivation for this PR?
These tests are not applicable on BMC topologies and should be skipped there.

#### How did you do it?
Added `'bmc' in topo_type` skip conditions in the conditional_mark YAML files:
- `tests_mark_conditions_platform_tests.yaml`: added a file-level skip for `platform_tests/api/test_thermal.py` (some per-testcase entries were missing the BMC condition) and a new entry for `platform_tests/daemon/test_sensord.py`. `platform_tests/daemon/test_pcied.py` already carried the BMC condition.
- `tests_mark_conditions.yaml`: consolidated the per-testcase `gnmi/test_gnmi_countersdb.py` BMC skips into a single file-level skip so the whole file (including any uncovered testcases) is skipped on BMC.

#### How did you verify/test it?
Validated the edited YAML files parse successfully with `yaml.safe_load`.

#### Any platform specific information?
Applies only to BMC topologies (`'bmc' in topo_type`).

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated conditional test handling for BMC environments.
  * Consolidated gNMI CountersDB skip conditions while preserving the existing platform requirement.
  * Added BMC-specific skips for thermal API and sensord daemon tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
