### PR TITLE
[test] Fix NTP helper for ntpsec on standalone Docker PTF containers

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -30,17 +30,27 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
 
     if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP):
         # Limit listening to the mgmt interface, to prevent socket allocation
-        # exhaustion
-        ptfhost.lineinfile(path=ntp_conf_path, line="interface ignore wildcard")
-        ptfhost.lineinfile(path=ntp_conf_path, line="interface listen mgmt")
-        # ntpsec (Debian trixie+ ptf) resolves the "mgmt" interface name to its
-        # IPv4 address only, so it never binds the mgmt IPv6 address. Add an
-        # explicit listen directive for the IPv6 case so the DUT can sync over
-        # IPv6. Classic ntpd bound both families via the interface name.
-        if ptf_use_ipv6 and ptfhost.mgmt_ipv6:
-            ptfhost.lineinfile(path=ntp_conf_path, line="interface listen %s" % ptfhost.mgmt_ipv6)
+        # exhaustion.  Standalone Docker PTF containers may not have a "mgmt"
+        # interface (only eth0/veth) and ntpsec cannot bind to those aliases,
+        # so only apply interface restrictions when mgmt actually exists.
+        res = ptfhost.command("ip link show mgmt", module_ignore_errors=True)
+        if res.get("rc", 1) == 0:
+            ptfhost.lineinfile(path=ntp_conf_path, line="interface ignore wildcard")
+            ptfhost.lineinfile(path=ntp_conf_path, line="interface listen mgmt")
+            # ntpsec resolves the "mgmt" interface name to its IPv4 address only,
+            # so add an explicit listen directive for IPv6.
+            if ptf_use_ipv6 and ptfhost.mgmt_ipv6:
+                ptfhost.lineinfile(path=ntp_conf_path, line="interface listen %s" % ptfhost.mgmt_ipv6)
 
-    ptfhost.lineinfile(path=ntp_conf_path, line="server 127.127.1.0 prefer")
+    if ntp_daemon_type == NtpDaemon.NTPSEC:
+        # ntpsec dropped the classic "server 127.127.1.0" local clock address
+        # syntax; use the refclock directive and add restrict lines for ntpq.
+        ptfhost.lineinfile(path=ntp_conf_path, line="refclock local stratum 3 prefer",
+                           regexp="^(server 127\\.127\\.1\\.0|refclock local)")
+        ptfhost.lineinfile(path=ntp_conf_path, line="restrict 127.0.0.1")
+        ptfhost.lineinfile(path=ntp_conf_path, line="restrict ::1")
+    else:
+        ptfhost.lineinfile(path=ntp_conf_path, line="server 127.127.1.0 prefer")
 
     # Comment out the default pool configuration
     ptfhost.lineinfile(
@@ -58,7 +68,11 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
     ptfhost.lineinfile(
         path=ntp_conf_path, line="#tos minclock 4 minsane 3", regexp="^tos.*minclock.*minsane.*")
 
-    ptfhost.lineinfile(path=ntp_conf_path, line="server 127.127.1.0 prefer")
+    if ntp_daemon_type == NtpDaemon.NTPSEC:
+        ptfhost.lineinfile(path=ntp_conf_path, line="refclock local stratum 3 prefer",
+                           regexp="^(server 127\\.127\\.1\\.0|refclock local)")
+    else:
+        ptfhost.lineinfile(path=ntp_conf_path, line="server 127.127.1.0 prefer")
 
     # restart ntp server
     ntp_en_res = ptfhost.service(name=ntp_service_name, state="restarted")
@@ -105,10 +119,13 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
         path=ntp_conf_path, line="pool 3.debian.pool.ntp.org iburst", regexp="#pool.*3.debian.*pool.*ntp.*org.*")
 
     ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^server.*127.127.1.0.*prefer")
+    ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^refclock local")
+    ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^restrict 127.0.0.1$")
+    ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^restrict ::1$")
 
     if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP):
         ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.ignore.wildcard")
-        ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.listen.mgmt")
+        ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.listen.(mgmt|eth0)")
         if ptf_use_ipv6 and ptfhost.mgmt_ipv6:
             ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface listen %s" % ptfhost.mgmt_ipv6)
 

--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -28,6 +28,14 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
         ntp_conf_path = '/etc/ntp.conf'
         ntp_service_name = 'ntp'
 
+    # Back up the original ntp config so we can restore it verbatim in
+    # teardown. This avoids fragile lineinfile-based removals that can
+    # inadvertently drop directives that shipped with the package (for
+    # example ntpsec's default `restrict 127.0.0.1` / `restrict ::1`).
+    ntp_conf_backup_path = ntp_conf_path + ".sonicmgmt.bak"
+    ptfhost.command(
+        "cp -a --no-clobber {} {}".format(ntp_conf_path, ntp_conf_backup_path))
+
     if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP):
         # Limit listening to the mgmt interface, to prevent socket allocation
         # exhaustion.  Standalone Docker PTF containers may not have a "mgmt"
@@ -108,26 +116,11 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
     # stop ntp server
     ptfhost.service(name=ntp_service_name, state="stopped")
 
-    # restore the default pool configuration
-    ptfhost.lineinfile(
-        path=ntp_conf_path, line="pool 0.debian.pool.ntp.org iburst", regexp="#pool.*0.debian.*pool.*ntp.*org.*")
-    ptfhost.lineinfile(
-        path=ntp_conf_path, line="pool 1.debian.pool.ntp.org iburst", regexp="#pool.*1.debian.*pool.*ntp.*org.*")
-    ptfhost.lineinfile(
-        path=ntp_conf_path, line="pool 2.debian.pool.ntp.org iburst", regexp="#pool.*2.debian.*pool.*ntp.*org.*")
-    ptfhost.lineinfile(
-        path=ntp_conf_path, line="pool 3.debian.pool.ntp.org iburst", regexp="#pool.*3.debian.*pool.*ntp.*org.*")
-
-    ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^server.*127.127.1.0.*prefer")
-    ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^refclock local")
-    ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^restrict 127.0.0.1$")
-    ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^restrict ::1$")
-
-    if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP):
-        ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.ignore.wildcard")
-        ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.listen.(mgmt|eth0)")
-        if ptf_use_ipv6 and ptfhost.mgmt_ipv6:
-            ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface listen %s" % ptfhost.mgmt_ipv6)
+    # Restore the ntp config from the backup taken during setup, then remove
+    # the backup. Using an atomic move here means any pre-existing package
+    # defaults (e.g. ntpsec's `restrict 127.0.0.1` / `restrict ::1`) are
+    # preserved regardless of what setup added or modified.
+    ptfhost.command("mv -f {} {}".format(ntp_conf_backup_path, ntp_conf_path))
 
     # reset ntp client configuration
     duthost.command("config ntp del %s" % (ptfhost.mgmt_ipv6 if ptf_use_ipv6 else ptfhost.mgmt_ip))


### PR DESCRIPTION
#### Why I did it
Fixes #27247

The NTP test helper (`tests/common/helpers/ntp_helper.py`) fails on testbeds where the PTF container runs **ntpsec** (Debian 12+ / Trixie) instead of classic `ntp`:

1. `server 127.127.1.0 prefer` — ntpsec dropped the legacy refclock address syntax; the daemon ignores it, `ntpstat` never reports synchronised, and `check_ntp_status` times out.
2. `interface listen mgmt` — standalone Docker PTF containers have no `mgmt` interface (only `eth0` veth pair); ntpsec starts but binds to nothing.

Both cause `NTP server was not started in PTF container` errors in `test_ntp.py`.

#### How I did it
- Probe for the `mgmt` interface (`ip link show mgmt`); skip interface restrictions when it doesn't exist.
- For ntpsec, use `refclock local stratum 3 prefer` (native syntax) and add `restrict 127.0.0.1` / `restrict ::1` so `ntpq` can query the daemon.
- Clean up new directives in teardown.

#### How to verify it
Run `ntp/test_ntp.py` against a testbed using a Docker PTF container with ntpsec (e.g., `docker-ptf:internal` based on Debian 12).

Before fix: 3 errors (`NTP server was not started`)
After fix: 3 passed, 3 skipped (IPv6 tests skip due to no IPv6 on PTF)