### PR TITLE
[constants] Add uma and lma to the neighbor maps

### DIFF
--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -43,7 +43,11 @@ UPSTREAM_NEIGHBOR_MAP = {
     "t1-isolated-d32": "t0",
     "c0": "m1",
     "lrh": "urh",
-    "urh": "rwa"
+    "urh": "rwa",
+    # Neighbor names are matched by suffix, so use the full "uma"/"lma"/"rwa"
+    # strings here. A bare "ma" would also match the LMA neighbors on a UMA DUT.
+    "uma": "rwa",
+    "lma": "uma"
 }
 
 # Describe ALL upstream neighbor of dut in different topos
@@ -60,7 +64,9 @@ UPSTREAM_ALL_NEIGHBOR_MAP = {
     "c0": ["m1"],
     'ft2': ['lt2'],
     'lrh': ["urh", "frh"],
-    'urh': ["rwa"]
+    'urh': ["rwa"],
+    "uma": ["rwa"],
+    "lma": ["uma"]
 }
 
 # Describe downstream neighbor of dut in different topos
@@ -76,7 +82,11 @@ DOWNSTREAM_NEIGHBOR_MAP = {
     "ft2": "lt2",
     "lt2": "t1",
     "lrh": "t2",
-    "urh": "lrh"
+    "urh": "lrh",
+    "uma": "lma",
+    # LMA has both M2 and M3 downstream; this map holds a single value, so it
+    # names the first tier. See DOWNSTREAM_ALL_NEIGHBOR_MAP for the full set.
+    "lma": "m2"
 }
 
 # Describe downstream neighbor of dut in different topos
@@ -92,5 +102,7 @@ DOWNSTREAM_ALL_NEIGHBOR_MAP = {
     "ft2": ["lt2"],
     "lt2": ["t1"],
     "lrh": ["t2", "ut2"],
-    "urh": ["lrh"]
+    "urh": ["lrh"],
+    "uma": ["lma", "m1"],
+    "lma": ["m2", "m3"]
 }


### PR DESCRIPTION
### Description of PR

Summary:
The UMA and LMA management aggregator topologies have no entry in the four neighbor maps in `tests/common/helpers/constants.py`. Any test that resolves its upstream or downstream neighbor role through those maps fails on a uma/lma testbed before it gets to do any work, so a whole set of otherwise applicable tests is unusable on those topologies.

This adds the missing entries:

```
uma   upstream rwa,  downstream lma (and m1)
lma   upstream uma,  downstream m2 and m3
```

One detail worth calling out for review. Neighbor descriptions are matched by suffix, so the values here have to be the full `"rwa"` / `"uma"` strings. A bare `"ma"` would also match the four downstream `VM0xLMA` neighbors on a UMA DUT and select the wrong side of the box. `rwa` is already used as a neighbor role in these maps (`"urh": "rwa"`), so nothing new is introduced.

The change is purely additive - it only adds new keys, so no existing topology takes a different path.

ADO number: 39275309

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Backport is requested to **msft-202603** via the `Request for msft-202603 branch` label, since that branch is not on the list above. That is the branch the uma/lma testbeds run.

Tracking issue/work item for backport/cherry-pick request: ADO number 39275309
Failure type: day-one issue - these topologies have never had entries in these maps.

### Tested branch

- [x] master
- [x] 202603
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: validated by this PR's own impacted-area kvmtest checks
- 202603: 20260310.15 - 29 pass / 0 fail on both a UMA and an LMA physical testbed, across the five bgp/test_bgp_aggregate_address_* modules. All 29 errored on neighbor lookup before this change. Controls in the same runs: test_bgp_confed_route_propagation 6 pass, telemetry_poll 4 pass, route_flap still self-skips.

Executed on the msft-202603 line, image `20260310.15`, on two physical management aggregator testbeds (7050cx3). Before raising this I diffed `tests/common/helpers/constants.py` between that branch and master and confirmed the four maps are identical apart from entries this PR does not touch, so the change applies to master unchanged.

| Module | UMA | LMA |
| --- | --- | --- |
| `bgp/test_bgp_aggregate_address_config_crud.py` | 5 pass | 5 pass |
| `bgp/test_bgp_aggregate_address_dual_stack.py` | 3 pass | 3 pass |
| `bgp/test_bgp_aggregate_address_link_failover.py` | 4 pass | 4 pass |
| `bgp/test_bgp_aggregate_address_negative.py` | 13 pass | 13 pass |
| `bgp/test_bgp_aggregate_address_route_withdrawal.py` | 4 pass | 4 pass |
| **total** | **29 pass, 0 fail** | **29 pass, 0 fail** |

All 29 of these errored on neighbor lookup before the change.

Also run in the same plans as controls, to show nothing else moved:

- `bgp/test_bgp_confed_route_propagation.py` - 6 pass on both, so BGP confederation is intact
- `telemetry/test_telemetry_poll.py` - 4 pass on both, matching what m1 produces
- `route/test_route_flap.py` - still self-skips, as it does on m1

### Approach

#### What is the motivation for this PR?

Bringing up nightly coverage on the UMA and LMA topologies. These tests are applicable to those topologies and pass once the neighbor role can be resolved; they were only failing because the lookup had no entry to return.

#### How did you do it?

Added `uma` and `lma` keys to `UPSTREAM_NEIGHBOR_MAP`, `UPSTREAM_ALL_NEIGHBOR_MAP`, `DOWNSTREAM_NEIGHBOR_MAP` and `DOWNSTREAM_ALL_NEIGHBOR_MAP`, using full role suffixes for the reason described above.

`DOWNSTREAM_NEIGHBOR_MAP` holds a single value per topology while LMA has two downstream tiers, so it names the first tier (`m2`) and `DOWNSTREAM_ALL_NEIGHBOR_MAP` carries the full set (`m2`, `m3`). There is a comment in the file to that effect.

#### How did you verify/test it?

Ran the affected modules on one UMA and one LMA physical testbed, results above. Both boxes gave identical numbers.

#### Any platform specific information?

The testbeds are 7050cx3, but nothing in this change is platform specific.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change needed - this extends existing internal maps.

