### PR TITLE
Fix multi-hop reboot log analyzer initialization

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -722,6 +722,7 @@ class AdvancedReboot:
 
         test_results = []
 
+        post_reboot_analysis = None
         for hop_index, _ in enumerate(upgrade_path_urls[1:], start=1):
             upgrade_path_str = "{from_image} -> {to_image} (hop {hop_index})".format(
                 hop_index=hop_index, from_image=upgrade_path_urls[hop_index-1], to_image=upgrade_path_urls[hop_index])


### PR DESCRIPTION
### Description of PR
Fixes SONiC nightly PBI 39369856. Multi-hop upgrade can enter the `finally` block before `post_reboot_analysis` is assigned, causing `UnboundLocalError` in `runMultiHopRebootTest`. Initialize the callback variable before the hop loop, matching the existing single-hop advanced reboot pattern.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
Nightly `metadata-scripts.test_multi_hop_upgrade_path::test_multi_hop_upgrade_path` failed on 202511 with `UnboundLocalError: cannot access local variable 'post_reboot_analysis' where it is not associated with a value`.

#### How did you do it?
Reset `post_reboot_analysis`, `marker` and `event_counters` to `None` at the top of every hop (mirroring the single-hop `runRebootTest` pattern), and require `event_counters` in the `finally` guard. The `finally` block dereferences all three, but each is assigned at a different point inside the `try`, so a failure before those assignments raised `UnboundLocalError` from the `finally` block and masked the real exception. `event_counters` is assigned after `marker`, so gating on it guarantees both are available; the per-hop reset also stops a failed hop from reusing the previous hop's marker/counters.

#### How did you verify/test it?
Ran `python -m py_compile tests/common/fixtures/advanced_reboot.py` and `python -m flake8 --max-line-length=120 tests/common/fixtures/advanced_reboot.py` (both clean). Not run on a testbed: this fixture drives multi-hop image upgrades and needs reboot hardware.

#### Any platform specific information?
Observed on Arista-7060CX-32S-C32 T0 in 202511 nightly.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
