### PR TITLE
[bgp] Disable memory_utilization for test_bgp_gr_with_suppress_fib

### DIFF
--- a/tests/bgp/test_bgp_gr_suppress_fib.py
+++ b/tests/bgp/test_bgp_gr_suppress_fib.py
@@ -257,6 +257,11 @@ def _get_gr_restart_timer(duthost, bgp_neighbor_ips):
     return default_timer
 
 
+# This case flaps the whole BGP RIB (module fixture's "clear bgp *" on all neighbors, plus
+# "systemctl restart bgp"), so frr_bgp before/after snapshots are meaningless: freed routes
+# stay on glibc's free list, making the pre-test uordblks read low and tripping a false
+# frr_bgp increase alarm (RSS is flat, no real leak). See sonic-net/sonic-mgmt#25085.
+@pytest.mark.disable_memory_utilization
 def test_bgp_gr_with_suppress_fib(duthosts, rand_one_dut_hostname, nbrhosts,
                                   setup_bgp_graceful_restart, enable_suppress_fib, tbinfo):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: test_bgp_gr_with_suppress_fib intermittently fails in the memory_utilization teardown with a false frr_bgp alarm:

  [ALARM]: frr_bgp:used memory usage increased by 54.9% (164.0 -> 254.0 MB)

The test flaps the whole BGP RIB: the module fixture setup_bgp_graceful_restart runs "clear bgp *" on all neighbors and the test runs "systemctl restart bgp". After the flap, bgpd frees a large chunk of Adj-RIB-In that glibc keeps on its free list, so the pre-test frr_bgp "used" (uordblks from `show memory bgp`) reads low (164 MB, ~93 MB on the free list) and settles back to ~254 MB after routes are re-learned. bgpd RSS stays flat, so this is a free-list artifact, not a leak, but the fixture trips the 50% increase threshold.


Fixes # (issue) #27191
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/sonic-net/sonic-mgmt/issues/27191
Failure type: <!-- day-one issue / regression / other --> day-one issue

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

- master: pass
- 202605: pass

### Approach
#### What is the motivation for this PR?

Fix the intermittent memory check failure

#### How did you do it?

disable memory check for the specific test case

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
run the test in physical environments with different platforms

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

N/A
