### PR TITLE
poll for async IP apply instead of immediate assert

### DIFF
--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -89,6 +89,15 @@ def _check_ip_removed(asichost, portchannel, is_ipv6=False):
     return not int_facts['ansible_interface_facts'][portchannel].get('ipv4')
 
 
+def _check_ip_added(asichost, portchannel, ip_addr, is_ipv6=False):
+    """Check if IP address is configured on portchannel."""
+    int_facts = asichost.interface_facts()['ansible_facts']
+    intf_info = int_facts.get('ansible_interface_facts', {}).get(portchannel, {})
+    if is_ipv6:
+        return ip_addr in [info['address'] for info in intf_info.get('ipv6', [])]
+    return intf_info.get('ipv4', {}).get('address') == ip_addr
+
+
 def has_bgp_neighbors(duthost, portchannel, is_ipv6=False):
     if is_ipv6:
         return duthost.shell("show ipv6 int | grep {} | awk '{{print $4}}'".format(portchannel))['stdout'] != 'N/A'
@@ -186,15 +195,10 @@ def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
 
         # Step 5: Add portchannel ip to tmp portchannel
         asichost.config_ip_intf(tmp_portchannel, portchannel_ip + "/" + prefix_len, "add")
-        int_facts = asichost.interface_facts()['ansible_facts']
-        if is_ipv6:
-            tmp_pc_ipv6_addrs = [ipv6_info['address']
-                                 for ipv6_info in int_facts['ansible_interface_facts'][tmp_portchannel].get('ipv6', [])]
-            pytest_assert(portchannel_ip in tmp_pc_ipv6_addrs,
-                          "IPv6 address {} not found on {}".format(portchannel_ip, tmp_portchannel))
-        else:
-            pytest_assert(int_facts['ansible_interface_facts'][tmp_portchannel]['ipv4']['address'] == portchannel_ip)
         add_tmp_portchannel_ip = True
+        # intfmgrd applies the IP to the kernel asynchronously, so poll for it
+        pytest_assert(wait_until(30, 5, 0, _check_ip_added, asichost, tmp_portchannel, portchannel_ip, is_ipv6),
+                      "IP address {} not found on {}".format(portchannel_ip, tmp_portchannel))
 
         pytest_assert(wait_until(30, 5, 5, _check_pc_link, asichost, tmp_portchannel, True),
                       "Portchannel {} link did not come up".format(tmp_portchannel))
@@ -341,8 +345,9 @@ def test_po_update_io_no_loss(
         asichost.config_ip_intf(tmp_pc, pc_ip + "/31", "add")
         add_tmp_pc_ip = True
 
-        int_facts = asichost.interface_facts()['ansible_facts']
-        pytest_assert(int_facts['ansible_interface_facts'][tmp_pc]['ipv4']['address'] == pc_ip)
+        # intfmgrd applies the IP to the kernel asynchronously, so poll for it
+        pytest_assert(wait_until(30, 5, 0, _check_ip_added, asichost, tmp_pc, pc_ip),
+                      "IP address {} not found on {}".format(pc_ip, tmp_pc))
 
         pytest_assert(wait_until(30, 5, 5, _check_pc_link, asichost, tmp_pc, True),
                       "Portchannel {} link did not come up".format(tmp_pc))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

`config interface ip add` updates CONFIG_DB and returns before intfmgrd applies the address to the kernel interface. The test then reads interface_facts() immediately and can fail while the address is still being applied.

The change removes a timing race between the CLI returning and asynchronous kernel configuration completing. It does not change the expected test behavior or weaken the assertion; it only allows the interface state to converge within a bounded timeout before verification.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?
- Add _check_ip_added() to poll for the expected IPv4 or IPv6 address.
- Use safe dictionary access while the interface facts are still incomplete.
- Replace the immediate IP assertions in test_po_update and test_po_update_io_no_loss with wait_until() polling.
- Preserve the existing failure behavior if the address is not applied within the timeout.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran the test for four consecutive runs and all runs passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
