### PR TITLE
[upgrade_helpers] Drop unused grpc_fixtures import that forces a pygnmi dependency

### DIFF
--- a/tests/common/helpers/upgrade_helpers.py
+++ b/tests/common/helpers/upgrade_helpers.py
@@ -5,7 +5,6 @@ import json
 import re
 from dataclasses import dataclass
 from six.moves.urllib.parse import urlparse
-import tests.common.fixtures.grpc_fixtures  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common import reboot
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue) — N/A, no linked issue (no backport requested).

`tests/common/helpers/upgrade_helpers.py` line 8 carried a bare, unused import:

```python
import tests.common.fixtures.grpc_fixtures  # noqa: F401
```

This PR deletes that single line. It is the only change (1 file changed, 1 deletion).

A bare `import package.module` statement does **not** register any pytest fixture. Pytest discovers fixtures through `conftest.py`, through `pytest_plugins`, or when fixture *names* are imported into a test/conftest namespace. Importing the module object alone does none of those, so this line registered nothing and its `# noqa: F401` correctly marked it as unused in the module body.

Its only real effect was to make `tests.common.fixtures.grpc_fixtures` — and transitively `pygnmi` — a hard **import-time** dependency of every importer of `upgrade_helpers`, including modules that have nothing to do with gNMI. On a test runner whose image does not ship `pygnmi`, collection failed outright:

```
ImportError while importing test module '.../test_metadata_upgrade_path.py'
  utilities.py:11:                    from tests.common.helpers.upgrade_helpers import install_sonic, check_sonic_version, reboot
  common/helpers/upgrade_helpers.py:  import tests.common.fixtures.grpc_fixtures  # noqa: F401
  common/fixtures/grpc_fixtures.py:   from tests.common.pygnmi_client import PygnmiClient
  common/pygnmi_client.py:            from pygnmi.client import gNMIclient, gNMIException
E ModuleNotFoundError: No module named 'pygnmi'
=== collected 0 items / 1 error ===
```

Importers of `upgrade_helpers` that were dragged into this dependency:
`tests/platform_tests/test_secure_upgrade.py`, `tests/decap/mellanox/test_ecn_mode.py`, `tests/container_upgrade/container_upgrade_helper.py`, `tests/upgrade_path/*`.

The line was introduced by `57dbf42ba` — "Added upgrade path via gnoi testcases. (#22176)".

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A - no backport requested
Failure type: N/A

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

This is a pure dead-import removal, so validation was static/collection-level. No DUT or testbed run was performed and no image version is claimed.

- **master — `flake8 --max-line-length=120 tests/common/helpers/upgrade_helpers.py` (settings per `.pre-commit-config.yaml`): clean, exit 0.** In particular no `F821` (undefined name) is introduced by removing the import.

- **master — pytest collection of the gNOI upgrade tests could NOT be executed in the development environment used for this change.** It fails before reaching the modified file, for an unrelated pre-existing reason: the repo root `tests/conftest.py` transitively imports the Unix-only `fcntl` module (`tests/conftest.py` -> `tests.common.multi_servers_utils` -> `tests/common/__init__.py` -> `tests/common/reboot.py` -> `tests/common/helpers/parallel_utils.py:1: import fcntl` -> `ModuleNotFoundError: No module named 'fcntl'`). `pygnmi` is likewise not installed there. **This is stated explicitly rather than reported as a pass — the collection check remains to be run in a sonic-mgmt container.**

  In its place, three checks were run that do not require a testbed:

  1. **Import-graph diff.** Walking only import-time (module-level/class-body) imports from `tests.common.helpers.upgrade_helpers`:

     | | modules reached | `pygnmi` reachable at import time |
     |---|---|---|
     | before | 55 | **yes** — `upgrade_helpers -> tests.common.fixtures.grpc_fixtures -> tests.common.pygnmi_client -> pygnmi.client` |
     | after | 38 | **no** |

     The "before" chain is exactly the traceback above, confirming the root cause and the fix. The same walk on `tests/upgrade_path/test_upgrade_gnoi.py` and `tests/upgrade_path/test_upgrade_smart_switch_gnoi.py` still reaches `grpc_fixtures`/`pygnmi` directly after the change, so the gNOI tests are unaffected.

  2. **Fixture-registration check.** A standalone pytest run comparing the two import forms on an equivalent minimal package:
     - `import pkg.fx` (the bare form removed here) -> `E fixture 'demo_fixture' not found`
     - `from pkg.fx import demo_fixture` (the form the real gNOI tests use) -> passed

     This confirms empirically that the deleted line registered no fixture.

  3. **Consumer audit.** An AST scan of all `test_*.py`/`conftest.py` under `tests/` found 10 modules that request a `grpc_fixtures` fixture (`gnmi_tls`, `ptf_gnoi`); **all 10 import the fixture names explicitly**, and 0 relied on the removed line:

     `tests/gnmi/test_gnoi_file.py`, `test_gnoi_killprocess.py`, `test_gnoi_os.py`, `test_gnoi_system.py`, `test_gnoi_system_reboot.py`, `test_pygnmi_client.py`, `tests/platform_tests/test_reboot.py`, `tests/smartswitch/platform_tests/test_reload_dpu.py`, `tests/upgrade_path/test_upgrade_gnoi.py`, `tests/upgrade_path/test_upgrade_smart_switch_gnoi.py`.

     No `conftest.py` anywhere under `tests/` references `grpc_fixtures` (`grep -rn "grpc_fixtures" tests/ --include=conftest.py` returns nothing), so nothing depended on the import side effect. `tests/upgrade_path/conftest.py` does import `xcvr_skip_list` from `upgrade_helpers`, but that fixture is defined in `upgrade_helpers.py` itself and is unaffected.

### Approach
#### What is the motivation for this PR?

The import provides no functionality and imposes a hard `pygnmi` dependency at import time on every consumer of `upgrade_helpers`, including test modules unrelated to gNMI/gNOI. On any image without `pygnmi` this turns into a collection-time `ModuleNotFoundError` that blocks unrelated upgrade tests from even being collected.

#### How did you do it?

Deleted the single line `import tests.common.fixtures.grpc_fixtures  # noqa: F401` from `tests/common/helpers/upgrade_helpers.py`. Nothing else in the file or repo is touched.

This is safe because:

- The name is unused in the module body — it was the only occurrence of `grpc_fixtures` in the file, and it was already annotated `# noqa: F401`.
- A bare `import package.module` does not register pytest fixtures, so the statement was not making any fixture available to anyone (demonstrated in Test result #2).
- Every module that genuinely needs the gNOI/gNMI fixtures already imports them **by name** — e.g. `tests/upgrade_path/test_upgrade_gnoi.py`: `from tests.common.fixtures.grpc_fixtures import gnmi_tls, ptf_grpc, ptf_gnoi, setup_gnoi_tls_server  # noqa: F401`. `upgrade_helpers.py:8` was the only bare-module form in the tree.
- Within `upgrade_helpers.py`, `ptf_gnoi` appears only as an ordinary **function parameter** of helpers such as `perform_gnoi_upgrade(duthost, tbinfo, ptf_gnoi, cfg)`; the calling test modules resolve the fixture themselves and pass it in. No fixture lookup in this module depends on the removed import.

Modules that need gNMI keep pulling in `grpc_fixtures` (and therefore `pygnmi`) directly; modules that do not are no longer forced to.

#### How did you verify/test it?

See **Test result** above: flake8 clean at `--max-line-length=120` with no new `F821`; import-graph walk showing `pygnmi` is no longer reachable at import time from `upgrade_helpers` (55 -> 38 modules) while the gNOI tests still reach it; a standalone pytest experiment proving the bare import form registers no fixture; and an AST audit showing all 10 fixture consumers import the names explicitly and no `conftest.py` relies on the side effect.

The pytest `--collect-only` check on `tests/upgrade_path/test_upgrade_gnoi.py` and `tests/upgrade_path/test_upgrade_smart_switch_gnoi.py` was **not** runnable in the environment used (root `conftest.py` requires the Unix-only `fcntl`, and `pygnmi` is not installed there); it still needs to be run inside a sonic-mgmt container.

#### Any platform specific information?

None. The change is platform-independent and affects only Python import behaviour.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case; no test logic, fixture, or topology marker is changed.

### Documentation

No documentation change needed — this removes a dead import and does not change any documented behaviour, fixture, or interface.
