### PR TITLE
[snappi] fix test_multidut_dequeue_ecn_brcm_dnx.py for single dut with single asic

### DIFF
--- a/tests/snappi_tests/ecn/test_multidut_dequeue_ecn_brcm_dnx.py
+++ b/tests/snappi_tests/ecn/test_multidut_dequeue_ecn_brcm_dnx.py
@@ -18,7 +18,7 @@ from tests.common.snappi_tests.common_helpers import packet_capture, get_wred_pr
 from tests.common.config_reload import config_reload
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('multidut-tgen')]
+pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
 @pytest.fixture(autouse=True, scope='module')
@@ -203,7 +203,8 @@ def test_dequeue_ecn_default(request,
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]
 
     # Reading WRED profile to get the default values.
-    asic_value = 'asic{}'.format(duthosts[0].get_asic_ids()[0])
+    asic_id = duthosts[0].get_asic_ids()[0]
+    asic_value = 'asic{}'.format(asic_id) if asic_id is not None else "None"
     wred_profile = get_wred_profiles(duthosts[0], asic_value=asic_value)
 
     # Selecting DEFAULT Kmin, Kmax and Pmax for the test.


### PR DESCRIPTION
Extend the test for single dut and also fix for single asic.



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
Test passed on single dut with single asic with this change:

ECN test result
```
------------------------------------------------- generated xml file: /data/tests/logs/snappi_tests/ecn.xml -------------------------------------------------
================================================================== short test summary info ==================================================================
SKIPPED [4] snappi_tests/ecn/test_bp_fabric_ecn_marking_with_snappi.py: This test is written only for T2-cisco-8000.
SKIPPED [2] snappi_tests/ecn/test_dequeue_ecn_with_snappi.py:33: ECN dequeue test is not supported on Arista-7280R4K-32QF-32DF-64O
SKIPPED [2] common/helpers/assertions.py:16: Port is not mapped to the expected DUT
SKIPPED [8] snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py:29: Current test case only work with cisco platform
SKIPPED [4] snappi_tests/ecn/test_ecn_marking_with_snappi.py: Current test case only work with cisco platform
SKIPPED [16] snappi_tests/ecn/test_ecn_marking_with_snappi.py:180: Current test case only work with cisco platform
================================================ 15 passed, 36 skipped, 1254 warnings in 8944.00s (2:29:03) =================================================
```


### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
