### PR TITLE
[DHCP_SERVER] Fix sonic-relay teardown readiness on topologies with dhcp_server enabled

### DIFF
--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -59,7 +59,7 @@ def _validate_relay_types(caller, relay_types):
     if not relay_types:
         raise ValueError("%s: relay_types must be a non-empty iterable" % caller)
     relay_types = list(relay_types)
-    valid = {'isc', 'isc-internal', 'sonic', 'v6'}
+    valid = {'isc', 'isc-internal', 'sonic', 'v6', 'orchestrator'}
     bad = [t for t in relay_types if t not in valid]
     if bad:
         raise ValueError("%s: invalid relay_types %s; allowed %s"
@@ -140,6 +140,11 @@ def restart_dhcp_service(duthost, relay_types):
                               will need to be extended to mirror the 'isc'
                               dhcpmon-<Vlan> check above.
                           TODO: revisit when dhcpv6mon ships.
+
+        'orchestrator' -> Only the dhcprelayd orchestrator is required RUNNING.
+                          Use after dhcp_server teardown or when the relay
+                          container has no v4/v6 helper programs in supervisord
+                          (e.g. multi_vlan tests that reshape VLAN relay layout).
 
     The orchestrator (`dhcprelayd`) is always required RUNNING. There is intentionally
     no default; each caller must declare which agent(s) it expects to be active.
@@ -577,6 +582,25 @@ def merge_counters(source_counter, merge_counter, is_v6=False):
                                                                     merge_counter.get(dir, {}).get(dhcp_type, 0)
 
 
+def _dhcp_server_feature_enabled(duthost):
+    features_state, _ = duthost.get_feature_status()
+    return 'enabled' in features_state.get('dhcp_server', '')
+
+
+def _relay_types_after_sonic_disable(duthost):
+    """
+    Readiness contract after removing has_sonic_dhcpv4_relay.
+
+    When the dhcp_server feature is enabled, dhcprelayd keeps supervisord
+    isc-dhcpv4-relay-* / dhcpmon-* STOPPED and manages v4 relay itself (or
+    none at all once DHCP_SERVER_IPV4 config is cleaned). Waiting for
+    relay_types=['isc'] is unsatisfiable in that mode.
+    """
+    if _dhcp_server_feature_enabled(duthost):
+        return ['orchestrator']
+    return ['isc']
+
+
 def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
     """
     Enable or disable the SONiC DHCPv4 feature flag and restart the DHCP service on the DUT.
@@ -590,7 +614,11 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
     # Save the config and restart DHCP relay service
     duthost.shell('sudo config save -y', module_ignore_errors=True)
-    restart_dhcp_service(duthost, ['sonic'] if dhcpv4_config_flag else ['isc'])
+    if dhcpv4_config_flag:
+        relay_types = ['sonic']
+    else:
+        relay_types = _relay_types_after_sonic_disable(duthost)
+    restart_dhcp_service(duthost, relay_types)
 
 
 @pytest.fixture()

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -57,11 +57,11 @@ def is_dhcprelayd_running(duthost):
 def dhcp_server_setup_teardown(duthost):
     features_state, _ = duthost.get_feature_status()
     py_require(DHCP_SERVER_FEATRUE_NAME in features_state, "Skip on vs testbed without dhcp server feature")
-    restore_state_flag = False
-    if "enabled" not in features_state.get(DHCP_SERVER_FEATRUE_NAME, ""):
-        restore_state_flag = True
+    was_enabled_at_start = "enabled" in features_state.get(DHCP_SERVER_FEATRUE_NAME, "")
+    if not was_enabled_at_start:
         duthost.shell("config feature state dhcp_server enabled")
         duthost.shell("sudo systemctl restart dhcp_relay.service")
+        duthost.critical_services_tracking_list()
 
     def is_supervisor_subprocess_running(duthost, container_name, app_name):
         return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}")["stdout"]
@@ -83,15 +83,23 @@ def dhcp_server_setup_teardown(duthost):
 
     yield
 
-    if restore_state_flag:
-        duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)
-        duthost.shell("sudo systemctl restart dhcp_relay.service")
-        duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
+    if not was_enabled_at_start:
+        # Leave dhcp_server enabled on platforms that ship the feature. Disabling
+        # it here persists disabled state in config while pytest may still track
+        # dhcp_server as critical (stale list from when the module enabled it),
+        # so later config_reload waits for a container that will not start.
+        duthost.shell("config feature state dhcp_server enabled", module_ignore_errors=True)
+        duthost.shell("sudo systemctl restart dhcp_relay.service", module_ignore_errors=True)
+        duthost.critical_services_tracking_list()
 
 
 @pytest.fixture(scope="function", autouse=True)
-def clean_dhcp_server_config_after_test(duthost):
+def clean_dhcp_server_config_after_test(duthost, request):
     clean_dhcp_server_config(duthost)
+
+    if "enable_sonic_dhcpv4_relay_agent" in request.fixturenames:
+        # Make relay restoration run after DHCP server configuration cleanup.
+        request.getfixturevalue("enable_sonic_dhcpv4_relay_agent")
 
     yield
 


### PR DESCRIPTION
Signed-off-by: Michail-Nektarios Karatzidis <michail-nektarios.karatzidis@nokia.com>

 FIXES: #27036 
  ### Description of PR
  Fixes teardown errors and downstream testbed breakage in `tests/dhcp_server/` on mx platforms when running
  `[sonic-relay-agent]` parametrizations.
  After PR #26284, `sonic_dhcpv4_flag_config_and_unconfig(..., False)` always waited for `relay_types=['isc']`, requiring
  every `isc-dhcpv4-relay-*` and `dhcpmon-*` supervisord entry to be RUNNING. With the **dhcp_server** feature enabled
  (required by this suite), **dhcprelayd** intentionally keeps those programs STOPPED and manages v4 relay via standalone
  `dhcrelay`. The test bodies passed; only fixture teardown failed.
  This change also:
  - Ensures `DHCP_SERVER_IPV4` cleanup runs **before** sonic relay restoration (same intent as #26732).
  - Stops disabling `dhcp_server` at module teardown while pytest may still track it as a critical service, which caused
  later `config_reload` / `critical_services_fully_started` waits to hang.
  **Reviewer start:** `tests/common/dhcp_relay_utils.py` (`_relay_types_after_sonic_disable`, new `orchestrator` relay
  type), then `tests/dhcp_server/conftest.py` (fixture order + module teardown).
  **Dependencies:** None. Complements the relay readiness refactor in #26284; does not require image changes.
  Summary:
  Fixes #<issue>
  ### Type of change
  - [ ] Bug fix
  - [x] Testbed and Framework(new/improvement)
  - [ ] New Test case
      - [ ] Skipped for non-supported platforms
  - [ ] Test case improvement
  ### Back port request
  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511
  - [ ] 202512
  - [x] 202605
  Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
  <!-- e.g. ADO: https://dev.azure.com/... or Fixes #12345 -->
  Failure type: regression (exposed by #26284 explicit `relay_types=['isc']` on sonic-relay disable; dhcp_server suite not
  covered in that PR’s validation)
  ### Tested branch
  - [x] master
  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511
  - [ ] 202512
  - [x] 202605
  - [ ] N/A
  ### Test result
  **TOPOLOGY:** `mx`,
  **Image:** `SONiC.HEAD.1609120-202605-4323ab96`
  **Before fix (master, same image):**
  - 20/40 errors in `test_dhcp_server.py` — all `[sonic-relay-agent]` teardown: `dhcp_relay is not ready
  (relay_types=['isc'] ... isc-dhcpv4-relay-Vlan1000': 'STOPPED')`
  - Test call assertions passed; failures were fixture teardown only
  **Regression:** `tests/dhcp_relay/` sonic-relay cases still use `['isc']` on disable when dhcp_server is not enabled
  **After the fix:**
 Majority of the testcases are passing with some failing due to another open issue: #24868 
  ### Approach
  #### What is the motivation for this PR?
  PR #26284 correctly made DHCP relay readiness explicit via `relay_types`, but `sonic_dhcpv4_flag_config_and_unconfig()`
  still assumed that disabling sonic relay implies legacy ISC supervisord helpers must be RUNNING. That contract is
  invalid when **dhcp_server** is enabled: dhcprelayd stops `isc-dhcpv4-relay-*` / `dhcpmon-*` by design.
  Separately, `dhcp_server_setup_teardown` disabled the dhcp_server feature at module exit after temporarily enabling it,
  while pytest could still list `dhcp_server` in `critical_services`, breaking subsequent modules on the same DUT.
  #### How did you do it?
  1. **`tests/common/dhcp_relay_utils.py`**
     - Add `orchestrator` relay type (only `dhcprelayd` RUNNING required).
     - Add `_dhcp_server_feature_enabled()` and `_relay_types_after_sonic_disable()`.
     - On sonic disable: use `['orchestrator']` when dhcp_server is enabled, else `['isc']`.
  2. **`tests/dhcp_server/conftest.py`**
     - Tie `clean_dhcp_server_config_after_test` to `enable_sonic_dhcpv4_relay_agent` so teardown order is: clean
  `DHCP_SERVER_IPV4*` → restore relay.
     - Module teardown: leave dhcp_server **enabled** and call `critical_services_tracking_list()` instead of `disabled` +
  `docker rm dhcp_server`.
  #### How did you verify/test it?
  - Ran full `tests/dhcp_server/` on MX topology, including all `[sonic-relay-agent]` and `[isc-relay-agent]`
  parametrizations, on **master** and **202605** with image `HEAD.1609120-202605-4323ab96`.
  - Confirmed on DUT after sonic-relay cases: `dhcprelayd` RUNNING, `dhcrelay` present, `isc-dhcpv4-relay-*` STOPPED
  (expected with dhcp_server on), `has_sonic_dhcpv4_relay` unset after teardown.
  - Verified downstream suites no longer hang on `config_reload` waiting for a disabled `dhcp_server` critical service.
  #### Any platform specific information?
  Observed on **mx** topology with **dhcp_server** feature enabled. The readiness mismatch applies
  whenever dhcp_server + sonic-relay-agent tests run together; fix is gated on FEATURE state, not hard-coded to a
  platform.
  Pure `tests/dhcp_relay/` paths with dhcp_server disabled still use `['isc']` on sonic disable.
  #### Supported testbed topology if it's a new test case?
  N/A — no new test cases.
  ### Documentation
  N/A — test harness / fixture fix only; inline comments and `restart_dhcp_service` docstring updated for `orchestrator`
  relay type.