### PR TITLE
fix(gnmi): persist restored management VRF state

### DIFF
--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -85,6 +85,8 @@ def setup_vrf_configuration(duthosts, rand_one_dut_hostname, vrf_config):
             duthost.shell('sudo systemctl stop snmpd snmp-subagent', module_ignore_errors=True)
             duthost.shell('sonic-db-cli CONFIG_DB hset "MGMT_VRF_CONFIG|vrf_global" "mgmtVrfEnabled" "false"')
             duthost.shell('sonic-db-cli CONFIG_DB hdel "MGMT_VRF_CONFIG|vrf_global" "mgmtVrfEnabled"')
+            # setup_gnmi_server saves while the management VRF is enabled.
+            duthost.shell("sudo config save -y")
             duthost.shell('sudo systemctl start snmpd snmp-subagent', module_ignore_errors=True)
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Persist the restored CONFIG_DB state after gNMI management-VRF scenarios so later configuration reloads cannot restore a stale `MGMT_VRF_CONFIG` entry and destabilize SNMP.

Fixes # (not linked)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other - intermittent state leak

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `SONiC.master.1196864-e565217cb` - reproduced the stale persisted management-VRF state; after the fix, a real configuration reload kept the key absent from live and persisted CONFIG_DB, retained DUT reachability, and kept both SNMP processes running.
- `gnmi/test_gnmi_configdb.py`: 48 tests collected successfully.

### Approach
#### What is the motivation for this PR?

The gNMI management-VRF fixture temporarily enables management VRF. A dependent fixture saves CONFIG_DB while that temporary state is active. The outer fixture removed the live key during teardown but did not persist the restored state, allowing a later configuration reload to reintroduce management VRF and disrupt SNMP.

#### How did you do it?

Save CONFIG_DB immediately after removing the temporary `MGMT_VRF_CONFIG` field and before restarting the SNMP services.

#### How did you verify/test it?

Reproduced the persisted-state leak on a VS t0 DUT, applied the restored-state save, and confirmed that the management-VRF key remained absent from both live and persisted CONFIG_DB after a real configuration reload. DUT management connectivity remained available and both SNMP processes remained running.

#### Any platform specific information?

Reproduced on VS t0. The fixture cleanup is platform independent.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A - test fixture cleanup only.
