### PR TITLE
Fix TACACS authorization denial message check

### DIFF
--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -144,7 +144,9 @@ def check_authorization_tacacs_only(
 
     # Verify TACACS+ user can't run command not in server side whitelist.
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, "cat /etc/passwd", expect_exit_code=1, verify=True)
-    check_ssh_output_any_of(stdout, ['/usr/bin/cat authorize failed by TACACS+ with given arguments, not executing'])
+    exp_outputs = ['/usr/bin/cat not authorized by TACACS+ with given arguments, not executing',
+                   '/usr/bin/cat authorize failed by TACACS+ with given arguments, not executing']
+    check_ssh_output_any_of(stdout, exp_outputs)
 
     # Verify Local user can't login.
     dutip = duthost.mgmt_ip
@@ -305,7 +307,9 @@ def test_authorization_tacacs_and_local(
 
     # Verify TACACS+ user can't run command not in server side whitelist but have local permission.
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, "cat /etc/passwd", expect_exit_code=1, verify=True)
-    check_ssh_output_any_of(stdout, ['/usr/bin/cat authorize failed by TACACS+ with given arguments, not executing'])
+    exp_outputs = ['/usr/bin/cat not authorized by TACACS+ with given arguments, not executing',
+                   '/usr/bin/cat authorize failed by TACACS+ with given arguments, not executing']
+    check_ssh_output_any_of(stdout, exp_outputs)
 
     # Verify Local user can't login.
     dutip = duthost.mgmt_ip


### PR DESCRIPTION
### Description of PR

Summary:
Fixes ADO: https://dev.azure.com/msazure/One/_workitems/edit/39341167

Accept both TACACS authorization denial message variants emitted by SONiC for `cat /etc/passwd` when the TACACS server rejects the command.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/39341167
Failure type: other

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Pre-commit on changed file passed locally:
`python -m pre_commit run --files tests/tacacs/test_authorization.py`

Nightly failure evidence from ADO PBI 39341167 on 20251110.44 showed the DUT returned `/usr/bin/cat not authorized by TACACS+ with given arguments, not executing`, while the test expected `/usr/bin/cat authorize failed by TACACS+ with given arguments, not executing`.

### Approach
#### What is the motivation for this PR?

`tacacs/test_authorization.py::test_authorization_tacacs_only_some_server_down` fails when SONiC returns the newer/alternate TACACS denial wording even though the command is correctly rejected.

#### How did you do it?

Updated the `cat /etc/passwd` denial checks to accept both known TACACS denial messages, matching the pattern already used by other authorization-command checks in this file.

#### How did you verify/test it?

Ran pre-commit on the changed file successfully.

#### Any platform specific information?

Observed on Cisco-8102-C64 / t1-64-lag in 20251110 nightly.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A