### PR TITLE
snmp: wait for LLDP remote table convergence

### DIFF
--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -151,27 +151,37 @@ def test_snmp_lldp(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_
             minigraph_lldp_nei.append(k)
     logger.info('minigraph_lldp_nei: {}'.format(minigraph_lldp_nei))
 
-    # Check if lldpRemTable is present
     active_intf = []
-    for k, v in list(snmp_facts['snmp_interfaces'].items()):
-        if "lldpRemChassisIdSubtype" in v and \
-           "lldpRemChassisId" in v and \
-           "lldpRemPortIdSubtype" in v and \
-           "lldpRemPortId" in v and \
-           "lldpRemPortDesc" in v and \
-           "lldpRemSysName" in v and \
-           "lldpRemSysDesc" in v and \
-           "lldpRemSysCapSupported" in v and \
-           "lldpRemSysCapEnabled" in v:
-            active_intf.append(k)
-    logger.info('lldpRemTable: {}'.format(active_intf))
 
-    assert len(active_intf) >= len(minigraph_lldp_nei) * 0.8, (
-        "Number of active interfaces is less than expected. "
-        "Expected at least 80% of minigraph LLDP neighbors to be active. "
-        "Active interfaces: {} "
-        "Minigraph LLDP neighbors: {}"
-    ).format(len(active_intf), len(minigraph_lldp_nei))
+    def _lldp_rem_table_ready():
+        nonlocal active_intf, snmp_facts
+        snmp_facts.update(get_snmp_facts(
+            duthost, localhost, host=hostip, version="v2c",
+            community=creds_all_duts[duthost.hostname]["snmp_rocommunity"],
+            module_ignore_errors=True).get('ansible_facts', {}))
+        active_intf = []
+        for k, v in list(snmp_facts['snmp_interfaces'].items()):
+            if "lldpRemChassisIdSubtype" in v and \
+               "lldpRemChassisId" in v and \
+               "lldpRemPortIdSubtype" in v and \
+               "lldpRemPortId" in v and \
+               "lldpRemPortDesc" in v and \
+               "lldpRemSysName" in v and \
+               "lldpRemSysDesc" in v and \
+               "lldpRemSysCapSupported" in v and \
+               "lldpRemSysCapEnabled" in v:
+                active_intf.append(k)
+        return len(active_intf) >= len(minigraph_lldp_nei) * 0.8
+
+    if not wait_until(120, 10, 0, _lldp_rem_table_ready):
+        collect_lldp_diagnostics(duthost)
+        pytest.fail(
+            "Number of active interfaces is less than expected. "
+            "Expected at least 80% of minigraph LLDP neighbors to be active. "
+            "Active interfaces: {} "
+            "Minigraph LLDP neighbors: {}".format(len(active_intf), len(minigraph_lldp_nei))
+        )
+    logger.info('lldpRemTable: {}'.format(active_intf))
 
     # skip neighbors that do not send chassis information via lldp
     lldp_facts = {}


### PR DESCRIPTION
### Description of PR

Summary:
`tests/snmp/test_snmp_lldp.py::test_snmp_lldp` reads `lldpRemTable` once and asserts that at least 80% of minigraph LLDP neighbors are present. Nightly failures show the table can be transiently incomplete while LLDP/snmp-subagent data reconverges, e.g. ADO 39373338 on Arista-7060X6-64PE-P64 reported `Active interfaces: 1 Minigraph LLDP neighbors: 63`.

This change wraps the existing remote-neighbor table check in a bounded `wait_until` poll. It re-fetches SNMP facts until the same 80% threshold is met, and still fails with diagnostics and the observed counts if the table never converges.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: ADO 39373338
Failure type: intermittent test-code timing issue in LLDP remote-table readiness polling.

### Approach
#### What is the motivation for this PR?
Avoid false nightly failures when the SNMP LLDP remote-neighbor table is sampled during a short LLDP/snmp-subagent reconvergence window.

#### How did you do it?
Kept the existing OID set and 80% threshold, but moved the check into a helper used by `wait_until(120, 10, 0, ...)`. The helper re-runs `get_snmp_facts(..., module_ignore_errors=True)` and recomputes active interfaces each attempt. On timeout the test collects LLDP diagnostics and fails with the same neighbor-count message.

#### How did you verify/test it?
- `python -m py_compile tests/snmp/test_snmp_lldp.py`
- Compared against nightly/Kusto signature from ADO 39373338 and existing related investigation PR #25902.

#### Any platform specific information?
Observed on Arista-7060X6-64PE-P64 / ft2-64 / 20251110.47, but the fix is platform-agnostic.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
N/A.