### PR TITLE
[pfcwd] Use the XGS PFC generator for Th4/Th5/Th6 SONiC fanouts

### DIFF
--- a/tests/common/helpers/pfc_gen_brcm_xgs.py
+++ b/tests/common/helpers/pfc_gen_brcm_xgs.py
@@ -163,16 +163,6 @@ class FanoutPfcStorm():
                 if (1 << prio) & self.priority:
                     self._cliCmd(f"en\nconf\n\nint {intf}\nno priority-flow-control priority {prio} no-drop")
 
-    def _endPfcStorm(self, intf):
-        '''
-        Intf format is Ethernet1/1
-
-        The users of this class are only expected to call
-        startPfcStorm and endAllPfcStorm
-        '''
-        self._clearPfcBackpressure(intf)
-        self._restorePfcConfig(intf)
-
     def startPfcStorm(self, intf):
         if intf in self.intfsEnabled:
             return

--- a/tests/common/helpers/pfc_gen_brcm_xgs.py
+++ b/tests/common/helpers/pfc_gen_brcm_xgs.py
@@ -134,12 +134,11 @@ class FanoutPfcStorm():
 
         return intfToMmuPort, intfTolPort
 
-    def _endPfcStorm(self, intf):
+    def _clearPfcBackpressure(self, intf):
         '''
-        Intf format is Ethernet1/1
+        Drop the ASIC PFC assertion for one interface.
 
-        The users of this class are only expected to call
-        startPfcStorm and endAllPfcStorm
+        This alone stops the storm; _restorePfcConfig() afterwards is bookkeeping.
         '''
         mmuPort = self.intfToMmuPort[intf]
         port = self.intfToPort[intf]
@@ -148,14 +147,31 @@ class FanoutPfcStorm():
             self._bcmltshellCmd(f"pt MMU_INTFO_TO_XPORT_BKPr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP=0")
         else:
             self._bcmshellCmd(f"setreg CHFC2PFC_STATE.{port} PRI_BKP=0")
+
+    def _restorePfcConfig(self, intf):
+        '''
+        Undo the PFC config startPfcStorm() applied to one interface.
+        '''
         if self.os == 'sonic':
             for prio in range(8):
-                self._shellCmd(f"config interface pfc priority {intf} {prio} off")
+                if (1 << prio) & self.priority:
+                    self._shellCmd(f"config interface pfc priority {intf} {prio} off")
             self._shellCmd(f"redis-cli -n 4 DEL \"PORT_QOS_MAP|{intf}\"")
         else:
             self._cliCmd(f"en\nconf\n\nint {intf}\nno priority-flow-control on")
             for prio in range(8):
-                self._cliCmd(f"en\nconf\n\nint {intf}\nno priority-flow-control priority {prio} no-drop")
+                if (1 << prio) & self.priority:
+                    self._cliCmd(f"en\nconf\n\nint {intf}\nno priority-flow-control priority {prio} no-drop")
+
+    def _endPfcStorm(self, intf):
+        '''
+        Intf format is Ethernet1/1
+
+        The users of this class are only expected to call
+        startPfcStorm and endAllPfcStorm
+        '''
+        self._clearPfcBackpressure(intf)
+        self._restorePfcConfig(intf)
 
     def startPfcStorm(self, intf):
         if intf in self.intfsEnabled:
@@ -182,8 +198,16 @@ class FanoutPfcStorm():
             self._bcmshellCmd(f"setreg CHFC2PFC_STATE.{port} PRI_BKP={self.priority}")
 
     def endAllPfcStorm(self):
+        '''
+        Stop the storm on every interface.
+
+        Backpressure is dropped everywhere first, then the config is restored, rather
+        than doing both per interface.
+        '''
         for intf in self.intfsEnabled:
-            self._endPfcStorm(intf)
+            self._clearPfcBackpressure(intf)
+        for intf in self.intfsEnabled:
+            self._restorePfcConfig(intf)
 
 
 def main():

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -88,6 +88,9 @@ class PFCStorm(object):
         self.fanout_info = fanout_graph_facts
         self.fanout_hosts = fanouthosts
         self.pfc_gen_file = kwargs.pop('pfc_gen_file', "pfc_gen.py")
+        # deploy_pfc_gen() overrides pfc_gen_file when the fanout is XGS; keep the
+        # caller's choice so a later, non-XGS fanout can be given it back
+        self._pfc_gen_file_requested = self.pfc_gen_file
         self.pfc_gen_multiprocess = kwargs.pop('pfc_gen_multiprocess', False)
         self.pfc_gen_chip_name = None
         self._xgs_chip = self._XGS_CHIP_UNRESOLVED
@@ -244,6 +247,11 @@ class PFCStorm(object):
                 self.pfc_gen_file = "pfc_gen_brcm_xgs.py"
                 self.pfc_gen_file_test_name = "pfc_gen_brcm_xgs.py"
                 self.pfc_gen_chip_name = chip_name
+            else:
+                # This instance may have been pointed at an XGS fanout before;
+                # a fanout that cannot run that generator must not inherit it.
+                self.pfc_gen_file = self._pfc_gen_file_requested
+                self.pfc_gen_chip_name = None
             src_pfc_gen_file = "common/helpers/{}".format(self.pfc_gen_file)
             self._create_pfc_gen()
             if self.fanout_asic_type == 'mellanox':
@@ -275,6 +283,9 @@ class PFCStorm(object):
             self._populate_peer_hwsku()
         self.update_platform_name()
         self.peer_device = self.fanout_hosts[self.peer_info['peerdevice']]
+        # The fanout may have changed, so the memoized chip answer is no longer
+        # valid; _xgs_chip_name() must ask this fanout.
+        self._xgs_chip = self._XGS_CHIP_UNRESOLVED
 
     def update_platform_name(self):
         """

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -58,9 +58,6 @@ def get_chip_name_if_asic_pfc_storm_supported(fanout):
 class PFCStorm(object):
     """ PFC storm/start on different interfaces on a fanout connected to the DUT"""
 
-    # sentinel so _xgs_chip_name() can cache a legitimate None result
-    _XGS_CHIP_UNRESOLVED = object()
-
     _PFC_GEN_DIR = {
         'sonic': '/tmp',
         'eos': '/mnt/flash',
@@ -93,7 +90,11 @@ class PFCStorm(object):
         self._pfc_gen_file_requested = self.pfc_gen_file
         self.pfc_gen_multiprocess = kwargs.pop('pfc_gen_multiprocess', False)
         self.pfc_gen_chip_name = None
-        self._xgs_chip = self._XGS_CHIP_UNRESOLVED
+        # Chip answer per fanout: one instance can walk several, and revisiting one
+        # should not ask it again.
+        self._xgs_chip_cache = {}
+        # Fanout deploy_pfc_gen() last ran against, so a fanout switch redeploys.
+        self._deployed_peer = None
         self.pfc_queue_idx = kwargs.pop('pfc_queue_index', 3)
         self.pfc_frames_number = kwargs.pop('pfc_frames_number', 100000)
         self.send_pfc_frame_interval = kwargs.pop('send_pfc_frame_interval', 0)
@@ -219,21 +220,24 @@ class PFCStorm(object):
     def _xgs_chip_name(self):
         """
         Fanout chip name if its ASIC supports register-based PFC storm generation,
-        else None. Memoized -- resolving it shells out to the fanout.
+        else None. Cached per fanout -- resolving it shells out to the fanout, and
+        callers update the fanout interface far more often than the fanout itself.
         """
-        if self._xgs_chip is self._XGS_CHIP_UNRESOLVED:
+        peer = self.peer_info['peerdevice']
+        if peer not in self._xgs_chip_cache:
             if self.peer_device.os == 'eos':
-                self._xgs_chip = get_chip_name_if_asic_pfc_storm_supported(
+                chip_name = get_chip_name_if_asic_pfc_storm_supported(
                     self._get_eos_fanout_version()[0])
             elif self.peer_device.os == 'sonic':
                 # Prefer what the ASIC reports; fall back to the HWSKU table so
                 # fanouts where bcmcmd is unavailable keep working as before.
-                self._xgs_chip = (self._get_sonic_fanout_chip_name() or
-                                  get_chip_name_if_asic_pfc_storm_supported(
-                                      self._get_sonic_fanout_hwsku()))
+                chip_name = (self._get_sonic_fanout_chip_name() or
+                             get_chip_name_if_asic_pfc_storm_supported(
+                                 self._get_sonic_fanout_hwsku()))
             else:
-                self._xgs_chip = None
-        return self._xgs_chip
+                chip_name = None
+            self._xgs_chip_cache[peer] = chip_name
+        return self._xgs_chip_cache[peer]
 
     def deploy_pfc_gen(self):
         """
@@ -251,6 +255,7 @@ class PFCStorm(object):
                 # This instance may have been pointed at an XGS fanout before;
                 # a fanout that cannot run that generator must not inherit it.
                 self.pfc_gen_file = self._pfc_gen_file_requested
+                self.pfc_gen_file_test_name = self._pfc_gen_file_requested
                 self.pfc_gen_chip_name = None
             src_pfc_gen_file = "common/helpers/{}".format(self.pfc_gen_file)
             self._create_pfc_gen()
@@ -263,6 +268,21 @@ class PFCStorm(object):
             if self.fanout_asic_type == 'mellanox':
                 cmd = f"docker cp {self._PFC_GEN_DIR[self.peer_device.os]}/{self.pfc_gen_file} syncd:/root/"
                 self.peer_device.shell(cmd)
+        self._deployed_peer = self.peer_info['peerdevice']
+
+    def _ensure_pfc_gen_deployed(self):
+        """
+        Deploy the generator if the fanout changed since the last deploy.
+
+        Callers that walk several fanouts do not all call deploy_pfc_gen() again on a
+        fanout they have visited before, but the generator on the fanout, the file
+        name rendered into the template and the chip name passed to it all have to
+        describe the same fanout.
+        """
+        if self.asic_type == 'vs':
+            return
+        if self._deployed_peer != self.peer_info['peerdevice']:
+            self.deploy_pfc_gen()
 
     def update_queue_index(self, q_idx):
         """
@@ -283,9 +303,11 @@ class PFCStorm(object):
             self._populate_peer_hwsku()
         self.update_platform_name()
         self.peer_device = self.fanout_hosts[self.peer_info['peerdevice']]
-        # The fanout may have changed, so the memoized chip answer is no longer
-        # valid; _xgs_chip_name() must ask this fanout.
-        self._xgs_chip = self._XGS_CHIP_UNRESOLVED
+        # The fanout may have changed, and this was resolved once in __init__ and
+        # never since. _xgs_chip_name() and the deployed generator key off the
+        # fanout themselves.
+        self.fanout_asic_type = self.peer_device.facts['asic_type'] \
+            if isinstance(self.peer_device.host, SonicHost) else None
 
     def update_platform_name(self):
         """
@@ -338,13 +360,13 @@ class PFCStorm(object):
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_eos.j2")
         elif (self.dut.topo_type == 't2' and self.peer_device.os == 'sonic' and
-              not self._xgs_chip_name()):
+              not self.pfc_gen_chip_name):
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_{}_t2.j2".format(self.peer_device.os))
         elif self.fanout_asic_type == 'mellanox' and self.peer_device.os == 'sonic':
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_mlnx_{}.j2".format(self.peer_device.os))
-        elif self._xgs_chip_name():
+        elif self.pfc_gen_chip_name:
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_arista_{}.j2".format(self.peer_device.os))
         else:
@@ -361,13 +383,13 @@ class PFCStorm(object):
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_eos.j2")
         elif (self.dut.topo_type == 't2' and self.peer_device.os == 'sonic' and
-              not self._xgs_chip_name()):
+              not self.pfc_gen_chip_name):
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_{}_t2.j2".format(self.peer_device.os))
         elif self.fanout_asic_type == 'mellanox' and self.peer_device.os == 'sonic':
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_mlnx_{}.j2".format(self.peer_device.os))
-        elif self._xgs_chip_name():
+        elif self.pfc_gen_chip_name:
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_arista_{}.j2".format(self.peer_device.os))
         else:
@@ -403,6 +425,7 @@ class PFCStorm(object):
         """
         Starts PFC storm on the fanout interfaces
         """
+        self._ensure_pfc_gen_deployed()
         self._prepare_start_template()
         if self.asic_type == 'vs':
             return

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -15,6 +15,15 @@ RUN_PLAYBOOK = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../s
 
 logger = logging.getLogger(__name__)
 
+# Broadcom part number -> chip name pfc_gen_brcm_xgs.py understands. Read from the
+# fanout ASIC at runtime, so a new HWSKU on a known chip needs no table change.
+BCM_CHIP_NAMES = {
+    'BCM78900': 'Tomahawk5',
+    'BCM78902': 'Tomahawk5',
+    'BCM78910': 'Tomahawk6',
+    'BCM78914': 'Tomahawk6',
+}
+
 
 def get_chip_name_if_asic_pfc_storm_supported(fanout):
     hwSkuInfo = {
@@ -49,6 +58,9 @@ def get_chip_name_if_asic_pfc_storm_supported(fanout):
 class PFCStorm(object):
     """ PFC storm/start on different interfaces on a fanout connected to the DUT"""
 
+    # sentinel so _xgs_chip_name() can cache a legitimate None result
+    _XGS_CHIP_UNRESOLVED = object()
+
     _PFC_GEN_DIR = {
         'sonic': '/tmp',
         'eos': '/mnt/flash',
@@ -78,6 +90,7 @@ class PFCStorm(object):
         self.pfc_gen_file = kwargs.pop('pfc_gen_file', "pfc_gen.py")
         self.pfc_gen_multiprocess = kwargs.pop('pfc_gen_multiprocess', False)
         self.pfc_gen_chip_name = None
+        self._xgs_chip = self._XGS_CHIP_UNRESOLVED
         self.pfc_queue_idx = kwargs.pop('pfc_queue_index', 3)
         self.pfc_frames_number = kwargs.pop('pfc_frames_number', 100000)
         self.send_pfc_frame_interval = kwargs.pop('send_pfc_frame_interval', 0)
@@ -177,6 +190,48 @@ class PFCStorm(object):
             if line.startswith('HwSKU:'):
                 return line.split()[1]
 
+    def _get_sonic_fanout_chip_name(self):
+        """
+        Chip name reported by the fanout ASIC itself, or None.
+
+        Asking the ASIC means a new HWSKU on an already-known chip needs no table
+        change, and it works for any vendor's SONiC fanout. Best effort: bcmcmd is
+        silent on some fanouts (syncd down, non-Broadcom SDK), and parts absent from
+        BCM_CHIP_NAMES fall back to the HWSKU table in _xgs_chip_name().
+        """
+        try:
+            output = self.peer_device.shell('bcmcmd "show unit"')['stdout']
+        except Exception as e:
+            logger.info("Could not read chip from fanout ASIC: {}".format(e))
+            return None
+        # e.g. "Unit 0 chip BCM78900_B0 (current)"
+        mo = re.search(r'chip (BCM\d+)', output)
+        if not mo:
+            logger.info("Fanout ASIC did not report a chip part number")
+            return None
+        chip_name = BCM_CHIP_NAMES.get(mo.group(1))
+        logger.info("Fanout ASIC reports {} -> chip name {}".format(mo.group(1), chip_name))
+        return chip_name
+
+    def _xgs_chip_name(self):
+        """
+        Fanout chip name if its ASIC supports register-based PFC storm generation,
+        else None. Memoized -- resolving it shells out to the fanout.
+        """
+        if self._xgs_chip is self._XGS_CHIP_UNRESOLVED:
+            if self.peer_device.os == 'eos':
+                self._xgs_chip = get_chip_name_if_asic_pfc_storm_supported(
+                    self._get_eos_fanout_version()[0])
+            elif self.peer_device.os == 'sonic':
+                # Prefer what the ASIC reports; fall back to the HWSKU table so
+                # fanouts where bcmcmd is unavailable keep working as before.
+                self._xgs_chip = (self._get_sonic_fanout_chip_name() or
+                                  get_chip_name_if_asic_pfc_storm_supported(
+                                      self._get_sonic_fanout_hwsku()))
+            else:
+                self._xgs_chip = None
+        return self._xgs_chip
+
     def deploy_pfc_gen(self):
         """
         Deploy the pfc generation file on the fanout
@@ -184,12 +239,8 @@ class PFCStorm(object):
         if self.asic_type == 'vs':
             return
         if self.peer_device.os in ('eos', 'sonic'):
-            chip_name = None
-            if self.peer_device.os == 'eos':
-                chip_name = get_chip_name_if_asic_pfc_storm_supported(self._get_eos_fanout_version()[0])
-            elif self.peer_device.os == 'sonic':
-                chip_name = get_chip_name_if_asic_pfc_storm_supported(self._get_sonic_fanout_hwsku())
-            if self.peer_device.os in ('eos', 'sonic') and chip_name:
+            chip_name = self._xgs_chip_name()
+            if chip_name:
                 self.pfc_gen_file = "pfc_gen_brcm_xgs.py"
                 self.pfc_gen_file_test_name = "pfc_gen_brcm_xgs.py"
                 self.pfc_gen_chip_name = chip_name
@@ -275,16 +326,14 @@ class PFCStorm(object):
         if self.asic_type == 'vs':
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_eos.j2")
-        elif self.dut.topo_type == 't2' and self.peer_device.os == 'sonic':
+        elif (self.dut.topo_type == 't2' and self.peer_device.os == 'sonic' and
+              not self._xgs_chip_name()):
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_{}_t2.j2".format(self.peer_device.os))
         elif self.fanout_asic_type == 'mellanox' and self.peer_device.os == 'sonic':
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_mlnx_{}.j2".format(self.peer_device.os))
-        elif ((self.peer_device.os == 'eos' and
-               get_chip_name_if_asic_pfc_storm_supported(self._get_eos_fanout_version()[0])) or
-              (self.peer_device.os == 'sonic' and
-               get_chip_name_if_asic_pfc_storm_supported(self._get_sonic_fanout_hwsku()))):
+        elif self._xgs_chip_name():
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_arista_{}.j2".format(self.peer_device.os))
         else:
@@ -300,16 +349,14 @@ class PFCStorm(object):
         if self.asic_type == 'vs':
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_eos.j2")
-        elif self.dut.topo_type == 't2' and self.peer_device.os == 'sonic':
+        elif (self.dut.topo_type == 't2' and self.peer_device.os == 'sonic' and
+              not self._xgs_chip_name()):
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_{}_t2.j2".format(self.peer_device.os))
         elif self.fanout_asic_type == 'mellanox' and self.peer_device.os == 'sonic':
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_mlnx_{}.j2".format(self.peer_device.os))
-        elif ((self.peer_device.os == 'eos' and
-               get_chip_name_if_asic_pfc_storm_supported(self._get_eos_fanout_version()[0])) or
-              (self.peer_device.os == 'sonic' and
-               get_chip_name_if_asic_pfc_storm_supported(self._get_sonic_fanout_hwsku()))):
+        elif self._xgs_chip_name():
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_arista_{}.j2".format(self.peer_device.os))
         else:


### PR DESCRIPTION
### Description of PR

Summary:
Choose the register-based Broadcom XGS PFC storm generator (`pfc_gen_brcm_xgs.py`) from what the fanout ASIC actually reports, instead of only from a hard-coded HwSKU list, and stop PFC on every interface before restoring config in `endAllPfcStorm()`.

Fixes # (issue): no upstream issue — found while running `pfcwd/test_pfcwd_all_port_storm.py` against SONiC fanouts.

#### What is the problem

`get_chip_name_if_asic_pfc_storm_supported()` knows only a fixed set of Arista, Nokia and M2 HwSKUs, so every other SONiC fanout — same Broadcom silicon or not — falls through to the software `pfc_gen.py`, an unpaced Python raw-socket loop. Holding XOFF at `-t 65535` quanta needs a refresh roughly every 84 µs on a 400G port, so any GC or scheduling hiccup lets the pause lapse. Measured on a 400G SONiC fanout, `PFC_STORM_START` → first deadlock notification was **192 ms on one iteration and 14.4 s on the next**, same build and same config.

That lapse is also visible as a false test failure: pfcwd reports `storm restored` while the fanout is still nominally storming, so the restore event lands inside the test's *storm* LogAnalyzer window and the restore window comes up empty (`expected_missing_match`):

```
09:21:14  start-LogAnalyzer-all_port_storm
09:21:20  report_pfc_storm     x8
09:21:29  report_pfc_restored  x8      <-- logged here, inside the storm window
09:21:34  end-LogAnalyzer-all_port_storm
09:21:39  start-LogAnalyzer-all_port_storm_restore
09:21:51  end-LogAnalyzer-all_port_storm_restore   <-- empty -> expected_missing_match
```

`pfc_gen_brcm_xgs.py` asserts PFC in fanout hardware and then idles, so there is nothing to lapse.

#### What changed

**1. `tests/common/helpers/pfc_storm.py` — read the fanout chip from the ASIC.**

`bcmcmd "show unit"` reports e.g. `Unit 0 chip BCM78900_B0`, so `_get_sonic_fanout_chip_name()` maps the part number through a new `BCM_CHIP_NAMES` dict. Asking the ASIC means a new HwSKU on an already-known chip needs no table edit, and any vendor's SONiC fanout on the same silicon resolves identically. The HwSKU table stays as a fallback for EOS fanouts and for any fanout where `bcmcmd` cannot answer (syncd down, non-Broadcom SDK), so nothing that works today regresses. Resolution order: ASIC → HwSKU table → `None`.

Part numbers in the dict were read off real hardware, not inferred. Two deliberate omissions:

- **DNX parts are absent by design.** `pfc_gen_brcm_xgs.py` programs XGS-only MMU registers, so DNX fanouts keep the CPU generator. DNX fanouts on the same HwSKU can report different part numbers, which is why exclusion is by absence rather than an explicit entry.
- **Tomahawk4 and older are absent.** The Arista TH/TH2/TH4 SKUs still resolve via the HwSKU table, and a wrong part number would be worse than a missing one — it would send the generator down the `MMU_INTFO_*` path on a chip that needs the legacy `CHFC2PFC_STATE` register. They can be added once read off hardware.

**2. `pfc_storm.py` — an XGS fanout now wins over the t2 branch.**

The generator is chosen from the *fanout's* ASIC in `deploy_pfc_gen()`, but template selection tests the *DUT's* topology first, so a t2 testbed always got `pfc_storm_sonic_t2.j2`. That template renders arguments for the CPU generator — `-t 65535 -s <period> -n <frames>`, plus `-m` when multiprocess is enabled — and never renders `-c <chip>`. `pfc_gen_brcm_xgs.py` parses with `optparse`, which rejects the first of those it sees and exits before it even reaches its own check for the missing chip name. The generator dies immediately: no `PFC_STORM_START`, no storm, and the test fails as though pfcwd never detected one.

This collision is reachable on master as it stands, not something this PR introduces. Any SONiC fanout already in `hwSkuInfo` resolves to `pfc_gen_brcm_xgs.py` in `deploy_pfc_gen()` today while still being handed the t2 template, and the table already carries SONiC-side entries (`M2-W6940-64X1-FR4`, `Nokia-IXR7220`, `NH-4210-F-O256`). Reading the chip from the ASIC widens the set of fanouts that reach that code, which is how we ran into it.

Nothing about the register mechanism depends on the DUT — it programs the fanout's own MMU registers and takes only fanout interfaces — so the t2 branch is now gated on there being no XGS chip. t2 testbeds behind a DNX fanout keep `pfc_gen_t2.py` and `pfc_storm_sonic_t2.j2`, unchanged.

**3. `pfc_storm.py` — memoize the chip lookup.**

Resolving the chip shells out to the fanout, and it was resolved up to three times per storm (both template selectors plus `deploy_pfc_gen()`). Now once, behind `_xgs_chip_name()`, with a sentinel so a legitimate `None` is cached too.

**4. `tests/common/helpers/pfc_gen_brcm_xgs.py` — stop PFC everywhere before restoring config.**

`endAllPfcStorm()` cleared backpressure and restored config one interface at a time. The config half is slow, so PFC kept flowing on interfaces later in the list while earlier ones had already stopped. On a 64-port fanout that spread the DUT's pfcwd restore events over minutes:

```
before   14:10:55.285 -> :58.688 -> 15:01.896 -> :05.326    ~3.4 s per port
after    16:45:57.801 -> :58.354 -> :58.755   -> :59.356    ~0.5 s per port
```

`test_all_port_storm_restore` needs 100% of stormed ports restored inside `wait_until(max(60, N*3))`, and the old ramp did not fit — the IPv6 parameterization failed on `Not enough ports reached restore state (threshold: 100%)`.

Splitting `_endPfcStorm()` into `_clearPfcBackpressure()` + `_restorePfcConfig()` also let the config half only turn off the priorities that were actually enabled: `startPfcStorm()` sets just the bitmap priorities, so clearing all eight was wasted work and destructive of unrelated lossless priorities on the fanout. Config commands on a 64-port fanout: **576 → 128**.

**5. `pfc_storm.py` — re-resolve the chip when the fanout changes.**

`test_pfcwd_function.py`, `test_pfcwd_cli.py` and `qos/test_pfc_pause.py` reuse a single `PFCStorm` instance across several fanouts via `update_peer_info()`. The answer memoized in (3) survived that switch, and so did `pfc_gen_file`/`pfc_gen_chip_name`, which `deploy_pfc_gen()` only ever *set* and never cleared. On a DUT whose ports land on two fanouts of different silicon, the second fanout therefore inherited the first one's verdict: an XGS fanout seen after a non-XGS one fell back to `pfc_gen.py`, and a non-XGS fanout seen after an XGS one was handed `pfc_gen_brcm_xgs.py` with `-c <first fanout's chip>`.

`update_peer_info()` now invalidates the cache and `deploy_pfc_gen()` re-derives the generator in both directions. On a fresh instance the new `else` branch is a no-op — `pfc_gen_file` still holds exactly what the caller passed — so single-fanout behaviour is unchanged. The second half of this also fixes a pre-existing bug on master: before this PR, a second, non-listed fanout already got `pfc_gen_brcm_xgs.py` rendered into the CPU-generator template, which dies in `optparse`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): none — no back port requested here.
Failure type: day-one issue (the HwSKU-only chip lookup has never resolved non-listed SONiC fanouts).

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

`pfcwd/test_pfcwd_all_port_storm.py::TestPfcwdAllPortStorm::test_all_port_storm_restore`, both the IPv4 and IPv6 parameterizations, on master:

| DUT | fanout | topology | result |
| --- | --- | --- | --- |
| DNX, 64 links | Tomahawk5 SONiC | t2-single-node-max-64p | **2/2 pass** — IPv6 119 s, IPv4 81 s (IPv4 was 694 s before) |
| DNX | Tomahawk5 SONiC | t2-single-node-min | 2/2 pass |
| Tomahawk5, HW pfcwd | Tomahawk5 SONiC | t0-8 | 2/2 pass (two testbeds) |
| Tomahawk5 | Tomahawk5 SONiC | t1-8 | 2/2 pass, 8/8 ports stormed and restored |
| DNX | DNX SONiC | t2 | unchanged on `pfc_gen_t2.py` — control for the DNX path |

The 64-link run is the strongest case: four 16-interface batches, `Fanout ASIC reports BCM78900 -> chip name Tomahawk5`, 91 references to `pfc_gen_brcm_xgs.py` in the log. On the t1-8 run all 8 ports appear in both the detect and restore logs, with restores landing inside the restore window ~0.45 s apart, and across the t0-8 runs no `report_pfc_restored` appeared inside any storm window.

Fanout/topology resolution was also checked off-hardware for the multi-fanout case, driving the real `deploy_pfc_gen()` and `_prepare_start_template()` with the DUT and fanouts stubbed and rendering the real template: a single `PFCStorm` walked across (XGS, DNX), (DNX, XGS) and the same pair on t2 now hands each fanout its own generator, chip and template, while the single-fanout cases are byte-identical to before.

Unrelated observation while validating: the `--- N ports entered storm state ---` counter under-reports, because `wait_until` returns as soon as the 75% threshold is met and `stormed_ports_list` captures only the ports that had stormed at that poll. One run logged all 8 ports restored while the counter said 6. It is bookkeeping, not a coverage gap — not touched here.

### Approach

#### What is the motivation for this PR?

Any SONiC fanout not in the HwSKU table gets the software PFC generator, whose pause assertion is not reliable at 400G. That produces intermittent, misleading pfcwd failures rather than honest ones, and it blocks XGS SONiC fanouts on t2 testbeds entirely.

#### How did you do it?

Resolve the chip from `bcmcmd "show unit"` with the HwSKU table as fallback, memoize it, gate the t2 template branch on the absence of an XGS chip, and make the generator's teardown drop backpressure on all interfaces before doing the slow config restore.

#### How did you verify/test it?

Hardware runs above. Beyond that, driving the real `_prepare_start_template()`, `_prepare_stop_template()` and `deploy_pfc_gen()`, the start template, stop template and deployed generator agree across every fanout/topology combination:

```
topo  fanout                  start template             generator
t0-8  XGS (TH5) SONiC         pfc_storm_arista_sonic.j2  pfc_gen_brcm_xgs.py
t2    XGS (TH5) SONiC         pfc_storm_arista_sonic.j2  pfc_gen_brcm_xgs.py   <- unblocked
t2    DNX SONiC               pfc_storm_sonic_t2.j2      pfc_gen_t2.py         <- unchanged
lt2   XGS SONiC               pfc_storm_arista_sonic.j2  pfc_gen_brcm_xgs.py   <- lt2 is not t2
t1    Arista-7060X6-64PE-P64  pfc_storm_arista_eos.j2    pfc_gen_brcm_xgs.py   <- unchanged
t0    Mellanox-SN4700         pfc_storm_mlnx_sonic.j2    pfc_gen.py            <- unchanged
```

Chip resolution was driven against verbatim `show unit` output captured from four different fanouts, plus both degraded paths (`bcmcmd` silent, `bcmcmd` raising) — ASIC-derived where available, HwSKU fallback otherwise, `None` for DNX.

`flake8 --max-line-length=120` clean.

#### Any platform specific information?

Broadcom XGS SONiC fanouts. DNX fanouts keep the CPU-based generator by design — neither the XGS MMU registers nor the SDKLT shell exist there. Fanouts running EOS are unaffected: they keep resolving through the HwSKU table exactly as before.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case.

### Documentation

No documentation change needed; this is internal test-framework behavior.
