### PR TITLE
[dhcp_relay]: Simplify uplink restoration cleanup

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -2,9 +2,6 @@ import pytest
 import random
 import time
 import logging
-import sys
-
-from _pytest.outcomes import OutcomeException
 
 from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmon_counters, restart_dhcpmon_in_debug
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
@@ -505,42 +502,21 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
     for dhcp_relay in dut_dhcp_relay_data:
         uplink_interfaces = dhcp_relay['uplink_interfaces']
 
-        def restore_uplinks():
-            first_cleanup_error = None
-
-            def cleanup_step(step_name, callback):
-                nonlocal first_cleanup_error
-                try:
-                    callback()
-                except (Exception, OutcomeException) as cleanup_error:
-                    logger.exception("DHCP relay uplink cleanup step '%s' failed", step_name)
-                    if first_cleanup_error is None:
-                        first_cleanup_error = cleanup_error
-
-            for iface in uplink_interfaces:
-                cleanup_step('startup {}'.format(iface),
-                             lambda iface=iface: duthost.shell('config interface startup {}'.format(iface)))
-            cleanup_step('verify routes',
-                         lambda: pytest_assert(
-                             wait_until(50, 5, 0, check_routes_to_dhcp_server, duthost, dut_dhcp_relay_data),
-                             "Not all DHCP servers are routed"))
-            return first_cleanup_error
-
         try:
             # Bring all uplink interfaces down
             for iface in uplink_interfaces:
                 duthost.shell('config interface shutdown {}'.format(iface))
 
-            pytest_assert(wait_until(50, 5, 0, check_link_status, duthost, uplink_interfaces, "down"),
-                          "Not all uplinks go down")
-
+            pytest_assert(
+                wait_until(50, 5, 0, check_link_status, duthost, uplink_interfaces, "down"),
+                "Not all uplinks go down")
             relay_types = ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc']
             restart_dhcp_service(duthost, relay_types)
         finally:
-            original_error = sys.exc_info()[1]
-            cleanup_error = restore_uplinks()
-            if cleanup_error is not None and original_error is None:
-                raise cleanup_error
+            for iface in uplink_interfaces:
+                duthost.shell('config interface startup {}'.format(iface), module_ignore_errors=True)
+            pytest_assert(wait_until(50, 5, 0, check_routes_to_dhcp_server, duthost, dut_dhcp_relay_data),
+                          "Not all DHCP servers are routed")
 
         # Run the DHCP relay test on the PTF host
         ptf_runner(ptfhost,


### PR DESCRIPTION
### Description of PR

Summary:
Simplify failure cleanup in `test_dhcp_relay_start_with_uplinks_down` by replacing the nested per-command exception aggregation introduced by https://github.com/sonic-net/sonic-mgmt/pull/26527 with direct `try/finally` restoration. Every uplink startup is attempted with `module_ignore_errors=True`, while the existing route-recovery assertion remains unchanged.

ADO Task: https://msazure.visualstudio.com/One/_workitems/edit/39347641
Parent PBI: https://msazure.visualstudio.com/One/_workitems/edit/38699914

Affected tests: 2 parameterized cases of
`tests/dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down`
(ISC and SONiC relay modes).

Fixes # (issue): N/A

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master base `f204f626e99de210b582b26b9aaaebc9f548172f`, exact head `8e81c121a9ede82e1d122e05f8a9c9fa79058f41`: `git diff --check`, Python compilation, and targeted pre-commit checks passed.

### Approach
#### What is the motivation for this PR?

The current cleanup uses a nested callback wrapper, private `_pytest.outcomes.OutcomeException`, and `sys.exc_info()` to attempt every cleanup step while preserving an original setup failure. The pending IPv6 state-restoration PR uses a simpler direct `try/finally` pattern instead.

#### How did you do it?

Remove the private pytest and `sys` imports plus the nested cleanup/error-capture helper. Restore every uplink from `finally` with ignored per-command errors, then retain the existing `pytest_assert` route-recovery check.

#### How did you verify/test it?

Ran the static checks recorded above. Exact-head CI is running on the active PR.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

Not a new test case; existing t0/m0 coverage.

### Documentation

No documentation update is required.


