### PR TITLE
fix(platform-tests): wait for pmon daemons after reboot

### DIFF
--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -135,7 +135,7 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list,
         if dut.facts["platform"] == "x86_64-cel_e1031-r0":
             result = wait_until(300, 20, 0, check_pmon_daemon_status, dut)
         else:
-            result = check_pmon_daemon_status(dut)
+            result = wait_until(60, 5, 0, check_pmon_daemon_status, dut)
         assert result, "Not all pmon daemons running."
 
     if dut.facts["asic_type"] in ["mellanox"]:


### PR DESCRIPTION
### Description of PR

Summary:
Wait briefly for pmon daemons to become ready after reboot instead of failing on a transient `STARTING` state.

Fixes # N/A

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: Intermittent timing failure

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `SONiC.master-28988.1200665-12831dfa3`
  - Before the change, the warm-reboot test reproduced `AssertionError: Not all pmon daemons running.`
  - After the change, six consecutive warm-reboot runs passed.
  - Four validation runs observed `stormond` in `STARTING`; the bounded retry then observed `RUNNING`.

### Approach

#### What is the motivation for this PR?

The reboot test performed a one-shot pmon daemon status check. On VS, `stormond` can still be in `STARTING` briefly after reboot and become `RUNNING` seconds later, causing an intermittent false failure.

The recent increase spans multiple image revisions, and identical inputs can both pass and fail. This PR therefore fixes the test's readiness contract without claiming a specific image commit caused the startup-latency shift.

This does not rule out an image-side latency regression. Persistent pmon failures remain visible because the bounded wait still fails after 60 seconds.

The closest image boundary changes only Mellanox-specific files while the failure is observed on VS, and the same image produced both passing and failing runs. This makes a direct DUT-image commit less likely than a timing or accumulated-state trigger.

#### How did you do it?

Use `wait_until` for non-E1031 platforms with a 60-second timeout and a 5-second polling interval. The existing E1031-specific 300-second timeout remains unchanged.

#### How did you verify/test it?

The failure was reproduced on a KVM `t0` testbed with the same assertion and daemon state transition. The pre-change run observed `stormond: STARTING` at failure and `RUNNING` 37 seconds later. With the change, six consecutive warm-reboot runs passed; four exercised the retry path.

#### Any platform specific information?

The failure was observed on the VS platform with `Force10-S6000`. The change applies the same bounded pmon readiness pattern already used by other platform tests.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
