### PR TITLE
[platform_tests]: Skip interface validation on BMC in check_all_interface_information

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -184,9 +184,10 @@ def check_interface_status(dut, asic_index, interfaces, xcvr_skip_list):
 
 # This API to check the interface information actoss all front end ASIC's
 def check_all_interface_information(dut, interfaces, xcvr_skip_list):
-    # No front-panel interfaces to check (e.g. SONiC BMC has no front-panel ports)
-    if len(interfaces) == 0:
+    # BMC SONiC images have no front-panel ports or transceivers to validate.
+    if dut.is_bmc():
         return True
+
     for asic_index in dut.get_frontend_asic_ids():
         # Get the interfaces pertaining to that asic
         interface_list = get_port_map(dut, asic_index)

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -377,6 +377,13 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     # Create a temporary file in tmpfs before reboot
     logger.info('DUT {} create a file /dev/shm/test_reboot before rebooting'.format(hostname))
     duthost.command('sudo touch /dev/shm/test_reboot')
+    # BMC images may report a stale or clock-shifted uptime after reboot. Capture
+    # the kernel boot ID so reboot verification does not depend on wall-clock time.
+    pre_reboot_boot_id = None
+    if duthost.is_bmc():
+        pre_reboot_boot_id = duthost.shell(
+            "cat /proc/sys/kernel/random/boot_id"
+        )["stdout"].strip()
     # Get reboot-cause history before reboot
     logger.info('DUT OS Version: {}'.format(duthost.os_version))
     prev_reboot_cause_history = None
@@ -494,6 +501,15 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     if file_check['stat']['exists']:
         raise Exception('DUT {} did not reboot'.format(hostname))
 
+    if pre_reboot_boot_id is not None:
+        post_reboot_boot_id = duthost.shell(
+            "cat /proc/sys/kernel/random/boot_id"
+        )["stdout"].strip()
+        pytest_assert(
+            pre_reboot_boot_id != post_reboot_boot_id,
+            "Device {} did not reboot: kernel boot ID did not change".format(hostname)
+        )
+
     DUT_ACTIVE.set()
     logger.info('{} reboot finished on {}'.format(reboot_type, hostname))
     if console_obj:
@@ -513,14 +529,15 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         curr_reboot_cause_history = duthost.show_and_parse("show reboot-cause history")
         pytest_assert(prev_reboot_cause_history != curr_reboot_cause_history, "No new input into history-queue")
     else:
-        if float(dut_uptime.strftime("%s")) < float(dut_datetime.strftime("%s")):
+        if not duthost.is_bmc() and float(dut_uptime.strftime("%s")) < float(dut_datetime.strftime("%s")):
             logger.info('DUT {} timestamp went backwards'.format(hostname))
             wait_until(120, 5, 0, positive_uptime, duthost, dut_datetime)
 
-        dut_uptime = duthost.get_up_time()
+        if not duthost.is_bmc():
+            dut_uptime = duthost.get_up_time()
 
-        assert float(dut_uptime.strftime("%s")) > float(dut_datetime.strftime("%s")), "Device {} did not reboot". \
-            format(hostname)
+            assert float(dut_uptime.strftime("%s")) > float(dut_datetime.strftime("%s")), "Device {} did not reboot". \
+                format(hostname)
 
     if wait_for_bgp:
         bgp_neighbors = duthost.get_bgp_neighbors_per_asic(state="all")

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -377,13 +377,6 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     # Create a temporary file in tmpfs before reboot
     logger.info('DUT {} create a file /dev/shm/test_reboot before rebooting'.format(hostname))
     duthost.command('sudo touch /dev/shm/test_reboot')
-    # BMC images may report a stale or clock-shifted uptime after reboot. Capture
-    # the kernel boot ID so reboot verification does not depend on wall-clock time.
-    pre_reboot_boot_id = None
-    if duthost.is_bmc():
-        pre_reboot_boot_id = duthost.shell(
-            "cat /proc/sys/kernel/random/boot_id"
-        )["stdout"].strip()
     # Get reboot-cause history before reboot
     logger.info('DUT OS Version: {}'.format(duthost.os_version))
     prev_reboot_cause_history = None
@@ -501,15 +494,6 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     if file_check['stat']['exists']:
         raise Exception('DUT {} did not reboot'.format(hostname))
 
-    if pre_reboot_boot_id is not None:
-        post_reboot_boot_id = duthost.shell(
-            "cat /proc/sys/kernel/random/boot_id"
-        )["stdout"].strip()
-        pytest_assert(
-            pre_reboot_boot_id != post_reboot_boot_id,
-            "Device {} did not reboot: kernel boot ID did not change".format(hostname)
-        )
-
     DUT_ACTIVE.set()
     logger.info('{} reboot finished on {}'.format(reboot_type, hostname))
     if console_obj:
@@ -529,15 +513,14 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         curr_reboot_cause_history = duthost.show_and_parse("show reboot-cause history")
         pytest_assert(prev_reboot_cause_history != curr_reboot_cause_history, "No new input into history-queue")
     else:
-        if not duthost.is_bmc() and float(dut_uptime.strftime("%s")) < float(dut_datetime.strftime("%s")):
+        if float(dut_uptime.strftime("%s")) < float(dut_datetime.strftime("%s")):
             logger.info('DUT {} timestamp went backwards'.format(hostname))
             wait_until(120, 5, 0, positive_uptime, duthost, dut_datetime)
 
-        if not duthost.is_bmc():
-            dut_uptime = duthost.get_up_time()
+        dut_uptime = duthost.get_up_time()
 
-            assert float(dut_uptime.strftime("%s")) > float(dut_datetime.strftime("%s")), "Device {} did not reboot". \
-                format(hostname)
+        assert float(dut_uptime.strftime("%s")) > float(dut_datetime.strftime("%s")), "Device {} did not reboot". \
+            format(hostname)
 
     if wait_for_bgp:
         bgp_neighbors = duthost.get_bgp_neighbors_per_asic(state="all")


### PR DESCRIPTION
### Description of PR

Summary:
BMC SONiC images have no front-panel ports or transceivers, so `check_all_interface_information` should not attempt to validate them. This PR skips interface/transceiver validation when the DUT is a BMC via `dut.is_bmc()`.

This is a follow-up derived from #27103 with the `tests/common/reboot.py` changes restored (reverted) — only the `interface_utils.py` change remains.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

### Approach
#### What is the motivation for this PR?
BMC SONiC images have no front-panel ports or transceivers to validate. Running `check_all_interface_information` against a BMC iterates over frontend ASICs that don't exist, producing spurious failures.

#### How did you do it?
Added an early `return True` in `check_all_interface_information` when `dut.is_bmc()` is true, before iterating over frontend ASIC interfaces/transceivers.

#### How did you verify/test it?
Validated on the VS topology. The BMC reboot-validation changes previously proposed in `tests/common/reboot.py` were restored to their original content and are not part of this change.

#### Any platform specific information?
Applies to BMC SONiC images only; behavior for non-BMC DUTs is unchanged.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A