### PR TITLE
[uma] Add an out-of-band neighbour to the uma topology

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -663,10 +663,11 @@ def fib_uma(topo, ptf_ip, action="announce", topo_routes={}):
         port, port6 = get_change_routes_ports(k, topo)
         routes_v4 = []
         routes_v6 = []
-        # The upstream RegionalWANAggregator (RWA) neighbors originate the default
-        # route toward the UpperMgmtAggregator DUT. Downstream leaf (LMA/M1)
-        # neighbors advertise only their own loopbacks via their own BGP.
-        if "core" in v["properties"]:
+        # The upstream RegionalWANAggregator (RWA) and out-of-band neighbors
+        # originate the default route toward the UpperMgmtAggregator DUT.
+        # Downstream leaf (LMA/M1) neighbors advertise only their own loopbacks
+        # via their own BGP.
+        if "core" in v["properties"] or "oob" in v["properties"]:
             routes_v4 = [("0.0.0.0/0", nhipv4, None)]
             routes_v6 = [("::/0", nhipv6, None)]
         topo_routes[k] = {}

--- a/ansible/vars/topo_uma.yml
+++ b/ansible/vars/topo_uma.yml
@@ -24,6 +24,10 @@ topology:
       vlans:
         - 5
       vm_offset: 5
+    VM07MB:
+      vlans:
+        - 6
+      vm_offset: 6
 
   DUT:
     loopback:
@@ -54,6 +58,9 @@ configuration_properties:
   m1:
     swrole: leaf
     device_type: MgmtLeafRouter          # VM06M1 (external downstream)
+  oob:
+    swrole: leaf
+    device_type: CoreTs                  # VM07MB (out-of-band upstream)
 
 configuration:
   VM01RWA:
@@ -191,3 +198,25 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.73/24
       ipv6: fc0a::4a/64
+
+  VM07MB:
+    properties:
+    - common
+    - oob
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65400
+      peers:
+        64582:
+        - 10.0.0.146
+        - fc00::125
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.74/32
+        ipv6: 2064:100::4a/128
+      Ethernet1:
+        ipv4: 10.0.0.147/31
+        ipv6: fc00::126/126
+    bp_interface:
+      ipv4: 10.10.246.74/24
+      ipv6: fc0a::4b/64


### PR DESCRIPTION
### Description of PR

Summary:
`ansible/vars/topo_uma.yml` defines an upstream RWA, four downstream LMAs and an M1, but no out-of-band (MB) peer - even though the product supports one.

The image already has BGP policy for this role. It is selected when a neighbour's `device_type` is `CoreTs` or `CoreMgmtRouter`, and `minigraph_png.j2` maps a VM name containing `MB` to `CoreTs`. The peer ends up in the `MB_PATH_V4` / `MB_PATH_V6` peer-groups, and the default route learned from it is AS-path prepended so it loses to RWA and acts as a backup upstream rather than an equal path.

With no such neighbour in the lab topology that path cannot be exercised at all, and a test that looks for an MB peer on uma has nothing to find.

This adds `VM07MB` on vlan 6 in a new `oob` property group with `device_type: CoreTs`.

Two things worth a reviewer's attention:

**`peer_in_bgp_confed: true` on an external peer.** This looks odd but matches what `VM01RWA` and `VM06M1` already do in this same file. The flag is read in exactly one place, `ansible/library/topo_facts.py`, where it only selects which key is read from the `peers` dict - the confederation identifier rather than the member AS. It does not make the neighbour a confederation member; that is decided by `bgp confederation peers`, which lists only the LMA AS. External peers of a confederation legitimately see the identifier.

**`device_type` is set explicitly.** `minigraph_png.j2` tests `'MA' in dev` before `'MB' in dev`, so name-based inference is not reliable alongside the `VM0xLMA` neighbours in this topology. Setting it explicitly avoids that.

The second change is in `fib_uma` in `ansible/library/announce_routes.py`. The DUT only accepts a default route from this peer, so with the neighbour present but announcing nothing the session establishes and then receives zero prefixes - not a useful backup path. The condition is widened to let the `oob` group originate the default alongside `core`.

`fib_lma` is deliberately untouched. There is no `lma.oob` template in the image and LMA has no out-of-band upstream.

ADO number: 39356054

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Backport is requested to **msft-202603** via the `Request for msft-202603 branch` label, since that branch is not on the list above. That is the branch the uma testbeds run.

Tracking issue/work item for backport/cherry-pick request: ADO number 39356054
Failure type: day-one issue - the uma topology has never had an out-of-band neighbour.

### Tested branch

- [x] master
- [x] 202603
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: validated by this PR's own impacted-area kvmtest checks
- 202603: 20260310.15 - BGP 7/7 established on both address families on the UMA testbed (was 6/6), MB_PATH_V4/V6 peer-groups applied, prepend policy present, IPv4 default route received and correctly losing to RWA, confederation intact after add-topo and deploy-mg. bgp/test_bgp_aspath_prepend now runs on uma and passes on IPv4.

Executed on the msft-202603 line, image `20260310.15`, on a physical UMA testbed (7050cx3) running the 7-VM topology. `ansible/vars/topo_uma.yml` is byte for byte identical between that branch and master, and the `fib_uma` change applied to master with no conflict - I checked both before raising.

| Check | Result |
| --- | --- |
| BGP sessions | **7/7 established, both address families** (was 6/6) |
| Peer-groups on the new neighbour | `MB_PATH_V4` and `MB_PATH_V6` as expected |
| Prepend policy | present, `set as-path prepend 64582` |
| Default route from MB, IPv4 | received, prepended, loses to RWA |
| BGP confederation | intact after add-topo and deploy-mg |

With this in place the internal `bgp/test_bgp_aspath_prepend` case now runs on uma and **passes on IPv4**.

IPv6 was failing when this PR was first raised, and it was not caused by this change - the image had a BGP policy defect that stopped the DUT accepting the IPv6 default route from this peer. That has since been fixed and verified on hardware, and both `test_bgp_aspath_prepend[4]` and `[6]` now pass. This topology change is what exposed it.

### Approach

#### What is the motivation for this PR?

The uma lab topology could not exercise the out-of-band backup upstream path that the image explicitly implements for this device role.

#### How did you do it?

Added a seventh neighbour with `device_type: CoreTs` and let it originate a default route in `fib_uma`.

#### How did you verify/test it?

Deployed the topology on hardware and checked BGP state, peer-group membership, the applied route-map and the received default route, then ran the internal test that consumes this path. Numbers above.

#### Any platform specific information?

None. The testbed happens to be a 7050cx3 but nothing here is platform specific. The extra neighbour needs one more cabled link; the testbed used has 44 and this brings usage to 7.

#### Supported testbed topology if it's a new test case?

Not a new test case. This extends the existing `uma` topology from 6 to 7 VMs.

### Documentation

No documentation change needed.


