### PR TITLE
Skip srv6/test_srv6_static_config.py on Marvell Teralynx (SRv6 not supported)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5347,7 +5347,7 @@ srv6/test_srv6_dataplane.py::TestSRv6DataPlaneBase::test_srv6_full_func:
 
 srv6/test_srv6_static_config.py:
   skip:
-    reason: "Only target mellanox SPC4+ platform with 202412 or 202511+ image. Requires particular image support (202412 or 202511+). SRv6 is not supported on older ASICs (Broadcom TH/TH2/TD3; Mellanox SPC1-3). Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32, t1-isolated-d32/128"
+    reason: "Only target mellanox SPC4+ platform with 202412 or 202511+ image. Requires particular image support (202412 or 202511+). SRv6 is not supported on older ASICs (Broadcom TH/TH2/TD3; Mellanox SPC1-3). Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32, t1-isolated-d32/128, Skipped because SRv6 is not supported on marvell-teralynx platform."
     conditions_logical_operator: or
     conditions:
       - "(release != 'master' and release != '202412' and release < '202511') and asic_type not in ['vpp']"
@@ -5355,12 +5355,13 @@ srv6/test_srv6_static_config.py:
       - "'Arista-7060X6-64PE' in hwsku and 'Arista-7060X6-64PE-B' not in hwsku"
       - "topo_name in ['t0-isolated-d96u32s2', 't1-isolated-d128', 't1-isolated-d32']"
       - "asic_type == 'broadcom' and asic_gen not in ['th5', 'th6', 'q3d']"
+      - "asic_type in ['marvell-teralynx']"
 
 srv6/test_srv6_static_config.py::test_uDT46_config:
   skip:
     reason: "Unsupported platform"
     conditions:
-      - "asic_type in ['mellanox', 'vpp']"
+      - "asic_type in ['mellanox', 'vpp', 'marvell-teralynx']"
 
 srv6/test_srv6_vlan_forwarding.py:
   skip:


### PR DESCRIPTION

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary:
Fixes # (issue)
`tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` skips
`srv6/test_srv6_static_config.py` for platforms/ASICs where SRv6 is not supported
(Broadcom TH/TH2/TD3, Mellanox SPC1-3, non-TH5 Arista-7060X6-64PE SKUs, certain isolated
topologies). Marvell Teralynx does not support SRv6 either, but was missing from these
skip conditions, so the test runs (and fails) on marvell-teralynx platforms. This PR adds
`asic_type in ['marvell-teralynx']` to the top-level skip conditions for
`srv6/test_srv6_static_config.py`, and to the `test_uDT46_config` skip conditions. 
Fixes https://github.com/sonic-net/sonic-mgmt/issues/27792

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
`srv6/test_srv6_static_config.py` (including `test_uDT46_config`) now correctly skipped on a Marvell Teralynx testbed instead of failing

### Approach
#### What is the motivation for this PR?
Marvell Teralynx does not support SRv6, but `srv6/test_srv6_static_config.py` had no skip
condition for `asic_type == 'marvell-teralynx'`, so the test attempts to run and fails on
this platform instead of being skipped like the other unsupported ASICs.

#### How did you do it?
Added `"asic_type in ['marvell-teralynx']"` to the `conditions` list (with
`conditions_logical_operator: or`) for the top-level `srv6/test_srv6_static_config.py`
skip entry, updated its `reason` text to mention marvell-teralynx, and added
`'marvell-teralynx'` to the `asic_type in [...]` skip condition for `test_uDT46_config`.

#### How did you verify/test it?
Ran the srv6 static config test suite on a Marvell Teralynx testbed and confirmed all
tests in `srv6/test_srv6_static_config.py` are now skipped with the updated reason,
instead of failing due to lack of SRv6 support.

#### Any platform specific information?
Marvell Teralynx ASIC only; skip behavior for Mellanox/Broadcom/Arista/vpp is unchanged.

#### Supported testbed topology if it's a new test case?
N/A - conditional-mark skip update, not a new test case.

### Documentation
N/A - no new feature or new test case, no doc/Wiki changes needed.
