### PR TITLE
Fix MultiAsic YANG validation empty patch input

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -991,7 +991,12 @@ class MultiAsicSonicHost(object):
         """
         Validate yang over running config
         """
-        output = self.shell("echo '[]' | sudo config apply-patch /dev/stdin", module_ignore_errors=True)
+        empty_patch_file = "/home/admin/yang_validation_empty_patch.json"
+        try:
+            self.copy(content="[]", dest=empty_patch_file)
+            output = self.shell(f"sudo config apply-patch {empty_patch_file}", module_ignore_errors=True)
+        finally:
+            self.file(path=empty_patch_file, state="absent")
         if output['rc'] != 0:
             return False
         if strict_yang_validation:


### PR DESCRIPTION
### Description of PR

Summary:
Fix `MultiAsicSonicHost.yang_validate()` to pass the empty JSON patch through a real file instead of `/dev/stdin`. This addresses nightly PBI 39369860, where `config_reload()` failed because `echo '[]' | sudo config apply-patch /dev/stdin` returned `Expecting value: line 1 column 1 (char 0)`.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/39369860

Companion to #27084, which applies the same fix to `tests/common/helpers/yang_utils.py::run_yang_validation`. The two PRs touch different helpers on different call paths (`config_reload()` / `device_utils.py` here, the autouse `yang_validation_check` module fixture there) and are not duplicates of each other.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39369860
Failure type: regression

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

master: static validation on this head (`0ed774d`). No testbed run.
- `python -m py_compile tests/common/devices/multi_asic.py` — passes.
- `python -m flake8 --max-line-length=120 tests/common/devices/multi_asic.py` — clean.
- Attribute resolution checked: `SonicAsic` defines `shell` but not `copy`/`file`, so `self.shell(...)` still runs per ASIC exactly as before, while `self.copy(...)` / `self.file(...)` resolve through `MultiAsicSonicHost.__getattr__` to the host-level Ansible modules. `self.file(..., state="absent")` is idempotent, so the `finally` cleanup is safe when the copy never happened.
- The identical `copy` → `sudo config apply-patch <file>` → `file state=absent` sequence in companion PR #27084 runs on every test module through the autouse `yang_validation_check` fixture (`--skip_yang` defaults to `False`) and is green across all KVM lanes there, which exercises the same mechanism on the same host objects.
- Azure.sonic-mgmt on this head: the two red lanes are baseline failures unrelated to this change - `impacted-area-kvmtest-t0` failed in `platform_tests/test_reboot.py` (Elastictest plan `6a897f1f51f39cced790f5a8`; same failure on 133 distinct PRs on t0 between 2026-08-15 and 2026-08-31) and `impacted-area-kvmtest-t2` failed in `fib/test_fib.py` (plan `6a897f1aeb9272f85921df07`; same failure on 10 distinct PRs in the same window). A fresh run is needed before merge.

202605: `tests/common/devices/multi_asic.py` on `202605` still carries the identical `self.shell("echo '[]' | sudo config apply-patch /dev/stdin", module_ignore_errors=True)`, so the same failure and the same fix apply there. No testbed run was performed on 202605; the evidence above is the master validation plus that code-state check.

### Approach
#### What is the motivation for this PR?

`test_counterpoll_queue_watermark_pg_drop` failed during `config_reload()` on Cisco-8101C01-C32 dualtor before reaching the counterpoll verification phase. The repeated failure came from `MultiAsicHost.yang_validate()` running `echo '[]' | sudo config apply-patch /dev/stdin`, where `config apply-patch` received empty input and returned `Expecting value: line 1 column 1 (char 0)`.

#### How did you do it?

Write the empty patch to `/home/admin/yang_validation_empty_patch.json`, run `sudo config apply-patch` with the file path, and remove the file in a `finally` block. This avoids the fragile pipe plus sudo plus `/dev/stdin` path while preserving the original validation behavior.

#### How did you verify/test it?

See **Test result** above.

#### Any platform specific information?

Observed on Cisco-8101C01-C32 dualtor 202605 nightly. The helper is shared and platform-independent.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A
