### PR TITLE
Handle missing gNMI shell output fields

### DIFF
--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -501,24 +501,25 @@ def dump_gnmi_log(duthost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     dut_command = "docker exec %s cat /root/gnmi.log" % (env.gnmi_container)
     res = duthost.shell(dut_command, module_ignore_errors=True)
-    logger.info("GNMI log: " + res['stdout'])
-    return res['stdout']
+    stdout = res.get('stdout') or ''
+    logger.info("GNMI log: " + stdout)
+    return stdout
 
 
 def dump_system_status(duthost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     dut_command = "docker exec %s ps -efwww" % (env.gnmi_container)
     res = duthost.shell(dut_command, module_ignore_errors=True)
-    logger.info("GNMI process: " + res['stdout'])
+    logger.info("GNMI process: " + (res.get('stdout') or ''))
     dut_command = "docker exec %s date" % (env.gnmi_container)
     res = duthost.shell(dut_command, module_ignore_errors=True)
-    logger.info("System time: " + res['stdout'] + res['stderr'])
+    logger.info("System time: " + (res.get('stdout') or '') + (res.get('stderr') or ''))
 
 
 def verify_tcp_port(localhost, ip, port):
     command = "ssh  -o ConnectTimeout=3 -v -p %s %s" % (port, ip)
     res = localhost.shell(command, module_ignore_errors=True)
-    logger.info("TCP: " + res['stdout'] + res['stderr'])
+    logger.info("TCP: " + (res.get('stdout') or '') + (res.get('stderr') or ''))
 
 
 def gnmi_capabilities(duthost, localhost):
@@ -535,13 +536,15 @@ def gnmi_capabilities(duthost, localhost):
     cmd += "-ca_crt /etc/sonic/telemetry/gnmiCA.pem "
     cmd += "-logtostderr -capabilities"
     output = duthost.shell(cmd, module_ignore_errors=True)
-    if output['stderr']:
+    stdout = output.get('stdout') or ''
+    stderr = output.get('stderr') or ''
+    rc = output.get('rc', 0)
+    if rc != 0 or stderr:
         dump_gnmi_log(duthost)
         dump_system_status(duthost)
         verify_tcp_port(localhost, ip, port)
-        return -1, output['stderr']
-    else:
-        return 0, output['stdout']
+        return -1, stderr or stdout
+    return 0, stdout
 
 
 def ensure_gnmi_insecure_mode(duthost, mode=GNMIEnvironment.GNMI_MODE):


### PR DESCRIPTION
### Description of PR

Summary:
Fix `gnmi_capabilities()` and its diagnostic helpers so missing `stdout`/`stderr` fields in Ansible shell results do not raise `KeyError` and mask the actual gNMI command result. This addresses SONiC nightly PBI 39376939, where `gnmi_e2e.test_gnmi_auth::test_gnmi_authorize_failed_with_invalid_cname` failed with `KeyError: 'stdout'`.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/39376939

Note on scope: besides the safe field access, the failure condition in `gnmi_capabilities()` changes from `if output['stderr']:` to `if rc != 0 or stderr:`. That is a deliberate widening - a non-zero `gnmi_cli` return code is now treated as a failure even when it printed nothing on stderr - and the failure path returns `stderr or stdout` so the caller still gets a non-empty message. Callers only ever inspect the returned message for `"Unauthenticated"` (`tests/gnmi_e2e/test_gnmi_auth.py`) or assert on the return code, so the contract is unchanged for them.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39376939
Failure type: regression

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

master: static validation on this head (`01194bf`). No testbed run.
- `python -m py_compile tests/common/helpers/gnmi_utils.py` — passes.
- Reviewed every touched call site against its callers: `dump_gnmi_log`, `dump_system_status` and `verify_tcp_port` only log/return the text, and the two `gnmi_capabilities` consumers in `tests/gnmi_e2e/test_gnmi_auth.py` assert on `"Unauthenticated" in msg` / `not in msg`. The invalid-cname case still returns stderr through `stderr or stdout`, so both assertions keep working.
- Azure.sonic-mgmt on this head: the only red lane is `impacted-area-kvmtest-t0`, which failed in `platform_tests/test_reboot.py` (Elastictest plan `6a8c04d724f9645a147a5456`) - a baseline failure that hit 133 distinct PRs on the t0 lane between 2026-08-15 and 2026-08-31, and the retry plan `6a8fe455d025e08c23cc54d9` failed with `LOCK_TESTBED_FAILED` (no free t0 testbed). Neither is related to this change; a fresh run is needed before merge.

202605: `tests/common/helpers/gnmi_utils.py` on `202605` still carries the identical unguarded `if output['stderr']:` / `output['stdout']` accesses, so the same `KeyError` and the same fix apply there. No testbed run was performed on 202605; the evidence above is the master validation plus that code-state check.

### Approach
#### What is the motivation for this PR?
Nightly gNMI auth tests can receive shell result dictionaries without `stdout` or `stderr`; direct indexing raises `KeyError` before the test can report the real command failure.

#### How did you do it?
Use safe `.get()` access with empty-string defaults for `stdout`/`stderr`, keep stderr-based failure detection and add `rc` to it, and make diagnostic logging robust against missing fields.

#### How did you verify/test it?
See **Test result** above.

#### Any platform specific information?
Observed on Cisco-8102-28FH-DPU-O, T1.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
