### PR TITLE
fix test_fib.py: filter out special ports from ptf

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -101,7 +101,7 @@ def check_default_route_from_fib_info(ptfhost, file_path):
 
 def get_all_ptf_port_indices_from_mg_facts(mg_facts):
     """
-    Retrieve all ptf port indices from the minigraph facts.
+    Retrieve all front end ptf port indices from the minigraph facts.
 
     Args:
         mg_facts: The minigraph facts containing ASIC information.
@@ -118,6 +118,9 @@ def get_all_ptf_port_indices_from_mg_facts(mg_facts):
 
         # Store (port_index: (asic_id, port_name)) in the dictionary
         for port_name, port_index in minigraph_indices.items():
+            if port_name.startswith(("Ethernet-Rec", "Ethernet-IB", "Ethernet-BP")):
+                logger.debug("Skipping special port {} in ptf port indecies".format(port_name))
+                continue
             all_port_indices[port_index] = (asic_id, port_name)
 
     return all_port_indices


### PR DESCRIPTION
minigraph[minigraph_port_indices] is a port index map obtained by get_port_indices_for_asic

get_port_indices_for_asic builds 2 lists front_end_port_name_list and back_end_port_name_list `port_index_map[val] = idx` is used on both lists, meaning the index of both a front panel port and an internal/special port will collide.

get_extended_minigraph_facts uses the ports in minigraph_port_indices to build mg_facts['minigraph_ptf_indices']

When test_fib calls get_all_ptf_port_indices_from_mg_facts `all_port_indices[port_index] = (asic_id, port_name)` it has the potential to override Ethernet0 with Ethernet-Rec0 for example and it flaps this REC port instead of a front-panel port as expected.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #27242
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
When test_fib calls get_all_ptf_port_indices_from_mg_facts
all_port_indices[port_index] = (asic_id, port_name)
it has the potential to override Ethernet0 with Ethernet-Rec0 for example and it flaps
this REC port instead of a front-panel port as expected.

#### How did you do it?
Filter out internal ports like Ethernet-Rec0 from ptf ports in test_fib

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran test_fib.py without the change, it would sometimes flap ethernet-recX even though this is not a front-panel port. The test was therefor not covering the expected cases.

Ran test_fib.py with the fix and now it selects the expected front-panel port.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
