### PR TITLE
Revert "Adapt dhcp relay stress test to vpp"

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -740,7 +740,9 @@ t1-lag-vpp:
   - vxlan/test_vxlan_route_advertisement.py
   - vxlan/test_vnet_route_leak.py
   - vxlan/test_vxlan_crm.py
+  - vxlan/test_vnet_bgp_route_precedence.py
   - vxlan/test_vxlan_multi_tunnel.py
+  - vxlan/test_vxlan_route_advertisement.py
 
 
 t0-vpp:
@@ -772,7 +774,6 @@ t0-vpp:
   - db_migrator/test_migrate_dns.py
   - decap/test_decap.py
   - dhcp_relay/test_dhcp_relay.py
-  - dhcp_relay/test_dhcp_relay_stress.py
   - disk/test_disk_exhaustion.py
   - dns/test_dns_resolv_conf.py
   - fdb/test_fdb_flush.py

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -120,8 +120,7 @@ def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_du
     """
     testing_mode, duthost = testing_config
     packets_send_duration = 120
-    is_vpp_kvm = duthost.facts.get("asic_type") == "vpp" and "kvm" in duthost.facts.get("platform", "")
-    client_packets_per_sec = 1000 if is_vpp_kvm else 10000
+    client_packets_per_sec = 10000
 
     for dhcp_relay in dut_dhcp_relay_data:
         client_port_name = str(dhcp_relay['client_iface']['name'])


### PR DESCRIPTION
```
dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[offer-sonic-relay-agent] FAILED [ 60%]
```

test_dhcp_relay_stress has regression after recent vpp changes.
Reverts sonic-net/sonic-mgmt#27065 to unblock buildimage pr test.