### PR TITLE
[202605][generic_config_updater]: Wait for DHCP relay readiness (#26532)

### DIFF
--- a/tests/generic_config_updater/test_dhcp_relay.py
+++ b/tests/generic_config_updater/test_dhcp_relay.py
@@ -2,14 +2,13 @@ import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until
 from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_orig,\
     utils_vlan_intfs_dict_add, utils_create_test_vlans      # noqa: F401
 from tests.common.gu_utils import apply_patch, expect_op_success, expect_res_success, expect_op_failure
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import format_json_patch_for_multiasic
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload, rollback
-from tests.common.dhcp_relay_utils import restart_dhcp_service
+from tests.common.dhcp_relay_utils import restart_dhcp_service, wait_dhcp_relay_ready
 
 
 pytestmark = [
@@ -18,8 +17,6 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
-DHCP_RELAY_TIMEOUT = 120
-DHCP_RELAY_INTERVAL = 10
 SETUP_ENV_CP = "test_setup_checkpoint"
 CONFIG_ADD_DEFAULT = "config_add_default"
 
@@ -50,15 +47,6 @@ def first_avai_vlan_port(rand_selected_dut, tbinfo):
 
     logger.error("No vlan port member ready for test")
     pytest_assert(False, "No vlan port member ready for test")
-
-
-def ensure_dhcp_relay_running(duthost):
-    if not duthost.is_service_fully_started('dhcp_relay'):
-        duthost.shell('sudo systemctl start dhcp_relay')
-        pytest_assert(
-            duthost.is_service_fully_started('dhcp_relay'),
-            "dhcp_relay service is not running before test dhcp servers"
-        )
 
 
 def create_test_vlans(duthost, cfg_facts, vlan_intfs_dict, first_avai_vlan_port):
@@ -149,7 +137,6 @@ def setup_vlan(duthosts, rand_one_dut_hostname, vlan_intfs_dict, first_avai_vlan
 
     # --------------------- Setup -----------------------
     create_test_vlans(duthost, cfg_facts, vlan_intfs_dict, first_avai_vlan_port)
-    ensure_dhcp_relay_running(duthost)
 
     default_setup(duthost, vlan_intfs_list)
 
@@ -186,31 +173,6 @@ def vlan_intfs_list(vlan_intfs_dict):
     return [key for key, value in list(vlan_intfs_dict.items()) if not value['orig']]
 
 
-def ensure_dhcp_server_up(duthost):
-    """Wait till dhcp-relay server is setup
-
-    Sample output
-    admin@vlab-01:~$ docker exec dhcp_relay supervisorctl status | grep ^dhcp-relay
-    dhcp-relay:isc-dhcpv4-relay-Vlan100    RUNNING   pid 72, uptime 0:00:09
-    dhcp-relay:isc-dhcpv4-relay-Vlan1000   RUNNING   pid 73, uptime 0:00:09
-
-    """
-    def _dhcp_server_up():
-        cmds = 'docker exec dhcp_relay supervisorctl status | grep ^dhcp-relay'
-        output = duthost.shell(cmds)
-        pytest_assert(
-            not output['rc'],
-            "'{}' is not running successfully".format(cmds)
-        )
-
-        return 'RUNNING' in output['stdout']
-
-    pytest_assert(
-        wait_until(DHCP_RELAY_TIMEOUT, DHCP_RELAY_INTERVAL, 0, _dhcp_server_up),
-        "The dhcp relay server is not running"
-    )
-
-
 def dhcp_severs_by_vlanid(duthost, vlanid):
     """Get pid and then only output the related dhcp server info for that pid
 
@@ -244,7 +206,6 @@ def dhcp_severs_by_vlanid(duthost, vlanid):
 
 
 def expect_res_success_by_vlanid(duthost, vlanid, expected_content_list, unexpected_content_list):
-    ensure_dhcp_server_up(duthost)
     output = dhcp_severs_by_vlanid(duthost, vlanid)
     expect_res_success(duthost, output, expected_content_list, unexpected_content_list)
 
@@ -329,10 +290,7 @@ def test_dhcp_relay_tc3_add_and_rm(rand_selected_dut, vlan_intfs_list):
     try:
         output = apply_patch(rand_selected_dut, json_data=dhcp_add_rm_json, dest_file=tmpfile)
         expect_op_success(rand_selected_dut, output)
-        pytest_assert(
-            rand_selected_dut.is_service_fully_started('dhcp_relay'),
-            "dhcp_relay service is not running"
-        )
+        wait_dhcp_relay_ready(rand_selected_dut, ['isc'])
 
         expected_content_list = ["192.0." + str(vlan_intfs_list[0]) + ".5"]
         unexpected_content_list = ["192.0." + str(vlan_intfs_list[1]) + ".4"]
@@ -374,10 +332,7 @@ def test_dhcp_relay_tc4_replace(rand_selected_dut, vlan_intfs_list):
     try:
         output = apply_patch(rand_selected_dut, json_data=dhcp_replace_json, dest_file=tmpfile)
         expect_op_success(rand_selected_dut, output)
-        pytest_assert(
-            rand_selected_dut.is_service_fully_started('dhcp_relay'),
-            "dhcp_relay service is not running"
-        )
+        wait_dhcp_relay_ready(rand_selected_dut, ['isc'])
 
         expected_content_list = ["192.0." + str(vlan_intfs_list[0]) + ".8"]
         unexpected_content_list = ["192.0." + str(vlan_intfs_list[0]) + ".1"]


### PR DESCRIPTION
### Description of PR

Summary:
Manual backport of https://github.com/sonic-net/sonic-mgmt/pull/26532 to `202605` after the approved automated backport reported `Cherry Pick Conflict_202605`.

This replaces redundant DHCP relay service starts and partial process checks in the generic-config-updater tests with the shared external ISC relay readiness helper.

Original ADO Task: https://msazure.visualstudio.com/One/_workitems/edit/39301053
Parent PBI: https://msazure.visualstudio.com/One/_workitems/edit/38699914

Fixes # (issue): N/A — manual delivery of the merged root PR above.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

No further backport is requested from this PR; it directly targets `202605`. Release workflow labels remain on the original PR.

### Approach
#### What is the motivation for this PR?

The release tests can proceed after only systemd or a partial supervisord signal instead of waiting for the complete external ISC relay layout. Automatic delivery of the reviewed master fix conflicted with the older release file.

#### How did you do it?

Remove the redundant relay starter and local readiness poll. Use `wait_dhcp_relay_ready(duthost, ['isc'])` after successful GCU patches before process-command assertions.

#### How did you verify/test it?

- Current `202605` base: `154150b3078801f28e358c5dc5d983179f5fd73a`
- Backport head: `63249884669e5dba08d27a7bbe041ad567d8bee6`
- The 3-addition/48-deletion backport has the exact stable patch ID of the merged root PR diff.
- `git diff --check`, Python compilation, and targeted pre-commit checks passed.
- Existing `202605` hardware validation from the original PR used `SONiC.20260510.07` (`1df5b92630`) on `testbed-bjw2-can-7215a1-4`; the full DHCP relay GCU module passed (4 passed).

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

Not a new test case; existing t0/m0 coverage.

### Documentation

No documentation update is required.
