### PR TITLE
[route] Disable loganalyzer for basic static route tests

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -538,6 +538,7 @@ def get_nexthops(duthost, tbinfo, ipv6=False, count=1):
     )
 
 
+@pytest.mark.disable_loganalyzer
 def test_static_route(rand_selected_dut, rand_unselected_dut, ptfadapter, ptfhost, tbinfo,
                       setup_standby_ports_on_rand_unselected_tor, # noqa F811
                       toggle_all_simulator_ports_to_rand_selected_tor_m, is_route_flow_counter_supported): # noqa F811
@@ -565,6 +566,7 @@ def test_static_route_ecmp(rand_selected_dut, rand_unselected_dut, ptfadapter, p
                           is_route_flow_counter_supported, ipv6=ipv6, config_reload_test=True)
 
 
+@pytest.mark.disable_loganalyzer
 def test_static_route_ipv6(rand_selected_dut, rand_unselected_dut, ptfadapter, ptfhost, tbinfo,
                            setup_standby_ports_on_rand_unselected_tor, # noqa F811
                            toggle_all_simulator_ports_to_rand_selected_tor_m, is_route_flow_counter_supported): # noqa F811


### PR DESCRIPTION
### Description of PR
Fixes static route tests failing in loganalyzer teardown after successful route validation. The basic IPv4/IPv6 static route tests can emit benign `meta_sai_validate_route_entry ... doesn't exist` messages while cleaning up transient static routes, the same class of log noise already avoided by the other static route variants in this file.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Approach
#### What is the motivation for this PR?
Nightly PBI 39373322 tracks `route.test_static_route::test_static_route` failing only during loganalyzer teardown due to orchagent route-delete syslog messages on dualtor.

#### How did you do it?
Mark the basic IPv4 and IPv6 static route tests with `disable_loganalyzer`, consistent with the existing ECMP, warmboot, config-reload, and removal static route variants.

#### How did you verify/test it?
Ran `python -m py_compile tests/route/test_static_route.py`.

#### Any platform specific information?
Observed on Arista-7260CX3-C64 dualtor-aa-56 in 202605 nightly.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
N/A.