### PR TITLE
Derive port_alias inputs from DUT properties, not the topology name

### DIFF
--- a/ansible/roles/vm_set/tasks/get_dut_port.yml
+++ b/ansible/roles/vm_set/tasks/get_dut_port.yml
@@ -11,20 +11,19 @@
     dut_mgmt_port: ""
   when: external_port is defined
 
-- name: determine whether to include internal ports
-  set_fact:
-    include_internal: true
-  when: is_vs_chassis is defined and is_vs_chassis == true
-
-- name: determine whether to sort port_alias by index
-  set_fact:
-    sort_by_index: false
-  when: is_vs_chassis is defined and is_vs_chassis == true
-
 - set_fact:
     hwsku: "{{ hostvars[dut_name].hwsku }}"
     num_asic: "{{ hostvars[dut_name]['num_asics'] | default(1) }}"
     card_type: "{{ hostvars[dut_name]['card_type'] | default('pizzabox') }}"
+    # Internal (Int/Inb/Rec) ports exist on chassis members, which declare card_type, and on
+    # VOQ systems. Both are properties of the DUT itself, unlike the topology name that
+    # is_vs_chassis was derived from.
+    include_internal: "{{ hostvars[dut_name]['card_type'] is defined
+      or hostvars[dut_name]['switch_type'] | default('') == 'voq' }}"
+    # Chassis members and VOQ systems keep port_config.ini order so per-asic ports stay
+    # grouped. Matches config_sonic_basedon_testbed.yml, which already keys this on switch_type.
+    sort_by_index: "{{ hostvars[dut_name]['card_type'] is not defined
+      and hostvars[dut_name]['switch_type'] | default('') != 'voq' }}"
   when: dut_name in hostvars
 
 - name: Get DUT port alias

--- a/ansible/roles/vm_set/tasks/start_sonic_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_sonic_vm.yml
@@ -39,6 +39,11 @@
     hwsku: "{{ hostvars[dut_name].hwsku }}"
     num_asic: "{{ hostvars[dut_name]['num_asics'] | default(1) }}"
     card_type: "{{ hostvars[dut_name]['card_type'] | default('pizzabox') }}"
+    # See get_dut_port.yml for the rationale behind these two port_alias inputs.
+    include_internal: "{{ hostvars[dut_name]['card_type'] is defined
+      or hostvars[dut_name]['switch_type'] | default('') == 'voq' }}"
+    sort_by_index: "{{ hostvars[dut_name]['card_type'] is not defined
+      and hostvars[dut_name]['switch_type'] | default('') != 'voq' }}"
     asic_type: "{{ hostvars[dut_name].asic_type | default('') }}"
 
 - set_fact:
@@ -64,16 +69,6 @@
 - name: Copy sonic EFI vars for {{ dut_name }}
   copy: src={{ src_disk_efi_vars }} dest={{ efi_vars }} remote_src=True
   when: not file_stat.stat.exists and use_uefi
-
-- name: determine whether to include internal ports
-  set_fact:
-    include_internal: true
-  when: is_vs_chassis is defined and is_vs_chassis == true
-
-- name: determine whether to sort port_alias by index
-  set_fact:
-    sort_by_index: false
-  when: is_vs_chassis is defined and is_vs_chassis == true
 
 - name: Get DUT port alias
   port_alias: hwsku={{ hwsku }} num_asic={{ num_asic }} card_type={{ card_type }} include_internal={{ include_internal | default(false) }} sort_by_index={{ sort_by_index | default(true) }}


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)

The `vm_set` role derives two `port_alias` inputs from `is_vs_chassis`, which is computed from the **topology name** (`base_topo == "t2"`, `testbed_add_vm_topology.yml:133-136`) rather than from the DUT:

- `include_internal` — admits `Int`/`Inb`/`Rec` ports into the alias list (`port_alias.py:178`, `:294`)
- `sort_by_index` — index order vs `port_config.ini` file order (`port_alias.py:479`)

So a DUT gets its internal ports only if it sits in a `t2*`-named topology, and a chassis member in a differently-named topology silently loses them.

That is the root cause behind https://github.com/sonic-net/sonic-mgmt/pull/26861, which adds a parallel `is_vs_urh` flag keyed on another topology name. With this change that flag is unnecessary — a VOQ DUT only needs to declare `switch_type: voq`, as `vlab-ut2` already does.

No dependencies. `port_alias.py` is unchanged; the same change is applied to both call sites.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A — no backport requested.
Failure type: N/A

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `SONiC.master.1199753-bbb651f4b` (sonic-vs) — `add-topo` of `vms-kvm-t2-single-node-min`. `Get DUT port alias` succeeded on both call sites; `vlab-ut2` came up with the expected 68 interfaces (1 mgmt + 66 `Ext` + 1 `Rec`), boots, and is reachable.

### Approach
#### What is the motivation for this PR?

Otherwise every new device class needs another topology-name-matched flag — #26861 is adding the second one now.

#### How did you do it?

Derive both inputs from the DUT, in the `set_fact` block that already reads `hwsku`/`num_asics`/`card_type` from `hostvars`:

```yaml
include_internal: card_type is defined or switch_type == 'voq'
sort_by_index:    card_type is not defined and switch_type != 'voq'
```

`card_type` is declared only by chassis members and `switch_type: voq` marks VOQ systems, so their union is exactly the set of DUTs with internal ports.

This also aligns with `config_sonic_basedon_testbed.yml:269-272`, which already sets `sort_by_index: false` for `switch_type == "voq" and type == "kvm"`. The two playbooks previously agreed only because every VOQ KVM DUT happened to sit in a `t2`-named topology.

Both facts are assigned in the existing unconditional block rather than as separate `when:`-gated tasks: `get_dut_port.yml` is `include_tasks`'d inside a loop over `duts_name` (`add_topo.yml:127`) and `set_fact` persists across iterations, so a one-way gated assignment of a per-DUT value would leak into later DUTs.

`is_vs_chassis` is untouched and still drives midplane bridge creation (`vm_topology.py:349`).

#### How did you verify/test it?

**No behavioral change.** Only `vms-kvm-t2` and `vms-kvm-t2-single-node-min` use a `t2*` topology, so the set of DUTs that ever saw `is_vs_chassis: true` is closed:

| DUT | card_type | switch_type | before | after |
|---|---|---|---|---|
| `vlab-t2-1-1`, `vlab-t2-1-2` | linecard | voq | `true` / `false` | `true` / `false` |
| `vlab-t2-1-sup` | supervisor | dummy-sup | `true` / `false` | `true` / `false` |
| `vlab-ut2` | — | voq | `true` / `false` | `true` / `false` |
| `vlab-01` and all others | — | — | `false` / `true` | `false` / `true` |

1. **Argument-level comparison.** The change alters only two argument values, so running the unmodified `port_alias` with the before-args and the after-args covers it completely — byte-identical output for every DUT above.
2. **Fact evaluation over the real inventory**, across all 31 KVM DUTs in `veos_vtb` + `lab`. Exactly four produce a non-default pair — the same four that had `is_vs_chassis: true`. Includes a control for `set_fact` persistence (`vlab-01` evaluated after `vlab-ut2` correctly returns `false`/`true`).
3. **KVM deploy** — see Test result.

#### Any platform specific information?

Real hardware is unaffected — both call sites are gated on `type == 'kvm'` (`get_dut_port.yml` directly, `start_sonic_vm.yml` via `manage_duts.yml:4`).

#### Supported testbed topology if it's a new test case?

N/A — not a test case.

### Documentation

Not needed — no user-facing change. `port_alias`'s arguments are unchanged, only how two of them are computed.