### PR TITLE
[conditional_mark][vxlan] Skip vxlan tests on G200 platforms without VXLAN UDP port override

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5924,11 +5924,12 @@ vxlan/test_scale_ecmp.py:
 
 vxlan/test_vnet_bgp_route_precedence.py:
   skip:
-    reason: "test_vnet_bgp_route_precedence can only run on cisco, mnlx and VPP platforms. Also skip in 202411"
+    reason: "test_vnet_bgp_route_precedence can only run on cisco, mnlx and VPP platforms. Also skip in 202411 and on cisco-8000 platforms x86_64-8122_64eh_o-r0 and x86_64-8122_64ehf_o-r0 where VXLAN UDP port override is not supported."
     conditions_logical_operator: or
     conditions:
       - "asic_type not in ['cisco-8000', 'mellanox', 'vpp']"
       - "release in ['202411']"
+      - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
   xfail:
     reason: "Testcase ignored due to github issue: https://github.com/sonic-net/sonic-buildimage/issues/23824"
     conditions_logical_operator: or
@@ -6164,9 +6165,11 @@ vxlan/test_vxlan_multiple_tunnels.py:
 
 vxlan/test_vxlan_route_advertisement.py:
   skip:
-    reason: "VxLAN route advertisement can only run on cisco , mnlx and marvell-teralynx platforms. "
+    reason: "VxLAN route advertisement can only run on cisco, mnlx and marvell-teralynx platforms. Also skip on cisco-8000 platforms x86_64-8122_64eh_o-r0 and x86_64-8122_64ehf_o-r0 where VXLAN UDP port override is not supported."
+    conditions_logical_operator: or
     conditions:
       - "asic_type not in ['cisco-8000', 'mellanox' , 'marvell-teralynx' , 'vs', 'vpp']"
+      - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
 
 vxlan/test_vxlan_route_advertisement.py::Test_VxLAN_route_Advertisement::test_basic_route_advertisement[v4_in_v4]:
   xfail:


### PR DESCRIPTION
Skip `vxlan/test_vxlan_route_advertisement.py` and `vxlan/test_vnet_bgp_route_precedence.py` on cisco-8000 platforms `x86_64-8122_64eh_o-r0` and `x86_64-8122_64ehf_o-r0`. These platforms do not support overriding the VXLAN UDP port via `SWITCH_TABLE`, and both test suites rely on programming `vxlan_port`.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

Both test suites program a non-default VXLAN UDP port. On `x86_64-8122_64eh_o-r0` and `x86_64-8122_64ehf_o-r0`, the VXLAN UDP port cannot be overridden via `SWITCH_TABLE`, so the tests fail instead of exercising the intended behavior.

#### How did you do it?

Added platform-specific skip conditions for both test entries in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`. For `test_vxlan_route_advertisement.py`, also added `conditions_logical_operator: or` so the new platform condition works alongside the existing `asic_type` skip.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

Validated the YAML change locally. Runtime verification on the affected platforms is pending.

#### Any platform specific information?

Affects cisco-8000 platforms `x86_64-8122_64eh_o-r0` and `x86_64-8122_64ehf_o-r0` only. Other supported cisco-8000 platforms are unchanged.

#### Supported testbed topology if it's a new test case?

N/A — skip rule for existing tests.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

N/A