### PR TITLE
Fix iface namingmode CMIS loganalyzer ignore

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -47,7 +47,8 @@ def ignore_host_lane_count_loganalyzer(enum_rand_one_per_hwsku_frontend_hostname
         # when loganalyzer is disabled, the object could be None
         if loganalyzer:
             ignoreRegex = [
-                (".*ERR pmon#xcvrd.*: no suitable app for the port appl .* host_lane_count [0-9] host_speed.*"),
+                (".*ERR pmon#(xcvrd|CmisManagerTask).*:.*no suitable app for the port appl .* "
+                 "host_lane_count [0-9]+ host_speed.*"),
             ]
             loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(ignoreRegex)
 
@@ -1314,7 +1315,8 @@ class TestConfigInterface():
         configure_speed = supported_speeds[0] if supported_speeds else native_speed
 
         ignore_host_lane_count_loganalyzer(ignore_condition=duthost.facts['hwsku'] in ["Arista-7060X6-64PE-P32O64",
-                                                                                       "Arista-7060X6-64PE-P64"])
+                                                                                       "Arista-7060X6-64PE-P64",
+                                                                                       "Cisco-8102-28FH-DPU-O"])
 
         if not self.check_speed_change(duthost, asic_index, interface, configure_speed):
             pytest.skip(


### PR DESCRIPTION
### Description of PR

Summary:
Fixes loganalyzer teardown failures in iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_speed on Cisco-8102-28FH-DPU-O.

ADO PBI: https://dev.azure.com/msazure/One/_workitems/edit/39376932

The test changes interface speed and its functional checks complete, but CmisManagerTask can emit the same expected CMIS 
o suitable app for the port ... host_lane_count ... host_speed ... message that the existing loganalyzer fixture already ignores for xcvrd on selected platforms. Include CmisManagerTask and Cisco-8102-28FH-DPU-O in that test-scoped ignore list.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605
- [ ] 202611

### Approach
#### What is the motivation for this PR?
Nightly PBI 39376932 shows 	est_config_interface_speed failing only during loganalyzer teardown because Cisco-8102-28FH-DPU-O logs benign CMIS application-selection errors while port speed is being changed.

#### How did you do it?
Extended the existing ignore_host_lane_count_loganalyzer regex to match pmon#CmisManagerTask as well as pmon#xcvrd, and enabled the existing ignore helper for Cisco-8102-28FH-DPU-O.

#### How did you verify/test it?
- python -m py_compile tests\iface_namingmode\test_iface_namingmode.py
- Local regex check against the PBI syslog samples from CmisManagerTask with host_lane_count 8 and host_speed 200000.

#### Any platform specific information?
Cisco-8102-28FH-DPU-O, T1.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
N/A.