### PR TITLE
[bgp] Exclude supervisor no-op DUTs from prefix_list tests

### DIFF
--- a/tests/bgp/test_prefix_list_suppress.py
+++ b/tests/bgp/test_prefix_list_suppress.py
@@ -96,6 +96,21 @@ def has_chassisdb_conf(duthost):
     return duthost.stat(path=CHASSISDB_CONF)["stat"]["exists"]
 
 
+def prefix_list_cli_skips_on_supervisor(duthost):
+    """Return True if ``prefix_list`` would no-op on this DUT as supervisor."""
+    if duthost.is_supervisor_node() or has_chassisdb_conf(duthost):
+        return True
+    cmd = (
+        'PLATFORM=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.platform '
+        '2>/dev/null || true); '
+        'if [ -n "$PLATFORM" ] && '
+        '[ -f "/usr/share/sonic/device/$PLATFORM/platform_env.conf" ]; then '
+        '. "/usr/share/sonic/device/$PLATFORM/platform_env.conf"; fi; '
+        '[ "$supervisor" = "1" ]'
+    )
+    return duthost.shell(cmd, module_ignore_errors=True)["rc"] == 0
+
+
 def op_prefix_with_cmd(duthost, prefix_type, prefix, action, ignore_error=False):
     """Run ``sudo prefix_list <action> <type> <prefix>``."""
     pytest_assert(
@@ -449,7 +464,7 @@ def rand_one_uplink_duthost(duthosts):
     """Pick one UpstreamLC / UpperSpineRouter duthost. Skip otherwise."""
     candidates = [
         dh for dh in duthosts
-        if not dh.is_supervisor_node() and is_upstream_spine(dh)
+        if not prefix_list_cli_skips_on_supervisor(dh) and is_upstream_spine(dh)
     ]
     if not candidates:
         pytest.skip("No UpstreamLC / UpperSpineRouter duthost in this testbed")
@@ -461,7 +476,7 @@ def rand_one_non_spine_duthost(duthosts):
     """Pick one non-spine, non-supervisor frontend duthost. Skip otherwise."""
     candidates = [
         dh for dh in duthosts
-        if not dh.is_supervisor_node() and not is_upstream_spine(dh)
+        if not prefix_list_cli_skips_on_supervisor(dh) and not is_upstream_spine(dh)
     ]
     if not candidates:
         pytest.skip("No non-spine frontend duthost in this testbed")
@@ -471,7 +486,7 @@ def rand_one_non_spine_duthost(duthosts):
 @pytest.fixture(scope="module")
 def rand_one_frontend_duthost(duthosts):
     """Pick any frontend (non-supervisor) duthost."""
-    candidates = [dh for dh in duthosts if not dh.is_supervisor_node()]
+    candidates = [dh for dh in duthosts if not prefix_list_cli_skips_on_supervisor(dh)]
     if not candidates:
         pytest.skip("No frontend duthost in this testbed")
     return random.choice(candidates)


### PR DESCRIPTION
### Description of PR
Keeps `bgp/test_prefix_list_suppress.py` operation fixtures from selecting a DUT where the `prefix_list` CLI intentionally no-ops as a chassis supervisor, without dropping any DUT where the CLI actually runs.

The `prefix_list` CLI decides this in `skip_chassis_supervisor()` (`sonic-buildimage:dockers/docker-fpm-frr/base_image_files/prefix_list`). Since sonic-buildimage [#28844](https://github.com/sonic-net/sonic-buildimage/pull/28844) (commit [`3aacf68`](https://github.com/sonic-net/sonic-buildimage/commit/3aacf68d66b628d2a1a8ed80f81094db8bf9377a), 202605 via [#29041](https://github.com/sonic-net/sonic-buildimage/pull/29041)) the no-op is keyed on `supervisor=1` in the platform's `platform_env.conf` only; it is no longer keyed on `/etc/sonic/chassisdb.conf`. This PR mirrors exactly that condition.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Tested branch
- [x] master
- [ ] 202605

### Test result
master: PR CI (Azure.sonic-mgmt) — impacted-area KVM runs by Elastictest, including `bgp/test_prefix_list_suppress.py`, on t0 / t0-sonic / t0-vpp / t1-lag / t1-lag-vpp / t2 / multi-asic-t1.
Local static checks on the changed file: `python -m py_compile tests/bgp/test_prefix_list_suppress.py` and `python -m flake8 --max-line-length=120 tests/bgp/test_prefix_list_suppress.py` (both pass).
No 202605 branch run and no chassis/SmartSwitch hardware run were performed by me; the fixture change is host-selection only and cannot be exercised without a multi-DUT chassis testbed.

### Approach
#### What is the motivation for this PR?
`rand_one_uplink_duthost` / `rand_one_non_spine_duthost` / `rand_one_frontend_duthost` excluded only `is_supervisor_node()`, which is inventory-derived. The CLI's own no-op condition is platform data, so the two can disagree and the operation tests then run against a DUT where `prefix_list` returns rc=0 with `Skipping Operation on chassis supervisor` and programs nothing.

#### How did you do it?
Added `prefix_list_cli_skips_on_supervisor()`, which returns `True` for `is_supervisor_node()` or for a DUT whose `platform_env.conf` sets `supervisor=1` — the exact condition the CLI uses — and used it in the three frontend-selecting fixtures.

Addressing @wenyiz2021's review feedback on the duplicate #26902: the helper no longer treats `/etc/sonic/chassisdb.conf` as a supervisor signal. That file is deployed whenever a platform sets `start_chassis_db=1`, which is also true on multi-ASIC DT2 line cards, SmartSwitch and disaggregated-chassis frontends where `prefix_list` runs normally, so keying on it would skip valid DUTs (and, on a single-DUT testbed, make the tests `pytest.skip`). Only `arista_7800_sup` and `nokia_ixr7250e_sup` set `supervisor=1` in the tree today, and both are also supervisor nodes, so no currently-covered DUT loses coverage.

This PR supersedes #26902 and the already-closed #26901, which used the old `chassisdb.conf` condition; only this one should be merged.

#### How did you verify/test it?
Static checks above plus the PR's Elastictest KVM runs. Traced the CLI source and the per-platform `platform_env.conf` / `chassisdb.conf` device data in sonic-buildimage to confirm which DUTs the CLI actually skips.

#### Any platform specific information?
Originally observed on Mellanox-SN4280-O28 T1; the helper is platform-independent.

#### Supported testbed topology if it's a new test case?
Existing t0/t1/t2 tests.

### Documentation
N/A
