### PR TITLE
[autorestart]: Make container autorestart test BMC-aware

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -539,9 +539,6 @@ def postcheck_critical_processes_status(duthost, feature_autorestart_states, up_
     )
 
     for feature_name in list(feature_autorestart_states.keys()):
-        # BMC has no bgp container/service; skip the bgp start-limit check on BMC.
-        if duthost.is_bmc() and feature_name == "bgp":
-            continue
         if feature_name in duthost.DEFAULT_ASIC_SERVICES:
             for asic in duthost.asics:
                 service_name = asic.get_service_name(feature_name)

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -406,7 +406,14 @@ def is_hiting_start_limit(duthost, service_name):
     @summary: Determine whether the service can not be restarted is due to
               start-limit-hit or not
     """
-    service_status = duthost.shell("sudo systemctl status {}.service | grep 'Active'".format(service_name))
+    # module_ignore_errors: `systemctl status <svc> | grep 'Active'` returns a non-zero
+    # rc whenever grep finds no match -- e.g. when the unit does not exist on this
+    # platform (bgp.service on a BMC device) or systemctl status itself exits non-zero.
+    # Without ignoring errors, duthost.shell() would raise RunAnsibleModuleFail instead
+    # of letting us conclude the service is simply not start-limit-hit.
+    service_status = duthost.shell(
+        "sudo systemctl status {}.service | grep 'Active'".format(service_name),
+        module_ignore_errors=True)
     for line in service_status["stdout_lines"]:
         if "start-limit-hit" in line:
             return True
@@ -532,6 +539,9 @@ def postcheck_critical_processes_status(duthost, feature_autorestart_states, up_
     )
 
     for feature_name in list(feature_autorestart_states.keys()):
+        # BMC has no bgp container/service; skip the bgp start-limit check on BMC.
+        if duthost.is_bmc() and feature_name == "bgp":
+            continue
         if feature_name in duthost.DEFAULT_ASIC_SERVICES:
             for asic in duthost.asics:
                 service_name = asic.get_service_name(feature_name)

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -555,10 +555,15 @@ def postcheck_critical_processes_status(duthost, feature_autorestart_states, up_
         check_all_critical_processes_status, duthost
     )
 
-    bgp_check = wait_until(
-        post_check_threshold, POST_CHECK_INTERVAL_SECS, 0,
-        duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"
-    )
+    if duthost.is_bmc():
+        # No bgp container on BMC; report BGP as passing so post-check reflects only
+        # critical-process health.
+        bgp_check = True
+    else:
+        bgp_check = wait_until(
+            post_check_threshold, POST_CHECK_INTERVAL_SECS, 0,
+            duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"
+        )
 
     return critical_proceses, bgp_check
 
@@ -599,7 +604,10 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     is_running = is_container_running(duthost, container_name)
     pytest_assert(is_running, "Container '{}' is not running. Exiting...".format(container_name))
 
-    up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
+    # BMC devices have no front-side ASIC / bgp container, so BGP fact gathering would
+    # error. Skip all BGP-related pre/post checks on BMC.
+    is_bmc = duthost.is_bmc()
+    up_bgp_neighbors = {} if is_bmc else duthost.get_bgp_neighbors_per_asic("established")
 
     logger.info("Start testing the container '{}'...".format(container_name))
 
@@ -656,7 +664,7 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
         # will appear established in the error message after recovery.
         failed_check = "[Critical Process] " if not critical_proceses else ""
         failed_check += "[BGP] " if not bgp_check else ""
-        bgp_failures = [
+        bgp_failures = [] if duthost.is_bmc() else [
             {x: v['state']}
             for x, v in list(duthost.get_bgp_neighbors().items())
             if v['state'] != 'established'

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -400,6 +400,13 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
     else:
         time.sleep(wait)
 
+    if wait_for_bgp and sonic_host.is_bmc():
+        # BMC devices have no front-side ASIC and therefore no bgp container/vtysh.
+        # get_bgp_neighbors_per_asic() below would fail collecting bgp facts, so skip
+        # the BGP convergence wait entirely on BMC.
+        logging.info("Skipping wait_for_bgp on BMC device")
+        wait_for_bgp = False
+
     if wait_for_bgp:
         bgp_neighbors = sonic_host.get_bgp_neighbors_per_asic(state="all")
         if not wait_for_ibgp:


### PR DESCRIPTION
### Description of PR
Summary:
Fixes #27271

BMC devices (`DEVICE_METADATA.localhost.type` / `router_type == 'NetworkBmc'`) have no front-side ASIC and therefore no `bgp` container/service/vtysh. `test_container_autorestart.py` performed BGP work unconditionally, so the test **errored on BMC for every non-skipped container** (`gnmi`, `lldp`, `pmon`, `redfish`, `telemetry` — `5 failed, 10 skipped`).

Two distinct problems are fixed:

1. **Root cause of the observed crash** — `postcheck_critical_processes_status()` loops over every feature returned by `show feature autorestart` (both enabled and disabled, so `bgp`/`swss`/`syncd`/etc. on BMC) and calls `is_hiting_start_limit()`, which ran `sudo systemctl status <svc>.service | grep 'Active'` via `duthost.shell()` **without** `module_ignore_errors=True`. When the unit does not exist, systemctl+grep return `rc=1` (`Unit bgp.service could not be found.`) and the shell call raised `RunAnsibleModuleFail`. The log shows `bgp` because the loop raised on the first missing unit.
2. **Surrounding BGP checks** — BGP pre-check, post-check, `wait_for_bgp` reloads, and BGP failure diagnostics also call BGP fact-gathering that has no meaning / errors on BMC.

Fixes mirror the existing `is_bmc()` pattern already used in `tests/common/config_reload.py` and `tests/common/devices/multi_asic.py`.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202608

### Approach
#### What is the motivation for this PR?
Make the container autorestart test usable on BMC topologies. The failure log shows every non-skipped container erroring in `is_hiting_start_limit` on a missing `.service` unit.

#### How did you do it?
- `tests/autorestart/test_container_autorestart.py`:
  - `is_hiting_start_limit()` now calls `duthost.shell(..., module_ignore_errors=True)`. A non-existent unit or a `grep` no-match cleanly returns `False` instead of raising. This is the root-cause fix and is platform-agnostic (`systemctl status <svc> | grep 'Active'` returns non-zero on any no-match), and it covers every absent unit on BMC — not just `bgp`.
  - `postcheck_critical_processes_status()` treats `bgp_check` as passing on BMC instead of polling `check_bgp_session_state_all_asics`.
  - Skip the BGP pre-check (`get_bgp_neighbors_per_asic`) and the BGP failure-diagnostics (`get_bgp_neighbors`) on BMC.
- `tests/common/config_reload.py`:
  - No-op the `wait_for_bgp` block on BMC (fixes the module-teardown reload plus the recovery reloads, all of which pass `wait_for_bgp=True`).

#### How did you verify/test it?
Static validation in this environment (no live BMC testbed): `pyflakes` and `flake8 --max-line-length=120` are clean. Changes are gated on `duthost.is_bmc()` (and `module_ignore_errors=True`), so non-BMC behavior is unchanged — for a real, running service `systemctl status` always emits an `Active:` line so `grep` matches (rc=0). The failure in the attached log (`RunAnsibleModuleFail: ... bgp.service could not be found`) is addressed by fix (1).

#### Any platform specific information?
BMC devices are identified via `SonicHost.is_bmc()` (`router_type == 'NetworkBmc'`). Reproduced on `vms77-bmc-7220-1` (Nokia-7220-Th6p, `bmc` topology).

#### Supported testbed topology if it's a new test case?
N/A — existing test; marker remains `topology('any')`.

### Documentation
N/A