### PR TITLE
test(dhcp_relay): xfail stress test on t0-vpp

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1260,6 +1260,10 @@ dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress:
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - "asic_type in ['vs']"
+  xfail:
+    reason: "DHCP relay stress test is unstable on t0-vpp"
+    conditions:
+      - "asic_type in ['vpp']"
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[discover:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1263,8 +1263,7 @@ dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress:
   xfail:
     reason: "DHCP relay stress test is unstable on t0-vpp"
     conditions:
-      - "asic_type in ['vpp']"
-      - "topo_name in ['t0']"
+      - "asic_type in ['vpp'] and topo_name in ['t0']"
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[discover:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1264,6 +1264,7 @@ dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress:
     reason: "DHCP relay stress test is unstable on t0-vpp"
     conditions:
       - "asic_type in ['vpp']"
+      - "topo_name in ['t0']"
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[discover:
   skip:


### PR DESCRIPTION
### Description of PR

Summary:
Mark `test_dhcp_relay_stress` as an expected failure on VPP so the t0-vpp PR check records the current instability without failing the full run.

Fixes # N/A

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: Parsed the conditional-mark YAML and verified the condition applies only to VPP on the t0 topology.

### Approach
#### What is the motivation for this PR?

`test_dhcp_relay_stress` is currently unstable on the t0-vpp testbed.

#### How did you do it?

Added an `xfail` conditional mark requiring both the VPP ASIC type and t0 topology for `test_dhcp_relay_stress`.

#### How did you verify/test it?

Parsed the updated YAML and evaluated the condition against VPP t0, VPP non-t0, and non-VPP combinations.

#### Any platform specific information?

The expected failure applies only when `asic_type` is `vpp` and `topo_name` is `t0`.

#### Supported testbed topology if it's a new test case?

N/A - this updates an existing test case for t0-vpp.

### Documentation

N/A
