### PR TITLE
[drop_packets] Add Micas M2-W6940 to combined L2/L3 drop counter list

### DIFF
--- a/tests/drop_packets/combined_drop_counters.yml
+++ b/tests/drop_packets/combined_drop_counters.yml
@@ -32,6 +32,7 @@ l2_l3:
     - "x86_64-marvell_dbmvtx9180-r0"
     - "x86_64-nokia.*"
     - "x86_64-nexthop*"
+    - "x86_64-micas_m2-w6940.*"
     - "x86_64-kvm_x86_64-r0"  # VPP
 
 acl_l2:


### PR DESCRIPTION
### Description of PR

Summary:
Fix the following error on Micas platform:

```
FAILED drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[rif_members-w6940-1]
FAILED drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[rif_members-w6940-1]
FAILED drop_packets/test_drop_counters.py::test_dst_ip_absent[rif_members-w6940-1]
FAILED drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[rif_members-w6940-1-ipv4]
FAILED drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[rif_members-w6940-1-ipv6]
FAILED drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-w6940-1-ipv4-src]
FAILED drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-w6940-1-ipv6-src]
FAILED drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-w6940-1-ipv4-dst]
FAILED drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-w6940-1-ipv6-dst]
FAILED drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[rif_members-w6940-1]
FAILED drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-w6940-1-version-1]
FAILED drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-w6940-1-chksum-10]
FAILED drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-w6940-1-ihl-1]
FAILED drop_packets/test_drop_counters.py::test_absent_ip_header[rif_members-w6940-1]
FAILED drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[rif_members-w6940-1-01:00:5e:00:01:02]
FAILED drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[rif_members-w6940-1-ff:ff:ff:ff:ff:ff]
```
```
>               pytest.fail(fail_msg)
E               Failed: 'RX_ERR' drop counter was not incremented on iface Ethernet256. DUT RX_ERR == [0]; Sent == 1000
```

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

All L3 drop counter tests fail on Micas M2-W6940 because GET_L3_COUNTERS is not supported on TH5 based asics. 

#### How did you do it?

Added `x86_64-micas_m2-w6940.*` to the `l2_l3` list, next to the other platforms that
combine L2/L3 drops into port counters.

#### How did you verify/test it?

Ran `drop_packets/test_drop_counters.py` on a physical W6940 testbed before and after,
same image: 16 failed / 4 passed -> 0 failed / 20 passed.

`test_not_expected_vlan_tag_drop` (an L2 test using `portstat`) passed both times, which
is what pointed at the RIF counter in the first place.

#### Any platform specific information?

Micas M2-W6940, platform string `x86_64-micas_m2-w6940-128x1-fr4-r0`.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A

