### PR TITLE
[202605][vlan] Serialize port changes with YANG validation

### DIFF
--- a/tests/common/helpers/config_db_utils.py
+++ b/tests/common/helpers/config_db_utils.py
@@ -1,0 +1,16 @@
+CONFIG_DB_LOCK_FILE = "/tmp/sonic_mgmt_config_db.lock"
+CONFIG_DB_LOCK_TIMEOUT = 600
+
+
+def run_config_db_command(duthost, command, **kwargs):
+    """
+    Run a CONFIG_DB command under a DUT-local cross-process lock.
+
+    The lock coordinates independent pytest and MARS processes that share a
+    DUT, preventing CONFIG_DB writes from overlapping consistency checks.
+    """
+    locked_command = (
+        f"sudo flock -x -w {CONFIG_DB_LOCK_TIMEOUT} "
+        f"{CONFIG_DB_LOCK_FILE} {command}"
+    )
+    return duthost.shell(locked_command, **kwargs)

--- a/tests/common/helpers/config_db_utils.py
+++ b/tests/common/helpers/config_db_utils.py
@@ -1,3 +1,6 @@
+import shlex
+
+
 CONFIG_DB_LOCK_FILE = "/tmp/sonic_mgmt_config_db.lock"
 CONFIG_DB_LOCK_TIMEOUT = 600
 
@@ -9,8 +12,9 @@ def run_config_db_command(duthost, command, **kwargs):
     The lock coordinates independent pytest and MARS processes that share a
     DUT, preventing CONFIG_DB writes from overlapping consistency checks.
     """
+    payload = shlex.quote(command)
     locked_command = (
         f"sudo flock -x -w {CONFIG_DB_LOCK_TIMEOUT} "
-        f"{CONFIG_DB_LOCK_FILE} {command}"
+        f"{CONFIG_DB_LOCK_FILE} sh -c {payload}"
     )
     return duthost.shell(locked_command, **kwargs)

--- a/tests/common/helpers/yang_utils.py
+++ b/tests/common/helpers/yang_utils.py
@@ -20,7 +20,7 @@ def run_yang_validation(duthost, stage="validation"):
     try:
         result = run_config_db_command(
             duthost,
-            'sh -c \'echo "[]" | config apply-patch /dev/stdin\'',
+            'echo "[]" | config apply-patch /dev/stdin',
             module_ignore_errors=True
         )
 

--- a/tests/common/helpers/yang_utils.py
+++ b/tests/common/helpers/yang_utils.py
@@ -1,5 +1,7 @@
 import logging
 
+from tests.common.helpers.config_db_utils import run_config_db_command
+
 logger = logging.getLogger(__name__)
 
 
@@ -16,8 +18,9 @@ def run_yang_validation(duthost, stage="validation"):
     """
     logger.info(f"Running YANG validation on {duthost.hostname} ({stage})")
     try:
-        result = duthost.shell(
-            'echo "[]" | sudo config apply-patch /dev/stdin',
+        result = run_config_db_command(
+            duthost,
+            'sh -c \'echo "[]" | config apply-patch /dev/stdin\'',
             module_ignore_errors=True
         )
 

--- a/tests/vlan/test_vlan_ports_down.py
+++ b/tests/vlan/test_vlan_ports_down.py
@@ -6,6 +6,7 @@ import time
 
 from netaddr import IPNetwork, NOHOST
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.config_db_utils import run_config_db_command
 from scapy.all import IP, Ether
 
 logger = logging.getLogger(__name__)
@@ -32,12 +33,12 @@ def vlan_ports_setup(duthosts, rand_one_dut_hostname):
     vlan_up_members = [port for port in vlan_members if ifs_status[port]["admin"] == "up"]
     logger.info(f"Bringing down all member ports of {vlan_name}...")
     for vlan_up_port in vlan_up_members:
-        duthost.shell(f"sudo config interface shutdown {vlan_up_port}")
+        run_config_db_command(duthost, f"config interface shutdown {vlan_up_port}")
     time.sleep(5)  # Sleep for 5 seconds to ensure T1 switches update their routing table
     yield vlan_name
     logger.info(f"Restoring the previous admin state of all member ports of {vlan_name}...")
     for vlan_port in vlan_up_members:
-        duthost.shell(f"sudo config interface startup {vlan_port}")
+        run_config_db_command(duthost, f"config interface startup {vlan_port}")
 
 
 def test_vlan_ports_down(vlan_ports_setup, duthosts, rand_one_dut_hostname, nbrhosts, tbinfo, ptfadapter):


### PR DESCRIPTION
## Summary
- add a DUT-local cross-process lock for CONFIG_DB commands
- serialize empty-patch YANG validation with `vlan_ports_down` port state changes
- prevent independent MARS/pytest processes sharing a DUT from changing CONFIG_DB during validation

## Test plan
- [x] `python3 -m py_compile tests/common/helpers/config_db_utils.py tests/common/helpers/yang_utils.py tests/vlan/test_vlan_ports_down.py`
- [x] verify the generated `flock` command with a mocked DUT host
- [x] `git diff --check`
- [ ] run `vlan/test_vlan_ports_down.py` with a concurrent YANG validation case on a physical T0 testbed