### PR TITLE
fix test_qos_probe.py: to collect proper src and dest ports on masic

### DIFF
--- a/tests/qos/test_qos_probe.py
+++ b/tests/qos/test_qos_probe.py
@@ -967,6 +967,12 @@ class TestQosProbe(QosSaiBase):
             # use all available test ports directly
             probing_port_ids = src_testPortIds
 
+        # dst port belongs at the end of the list, if src and dst are the same then move it, otherwise add it
+        dst_port_id = qosConfig["hdrm_pool_size"]["dst_port_id"]
+        if src_dut_index == dst_dut_index and src_asic_index == dst_asic_index:
+            probing_port_ids = [port for port in probing_port_ids if port != dst_port_id]
+        probing_port_ids = probing_port_ids + [dst_port_id]
+
         logger.info(
             f"probing_port_ids {probing_port_ids},\n"
             f"sonic_asic_type {sonic_asic_type},\n"

--- a/tests/saitests/mock/ut/test_egress_drop_probing.py
+++ b/tests/saitests/mock/ut/test_egress_drop_probing.py
@@ -81,6 +81,10 @@ class TestEgressDropProbingInstance:
         self.probe_packet_length = 64
         self.probe_cells_per_packet = 1
         self.egress_lossy_pool_size = 104000
+        self.src_dut_index = 0
+        self.src_asic_index = 0
+        self.dst_dut_index = 0
+        self.dst_asic_index = 0
 
         # Probing configuration
         self.PROBE_TARGET = "egress_drop"
@@ -136,7 +140,8 @@ class TestEgressDropProbingParameterParsing(unittest.TestCase):
 
         config = EgressDropProbing.get_probe_config(instance)
 
-        assert config.probing_port_ids == instance.probing_port_ids
+        assert config.src_port_ids == instance.probing_port_ids[:1]
+        assert config.dst_port_ids == instance.probing_port_ids[1:]
         assert config.thrift_client == instance.dst_client
         assert config.asic_type == instance.asic_type
 

--- a/tests/saitests/mock/ut/test_headroom_pool_probing.py
+++ b/tests/saitests/mock/ut/test_headroom_pool_probing.py
@@ -82,6 +82,10 @@ class TestHeadroomPoolProbingInstance:
         self.probe_packet_length = 64
         self.probe_cells_per_packet = 1
         self.ingress_drop_counter_mode = 'port_drop'
+        self.src_dut_index = 0
+        self.src_asic_index = 0
+        self.dst_dut_index = 0
+        self.dst_asic_index = 0
 
         # Probing configuration
         self.PROBE_TARGET = "headroom_pool"
@@ -188,7 +192,8 @@ class TestHeadroomPoolProbingConfiguration(unittest.TestCase):
 
         config = HeadroomPoolProbing.get_probe_config(instance)
 
-        assert config.probing_port_ids == instance.probing_port_ids
+        assert config.src_port_ids == instance.probing_port_ids[:-1]
+        assert config.dst_port_ids == instance.probing_port_ids[-1:]
         assert config.thrift_client == instance.dst_client
         assert config.asic_type == instance.asic_type
 

--- a/tests/saitests/mock/ut/test_ingress_drop_probing.py
+++ b/tests/saitests/mock/ut/test_ingress_drop_probing.py
@@ -78,6 +78,10 @@ class TestIngressDropProbingInstance:
         self.probe_packet_length = 64
         self.probe_cells_per_packet = 1
         self.ingress_drop_counter_mode = 'port_drop'
+        self.src_dut_index = 0
+        self.src_asic_index = 0
+        self.dst_dut_index = 0
+        self.dst_asic_index = 0
 
         # Probing configuration
         self.PROBE_TARGET = "ingress_drop"
@@ -129,7 +133,8 @@ class TestIngressDropProbingParameterParsing(unittest.TestCase):
 
         config = IngressDropProbing.get_probe_config(instance)
 
-        assert config.probing_port_ids == instance.probing_port_ids
+        assert config.src_port_ids == instance.probing_port_ids[:1]
+        assert config.dst_port_ids == instance.probing_port_ids[1:]
         assert config.thrift_client == instance.dst_client
         assert config.asic_type == instance.asic_type
 

--- a/tests/saitests/mock/ut/test_pfc_xoff_probing.py
+++ b/tests/saitests/mock/ut/test_pfc_xoff_probing.py
@@ -68,6 +68,10 @@ class TestPfcXoffProbingInstance(PfcXoffProbing):
         self.packet_size = 64
         self.probe_packet_length = 64
         self.probe_cells_per_packet = 1
+        self.src_dut_index = 0
+        self.src_asic_index = 0
+        self.dst_dut_index = 0
+        self.dst_asic_index = 0
 
         def mock_get_rx_port(src_port, dst_port):
             return dst_port
@@ -130,7 +134,8 @@ class TestPfcXoffProbingConfiguration:
 
         assert isinstance(config, ProbeConfig), \
             f"Expected ProbeConfig, got {type(config)}"
-        assert config.probing_port_ids == [24]
+        assert config.src_port_ids == [24]
+        assert config.dst_port_ids == []
         assert config.asic_type == 'broadcom'
         print("[OK] ProbeConfig correctly created")
 
@@ -687,7 +692,7 @@ class TestPfcXoffProbingProbeMethod:
         print("\n=== Test: probe_config attribute ===")
 
         pfc = TestPfcXoffProbingInstance()
-        config = ProbeConfig([24], Mock(), 'broadcom')
+        config = ProbeConfig([24], [], Mock(), 'broadcom')
         pfc.probe_config = config
 
         assert pfc.probe_config is config, "ProbeConfig should be settable"
@@ -711,7 +716,7 @@ class TestPfcXoffProbingProbeMethod:
         pfc.stream_mgr.get_port_ids.return_value = [28]
 
         # Mock probe_config
-        pfc.probe_config = ProbeConfig([24, 28], Mock(), 'broadcom')
+        pfc.probe_config = ProbeConfig([24], [28], Mock(), 'broadcom')
 
         # Mock algorithm execution
         mock_algorithms = {
@@ -755,7 +760,7 @@ class TestPfcXoffProbingProbeMethod:
 
         pfc.stream_mgr = Mock()
         pfc.stream_mgr.get_port_ids.return_value = [28]
-        pfc.probe_config = ProbeConfig([24, 28], Mock(), 'broadcom')
+        pfc.probe_config = ProbeConfig([24], [28], Mock(), 'broadcom')
 
         # Mock failed algorithm
         mock_algorithms = {
@@ -798,7 +803,7 @@ class TestPfcXoffProbingProbeMethod:
 
         pfc.stream_mgr = Mock()
         pfc.stream_mgr.get_port_ids.return_value = [28]
-        pfc.probe_config = ProbeConfig([24, 28], Mock(), 'broadcom')
+        pfc.probe_config = ProbeConfig([24], [28], Mock(), 'broadcom')
 
         mock_algorithms = {
             "upper_bound": Mock(run=Mock(return_value=(1000, None))),

--- a/tests/saitests/mock/ut/test_probing_base.py
+++ b/tests/saitests/mock/ut/test_probing_base.py
@@ -61,7 +61,8 @@ class ConcreteProbingBase(ProbingBase):
     def get_probe_config(self):
         """Return mock config"""
         return ProbeConfig(
-            probing_port_ids=[1, 2, 3],
+            src_port_ids=[1],
+            dst_port_ids=[2, 3],
             thrift_client=Mock(),
             asic_type='test_asic'
         )
@@ -714,6 +715,7 @@ class TestProbingBaseRunTest:
         pb = ConcreteProbingBase()
 
         call_order = []
+        tx_enable_port_lists = []
 
         # Track method calls
         original_get_probe_config = pb.get_probe_config
@@ -726,6 +728,7 @@ class TestProbingBaseRunTest:
 
         def tracked_sai_thrift_port_tx_enable(*args, **kwargs):
             call_order.append('sai_thrift_port_tx_enable')
+            tx_enable_port_lists.append(args[2])
 
         def tracked_setup_traffic():
             call_order.append('setup_traffic')
@@ -761,7 +764,8 @@ class TestProbingBaseRunTest:
             'setup_traffic',                 # Line 30
             'BufferOccupancyController',     # Line 31
             'probe',                         # Line 33
-            'assert_probing_result'          # Line 33 (implied)
+            'assert_probing_result',         # Line 33 (implied)
+            'sai_thrift_port_tx_enable'      # Final cleanup
         ]
 
         print(f"  Expected sequence: {expected_sequence}")
@@ -769,6 +773,8 @@ class TestProbingBaseRunTest:
 
         assert call_order == expected_sequence, \
             f"Call sequence mismatch!\nExpected: {expected_sequence}\nActual: {call_order}"
+        assert tx_enable_port_lists == [[2, 3], [2, 3]], \
+            "Only destination ports should have TX enabled"
 
         print("[OK] runTest() call sequence verified (matches lines 28-33)")
 

--- a/tests/saitests/probe/egress_drop_probing.py
+++ b/tests/saitests/probe/egress_drop_probing.py
@@ -94,7 +94,8 @@ class EgressDropProbing(ProbingBase):
         Uses dst_client for both BufferOccupancyController and executor counter reads.
         """
         return ProbeConfig(
-            probing_port_ids=self.probing_port_ids,
+            src_port_ids=self.probing_port_ids[:1],
+            dst_port_ids=self.probing_port_ids[1:],
             thrift_client=self.dst_client,
             asic_type=self.asic_type
         )
@@ -151,23 +152,22 @@ class EgressDropProbing(ProbingBase):
             return
 
         # Use first available dut/asic index from test_port_ips
-        dut_idx = next(iter(self.test_port_ips))
-        asic_idx = next(iter(self.test_port_ips[dut_idx]))
-        port_ips = self.test_port_ips[dut_idx][asic_idx]
+        src_port_ips = self.test_port_ips[self.src_dut_index][self.src_asic_index]
+        dst_port_ips = self.test_port_ips[self.dst_dut_index][self.dst_asic_index]
 
         # 1 src -> 1 dst
         srcport = PortInfo(
             self.probing_port_ids[0],
             mac=self.dataplane.get_mac(0, self.probing_port_ids[0]),
-            ip=port_ips[self.probing_port_ids[0]]["peer_addr"],
-            vlan=port_ips[self.probing_port_ids[0]].get("vlan_id", None)
+            ip=src_port_ips[self.probing_port_ids[0]]["peer_addr"],
+            vlan=src_port_ips[self.probing_port_ids[0]].get("vlan_id", None)
         )
 
         dstport = PortInfo(
             self.probing_port_ids[1],
             mac=self.dataplane.get_mac(0, self.probing_port_ids[1]),
-            ip=port_ips[self.probing_port_ids[1]]["peer_addr"],
-            vlan=port_ips[self.probing_port_ids[1]].get("vlan_id", None)
+            ip=dst_port_ips[self.probing_port_ids[1]]["peer_addr"],
+            vlan=dst_port_ips[self.probing_port_ids[1]].get("vlan_id", None)
         )
 
         # Probe packet config (resolved by ProbeParamsResolver in test_qos_probe.py)

--- a/tests/saitests/probe/headroom_pool_probing.py
+++ b/tests/saitests/probe/headroom_pool_probing.py
@@ -134,7 +134,8 @@ class HeadroomPoolProbing(ProbingBase):
     def get_probe_config(self):
         """Return standardized probe configuration."""
         return ProbeConfig(
-            probing_port_ids=self.probing_port_ids,
+            src_port_ids=self.probing_port_ids[:-1],
+            dst_port_ids=self.probing_port_ids[-1:],
             thrift_client=self.dst_client,
             asic_type=self.asic_type
         )
@@ -168,9 +169,8 @@ class HeadroomPoolProbing(ProbingBase):
             return
 
         # Use first available dut/asic index from test_port_ips (handles dualtor where keys may not be 0)
-        dut_idx = next(iter(self.test_port_ips))
-        asic_idx = next(iter(self.test_port_ips[dut_idx]))
-        port_ips = self.test_port_ips[dut_idx][asic_idx]
+        src_port_ips = self.test_port_ips[self.src_dut_index][self.src_asic_index]
+        dst_port_ips = self.test_port_ips[self.dst_dut_index][self.dst_asic_index]
 
         # N src -> 1 dst: Last port is dst, all others are src
         src_port_ids = self.probing_port_ids[:-1]
@@ -180,8 +180,8 @@ class HeadroomPoolProbing(ProbingBase):
         dstport = PortInfo(
             dst_port_id,
             mac=self.dataplane.get_mac(0, dst_port_id),
-            ip=port_ips[dst_port_id]["peer_addr"],
-            vlan=port_ips[dst_port_id].get("vlan_id", None)
+            ip=dst_port_ips[dst_port_id]["peer_addr"],
+            vlan=dst_port_ips[dst_port_id].get("vlan_id", None)
         )
 
         # Create src ports list
@@ -190,8 +190,8 @@ class HeadroomPoolProbing(ProbingBase):
             srcport = PortInfo(
                 spid,
                 mac=self.dataplane.get_mac(0, spid),
-                ip=port_ips[spid]["peer_addr"],
-                vlan=port_ips[spid].get("vlan_id", None)
+                ip=src_port_ips[spid]["peer_addr"],
+                vlan=src_port_ips[spid].get("vlan_id", None)
             )
             srcports.append(srcport)
 

--- a/tests/saitests/probe/ingress_drop_probing.py
+++ b/tests/saitests/probe/ingress_drop_probing.py
@@ -113,7 +113,8 @@ class IngressDropProbing(ProbingBase):
     def get_probe_config(self):
         """Return standardized probe configuration."""
         return ProbeConfig(
-            probing_port_ids=self.probing_port_ids,
+            src_port_ids=self.probing_port_ids[:1],
+            dst_port_ids=self.probing_port_ids[1:],
             thrift_client=self.dst_client,
             asic_type=self.asic_type
         )
@@ -140,16 +141,15 @@ class IngressDropProbing(ProbingBase):
             return
 
         # Use first available dut/asic index from test_port_ips (handles dualtor where keys may not be 0)
-        dut_idx = next(iter(self.test_port_ips))
-        asic_idx = next(iter(self.test_port_ips[dut_idx]))
-        port_ips = self.test_port_ips[dut_idx][asic_idx]
+        src_port_ips = self.test_port_ips[self.src_dut_index][self.src_asic_index]
+        dst_port_ips = self.test_port_ips[self.dst_dut_index][self.dst_asic_index]
 
         # 1 src -> N dst: First is src, rest are dst
         srcport = PortInfo(
             self.probing_port_ids[0],
             mac=self.dataplane.get_mac(0, self.probing_port_ids[0]),
-            ip=port_ips[self.probing_port_ids[0]]["peer_addr"],
-            vlan=port_ips[self.probing_port_ids[0]].get("vlan_id", None)
+            ip=src_port_ips[self.probing_port_ids[0]]["peer_addr"],
+            vlan=src_port_ips[self.probing_port_ids[0]].get("vlan_id", None)
         )
 
         dstports = []
@@ -157,8 +157,8 @@ class IngressDropProbing(ProbingBase):
             dstports.append(PortInfo(
                 dpid,
                 mac=self.dataplane.get_mac(0, dpid),
-                ip=port_ips[dpid]["peer_addr"],
-                vlan=port_ips[dpid].get("vlan_id", None)
+                ip=dst_port_ips[dpid]["peer_addr"],
+                vlan=dst_port_ips[dpid].get("vlan_id", None)
             ))
 
         # Probe packet config (resolved by ProbeParamsResolver in test_qos_probe.py)

--- a/tests/saitests/probe/pfc_xoff_probing.py
+++ b/tests/saitests/probe/pfc_xoff_probing.py
@@ -115,7 +115,8 @@ class PfcXoffProbing(ProbingBase):
     def get_probe_config(self):
         """Return standardized probe configuration."""
         return ProbeConfig(
-            probing_port_ids=self.probing_port_ids,
+            src_port_ids=self.probing_port_ids[:1],
+            dst_port_ids=self.probing_port_ids[1:],
             thrift_client=self.dst_client,
             asic_type=self.asic_type
         )
@@ -142,16 +143,15 @@ class PfcXoffProbing(ProbingBase):
             return
 
         # Use first available dut/asic index from test_port_ips (handles dualtor where keys may not be 0)
-        dut_idx = next(iter(self.test_port_ips))
-        asic_idx = next(iter(self.test_port_ips[dut_idx]))
-        port_ips = self.test_port_ips[dut_idx][asic_idx]
+        src_port_ips = self.test_port_ips[self.src_dut_index][self.src_asic_index]
+        dst_port_ips = self.test_port_ips[self.dst_dut_index][self.dst_asic_index]
 
         # 1 src -> N dst: First is src, rest are dst
         srcport = PortInfo(
             self.probing_port_ids[0],
             mac=self.dataplane.get_mac(0, self.probing_port_ids[0]),
-            ip=port_ips[self.probing_port_ids[0]]["peer_addr"],
-            vlan=port_ips[self.probing_port_ids[0]].get("vlan_id", None)
+            ip=src_port_ips[self.probing_port_ids[0]]["peer_addr"],
+            vlan=src_port_ips[self.probing_port_ids[0]].get("vlan_id", None)
         )
 
         dstports = []
@@ -159,8 +159,8 @@ class PfcXoffProbing(ProbingBase):
             dstports.append(PortInfo(
                 dpid,
                 mac=self.dataplane.get_mac(0, dpid),
-                ip=port_ips[dpid]["peer_addr"],
-                vlan=port_ips[dpid].get("vlan_id", None)
+                ip=dst_port_ips[dpid]["peer_addr"],
+                vlan=dst_port_ips[dpid].get("vlan_id", None)
             ))
 
         # Probe packet config (resolved by ProbeParamsResolver in test_qos_probe.py)

--- a/tests/saitests/probe/probing_base.py
+++ b/tests/saitests/probe/probing_base.py
@@ -65,9 +65,10 @@ class ProbeConfig(NamedTuple):
     Subclasses must implement get_probe_config() to return this.
     This ensures consistent parameter naming across all probes.
     """
-    probing_port_ids: List[int]  # Port IDs to probe
-    thrift_client: object        # dst_client or src_client
-    asic_type: str               # ASIC type string
+    src_port_ids: List[int]  # Source port IDs
+    dst_port_ids: List[int]  # Destination port IDs controlled during probing
+    thrift_client: object    # Client for the destination ASIC
+    asic_type: str           # ASIC type string
 
 
 class ProbingBase(sai_base_test.ThriftInterfaceDataPlane):
@@ -178,7 +179,7 @@ class ProbingBase(sai_base_test.ThriftInterfaceDataPlane):
 
         Steps:
         1. Get standardized config from subclass
-        2. Enable TX on all probing ports
+        2. Enable TX on destination ports
         3. Setup traffic streams (subclass)
         4. Initialize BufferOccupancyController
         5. Execute probing logic (subclass)
@@ -192,10 +193,10 @@ class ProbingBase(sai_base_test.ThriftInterfaceDataPlane):
         # Step 1: Get config from subclass (ensures standardized param names)
         config = self.get_probe_config()
 
-        # Step 2: Enable TX on all probing ports
+        # Step 2: Ensure destination TX is enabled before probing
         self.sai_thrift_port_tx_enable(
             config.thrift_client, config.asic_type,
-            config.probing_port_ids, last_port=False
+            config.dst_port_ids, last_port=True
         )
 
         # Step 3: Setup traffic streams (abstract method)
@@ -226,8 +227,9 @@ class ProbingBase(sai_base_test.ThriftInterfaceDataPlane):
         Abstract method: Return standardized probe configuration.
 
         Must return ProbeConfig with:
-        - probing_port_ids: List of port IDs to probe
-        - thrift_client: self.dst_client or self.src_client
+        - src_port_ids: List of source port IDs
+        - dst_port_ids: List of destination port IDs
+        - thrift_client: self.dst_client
         - asic_type: self.asic_type
 
         Raises:


### PR DESCRIPTION
These tests attempt to enable tx on the src asic using the dest asic client. `self.ptftest.buffer_ctrl.hold_buffer([dst_port])` even though only the dest port had tx disabled (as it should)

The fix is to split up the probing ports between src and dest and to only pass the dest ports to sai_thrift_port_tx_enable.

The tests also did not handle building the port_ips list from the correct asics.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #27240
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
These tests attempt to enable tx on the src asic using the dest asic client. self.ptftest.buffer_ctrl.hold_buffer([dst_port]) even though only the dest port had tx disabled (as it should)

The tests also did not handle building the port_ips list from the correct asics.

#### How did you do it?

Treat source and destination ports as separate ASICs instead of one mixed port list.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran test_qos_probe against a multi-asic pizza box. the tests would fail with 
`client\.sai_thrift_set_port_attribute\(port_list\[target\]\[port_id\], attr\)\\n\",\n.{1,200}\n.{1,200}KeyError: `
and other related messages

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
