### PR TITLE
mg_facts: Handle ACL bind points being non-alias

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -478,6 +478,8 @@ def parse_dpg(dpg, hname):
                           " is attached to a Vlan interface, which is currently not supported", file=sys.stderr)
                 elif member in port_alias_to_name_map:
                     acl_intfs.append(port_alias_to_name_map[member])
+                elif member in port_name_to_alias_map:
+                    acl_intfs.append(member)
             if acl_intfs:
                 acls[aclname] = acl_intfs
 


### PR DESCRIPTION
### Description of PR
https://github.com/sonic-net/sonic-mgmt/pull/22166 made single-asic SKUs use non-alias ports as the bind points for ACLs.
The minigraph_facts.py was never updated to handle non-alias ports in the ACLs.

More details in https://github.com/sonic-net/sonic-mgmt/issues/27215

Summary:
Fixes #27215 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- 202605: internal image built on Aug 20th

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/pull/22166 converted the ACL bindpoints to use non-alias ports.
We need to update minigraph_facts.py to handle non-alias ports otherwise `crm/test_crm.py::test_acl_entry` will fail

#### How did you do it?
Check if the port in the ACL `AttachTo` entry is in both `port_alias_to_name_map` and `port_name_to_alias_map`

#### How did you verify/test it?
Ran `crm/test_crm.py::test_acl_entry` and saw it passing on 202605 after the change

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
