### PR TITLE
[everflow]: Skip TD3 policer mirror TX-drop checks

### DIFF
--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -856,9 +856,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             # Skip counter checks on ASICs that count policer-dropped packets as TX drops.
             mirror_port = get_mirror_port(everflow_dut, "TEST_POLICER_SESSION")
             asic = everflow_dut.get_asic_name()
-            if asic != "th2":
-                assert_no_tx_drops_on_mirror_port(everflow_dut, mirror_port)
             if asic not in {"th2", "td3"}:
+                assert_no_tx_drops_on_mirror_port(everflow_dut, mirror_port)
                 assert_no_tx_queue_drops_on_mirror_port(everflow_dut, mirror_port)
         finally:
             # Clean up ACL rules and routes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Everflow policer validation can pass on TD3, but the test can fail afterward
in the mirror-port TX-drop counter assertion. This PR skips the same
mirror-port TX-drop checks on TD3 that are already skipped for unsupported ASIC
counter behavior, while keeping the PTF policer traffic/rate validation enabled.

Fixes #27256

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
_202605:_
Image: branch.202605-ars.111785e8-buildimage.84d74ca1aa3b233d1198b3eae18e79c420893493-nightly-2026.08.19.14.40
Platform: x86_64-arista_7050cx3_32c
HWSKU: Arista-7050CX3-32C-C32

***Before fix:***
  Everflow policer failed on TD3 with mirror-port TX drops:
  - test_everflow_dscp_with_policer[erspan_ipv4-cli-downstream-default]
    Failed: Expected no tx drops on mirror port Ethernet112/Ethernet116,
    but found around 31K drops.
  - test_everflow_dscp_with_policer[erspan_ipv4-cli-upstream-default]
    Failed: Expected no tx drops on mirror port Ethernet120,
    but found around 30K drops.
[test_everflow_testbed.log](https://github.com/user-attachments/files/31348794/test_everflow_testbed.log)
[test_everflow_testbed.xml](https://github.com/user-attachments/files/31348796/test_everflow_testbed.xml)

***After Fix:***
 Result:
  tests=4, failures=0, errors=0, skipped=2
  Passed:
  - test_everflow_dscp_with_policer[erspan_ipv4-cli-downstream-default]
  - test_everflow_dscp_with_policer[erspan_ipv4-cli-upstream-default]
  Skipped:
  - test_everflow_dscp_with_policer[erspan_ipv6-cli-downstream-default]
  - test_everflow_dscp_with_policer[erspan_ipv6-cli-upstream-default]
  
[test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer.log](https://github.com/user-attachments/files/31348803/test_everflow_testbed.py.TestEverflowV4IngressAclIngressMirror.test_everflow_dscp_with_policer.log)
[test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer.xml](https://github.com/user-attachments/files/31348804/test_everflow_testbed.py.TestEverflowV4IngressAclIngressMirror.test_everflow_dscp_with_policer.xml)


### Approach

#### What is the motivation for this PR?
On TD3, the PTF Everflow policer traffic/rate validation succeeds, but the test
 can fail afterward on mirror-port TX-drop counters. The failure is not in the
 policer traffic validation itself; it is in the platform-sensitive counter
 assertion.

#### How did you do it?
 Use the existing TH2/TD3 ASIC condition for both mirror-port TX-drop
  assertions. This keeps policer traffic/rate validation enabled and only skips
  the unreliable post-validation counter checks on TH2/TD3.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

Ran the targeted Everflow policer test on 202605 dt fixed-testbed. The
 IPv4 downstream and upstream policer cases passed. The IPv6 cases skipped
 because the image could not create the IPv6 ERSPAN mirror session.

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A