### PR TITLE
[snappi_tests/lacp] Skip LACP cases when testbed has fewer TGEN ports than required

### DIFF
--- a/tests/snappi_tests/lacp/test_add_remove_link_from_dut.py
+++ b/tests/snappi_tests/lacp/test_add_remove_link_from_dut.py
@@ -4,6 +4,7 @@ from tests.common.snappi_tests.snappi_fixtures import (                         
 from tests.snappi_tests.lacp.files.lacp_dut_helper import run_lacp_add_remove_link_from_dut
 from tests.common.fixtures.conn_graph_facts import (                    # noqa: F401
     conn_graph_facts, fanout_graph_facts)
+from tests.common.helpers.assertions import pytest_require
 import pytest
 
 pytestmark = [pytest.mark.topology('tgen')]
@@ -50,6 +51,9 @@ def test_lacp_add_remove_link_from_dut(snappi_api,                      # noqa: 
         number_of_routes:  Number of IPv4/IPv6 Routes
     """
     # port_count, number_of_routes ,iterations and port_speed parameters can be modified as per user preference
+    pytest_require(len(tgen_ports) >= port_count,
+                   "This test requires at least {} TGEN ports, testbed has {}"
+                   .format(port_count, len(tgen_ports)))
     run_lacp_add_remove_link_from_dut(snappi_api,
                                       duthost,
                                       tgen_ports,

--- a/tests/snappi_tests/lacp/test_add_remove_link_physically.py
+++ b/tests/snappi_tests/lacp/test_add_remove_link_physically.py
@@ -4,6 +4,7 @@ from tests.common.snappi_tests.snappi_fixtures import (                         
 from tests.snappi_tests.lacp.files.lacp_physical_helper import run_lacp_add_remove_link_physically
 from tests.common.fixtures.conn_graph_facts import (                # noqa: F401
     conn_graph_facts, fanout_graph_facts)
+from tests.common.helpers.assertions import pytest_require
 import pytest
 
 pytestmark = [pytest.mark.topology('tgen')]
@@ -53,6 +54,9 @@ def test_lacp_add_remove_link_physically(snappi_api,                   # noqa: F
         lacpdu_timeout: LACP Timeout value (0 - Auto, 3 - Short, 90 - Long)
     """
     # port_count, number_of_routes ,iterations and port_speed parameters can be modified as per user preference
+    pytest_require(len(tgen_ports) >= port_count,
+                   "This test requires at least {} TGEN ports, testbed has {}"
+                   .format(port_count, len(tgen_ports)))
     run_lacp_add_remove_link_physically(snappi_api,
                                         duthost,
                                         tgen_ports,

--- a/tests/snappi_tests/lacp/test_lacp_timers_effect.py
+++ b/tests/snappi_tests/lacp/test_lacp_timers_effect.py
@@ -4,6 +4,7 @@ from tests.common.snappi_tests.snappi_fixtures import (                         
 from tests.snappi_tests.lacp.files.lacp_physical_helper import run_lacp_timers_effect
 from tests.common.fixtures.conn_graph_facts import (            # noqa: F401
     conn_graph_facts, fanout_graph_facts)
+from tests.common.helpers.assertions import pytest_require
 import pytest
 
 pytestmark = [pytest.mark.topology('tgen')]
@@ -59,6 +60,9 @@ def test_lacp_timers(snappi_api,                       # noqa: F811
     """
     # port_count, number_of_routes ,iterations, port_speed, lacpdu_interval_period,
     # lacpdu_timeout parameters can be modified as per user preference
+    pytest_require(len(tgen_ports) >= port_count,
+                   "This test requires at least {} TGEN ports, testbed has {}"
+                   .format(port_count, len(tgen_ports)))
     run_lacp_timers_effect(snappi_api,
                            duthost,
                            tgen_ports,


### PR DESCRIPTION
### Description of PR

Summary:
The three snappi LACP test modules are hard-parametrized with `port_count=4`, but the `tgen` testbeds that run them are wired with only 3 Ixia links. `duthost_bgp_config()` indexes `tgen_ports[i]` for `i in range(0, port_count)`, so the tests die with `IndexError: list index out of range` during DUT BGP setup — before any LACP logic runs. This replaces the crash with an explicit skip when the testbed doesn't meet the port requirement.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch

- [ ] master
- [x] 202605

### Test result

- 202605: `SONiC.20260510.11` (Arista-7050CX3-32S-C32, broadcom/td3, testbed `vms20-rdma-t0-7050cx3`, topo `tgen-t0-3-32`)

| Module | Before | After |
|---|---|---|
| `snappi_tests/lacp/test_add_remove_link_from_dut.py` | error — `IndexError` | **skipped** |
| `snappi_tests/lacp/test_add_remove_link_physically.py` | error — `IndexError` | **skipped** |
| `snappi_tests/lacp/test_lacp_timers_effect.py` | error — `IndexError` | **skipped** |

```
SKIPPED (This test requires at least 4 TGEN ports, testbed has 3)  [100%]
SKIPPED [1] common/helpers/assertions.py:16: This test requires at least 4 TGEN ports, testbed has 3
================= 1 skipped, 61 warnings in 254.36s =================
```

### Approach
#### What is the motivation for this PR?

`port_count` is hard-coded to 4 via `@pytest.mark.parametrize('port_count', [4])`, but `tgen_ports` returns only the TGEN-facing links the testbed actually has. On a 3-port `tgen` testbed the mismatch surfaces as an opaque `IndexError` inside `lacp_dut_helper.py`, which reads as a product failure in nightly reports rather than an unmet testbed requirement.

#### How did you do it?

Added a `pytest_require(len(tgen_ports) >= port_count, ...)` guard at the top of each of the three test functions, before `run_lacp_*` touches the DUT. This follows the pattern already used elsewhere in `snappi_tests` (`files/helper.py`, `test_orchagent_icmp_hw_offload.py`). No behavioral change on testbeds that do have 4+ TGEN ports.

#### How did you verify/test it?

Ran all three modules on a physical `tgen-t0-3-32` testbed (3 TGEN ports) on the 202605 image. All three now report `skipped` with the explicit message instead of erroring; `flake8 --max-line-length=120` is clean.

#### Any platform specific information?

None — the guard is platform- and topology-agnostic; it only inspects the length of `tgen_ports`.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case. The existing `pytest.mark.topology('tgen')` marker is unchanged.

### Documentation

N/A
