### PR TITLE
Fix test_sfp_oir: use skipif marker so nightly JUnit parser accepts the skipped result

### DIFF
--- a/tests/transceiver/oir/test_sfp_oir.py
+++ b/tests/transceiver/oir/test_sfp_oir.py
@@ -18,7 +18,18 @@ except ImportError:
     # PhysicalOir class does not exist, skip the test
     # To run these tests, please implement the API defined in
     # docs/testplan/transceiver_onboarding/optics_insertion_removal_testplan.md#physical-oir-api .
-    pytest.skip("physical_oir.py does not exist. Skipping all the SFP OIR tests.", allow_module_level=True)
+    PhysicalOir = None
+
+# Use a module-level skipif marker instead of pytest.skip(..., allow_module_level=True).
+# A module-level collection skip aborts collection and emits only a synthetic pseudo-test-case
+# that is missing the "line" attribute required by the nightly JUnit XML parser
+# (test_reporting/junit_xml_parser.py). That makes the parser reject the whole XML file and the
+# run is reported as "Test failed and no xml file created". With a skipif marker the real test
+# functions are still collected and reported as proper skipped test cases with all required
+# attributes, so the run is correctly recorded as skipped.
+pytestmark = pytest.mark.skipif(
+    PhysicalOir is None,
+    reason="physical_oir.py does not exist. Skipping all the SFP OIR tests.")
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes the `transceiver/oir/test_sfp_oir.py` nightly failure that is reported on every testbed as `Test failed and no xml file created`.
ADO: 39294846

`test_sfp_oir.py` calls `pytest.skip("physical_oir.py does not exist...", allow_module_level=True)` whenever `tests/common/physical_oir.py` is not implemented, which is its default upstream state. A module-level collection skip aborts collection and makes pytest emit only a single synthetic pseudo-test-case that is **missing the `line` attribute** (and has an empty `classname`). The nightly result parser (`test_reporting/junit_xml_parser.py`) requires `classname`, `file`, `line`, `name` and `time` on every `<testcase>`; the missing `line` makes it raise `JUnitXMLValidationError` and reject the whole XML, so the run is recorded as `Test failed and no xml file created` instead of skipped.

This replaces the module-level skip with a module-level `pytest.mark.skipif` marker. The real test functions are then collected and reported as proper skipped test cases (with all required JUnit attributes), so the nightly parser accepts the result and records it as skipped. Behaviour is otherwise unchanged: when `physical_oir.py` is implemented, the marker condition is `False` and the tests run exactly as before.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): ADO 39294846
Failure type: day-one issue

### Tested branch
- [x] master
- [ ] N/A

### Test result
Reproduced the JUnit generation locally with `junit_family=xunit1` (nightly config):
- **Before** (module-level skip): `collected 0 items / 1 skipped`; the emitted `<testcase>` is missing the `line` attribute, so `junit_xml_parser` validation fails.
- **After** (skipif marker): both `test_oir_remove_sfps` and `test_oir_insert_sfps` are collected and reported as skipped, each `<testcase>` carries `classname`/`file`/`line`/`name`/`time` and passes `junit_xml_parser` validation.

`pre-commit` (flake8 etc.) passes on the changed file.

### Approach
#### What is the motivation for this PR?
Remove a recurring, noisy nightly `failure` that is actually an intended skip, so real regressions in this area are not masked.

#### How did you do it?
Set `PhysicalOir = None` on `ImportError` and gate the module with `pytestmark = pytest.mark.skipif(PhysicalOir is None, ...)` instead of `pytest.skip(allow_module_level=True)`.

#### How did you verify/test it?
Generated JUnit XML for both variants under `junit_family=xunit1` and validated them against the required-attribute checks in `test_reporting/junit_xml_parser.py` (before: rejected; after: accepted as 2 skipped cases).

#### Any platform specific information?
None.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
No documentation change required.