### PR TITLE
[telemetry] add gnmi dial-out tests with a PTF collector

### DIFF
--- a/tests/gnmi/dialout/conftest.py
+++ b/tests/gnmi/dialout/conftest.py
@@ -1,0 +1,421 @@
+import base64
+import itertools
+import json
+import logging
+import shlex
+
+import pytest
+from pygnmi.spec.v080.gnmi_pb2 import SubscribeResponse
+
+from tests.common.cert_utils import TlsCertificateGenerator
+from tests.common.helpers.assertions import pytest_assert as pt_assert
+from tests.common.utilities import wait_until
+
+logger = logging.getLogger(__name__)
+
+COLLECTOR_SRC = "gnmi/dialout/dialout_collector.py"
+COLLECTOR_DST = "/root/dialout_collector.py"
+CERT_DST = "/root/dialout_collector.crt"
+KEY_DST = "/root/dialout_collector.key"
+# Below the default net.ipv4.ip_local_port_range (32768-60999) so the kernel
+# can never hand a collector port to an outbound connection first.
+BASE_PORT = 20075
+
+# The keys this suite writes; cleanup must touch nothing else.
+OWNED_KEYS = ("Global", "DestinationGroup_TEST", "Subscription_TEST")
+
+
+# ---------------------------------------------------------------------------
+# tests/gnmi/conftest.py defines a module-scoped autouse fixture,
+# setup_vrf_configuration, which drags the vrf_config parametrization into
+# every test id; dial-out does not touch the gNMI server VRF binding, so
+# shadow it with a no-op. download_gnmi_client (in-tree it currently lives
+# in tests/gnmi/test_gnmi_configdb.py; some sonic-mgmt forks define it as a
+# package-level autouse fixture) docker-cps gNMI client binaries out of the
+# gnmi container with no error tolerance and picks its DUT via
+# rand_one_dut_hostname, which need not match this suite's
+# enum_rand_one_per_hwsku_hostname selection; its shadow keeps this suite
+# independent of it wherever it is package-level.
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="module", autouse=True)
+def download_gnmi_client():
+    yield
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_vrf_configuration():
+    yield
+
+
+# supervisorctl status prints one of these for a program that exists; a
+# missing program prints "dialout: ERROR (no such process)", which must not
+# match. Note: single-asic container names only — on multi-asic DUTs the
+# per-asic containers (gnmi0, telemetry0, ...) are not probed, so the module
+# skips there.
+SUPERVISOR_PROGRAM_STATES = ("RUNNING", "STARTING", "STOPPING", "STOPPED",
+                             "EXITED", "FATAL", "BACKOFF", "UNKNOWN")
+
+
+def dialout_program_status(duthost, container, timeout=30):
+    """Return supervisorctl's status line for the dialout program, or None.
+
+    Right after a container starts, supervisord's control socket does not
+    exist yet and supervisorctl fails with a socket error; poll until it
+    answers authoritatively: rc 0 (all programs running), rc 3 (a program in
+    a non-running state), or an explicit "no such process" for a program
+    that does not exist in this container.
+    """
+    result = {"out": None}
+
+    def _answered():
+        res = duthost.shell("docker exec %s supervisorctl status dialout" % container,
+                            module_ignore_errors=True)
+        out = (res["stdout"] or "") + (res["stderr"] or "")
+        if res["rc"] in (0, 3) or "no such process" in out:
+            result["out"] = res["stdout"]
+            return True
+        return False
+
+    if not wait_until(timeout, 5, 0, _answered):
+        return None
+    return result["out"]
+
+
+def find_dialout_container(duthost):
+    """Find the container hosting the dialout program.
+
+    Returns (container, status_line) — the status line is captured before
+    anything restarts the program, so callers can assert on the state the
+    image booted into. Returns (None, None) if no container has the program.
+    """
+    for container in ("gnmi", "telemetry"):
+        res = duthost.shell("docker ps --filter name=%s --format '{{.Names}}'" % container,
+                            module_ignore_errors=True)
+        # The docker name filter is a substring match ("gnmi" also matches a
+        # multi-asic "gnmi0"), so require an exact name before docker exec.
+        if res["rc"] != 0 or container not in [ln.strip() for ln in res["stdout_lines"]]:
+            continue
+        status = dialout_program_status(duthost, container)
+        if status and any(state in status for state in SUPERVISOR_PROGRAM_STATES):
+            return container, status
+    return None, None
+
+
+def dump_telemetry_client_rows(duthost):
+    """Snapshot all TELEMETRY_CLIENT rows as {key: {field: value}}.
+
+    Uses redis-dump because it emits real JSON: values containing quotes or
+    newlines survive the snapshot/restore round-trip exactly, where parsing
+    sonic-db-cli HGETALL's pseudo-dict output would not. Fails the module
+    (before anything is deleted) rather than silently dropping a row it
+    cannot snapshot.
+    """
+    res = duthost.shell("redis-dump -d 4 -k 'TELEMETRY_CLIENT|*'",
+                        module_ignore_errors=True)
+    pt_assert(res["rc"] == 0,
+              "could not snapshot TELEMETRY_CLIENT rows: %s" % res["stderr"])
+    dump = json.loads(res["stdout"].strip() or "{}")
+    return {key: entry["value"] for key, entry in dump.items()}
+
+
+def hset_row(duthost, key, fields, ignore_errors=False):
+    pairs = " ".join("%s %s" % (shlex.quote(str(k)), shlex.quote(str(v)))
+                     for k, v in sorted(fields.items()))
+    res = duthost.shell("sonic-db-cli CONFIG_DB HSET %s %s" % (shlex.quote(key), pairs),
+                        module_ignore_errors=ignore_errors)
+    if ignore_errors and res["rc"] != 0:
+        logger.error("HSET %s failed: %s", key, res["stderr"])
+    return res
+
+
+@pytest.fixture(scope="module")
+def dialout_setup(request, duthosts, enum_rand_one_per_hwsku_hostname, ptfhost):
+    """Locate the dialout program, quiesce pre-existing config, restart clean.
+
+    Pre-existing TELEMETRY_CLIENT rows are snapshotted and restored on module
+    teardown; they must be absent while the suite runs (they would create
+    competing publish streams after the restart below).
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    # Retry the whole discovery: right after an image install / config
+    # reload the gnmi/telemetry containers come up late in the boot
+    # sequence, so a single docker-ps probe can miss a container that is
+    # seconds away from existing. Only a stable absence means "skip".
+    found = {}
+
+    def _discover():
+        container, status = find_dialout_container(duthost)
+        if container is None:
+            return False
+        found["container"] = container
+        found["status"] = status
+        return True
+
+    if not wait_until(180, 15, 0, _discover):
+        pytest.skip("No single-asic gnmi/telemetry container with a dialout program on %s "
+                    "(multi-asic DUTs are not covered by this suite)" % duthost.hostname)
+    container, initial_status = found["container"], found["status"]
+
+    # The program is autostart=false and brought up via dependent_startup
+    # once gnmi-native is running, so right after boot the authoritative
+    # answer can legitimately still be STOPPED/STARTING. Give that wiring a
+    # bounded window to reach RUNNING before freezing the snapshot that
+    # test_dialout_process_running asserts on.
+    if "RUNNING" not in (initial_status or ""):
+        def _booted():
+            status = dialout_program_status(duthost, container, timeout=5)
+            if status:
+                found["status"] = status
+            return status is not None and "RUNNING" in status
+
+        wait_until(60, 5, 0, _booted)
+        initial_status = found["status"]
+
+    saved_rows = dump_telemetry_client_rows(duthost)
+    if saved_rows:
+        logger.info("snapshotting %d pre-existing TELEMETRY_CLIENT rows: %s",
+                    len(saved_rows), sorted(saved_rows))
+
+    # Registered before the first delete so the restore runs even if this
+    # fixture fails between the delete and its yield (a generator fixture
+    # that raises before yielding never reaches code after it).
+    def _restore():
+        TelemetryClientConfig(duthost).cleanup()
+        for key, fields in saved_rows.items():
+            hset_row(duthost, key, fields, ignore_errors=True)
+        if saved_rows:
+            logger.info("restored %d pre-existing TELEMETRY_CLIENT rows", len(saved_rows))
+        # Restoring rows in redis does not reset the client's in-memory
+        # state (e.g. the retry interval from this suite's Global row), so
+        # restart the program once the original configuration is back.
+        duthost.shell("docker exec %s supervisorctl restart dialout" % container,
+                      module_ignore_errors=True)
+        if not wait_until(30, 3, 0, lambda: "RUNNING" in
+                          (dialout_program_status(duthost, container, timeout=5) or "")):
+            logger.warning("dialout did not reach RUNNING after config restore")
+
+    request.addfinalizer(_restore)
+    for key in saved_rows:
+        duthost.shell("sonic-db-cli CONFIG_DB DEL %s" % shlex.quote(key),
+                      module_ignore_errors=True)
+
+    def dialout_running():
+        status = dialout_program_status(duthost, container, timeout=5)
+        return status is not None and "RUNNING" in status
+
+    # Restart the client so no publish/retry state from earlier sessions
+    # survives: a subscription deleted while its goroutine was still dialing
+    # can keep retrying and connect to a later collector on the same port.
+    duthost.shell("docker exec %s supervisorctl restart dialout" % container,
+                  module_ignore_errors=True)
+    pt_assert(wait_until(30, 3, 0, dialout_running),
+              "dialout program did not reach RUNNING in %s" % container)
+
+    yield {"duthost": duthost, "container": container, "ptfhost": ptfhost,
+           "initial_dialout_status": initial_status}
+
+
+class TelemetryClientConfig(object):
+    """Writes TELEMETRY_CLIENT rows the dialout client watches via keyspace events.
+
+    Keys use the underscore form (DestinationGroup_<name> / Subscription_<name>);
+    the YANG pipe form is only accepted by recent sonic-gnmi versions,
+    so tests stick to the spelling every release understands.
+
+    cleanup() deletes only the keys this suite owns (OWNED_KEYS); rows that
+    predate the run are handled by dialout_setup's snapshot/restore.
+    """
+
+    def __init__(self, duthost):
+        self.duthost = duthost
+
+    def hset(self, key, **fields):
+        hset_row(self.duthost, "TELEMETRY_CLIENT|%s" % key, fields)
+
+    def delete(self, key):
+        self.duthost.shell("sonic-db-cli CONFIG_DB DEL 'TELEMETRY_CLIENT|%s'" % key,
+                           module_ignore_errors=True)
+
+    def cleanup(self):
+        for key in OWNED_KEYS:
+            self.delete(key)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def telemetry_client_config(dialout_setup):
+    """Per-test TELEMETRY_CLIENT config writer with guaranteed cleanup.
+
+    Also re-checks the dialout program before each test: it runs with
+    autorestart=false, so a crash mid-module would otherwise surface as a
+    cascade of misleading "no updates received" failures in later tests.
+    """
+    duthost = dialout_setup["duthost"]
+    container = dialout_setup["container"]
+    status = dialout_program_status(duthost, container, timeout=5)
+    pt_assert(status is not None and "RUNNING" in status,
+              "dialout program is not RUNNING before test (status: %s) — it may have "
+              "crashed during an earlier test (autorestart=false)" % (status or "unknown"))
+    config = TelemetryClientConfig(duthost)
+    config.cleanup()
+    yield config
+    config.cleanup()
+
+
+def _decode_update(update):
+    """Return (path, payload) for one gNMI Update.
+
+    path is the slash-joined element names; payload is the decoded JSON
+    value (a dict for SONiC DB table content) or the TypedValue's string
+    form when it is not JSON.
+    """
+    path = "/".join(elem.name for elem in update.path.elem)
+    val_kind = update.val.WhichOneof("value")
+    if val_kind in ("json_ietf_val", "json_val"):
+        raw_val = getattr(update.val, val_kind)
+        try:
+            return path, json.loads(raw_val)
+        except ValueError:
+            return path, raw_val.decode("utf-8", "replace")
+    return path, str(update.val)
+
+
+def decode_record(record):
+    """Decode a collector record's raw SubscribeResponse bytes in place.
+
+    The collector stores raw base64 bytes (docker-ptf has no pygnmi, and
+    keeping it proto-free avoids stub codegen there entirely); decoding
+    happens here with pygnmi's bundled gnmi_pb2. raw_b64 is kept only when
+    the decoded fields cannot tell the tests what the message was.
+    """
+    raw = base64.b64decode(record["raw_b64"])
+    try:
+        resp = SubscribeResponse()
+        resp.ParseFromString(raw)
+    except Exception as exc:  # noqa: BLE001 - classify and keep going
+        record["kind"] = "decode_error"
+        record["error"] = str(exc)
+        return record
+    if resp.HasField("sync_response"):
+        record["kind"] = "sync"
+        record["sync_response"] = resp.sync_response
+        del record["raw_b64"]
+    elif resp.HasField("update"):
+        record["kind"] = "update"
+        record["target"] = resp.update.prefix.target
+        record["update_count"] = len(resp.update.update)
+        record["notification_timestamp"] = resp.update.timestamp
+        record["updates"] = [_decode_update(u) for u in resp.update.update]
+        del record["raw_b64"]
+    else:
+        record["kind"] = "other"
+    return record
+
+
+class CollectorHandle(object):
+    def __init__(self, ptfhost, port):
+        self.ptfhost = ptfhost
+        self.port = port
+        self.pid = None
+        self.data_file = "/tmp/dialout_collector_%d.jsonl" % port
+        self.log_file = "/tmp/dialout_collector_%d.log" % port
+
+    @property
+    def address(self):
+        host = str(self.ptfhost.mgmt_ip)
+        if ":" in host:
+            # An unbracketed IPv6 host:port fails net.SplitHostPort in the
+            # Go dialout client (--ipv6_only_mgmt testbeds).
+            host = "[%s]" % host
+        return "%s:%d" % (host, self.port)
+
+    def records(self):
+        res = self.ptfhost.shell("cat %s" % self.data_file, module_ignore_errors=True)
+        if res["rc"] != 0:
+            return []
+        records = []
+        for line in res["stdout_lines"]:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(decode_record(json.loads(line)))
+            except ValueError:
+                # The file is read while the collector appends; the final
+                # line can be torn mid-write. Skip it — it will be complete
+                # on the next read.
+                logger.debug("skipping partial JSONL line (%d bytes)", len(line))
+        return records
+
+    def count(self, kind=None):
+        records = self.records()
+        if kind is None:
+            return len(records)
+        return len([r for r in records if r.get("kind") == kind])
+
+    def stop(self):
+        # Kill only this collector's own PID: on a PTF shared by two
+        # sessions, a pattern-based pkill could stop the other session's
+        # collector.
+        if self.pid is not None:
+            self.ptfhost.shell("kill -9 %d" % self.pid, module_ignore_errors=True)
+
+
+@pytest.fixture(scope="module")
+def copy_collector(ptfhost):
+    """Deploy the collector and its TLS server cert pair to the PTF.
+
+    The collector's only dependency is grpcio — no proto stubs, no pygnmi.
+    The SONiC client dials with server verification disabled but always over
+    TLS, so a throwaway pair from the shared generator is deployed alongside.
+    """
+    ptfhost.copy(src=COLLECTOR_SRC, dest=COLLECTOR_DST)
+    certs = TlsCertificateGenerator(server_ip=str(ptfhost.mgmt_ip)).get_cert_bytes()
+    ptfhost.copy(content=certs["server_cert"].decode("ascii"), dest=CERT_DST)
+    ptfhost.copy(content=certs["server_key"].decode("ascii"), dest=KEY_DST)
+
+
+_port_counter = itertools.count(BASE_PORT)
+
+
+@pytest.fixture(scope="function")
+def start_collector(ptfhost, copy_collector):
+    """Factory starting a collector on the PTF; all instances stopped on teardown.
+
+    Ports are never reused within a session so a stale publish stream aimed
+    at an earlier test's collector can not pollute a later test's data.
+    """
+    handles = []
+
+    def _start():
+        port = next(_port_counter)
+        handle = CollectorHandle(ptfhost, port)
+        ptfhost.shell("rm -f %s %s" % (handle.data_file, handle.log_file))
+        res = ptfhost.shell("nohup python3 %s --port %d --data %s --cert %s --key %s > %s 2>&1 "
+                            "& echo $!"
+                            % (COLLECTOR_DST, port, handle.data_file, CERT_DST, KEY_DST,
+                               handle.log_file))
+        handle.pid = int(res["stdout_lines"][-1].strip())
+        # Registered before the readiness wait so teardown also stops a
+        # collector that launched but never became ready. A process that
+        # survives an aborted run holds its port, and the next bind on it
+        # fails loudly (SO_REUSEPORT is disabled in the collector) — never
+        # silently killed, since it may belong to another session.
+        handles.append(handle)
+
+        def ready():
+            res = ptfhost.shell("grep -c 'Ready to serve' %s" % handle.log_file,
+                                module_ignore_errors=True)
+            return res["rc"] == 0 and int(res["stdout"].strip()) > 0
+
+        if not wait_until(30, 1, 0, ready):
+            log_tail = ptfhost.shell("tail -20 %s" % handle.log_file,
+                                     module_ignore_errors=True)["stdout"]
+            pt_assert(False, "dialout collector on port %d did not become ready; "
+                             "collector log:\n%s" % (port, log_tail))
+        return handle
+
+    yield _start
+
+    for handle in handles:
+        handle.stop()

--- a/tests/gnmi/dialout/dialout_collector.py
+++ b/tests/gnmi/dialout/dialout_collector.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""gNMI dial-out collector for sonic-mgmt tests.
+
+Implements the server side of SONiC's gnmi.sonic.gNMIDialOut service
+(sonic-gnmi/proto/dial_out.proto): a bidirectional-streaming Publish RPC
+whose request messages are standard gNMI SubscribeResponse. The service is
+registered as a generic gRPC handler over raw bytes, so the collector needs
+no proto codegen at all — its only dependency is grpcio. Received messages
+are appended as base64 JSON lines with receive metadata to a data file;
+decoding happens test-side in conftest.py via pygnmi's bundled gnmi_pb2
+(docker-sonic-mgmt ships pygnmi; docker-ptf does not).
+
+The SONiC dialout client always dials with TLS (server verification
+disabled via -insecure), so the collector serves TLS with the throwaway
+cert pair deployed by the test (see conftest.py copy_collector).
+
+Runs on the PTF host, started with nohup (see conftest.py); stdout/stderr
+are redirected to a log file because nohup breaks stderr for long-running
+python processes (same pattern as tests/gnmi/crl/crl_server.py).
+"""
+import argparse
+import base64
+import json
+import sys
+import threading
+import time
+from concurrent import futures
+
+import grpc
+
+PUBLISH_METHOD = "/gnmi.sonic.gNMIDialOut/Publish"
+
+
+class Recorder(object):
+    def __init__(self, data_file):
+        self.data_file = data_file
+        self.lock = threading.Lock()
+
+    def record(self, raw, peer):
+        entry = {
+            "size": len(raw),
+            "raw_b64": base64.b64encode(raw).decode("ascii"),
+            "ts": time.time(),
+            "peer": peer,
+        }
+        with self.lock:
+            with open(self.data_file, "a") as f:
+                f.write(json.dumps(entry) + "\n")
+                f.flush()
+
+
+class DialOutHandler(grpc.GenericRpcHandler):
+    """Serves gnmi.sonic.gNMIDialOut/Publish over raw bytes."""
+
+    def __init__(self, recorder):
+        self.recorder = recorder
+
+    def service(self, handler_call_details):
+        if handler_call_details.method != PUBLISH_METHOD:
+            return None
+        recorder = self.recorder
+
+        def publish(request_iterator, context):
+            peer = context.peer()
+            print("Publish stream opened from %s" % peer)
+            sys.stdout.flush()
+            for raw in request_iterator:
+                recorder.record(raw, peer)
+            print("Publish stream closed from %s" % peer)
+            sys.stdout.flush()
+            return
+            yield  # pragma: no cover - makes publish a generator
+
+        return grpc.stream_stream_rpc_method_handler(
+            publish, request_deserializer=None, response_serializer=None)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--data", required=True, help="JSONL output file")
+    parser.add_argument("--cert", required=True, help="TLS server certificate (PEM)")
+    parser.add_argument("--key", required=True, help="TLS server private key (PEM)")
+    args = parser.parse_args()
+
+    with open(args.key, "rb") as f:
+        key_bytes = f.read()
+    with open(args.cert, "rb") as f:
+        crt_bytes = f.read()
+
+    # SO_REUSEPORT (grpc's default on Linux) would let a second collector —
+    # e.g. from another sonic-mgmt session sharing this PTF — bind the same
+    # port and silently steal a share of the publish streams. Disable it so
+    # a port collision fails loudly here instead.
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=4),
+                         options=(("grpc.so_reuseport", 0),))
+    server.add_generic_rpc_handlers((DialOutHandler(Recorder(args.data)),))
+    creds = grpc.ssl_server_credentials([(key_bytes, crt_bytes)])
+    bound = server.add_secure_port("[::]:%d" % args.port, creds)
+    if bound != args.port:
+        print("FATAL: could not bind port %d (got %d) — already in use?"
+              % (args.port, bound))
+        sys.stdout.flush()
+        sys.exit(1)
+    server.start()
+    print("Ready to serve on %d" % args.port)
+    sys.stdout.flush()
+    while True:
+        time.sleep(3600)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/gnmi/dialout/test_gnmi_dialout.py
+++ b/tests/gnmi/dialout/test_gnmi_dialout.py
@@ -1,0 +1,254 @@
+"""gNMI dial-out tests.
+
+SONiC telemetry dial-out: the DUT's dialout client watches the
+TELEMETRY_CLIENT table in CONFIG_DB and pushes gNMI SubscribeResponse
+messages over the gnmi.sonic.gNMIDialOut/Publish gRPC stream to a
+configured collector. These tests run a collector on the PTF host and
+verify the full path: config ingestion via redis keyspace events, the
+periodic/stream/once report types, multi-destination failover, and
+unconfiguration.
+"""
+import logging
+import time
+
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.disable_loganalyzer,
+]
+
+REPORT_INTERVAL_MS = 2000
+RETRY_INTERVAL_S = 5
+
+
+def configure_dialout(config, dst_addrs, report_type, paths="COUNTERS_PORT_NAME_MAP",
+                      report_interval=REPORT_INTERVAL_MS):
+    """Write a full Global + DestinationGroup + Subscription config set.
+
+    report_interval is always set explicitly: the client's fallback for an
+    omitted field is currently a microseconds-scale busy loop, not the 5s
+    its code comment intends.
+    """
+    config.hset("Global", retry_interval=RETRY_INTERVAL_S)
+    config.hset("DestinationGroup_TEST", dst_addr=",".join(dst_addrs))
+    fields = {
+        "dst_group": "TEST",
+        "path_target": "COUNTERS_DB",
+        "paths": paths,
+        "report_type": report_type,
+        "report_interval": report_interval,
+    }
+    config.hset("Subscription_TEST", **fields)
+
+
+def wait_for_updates(collector, minimum, timeout=90):
+    return wait_until(timeout, 3, 0, lambda: collector.count(kind="update") >= minimum)
+
+
+def updates_contain(records, path, key, value):
+    """True when some decoded update matches `path` exactly and its JSON
+    payload carries key=value. Anything else — another path, another value,
+    a non-dict payload — does not satisfy it."""
+    for record in records:
+        for upd_path, payload in record.get("updates", []):
+            if upd_path == path and isinstance(payload, dict) and payload.get(key) == value:
+                return True
+    return False
+
+
+def counters_port_map_entry(duthost):
+    """One (port, oid) entry read live from the DUT's COUNTERS_PORT_NAME_MAP."""
+    port = duthost.shell(
+        "sonic-db-cli COUNTERS_DB HKEYS COUNTERS_PORT_NAME_MAP")["stdout_lines"][0].strip()
+    oid = duthost.shell(
+        "sonic-db-cli COUNTERS_DB HGET COUNTERS_PORT_NAME_MAP '%s'" % port)["stdout"].strip()
+    return port, oid
+
+
+def test_dialout_process_running(dialout_setup):
+    """The dialout client program comes up by default in the gnmi/telemetry container.
+
+    Asserts on the supervisorctl status captured before dialout_setup's own
+    restart, so what is verified is the state the image booted into — i.e.
+    the dependent_startup wiring (the program is autostart=false and started
+    only via dependent_startup_wait_for), not this suite's restart.
+    """
+    initial = dialout_setup["initial_dialout_status"]
+    pytest_assert(initial is not None and "RUNNING" in initial,
+                  "dialout was not RUNNING in %s before this suite restarted it "
+                  "(initial status: %s)" % (dialout_setup["container"], initial))
+
+
+def test_dialout_periodic(dialout_setup, telemetry_client_config, start_collector):
+    """Periodic report: collector receives COUNTERS_DB snapshots, not a busy loop."""
+    collector = start_collector()
+    configure_dialout(telemetry_client_config, [collector.address], "periodic")
+
+    pytest_assert(wait_for_updates(collector, 3),
+                  "collector received %d update messages, want >= 3" % collector.count(kind="update"))
+
+    updates = [r for r in collector.records() if r.get("kind") == "update"]
+    pytest_assert(updates, "no update records readable from the collector on re-read "
+                           "(records: %d)" % collector.count())
+    for record in updates:
+        pytest_assert(record.get("target") == "COUNTERS_DB",
+                      "unexpected notification target: %s" % record)
+        pytest_assert(record.get("update_count", 0) >= 1,
+                      "notification carries no updates: %s" % record)
+
+    # Payload check against the DUT's own table content: the requested path
+    # must arrive carrying a real COUNTERS_PORT_NAME_MAP entry, so an
+    # unrelated update with the right target can not satisfy this test.
+    port, oid = counters_port_map_entry(dialout_setup["duthost"])
+    pytest_assert(updates_contain(updates, "COUNTERS_PORT_NAME_MAP", port, oid),
+                  "no update carried %s=%s at path COUNTERS_PORT_NAME_MAP; got: %s"
+                  % (port, oid, [r.get("updates") for r in updates[:3]]))
+    # Validator self-check: records with the correct target and update
+    # count but a wrong path, or a wrong value, must be rejected.
+    base = {"kind": "update", "target": "COUNTERS_DB", "update_count": 1}
+    wrong_path = [dict(base, updates=[("NOT_THE_REQUESTED_PATH", {port: oid})])]
+    wrong_value = [dict(base, updates=[("COUNTERS_PORT_NAME_MAP", {port: "oid:0xbad"})])]
+    pytest_assert(not updates_contain(wrong_path, "COUNTERS_PORT_NAME_MAP", port, oid),
+                  "payload validation accepted an update with the wrong path")
+    pytest_assert(not updates_contain(wrong_value, "COUNTERS_PORT_NAME_MAP", port, oid),
+                  "payload validation accepted an update with the wrong value")
+
+    # Busy-loop guard (lower bound only): within a single publish stream
+    # (peer), consecutive messages must not arrive much faster than
+    # report_interval. Group by peer so a reconnect (new stream) can not
+    # produce a misleading small gap, and assert on the median gap: the
+    # timestamps are receive-side, so a stalled read can stamp one message
+    # late and the next on time, shortening a single gap on a healthy
+    # client — while the busy-loop bug compresses every gap to microseconds.
+    by_peer = {}
+    for r in updates:
+        by_peer.setdefault(r.get("peer"), []).append(r["ts"])
+    peer, timestamps = max(by_peer.items(), key=lambda kv: len(kv[1]))
+    gaps = [b - a for a, b in zip(timestamps, timestamps[1:])]
+    pytest_assert(len(gaps) >= 1,
+                  "not enough same-stream samples to measure cadence "
+                  "(peers: %s)" % {p: len(t) for p, t in by_peer.items()})
+    median_gap = sorted(gaps)[len(gaps) // 2]
+    pytest_assert(median_gap > REPORT_INTERVAL_MS / 1000.0 * 0.5,
+                  "updates from %s arrived too fast (median gap %.3fs, gaps %s); "
+                  "busy loop?" % (peer, median_gap, gaps))
+
+
+def test_dialout_stream(dialout_setup, telemetry_client_config, start_collector):
+    """Stream report: update notifications and a sync_response arrive at the collector."""
+    collector = start_collector()
+    configure_dialout(telemetry_client_config, [collector.address], "stream",
+                      paths="COUNTERS/Ethernet*")
+
+    pytest_assert(wait_until(90, 3, 0, lambda: collector.count(kind="sync") >= 1),
+                  "no sync_response received; records: %d" % collector.count())
+    pytest_assert(collector.count(kind="update") >= 1,
+                  "no update notifications received")
+
+    # Payload check: the client publishes the path as requested — the
+    # wildcard stays unexpanded (COUNTERS/Ethernet*) with a payload keyed
+    # by the DUT's real port names; a later on-change update can also
+    # arrive per port (COUNTERS/<port>). Either way the counters must be
+    # for ports this DUT actually has, and non-empty.
+    duthost = dialout_setup["duthost"]
+    ports = {ln.strip() for ln in duthost.shell(
+        "sonic-db-cli COUNTERS_DB HKEYS COUNTERS_PORT_NAME_MAP")["stdout_lines"] if ln.strip()}
+    matched = 0
+    for record in collector.records():
+        for path, payload in record.get("updates", []):
+            if not path.startswith("COUNTERS/"):
+                continue
+            pytest_assert(isinstance(payload, dict) and payload,
+                          "counters update %s carries no payload: %r" % (path, payload))
+            tail = path.split("/", 1)[1]
+            per_port = {tail: payload} if tail in ports else payload
+            known = {p: c for p, c in per_port.items() if p in ports}
+            pytest_assert(known,
+                          "update %s carries no data for any port this DUT has "
+                          "(payload keys: %s)" % (path, sorted(per_port)[:5]))
+            for port, counters in known.items():
+                pytest_assert(isinstance(counters, dict) and counters,
+                              "empty counters for %s in update %s" % (port, path))
+            matched += 1
+    pytest_assert(matched >= 1,
+                  "no update matched the requested COUNTERS/Ethernet* paths")
+
+
+@pytest.mark.xfail(strict=True,
+                   reason="report_type 'once' is accepted by TELEMETRY_CLIENT config but "
+                          "unimplemented in the dialout client: publishRun has no Once arm, "
+                          "so the subscription is silently ignored")
+def test_dialout_once(dialout_setup, telemetry_client_config, start_collector):
+    """Once report: a single snapshot should arrive after configuration."""
+    collector = start_collector()
+    configure_dialout(telemetry_client_config, [collector.address], "once")
+    pytest_assert(wait_for_updates(collector, 1, timeout=60),
+                  "no snapshot received for report_type=once")
+
+
+def test_dialout_failover(dialout_setup, telemetry_client_config, start_collector):
+    """With two destinations, killing the active collector moves the stream to the other."""
+    first = start_collector()
+    second = start_collector()
+    configure_dialout(telemetry_client_config, [first.address, second.address], "periodic")
+
+    # The client connects to one destination (round-robin from the first).
+    pytest_assert(wait_until(90, 3, 0,
+                             lambda: first.count(kind="update") + second.count(kind="update") >= 2),
+                  "no updates on either collector")
+
+    def last_update_ts(collector):
+        stamps = [r["ts"] for r in collector.records() if r.get("kind") == "update"]
+        return max(stamps) if stamps else 0.0
+
+    # The live stream is wherever the most recent update landed — a
+    # reconnect during the initial wait can leave old updates on both.
+    active, standby = ((first, second) if last_update_ts(first) >= last_update_ts(second)
+                       else (second, first))
+
+    # Confirm the standby really is idle before the kill, so the rise
+    # asserted below can only mean failover (not a mislabelled active).
+    standby_before = standby.count(kind="update")
+    time.sleep(1.5 * REPORT_INTERVAL_MS / 1000.0)
+    pytest_assert(standby.count(kind="update") == standby_before,
+                  "standby collector received updates before failover — "
+                  "active/standby misidentified")
+
+    active.stop()
+    pytest_assert(wait_until(120, 5, 0,
+                             lambda: standby.count(kind="update") > standby_before),
+                  "no updates on standby collector after killing the active one")
+
+
+def test_dialout_unconfigure_stops_publishing(dialout_setup, telemetry_client_config,
+                                              start_collector):
+    """Deleting the Subscription row stops the publish stream."""
+    collector = start_collector()
+    configure_dialout(telemetry_client_config, [collector.address], "periodic")
+    pytest_assert(wait_for_updates(collector, 2), "dial-out stream never started")
+
+    telemetry_client_config.delete("Subscription_TEST")
+
+    # Wait for the stream to quiesce first: the deletion propagates via
+    # keyspace events and a message already in flight may still land, so a
+    # fixed grace period would make the equality check below flaky.
+    def quiesced():
+        n = collector.count(kind="update")
+        time.sleep(REPORT_INTERVAL_MS / 1000.0)
+        return collector.count(kind="update") == n
+
+    pytest_assert(wait_until(30, 1, 0, quiesced),
+                  "updates never stopped arriving after Subscription was deleted")
+
+    before = collector.count(kind="update")
+    time.sleep(3 * REPORT_INTERVAL_MS / 1000.0)
+    after = collector.count(kind="update")
+    pytest_assert(after == before,
+                  "updates kept arriving after Subscription was deleted (%d -> %d)"
+                  % (before, after))


### PR DESCRIPTION
### Description of PR

Summary:

SONiC telemetry dial-out — the DUT-initiated push path where the dialout client watches the `TELEMETRY_CLIENT` CONFIG_DB table and streams gNMI `SubscribeResponse` messages to a configured collector over the `gnmi.sonic.gNMIDialOut/Publish` gRPC — has no sonic-mgmt coverage today (sonic-gnmi unit tests only, one scenario). This adds `tests/gnmi/dialout/` with a collector that runs on the PTF host and six test cases exercising the full path end to end.

**What's in the module:**

* `dialout_collector.py` — TLS gRPC collector for the PTF. Implements the `Publish` RPC as a generic raw-bytes handler, so no proto codegen is needed anywhere on the PTF (its only dependency is grpcio); it records raw `SubscribeResponse` messages as base64 JSONL with receive metadata. Decoding happens test-side in conftest via pygnmi's bundled `gnmi_pb2` (docker-sonic-mgmt ships pygnmi; docker-ptf does not). TLS uses a server cert pair generated with `tests/common/cert_utils.TlsCertificateGenerator` and deployed by the test (the SONiC client dials with verification disabled).
* `conftest.py` — dialout program discovery (gnmi or telemetry container) with a restart at module setup (purges stale publish/retry streams from earlier sessions), a `TELEMETRY_CLIENT` config writer with snapshot/restore of pre-existing rows guarded by `request.addfinalizer` (cleanup runs even if setup fails midway), and collector lifecycle with session-unique ports so a stale stream aimed at an old port can never pollute a later test.

**Test cases** (`test_gnmi_dialout.py`):

| test | verifies |
|---|---|
| `test_dialout_process_running` | dialout client comes up by default under supervisord (asserts on the pre-restart status, i.e. the dependent_startup wiring) |
| `test_dialout_periodic` | periodic snapshots arrive; target/payload checked; per-stream median cadence matches `report_interval` (busy-loop guard) |
| `test_dialout_stream` | stream mode: initial updates then `sync_response` |
| `test_dialout_once` | `xfail(strict=True)`: `report_type: once` is accepted by config but unimplemented in the dialout client (`publishRun` has no `Once` arm), so the subscription is silently ignored |
| `test_dialout_failover` | two `dst_addr` destinations; killing the active collector moves the stream to the standby |
| `test_dialout_unconfigure_stops_publishing` | deleting the Subscription row stops the stream |

**Known-bug accommodations** (called out in the module docstring):
* `report_interval` is always set explicitly — when omitted, the current dialout client default is a microseconds-scale busy loop instead of the intended 5s (`clientSubscription{interval: 5000}` assigns 5000 nanoseconds to a `time.Duration`).
* Keys use the underscore form (`Subscription_<name>`); the YANG pipe form is only accepted by recent sonic-gnmi, so underscore is the spelling every release understands.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] master

### Approach
#### What is the motivation for this PR?

Close the dial-out test gap: the feature path is enabled by default in images that ship the dialout program, but nothing in sonic-mgmt exercises it, and real product bugs (the `once` report type and the `report_interval` default above) sit undetected on exactly this path.

#### How did you do it?

Collector on the PTF following the `tests/gnmi/crl/crl_server.py` precedent (nohup + log-line readiness + pkill teardown). DUT config via `sonic-db-cli` HSET/DEL — the dialout client picks changes up live through redis keyspace notifications, which is itself part of what the lifecycle tests verify. No service restarts needed in the tests themselves. The suite skips gracefully on DUTs without a dialout program (and on multi-asic devices, named explicitly in the skip reason).

#### How did you verify/test it?

Full suite green on multiple physical t0 testbeds (different platforms/images): `5 passed, 1 xfailed`, ~3 minutes wall clock. One validation ran against a community `docker-ptf:202605` image, confirming the collector needs only grpcio on the PTF (no pygnmi, no proto stubs).

#### Any platform specific information?

None — platform-independent. Works with either the `gnmi` or `telemetry` container hosting the dialout program; skips if neither is present.

#### Supported testbed topology if it's a new test case?

`any` (needs only duthost + ptfhost, no fanout/traffic).

### Documentation

Module docstrings document the collector protocol and the two known-bug accommodations.