### PR TITLE
[packet_trimming]: Add test for trimming continuity during warm reboot

### DIFF
--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import time
 
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from tests.common.helpers.assertions import pytest_assert
@@ -7,7 +8,9 @@ from tests.common.utilities import wait_until, configure_packet_aging
 from tests.common.mellanox_data import is_mellanox_device
 from tests.packet_trimming.constants import (
     DEFAULT_PACKET_SIZE, DEFAULT_DSCP, MIN_PACKET_SIZE, CONFIG_TOGGLE_COUNT,
-    JUMBO_PACKET_SIZE, PORT_TOGGLE_COUNT, TRIMMING_COUNTER_INTERVAL)
+    JUMBO_PACKET_SIZE, PORT_TOGGLE_COUNT, TRIMMING_COUNTER_INTERVAL,
+    WARM_REBOOT_TRAFFIC_DURATION, WARM_REBOOT_STEADY_STATE_WAIT,
+    WARM_REBOOT_MIN_PACKET_RATE, WARM_REBOOT_MAX_CONTIGUOUS_LOSS)
 from tests.packet_trimming.packet_trimming_config import PacketTrimmingConfig
 from tests.packet_trimming.packet_trimming_helper import (
     configure_trimming_action, configure_trimming_acl, verify_srv6_packet_with_trimming, cleanup_trimming_acl,
@@ -16,7 +19,8 @@ from tests.packet_trimming.packet_trimming_helper import (
     verify_queue_and_port_trim_counter_consistency, get_queue_trim_counters_json, compare_counters,
     has_non_zero_trim_counters, configure_port_mirror_session, remove_port_mirror_session,
     verify_queue_and_port_trim_sent_counter_consistency, verify_queue_and_port_trim_drop_counter_consistency,
-    compute_buffer_threshold, fill_egress_buffer)
+    compute_buffer_threshold, fill_egress_buffer, ConfigTrimming, start_warm_reboot_traffic,
+    start_warm_reboot_capture, collect_warm_reboot_loss_report)
 
 logger = logging.getLogger(__name__)
 
@@ -343,6 +347,56 @@ class BasePacketTrimming:
                                              has_non_zero_trim_counters, duthost, port),
                                   f"port level trim counters are zero for {port}")
                     verify_queue_and_port_trim_counter_consistency(duthost, port)
+
+    def test_trimming_during_warm_reboot(self, duthost, ptfadapter, ptfhost, test_params, localhost,
+                                         clean_warm_reboot_traffic):
+        """
+        Test Case: Verify Trimming Is Not Disrupted During Warm Reboot
+
+        This test verifies that the trimmed packets keep being forwarded while the system goes
+        through a warm reboot. A sequence numbered stream is sent into a blocked egress queue, so
+        that every packet is trimmed, and the trimmed copies received on the PTF host are checked
+        for sequence gaps. A contiguous gap of trimmed packets means the trimming dataplane was
+        disrupted while syncd was applying the restored view.
+        """
+        with allure.step(f"Configure packet trimming in global level for {self.trimming_mode} mode"):
+            self.configure_trimming_global_by_mode(duthost)
+
+        with allure.step("Enable trimming in buffer profile"):
+            for buffer_profile in test_params['trim_buffer_profiles']:
+                configure_trimming_action(duthost, test_params['trim_buffer_profiles'][buffer_profile], "on")
+
+        egress_port = test_params['egress_ports'][0]
+        # The egress queue is blocked for the whole measurement, so that the packets keep being
+        # trimmed during the warm reboot. It is released before the trimming is verified again,
+        # because verify_trimmed_packet blocks the same queue by itself.
+        with ConfigTrimming(duthost, egress_port['dut_members'], test_params['block_queue']):
+            with allure.step("Start sequence numbered traffic and wait for the egress queue to fill up"):
+                start_warm_reboot_traffic(ptfhost, test_params['ingress_port'], egress_port,
+                                          duthost.facts["router_mac"], WARM_REBOOT_TRAFFIC_DURATION)
+                time.sleep(WARM_REBOOT_STEADY_STATE_WAIT)
+
+            with allure.step("Start capturing the trimmed packets on the PTF host"):
+                start_warm_reboot_capture(ptfhost, egress_port)
+
+            with allure.step("Perform warm reboot while the trimmed traffic is running"):
+                reboot_dut(duthost, localhost, reboot_type="warm")
+
+            with allure.step("Verify trimmed packets were not lost during warm reboot"):
+                loss_report = collect_warm_reboot_loss_report(ptfhost)
+                pytest_assert(loss_report['rate'] >= WARM_REBOOT_MIN_PACKET_RATE,
+                              f"Trimmed packets were received at only {loss_report['rate']} pps, which is too "
+                              f"slow to detect a short disruption, loss report: {loss_report}")
+                pytest_assert(loss_report['max_contiguous_loss'] <= WARM_REBOOT_MAX_CONTIGUOUS_LOSS,
+                              f"Trimmed packets were lost during warm reboot, loss report: {loss_report}")
+
+        if is_mellanox_device(duthost):
+            with allure.step("Disable packet aging for mellanox device after warm reboot"):
+                configure_packet_aging(duthost, disabled=True)
+
+        with allure.step(f"Verify trimming function in {self.trimming_mode} mode after warm reboot"):
+            kwargs = self.get_verify_trimmed_packet_kwargs(duthost, ptfadapter, {**test_params})
+            verify_trimmed_packet(**kwargs)
 
     def test_trimming_counters(self, duthost, ptfadapter, test_params, trim_counter_params,
                                queue_level_trim_supported):

--- a/tests/packet_trimming/conftest.py
+++ b/tests/packet_trimming/conftest.py
@@ -17,7 +17,7 @@ from tests.packet_trimming.packet_trimming_helper import (
     create_blocking_scheduler, configure_trimming_action, cleanup_trimming_acl, get_queue_id_by_dscp,
     get_test_ports, configure_srv6_loop_break_acl, cleanup_srv6_loop_break_acl,
     create_trim_queue_test_buffer_profile, delete_trim_queue_test_buffer_profile,
-    is_queue_level_trim_sent_drop_supported)
+    is_queue_level_trim_sent_drop_supported, stop_warm_reboot_traffic)
 
 
 logger = logging.getLogger(__name__)
@@ -334,6 +334,18 @@ def clean_trimming_acl_tables(duthost):
 
     logger.info("Cleaning up ACL tables after testing")
     cleanup_trimming_acl(duthost)
+
+
+@pytest.fixture(scope="function")
+def clean_warm_reboot_traffic(ptfhost):
+    """
+    Stop the traffic and the capture started on the PTF host after testing.
+    """
+
+    yield
+
+    logger.info("Stopping the traffic and the capture on the PTF host after testing")
+    stop_warm_reboot_traffic(ptfhost)
 
 
 def pytest_addoption(parser):

--- a/tests/packet_trimming/constants.py
+++ b/tests/packet_trimming/constants.py
@@ -173,6 +173,28 @@ QUEUE_LEVEL_TRIM_SENT_DROP_SUPPORTED_PLATFORMS = [
     "nvidia_sn6",
 ]
 
+# Constants for the trimming during warm reboot test
+WARM_REBOOT_SCRIPT_NAME = "trim_warm_reboot_traffic.py"
+WARM_REBOOT_SCRIPT_PATH = f"/tmp/{WARM_REBOOT_SCRIPT_NAME}"
+WARM_REBOOT_SENDER_LOG = "/tmp/trim_warm_reboot_sender.log"
+WARM_REBOOT_CAPTURE_LOG = "/tmp/trim_warm_reboot_capture.log"
+WARM_REBOOT_REPORT_FILE = "/tmp/trim_warm_reboot_report.json"
+WARM_REBOOT_PACKET_RATE = 10000  # Packets per second, high enough to make a short disruption countable
+WARM_REBOOT_PACKET_SIZE = 1000  # Payload size, big enough for the packets to always be trimmed
+WARM_REBOOT_CAPTURE_SNAP_LEN = 128  # Only the headers and the counter are needed, IPv6 needs a bit more room
+WARM_REBOOT_CAPTURE_BUFFER_SIZE = 65536  # Capture buffer size in KB, big enough to never drop a packet
+WARM_REBOOT_TRAFFIC_DURATION = 900  # Must cover the whole warm reboot, including the warmboot finalizer
+WARM_REBOOT_STEADY_STATE_WAIT = 10  # Time for the egress queue to fill up, so that all packets are trimmed
+WARM_REBOOT_CAPTURE_START_WAIT = 5  # Time for tcpdump to open its capture socket
+WARM_REBOOT_ANALYZER_WAIT = 15  # Time for the analyzer to drain the capture pipe and write the report
+# The trimming disruption during warm reboot shows up as a single contiguous burst of at least 63 lost
+# packets, so the threshold keeps a large margin below it while tolerating a few packets lost by the capture
+WARM_REBOOT_MAX_CONTIGUOUS_LOSS = 20
+# The disruption lasts about 6 ms, so at this rate it drops at least 30 packets, which stays above
+# WARM_REBOOT_MAX_CONTIGUOUS_LOSS. A slower stream would silently lose the ability to detect it, and an
+# idle stream reports no rate at all, so this guards the measurement against both.
+WARM_REBOOT_MIN_PACKET_RATE = 5000
+
 # Mirror session configuration
 MIRROR_SESSION_NAME = "test_mirror"
 MIRROR_SESSION_SRC_IP = "1.1.1.1"

--- a/tests/packet_trimming/files/trim_warm_reboot_traffic.py
+++ b/tests/packet_trimming/files/trim_warm_reboot_traffic.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+Sequence numbered traffic generator and trimmed packet loss analyzer.
+
+This script runs on the PTF host and is used by the packet trimming warm reboot test:
+    send <iface> <router_mac> <dst_ip> <dscp> <pps> <duration> <packet_size>
+        Send UDP packets carrying an incrementing "COUNT:<9 digits>|" marker. The marker is placed
+        at the beginning of the payload, so that it is still present after the packet is trimmed.
+    analyze
+        Read a pcap stream from stdin and report the trimmed packet loss as JSON on stdout.
+"""
+import json
+import signal
+import struct
+import sys
+import time
+
+COUNTER_PREFIX = "COUNT:"
+COUNTER_DIGITS = 9
+# Source addresses of the generated packets, they only have to be unused addresses
+SRC_MAC = "00:11:22:33:44:55"
+SRC_IP = "8.8.8.8"
+SRC_IPV6 = "2000::1"
+SRC_PORT = 4321
+DST_PORT = 1234
+# TTL of the generated packets, the DUT decrements it, so the captured copies have TTL - 1
+TTL = 64
+# ECN Capable Transport(0), ECT(0)
+ECN = 2
+# Packets bigger than this size were forwarded by the DUT without being trimmed
+UNTRIMMED_SIZE_THRESHOLD = 1000
+# Reporting the first entries is enough to tell when and where the disruption happened
+MAX_REPORTED_ENTRIES = 20
+# Byte order of a pcap stream, the second magic of each byte order is the nanosecond variant
+PCAP_MAGIC_BYTE_ORDER = {b"\xd4\xc3\xb2\xa1": "<", b"\x4d\x3c\xb2\xa1": "<",
+                         b"\xa1\xb2\xc3\xd4": ">", b"\xa1\xb2\x3c\x4d": ">"}
+# The magic numbers of the pcap variants that store the timestamp fraction in nanoseconds
+PCAP_NANOSECOND_MAGIC = (b"\x4d\x3c\xb2\xa1", b"\xa1\xb2\x3c\x4d")
+
+
+def send_traffic(iface, router_mac, dst_ip, dscp, pps, duration, packet_size):
+    """
+    Send a paced stream of sequence numbered UDP packets until the duration expires.
+
+    Args:
+        iface (str): Interface to send the packets from
+        router_mac (str): Router MAC address of the DUT
+        dst_ip (str): Destination IP address
+        dscp (int): DSCP value, it decides which egress queue the packets land on
+        pps (int): Packets per second
+        duration (int): How long to keep sending the traffic, in seconds
+        packet_size (int): Payload size in bytes
+    """
+    # Imported here because only the traffic generator needs scapy, the analyzer does not
+    from scapy.all import Ether, IP, IPv6, UDP, Raw, conf, raw
+
+    padding = "F" * (packet_size - len(COUNTER_PREFIX) - COUNTER_DIGITS - 1)
+    payload = f"{COUNTER_PREFIX}{'0' * COUNTER_DIGITS}|{padding}"
+    # The DSCP and ECN bits sit in the same place in the IPv4 ToS and the IPv6 Traffic Class
+    if ":" in dst_ip:
+        ip_layer = IPv6(src=SRC_IPV6, dst=dst_ip, tc=(dscp << 2) | ECN, hlim=TTL)
+    else:
+        ip_layer = IP(src=SRC_IP, dst=dst_ip, tos=(dscp << 2) | ECN, ttl=TTL)
+    packet = (Ether(src=SRC_MAC, dst=router_mac) /
+              ip_layer /
+              UDP(sport=SRC_PORT, dport=DST_PORT, chksum=0) /
+              Raw(load=payload))
+
+    packet_bytes = bytearray(raw(packet))
+    counter_offset = packet_bytes.find(b"0" * COUNTER_DIGITS)
+    socket = conf.L2socket(iface=iface)
+    interval = 1.0 / pps
+    end_time = time.time() + duration
+    next_send_time = time.time()
+    counter = 0
+
+    def report_sent_count(signum, frame):
+        """
+        Report the sent count when the test stops the traffic before the duration expires,
+        otherwise the count is lost and the achieved rate cannot be told from the log.
+        """
+        print(f"SENT={counter}")
+        sys.stdout.flush()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, report_sent_count)
+
+    try:
+        while time.time() < end_time:
+            counter += 1
+            # Update the counter in place, so that the packet size stays constant
+            packet_bytes[counter_offset:counter_offset + COUNTER_DIGITS] = b"%09d" % counter
+            socket.ins.send(packet_bytes)
+            # Pace against a deadline, so that a slow iteration does not slow down the whole stream
+            next_send_time += interval
+            sleep_time = next_send_time - time.time()
+            if sleep_time > 0:
+                time.sleep(sleep_time)
+    finally:
+        socket.close()
+
+    print(f"SENT={counter}")
+
+
+def analyze_capture():
+    """
+    Read a pcap stream from stdin and report the trimmed packet loss as JSON on stdout.
+
+    The packets are received in the order they were sent, so the loss is detected by comparing each
+    counter with the previous one. This keeps the memory usage constant no matter how many packets
+    are captured.
+
+    The rate of the received trimmed packets is reported as well, because it decides how many
+    packets a short disruption can drop, and therefore whether the measurement can detect one.
+    """
+    report = {"trimmed": 0, "untrimmed": 0, "untrimmed_counters": [], "total_loss": 0,
+              "max_contiguous_loss": 0, "gaps": [], "duration": 0, "rate": 0}
+    stream = sys.stdin.buffer
+    magic = stream.read(24)[:4]
+    if magic not in PCAP_MAGIC_BYTE_ORDER:
+        # Report instead of failing, so that the caller always gets a valid report to log
+        report["error"] = f"unexpected capture format, magic is {magic.hex()}"
+        print(json.dumps(report))
+        return
+
+    endian = PCAP_MAGIC_BYTE_ORDER[magic]
+    fraction_divisor = 1e9 if magic in PCAP_NANOSECOND_MAGIC else 1e6
+    marker = COUNTER_PREFIX.encode()
+    previous_counter = None
+    first_timestamp = None
+    last_timestamp = None
+
+    while True:
+        record_header = stream.read(16)
+        if len(record_header) < 16:
+            break
+        timestamp_sec, timestamp_fraction, capture_len, packet_len = struct.unpack(endian + "IIII", record_header)
+        timestamp = timestamp_sec + timestamp_fraction / fraction_divisor
+        packet_bytes = stream.read(capture_len)
+
+        marker_offset = packet_bytes.find(marker)
+        if marker_offset < 0:
+            continue
+        counter_offset = marker_offset + len(marker)
+        counter = int(packet_bytes[counter_offset:counter_offset + COUNTER_DIGITS])
+
+        if packet_len > UNTRIMMED_SIZE_THRESHOLD:
+            report["untrimmed"] += 1
+            if len(report["untrimmed_counters"]) < MAX_REPORTED_ENTRIES:
+                report["untrimmed_counters"].append(counter)
+            continue
+
+        report["trimmed"] += 1
+        if first_timestamp is None:
+            first_timestamp = timestamp
+        last_timestamp = timestamp
+
+        if previous_counter is not None and counter > previous_counter + 1:
+            loss = counter - previous_counter - 1
+            report["total_loss"] += loss
+            report["max_contiguous_loss"] = max(report["max_contiguous_loss"], loss)
+            if len(report["gaps"]) < MAX_REPORTED_ENTRIES:
+                report["gaps"].append({"loss": loss, "after_counter": previous_counter,
+                                       "timestamp": f"{timestamp:.6f}"})
+        previous_counter = counter
+
+    if first_timestamp is not None and last_timestamp > first_timestamp:
+        # Divide by the exact duration, the reported one is rounded and can be zero for a very
+        # short capture
+        duration = last_timestamp - first_timestamp
+        report["duration"] = round(duration, 3)
+        report["rate"] = int(report["trimmed"] / duration)
+
+    print(json.dumps(report))
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "send":
+        send_traffic(sys.argv[2], sys.argv[3], sys.argv[4], int(sys.argv[5]), int(sys.argv[6]),
+                     int(sys.argv[7]), int(sys.argv[8]))
+    else:
+        analyze_capture()

--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -33,7 +33,12 @@ from tests.packet_trimming.constants import (DEFAULT_SRC_PORT, DEFAULT_DST_PORT,
                                              MIRROR_SESSION_SRC_IP, MIRROR_SESSION_DST_IP, MIRROR_SESSION_DSCP,
                                              MIRROR_SESSION_TTL, MIRROR_SESSION_GRE, MIRROR_SESSION_QUEUE,
                                              SCHEDULER_CIR, SCHEDULER_METER_TYPE, PACKET_SIZE_MARGIN,
-                                             TRIMMING_COUNTER_INTERVAL,
+                                             TRIMMING_COUNTER_INTERVAL, DEFAULT_DSCP, WARM_REBOOT_SCRIPT_NAME,
+                                             WARM_REBOOT_SCRIPT_PATH, WARM_REBOOT_SENDER_LOG,
+                                             WARM_REBOOT_CAPTURE_LOG, WARM_REBOOT_REPORT_FILE,
+                                             WARM_REBOOT_PACKET_RATE, WARM_REBOOT_PACKET_SIZE,
+                                             WARM_REBOOT_CAPTURE_SNAP_LEN, WARM_REBOOT_CAPTURE_BUFFER_SIZE,
+                                             WARM_REBOOT_CAPTURE_START_WAIT, WARM_REBOOT_ANALYZER_WAIT,
                                              QUEUE_LEVEL_TRIM_SENT_DROP_SUPPORTED_PLATFORMS)
 from tests.packet_trimming.packet_trimming_config import PacketTrimmingConfig
 
@@ -2583,16 +2588,116 @@ def reboot_dut(duthost, localhost, reboot_type):
     Args:
         duthost: DUT host object
         localhost: localhost object
-        reboot_type: Type of reboot to perform. Options: 'reload' or 'cold'
+        reboot_type: Type of reboot to perform. Options: 'reload', 'cold' or 'warm'
     """
     # Perform the selected reboot
     if reboot_type == "reload":
         logger.info('Performing config reload')
         config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
-    else:  # cold reboot
-        logger.info('Performing cold reboot')
+    else:  # cold or warm reboot
+        logger.info(f'Performing {reboot_type} reboot')
         reboot(duthost, localhost, reboot_type=reboot_type, wait_warmboot_finalizer=True,
                safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
+
+
+def start_warm_reboot_traffic(ptfhost, ingress_port, egress_port, router_mac, duration):
+    """
+    Start a continuous sequence numbered stream on the PTF host.
+
+    The stream is sent with DEFAULT_DSCP, so that it lands on the blocked egress queue and every
+    packet is trimmed. Each packet carries an incrementing counter at the beginning of the payload,
+    so the counter survives the trimming and the trimmed copies can be checked for sequence gaps.
+
+    Args:
+        ptfhost: PTF host object
+        ingress_port (dict): Ingress port
+        egress_port (dict): Egress port
+        router_mac (str): Router MAC address of the DUT
+        duration (int): How long to keep sending the traffic, in seconds
+    """
+    script_src = os.path.join(os.path.dirname(__file__), "files", WARM_REBOOT_SCRIPT_NAME)
+    ptfhost.copy(src=script_src, dest=WARM_REBOOT_SCRIPT_PATH)
+
+    # Fall back to IPv6 for the v6 only topologies, where the egress port has no IPv4 address
+    dst_ip = egress_port['ipv4'] or egress_port['ipv6']
+    cmd = (f"nohup python3 {WARM_REBOOT_SCRIPT_PATH} send eth{ingress_port['ptf_id']} "
+           f"{router_mac} {dst_ip} {DEFAULT_DSCP} {WARM_REBOOT_PACKET_RATE} "
+           f"{duration} {WARM_REBOOT_PACKET_SIZE} > {WARM_REBOOT_SENDER_LOG} 2>&1 &")
+    ptfhost.shell(cmd)
+
+    logger.info(f"Started sequence numbered traffic on the PTF host: {cmd}")
+
+
+def start_warm_reboot_capture(ptfhost, egress_port):
+    """
+    Start capturing the packets forwarded by the DUT on the PTF host, and pipe the capture into the
+    analyzer, so that no large pcap file has to be stored on the PTF host or copied back.
+
+    The filter matches the already decremented TTL, so that only the packets routed by the DUT are
+    captured, and not the packets that the traffic generator puts on the wire. All the interfaces
+    are captured because the egress port can be a PortChannel and the traffic can be hashed to any
+    of its members.
+
+    Args:
+        ptfhost: PTF host object
+        egress_port (dict): Egress port
+    """
+    # Fall back to IPv6 for the v6 only topologies, where the egress port has no IPv4 address
+    dst_ip = egress_port['ipv4'] or egress_port['ipv6']
+    # The hop limit sits at ip6[7] in IPv6 and the TTL sits at ip[8] in IPv4
+    ttl_filter = f"ip6[7] == {DEFAULT_TTL - 1}" if ':' in dst_ip else f"ip[8] == {DEFAULT_TTL - 1}"
+    capture_filter = f"udp and dst host {dst_ip} and {ttl_filter}"
+    tcpdump_cmd = (f"tcpdump -i any -s {WARM_REBOOT_CAPTURE_SNAP_LEN} -B {WARM_REBOOT_CAPTURE_BUFFER_SIZE} "
+                   f"-U -w - '{capture_filter}' 2> {WARM_REBOOT_CAPTURE_LOG}")
+    analyzer_cmd = f"python3 {WARM_REBOOT_SCRIPT_PATH} analyze > {WARM_REBOOT_REPORT_FILE}"
+    cmd = f"nohup sh -c \"{tcpdump_cmd} | {analyzer_cmd}\" > /dev/null 2>&1 &"
+    ptfhost.shell(cmd)
+
+    # Let tcpdump open its capture socket before the measurement starts
+    time.sleep(WARM_REBOOT_CAPTURE_START_WAIT)
+    logger.info(f"Started trimmed packet capture on the PTF host: {cmd}")
+
+
+def stop_warm_reboot_traffic(ptfhost):
+    """
+    Stop the traffic and the capture started on the PTF host.
+
+    Args:
+        ptfhost: PTF host object
+    """
+    ptfhost.shell(f"pkill -f '{WARM_REBOOT_SCRIPT_NAME} send'", module_ignore_errors=True)
+    ptfhost.shell("pkill -SIGINT tcpdump", module_ignore_errors=True)
+
+
+def collect_warm_reboot_loss_report(ptfhost):
+    """
+    Stop the capture and the traffic on the PTF host, and return the trimmed packet loss report.
+
+    Args:
+        ptfhost: PTF host object
+
+    Returns:
+        dict: Loss report with the trimmed and untrimmed packet counts, the detected sequence gaps
+              and the number of packets that the kernel dropped while capturing
+    """
+    # SIGINT makes tcpdump flush its buffers and close the pipe, so that the analyzer reports
+    ptfhost.shell("pkill -SIGINT tcpdump", module_ignore_errors=True)
+    time.sleep(WARM_REBOOT_ANALYZER_WAIT)
+    stop_warm_reboot_traffic(ptfhost)
+
+    capture_log = ptfhost.shell(f"cat {WARM_REBOOT_CAPTURE_LOG}", module_ignore_errors=True)['stdout']
+    sender_log = ptfhost.shell(f"cat {WARM_REBOOT_SENDER_LOG}", module_ignore_errors=True)['stdout']
+    logger.info(f"Capture log on the PTF host: {capture_log}")
+    logger.info(f"Traffic generator log on the PTF host: {sender_log}")
+
+    loss_report = json.loads(ptfhost.shell(f"cat {WARM_REBOOT_REPORT_FILE}")['stdout'])
+    # The packets dropped by the kernel look exactly like the packets lost by the DUT, so report
+    # them as well to tell an unreliable capture apart from a real trimming disruption
+    kernel_drops = re.search(r"(\d+) packets dropped by kernel", capture_log)
+    loss_report['kernel_drops'] = int(kernel_drops.group(1)) if kernel_drops else 0
+    logger.info(f"Trimmed packet loss report: {loss_report}")
+
+    return loss_report
 
 
 def configure_tc_to_dscp_map(duthost, egress_ports):


### PR DESCRIPTION
### Description of PR

Summary:
Add `test_trimming_during_warm_reboot` to the packet trimming test suite, verifying that trimmed packets keep being forwarded while the DUT goes through a warm reboot (ISSU).

A sequence numbered UDP stream is sent into a blocked egress queue so that every packet is trimmed, and the trimmed copies received on the PTF host are checked for contiguous sequence gaps. A contiguous gap of trimmed packets means the trimming dataplane was disrupted while syncd was applying the restored view.

Test plan: https://github.com/sonic-net/sonic-mgmt/pull/25851

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: case pass
- 202605: case pass


### Approach
#### What is the motivation for this PR?

Packet trimming is a dataplane feature, so a warm reboot must not interrupt it. There was no coverage that checks trimming continuity across a warm reboot, so a short disruption while syncd applies the restored view would go unnoticed.

#### How did you do it?
Regression pass

#### How did you verify/test it?

Ran `test_packet_trimming_symmetric.py::TestPacketTrimmingSymmetric::test_trimming_during_warm_reboot` and the asymmetric equivalent on a trimming capable testbed, checking that the generated stream is fully trimmed while the egress queue is blocked, that a healthy run reports no contiguous loss above the threshold, and that the test detects and reports the loss burst when the trimming dataplane is disrupted.

#### Any platform specific information?

No platform specific logic is added. The whole suite is already skipped on devices that do not report `SWITCH_TRIMMING_CAPABLE`, via the existing `skip_if_packet_trimming_not_supported` session fixture.

#### Supported testbed topology if it's a new test case?

t0, t1 — same as the rest of the packet trimming suite (`pytest.mark.topology("t0", "t1")`).

### Documentation

No new documentation, the test is covered by the existing packet trimming test plan.
