### PR TITLE
[platform_tests]: skip BMC platform API tests on BMC topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -10,6 +10,15 @@ platform_tests/api:
       - "asic_type in ['vs']"
 
 #######################################
+#####      api/test_bmc.py        #####
+#######################################
+platform_tests/api/test_bmc.py:
+  skip:
+    reason: "Not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
+#######################################
 #####      api/test_chassis.py    #####
 #######################################
 platform_tests/api/test_chassis.py::TestChassisApi::test_components:


### PR DESCRIPTION
### Description of PR

Summary

Add a `conditional_mark` skip for `platform_tests/api/test_bmc.py` so the BMC platform API tests are skipped on the `bmc` topology. The reason is that the tests should be run on Switch host.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: conditional_mark YAML validated with `yaml.safe_load`; the parsed entry is `{'skip': {'reason': 'Not available on BMC', 'conditions': ["'bmc' in topo_type"]}}`.

### Approach
#### What is the motivation for this PR?

The BMC platform API tests in `platform_tests/api/test_bmc.py` only apply to Switch hosts. On `bmc` topologies these tests are not applicable and previously relied solely on an in-code runtime skip. Aligning them with the existing conditional_mark BMC entries makes the intent explicit and consistent.

#### How did you do it?

Added an entry for `platform_tests/api/test_bmc.py` in `tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml` that skips with reason "Not available on BMC" under the condition `'bmc' in topo_type`, mirroring the `test_fancontrol.py` and `test_ledd.py` entries.

#### How did you verify/test it?

Validated the YAML parses correctly and the new entry is present and well-formed.

#### Any platform specific information?

Applies to `bmc` topologies only.

#### Supported testbed topology if it's a new test case?

N/A — this is a framework/condition change, not a new test case.

### Documentation

N/A
