### PR TITLE
Make test_cal_application less flaky on T2 KVM

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -12,6 +12,12 @@ from tests.common.helpers.assertions import pytest_assert
 
 logger = logging.getLogger(__name__)
 
+# caclmgrd programs the control plane ACLs asynchronously in response to config/state changes.
+# On multi-ASIC platforms the per-namespace rules can converge noticeably later than the host's,
+# so sampling the rules a single time races the programming and yields spurious failures.
+CACL_RULE_SYNC_TIMEOUT = 120
+CACL_RULE_SYNC_INTERVAL = 5
+
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer globally
     pytest.mark.topology('any', 'bmc')
@@ -1136,22 +1142,43 @@ def verify_cacl_show_acl_rule(duthost, acl_file):
     )
 
 
+def wait_for_expected_rules(duthost, asic_index, command, expected_rules,
+                            timeout=CACL_RULE_SYNC_TIMEOUT, interval=CACL_RULE_SYNC_INTERVAL):
+    """Poll the rules reported by `command` until they converge to `expected_rules`.
+
+    Returns the (missing, unexpected, actual) rules observed by the final poll, so that
+    callers keep reporting the exact same assertion details on failure as a single read would.
+    """
+    last_seen = {"missing": set(expected_rules), "unexpected": set(), "actual": []}
+
+    def _rules_converged():
+        actual_rules = duthost.get_asic_or_sonic_host(asic_index).command(command)["stdout"].strip().split("\n")
+        last_seen["actual"] = actual_rules
+        last_seen["missing"] = set(expected_rules) - set(actual_rules)
+        last_seen["unexpected"] = set(actual_rules) - set(expected_rules)
+        return not last_seen["missing"] and not last_seen["unexpected"]
+
+    if not wait_until(timeout, interval, 0, _rules_converged):
+        logger.error("Rules from '{}' did not converge within {}s. Missing: {}, unexpected: {}"
+                     .format(command, timeout, repr(last_seen["missing"]), repr(last_seen["unexpected"])))
+
+    return last_seen["missing"], last_seen["unexpected"], last_seen["actual"]
+
+
 def verify_cacl(duthost, tbinfo, localhost, creds, docker_network,
                 expected_dhcp_rules_for_standby=None, asic_index=None):
     expected_iptables_rules, expected_ip6tables_rules = \
         generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expected_dhcp_rules_for_standby)
 
-    stdout = duthost.get_asic_or_sonic_host(asic_index).command("iptables -S")["stdout"]
-    actual_iptables_rules = stdout.strip().split("\n")
+    missing_iptables_rules, unexpected_iptables_rules, actual_iptables_rules = \
+        wait_for_expected_rules(duthost, asic_index, "iptables -S", expected_iptables_rules)
 
     logger.info("Number of expected iptable rules:{}, number of actual iptables rules:{}"
                 .format(len(set(expected_iptables_rules)), len(set(actual_iptables_rules))))
 
-    missing_iptables_rules = set(expected_iptables_rules) - set(actual_iptables_rules)
     pytest_assert(len(missing_iptables_rules) == 0, "Missing expected iptables rules: {}"
                   .format(repr(missing_iptables_rules)))
 
-    unexpected_iptables_rules = set(actual_iptables_rules) - set(expected_iptables_rules)
     pytest_assert(len(unexpected_iptables_rules) == 0, "Unexpected iptables rules: {}"
                   .format(repr(unexpected_iptables_rules)))
 
@@ -1163,17 +1190,15 @@ def verify_cacl(duthost, tbinfo, localhost, creds, docker_network,
     # for i in range(len(expected_iptables_rules)):
     #    pytest_assert(actual_iptables_rules[i] == expected_iptables_rules[i], "iptables rules not in expected order")
 
-    stdout = duthost.get_asic_or_sonic_host(asic_index).command("ip6tables -S")["stdout"]
-    actual_ip6tables_rules = stdout.strip().split("\n")
+    missing_ip6tables_rules, unexpected_ip6tables_rules, actual_ip6tables_rules = \
+        wait_for_expected_rules(duthost, asic_index, "ip6tables -S", expected_ip6tables_rules)
 
     logger.info("Number of expected ip6table rules:{}, number of actual ip6tables rules:{}"
                 .format(len(set(expected_ip6tables_rules)), len(set(actual_ip6tables_rules))))
 
-    missing_ip6tables_rules = set(expected_ip6tables_rules) - set(actual_ip6tables_rules)
     pytest_assert(len(missing_ip6tables_rules) == 0, "Missing expected ip6tables rules: {}"
                   .format(repr(missing_ip6tables_rules)))
 
-    unexpected_ip6tables_rules = set(actual_ip6tables_rules) - set(expected_ip6tables_rules)
     pytest_assert(len(unexpected_ip6tables_rules) == 0, "Unexpected ip6tables rules: {}"
                   .format(repr(unexpected_ip6tables_rules)))
 
@@ -1191,29 +1216,25 @@ def verify_nat_cacl(duthost, localhost, creds, docker_network, asic_index):
     expected_iptables_rules, expected_ip6tables_rules = \
          generate_nat_expected_rules(duthost, docker_network, asic_index)
 
-    stdout = duthost.get_asic_or_sonic_host(asic_index).command("iptables -t nat -S")["stdout"]
-    actual_iptables_rules = stdout.strip().split("\n")
+    missing_iptables_rules, unexpected_iptables_rules, _ = \
+        wait_for_expected_rules(duthost, asic_index, "iptables -t nat -S", expected_iptables_rules)
 
     # Ensure all expected iptables rules are present on the DuT
-    missing_iptables_rules = set(expected_iptables_rules) - set(actual_iptables_rules)
     pytest_assert(len(missing_iptables_rules) == 0, "Missing expected iptables nat rules: {}"
                   .format(repr(missing_iptables_rules)))
 
     # Ensure there are no unexpected iptables rules present on the DuT
-    unexpected_iptables_rules = set(actual_iptables_rules) - set(expected_iptables_rules)
     pytest_assert(len(unexpected_iptables_rules) == 0, "Unexpected iptables nat rules: {}"
                   .format(repr(unexpected_iptables_rules)))
 
-    stdout = duthost.get_asic_or_sonic_host(asic_index).command("ip6tables -t nat -S")["stdout"]
-    actual_ip6tables_rules = stdout.strip().split("\n")
+    missing_ip6tables_rules, unexpected_ip6tables_rules, _ = \
+        wait_for_expected_rules(duthost, asic_index, "ip6tables -t nat -S", expected_ip6tables_rules)
 
     # Ensure all expected ip6tables rules are present on the DuT
-    missing_ip6tables_rules = set(expected_ip6tables_rules) - set(actual_ip6tables_rules)
     pytest_assert(len(missing_ip6tables_rules) == 0, "Missing expected ip6tables nat rules: {}"
                   .format(repr(missing_ip6tables_rules)))
 
     # Ensure there are no unexpected ip6tables rules present on the DuT
-    unexpected_ip6tables_rules = set(actual_ip6tables_rules) - set(expected_ip6tables_rules)
     pytest_assert(len(unexpected_ip6tables_rules) == 0, "Unexpected ip6tables nat rules: {}"
                   .format(repr(unexpected_ip6tables_rules)))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Previously the test case used a single read to check the convergence of CACL table. However, sometimes the convergence can be slow on multi-ASIC platform, so when the single read happned, the CACL table is not converged yet. We now use a wait util method.
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

MSFT ADO number: 39290822

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
