### PR TITLE
Fix DPG alias name collision for Wistron and D64p512T platforms in minigraph_dpg.j2

### DIFF
--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -6,7 +6,7 @@
    minigraph parser will perform its own alias->name lookup; pre-converting
    here would cause a second lookup on a string that is also a valid alias
    for a *different* port (see PR #24516 / regression from PR #22166). #}
-{% set alias_name_collision_hwsku_patterns = ['Arista-7050CX3'] %}
+{% set alias_name_collision_hwsku_patterns = ['Arista-7050CX3','d64p512t_64x800G-2x10G_lab','wistron_6512_32r_32x50_lab'] %}
 {% set hwsku_has_alias_name_collision = (alias_name_collision_hwsku_patterns | select('in', hwsku) | list | length > 0) %}
   <DpgDec>
     <DeviceDataPlaneInfo>


### PR DESCRIPTION

### Description of PR

Summary:
`ansible/templates/minigraph_dpg.j2` maintains an `alias_name_collision_hwsku_patterns`
list of HWSKUs where a port's alias string is itself a valid alias for a *different*
port, so the template must skip its own alias->name pre-conversion and let the minigraph
parser do the lookup (see PR #24516 / regression from PR #22166). Only `Arista-7050CX3`
was in this list. The `wistron_6512_32r_32x50_lab` and `d64p512t_64x800G-2x10G_lab`
HWSKUs have the same alias/name collision, causing DPG generation to resolve the wrong
port on these platforms. This PR adds both HWSKUs to the collision-pattern list. 
Fixes https://github.com/sonic-net/sonic-mgmt/issues/27791

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
minigraph generated correctly for `wistron_6512_32r_32x50_lab` and `d64p512t_64x800G-2x10G_lab`, DPG ports resolved to the correct name (no cross-port alias collision)

### Approach
DPG generation on Wistron (`wistron_6512_32r_32x50_lab`) and D64P512T
(`d64p512t_64x800G-2x10G_lab`) HWSKUs produces incorrect port mappings because their port
aliases collide with a different port's name, and the template's alias->name
pre-conversion runs before the minigraph parser's own lookup, causing a second incorrect
resolution.

#### How did you do it?
Added `'d64p512t_64x800G-2x10G_lab'` and `'wistron_6512_32r_32x50_lab'` to the
`alias_name_collision_hwsku_patterns` list in `ansible/templates/minigraph_dpg.j2`, so
these HWSKUs skip the pre-conversion and defer to the minigraph parser's alias->name
lookup

#### How did you verify/test it?
Generated the minigraph for testbeds using `wistron_6512_32r_32x50_lab` and
`d64p512t_64x800G-2x10G_lab` HWSKUs and confirmed DPG port entries now resolve to the
correct port name instead of colliding with a different port's alias.

#### Any platform specific information?
Wistron 6512-32R (32x50G) and D64P512T (64x800G-2x10G) HWSKUs only.

#### Supported testbed topology if it's a new test case?

### Documentation

