### PR TITLE
[202605][dhcp_relay]: Wait for relay readiness with uplinks down (#26527)

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -3,6 +3,9 @@ import random
 import time
 import logging
 import re
+import sys
+
+from _pytest.outcomes import OutcomeException
 
 from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmon_counters
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
@@ -530,30 +533,44 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
     testing_mode, duthost = testing_config
 
     for dhcp_relay in dut_dhcp_relay_data:
-        # Bring all uplink interfaces down
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('config interface shutdown {}'.format(iface))
+        uplink_interfaces = dhcp_relay['uplink_interfaces']
 
-        pytest_assert(wait_until(50, 5, 0, check_link_status, duthost, dhcp_relay['uplink_interfaces'], "down"),
-                      "Not all uplinks go down")
+        def restore_uplinks():
+            first_cleanup_error = None
 
-        # Restart DHCP relay service on DUT
-        # dhcp_relay service has 3 times restart limit in 20 mins, for 4 vlans config it will hit the maximum limit
-        # reset-failed before restart service
-        cmds = ['systemctl reset-failed dhcp_relay', 'systemctl restart dhcp_relay']
-        duthost.shell_cmds(cmds=cmds)
+            def cleanup_step(step_name, callback):
+                nonlocal first_cleanup_error
+                try:
+                    callback()
+                except (Exception, OutcomeException) as cleanup_error:
+                    logger.exception("DHCP relay uplink cleanup step '%s' failed", step_name)
+                    if first_cleanup_error is None:
+                        first_cleanup_error = cleanup_error
 
-        # Sleep to give the DHCP relay container time to start up and
-        # allow the relay agent to begin listening on the down interfaces
-        time.sleep(40)
+            for iface in uplink_interfaces:
+                cleanup_step('startup {}'.format(iface),
+                             lambda iface=iface: duthost.shell('config interface startup {}'.format(iface)))
+            cleanup_step('verify routes',
+                         lambda: pytest_assert(
+                             wait_until(50, 5, 0, check_routes_to_dhcp_server, duthost, dut_dhcp_relay_data),
+                             "Not all DHCP servers are routed"))
+            return first_cleanup_error
 
-        # Bring all uplink interfaces back up
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('config interface startup {}'.format(iface))
+        try:
+            # Bring all uplink interfaces down
+            for iface in uplink_interfaces:
+                duthost.shell('config interface shutdown {}'.format(iface))
 
-        # Wait until uplinks are up and routes are recovered
-        pytest_assert(wait_until(50, 5, 0, check_routes_to_dhcp_server, duthost, dut_dhcp_relay_data),
-                      "Not all DHCP servers are routed")
+            pytest_assert(wait_until(50, 5, 0, check_link_status, duthost, uplink_interfaces, "down"),
+                          "Not all uplinks go down")
+
+            relay_types = ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc']
+            restart_dhcp_service(duthost, relay_types)
+        finally:
+            original_error = sys.exc_info()[1]
+            cleanup_error = restore_uplinks()
+            if cleanup_error is not None and original_error is None:
+                raise cleanup_error
 
         # Run the DHCP relay test on the PTF host
         ptf_runner(ptfhost,


### PR DESCRIPTION
### Description of PR

Summary:
Manual backport of https://github.com/sonic-net/sonic-mgmt/pull/26527 to `202605` after the approved automated backport reported `Cherry Pick Conflict_202605`.

This carries the shared DHCP relay restart/readiness behavior into the two parameterized uplinks-down cases, selects the expected SONiC or ISC relay agent, and restores every affected uplink when setup fails.

Original ADO Task: https://msazure.visualstudio.com/One/_workitems/edit/39301052
Parent PBI: https://msazure.visualstudio.com/One/_workitems/edit/38699914

Fixes # (issue): N/A — manual delivery of the merged root PR above.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

No further backport is requested from this PR; it directly targets `202605`. Release workflow labels remain on the original PR.

### Approach
#### What is the motivation for this PR?

The `202605` test used a fixed delay after a manual relay restart and could proceed before the selected relay agent was ready. Automatic delivery of the reviewed master fix conflicted with release-branch context.

#### How did you do it?

Replace the manual restart and fixed sleep with `restart_dhcp_service`, selecting `sonic` for the SONiC relay parameter and `isc` otherwise. Preserve failure-safe cleanup that restores every uplink and verifies route recovery without masking an active setup failure.

The conflict resolution preserves every behavioral hunk from the original 38-addition/21-deletion PR diff. The only differences are release-branch import context: `re` remains in `202605`, and the newer dhcpmon debug import is absent.

#### How did you verify/test it?

- Current `202605` base: `154150b3078801f28e358c5dc5d983179f5fd73a`
- Backport head: `44d4159e7f4f3dacde478063172b2049606c9958`
- `git diff --check`, Python compilation, and targeted pre-commit checks passed.
- Existing `202605` hardware validation from the original PR used `SONiC.20260510.07` (`1df5b92630`) on `testbed-bjw2-can-7215a1-4`; both ISC and SONiC parameterized cases passed (2 passed).

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation update is required.
