### PR TITLE
Skip the QoS and PFC tests on the uma and lma topologies

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -510,7 +510,7 @@ bgp/test_bgp_queue.py:
     reason: "Not supported on mgmt device or VPP platform that doesn't have queues"
     conditions_logical_operator: or
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1']"
+      - "topo_type in ['m0', 'mx', 'm1', 'uma', 'lma']"
       - "asic_type in ['vpp']"
   xfail:
     reason: "Skipped due to issue https://github.com/sonic-net/sonic-mgmt/issues/18349"
@@ -4018,10 +4018,10 @@ pfc_asym/test_pfc_asym.py:
 #######################################
 pfcwd:
   skip:
-    reason: "Pfcwd tests skipped on M* testbed, and some isolated topologies and '202412' for now"
+    reason: "Pfcwd tests skipped on M* and MA testbeds, and some isolated topologies and '202412' for now"
     conditions_logical_operator: or
     conditions:
-      - "topo_type in ['bmc', 'm0', 'm1', 'mx']"
+      - "topo_type in ['bmc', 'm0', 'm1', 'mx', 'uma', 'lma']"
       - *lossyTopos
       - "release in ['202412']"
 
@@ -4248,10 +4248,10 @@ ptftests:
 #######################################
 qos:
   skip:
-    reason: "M* topo does not support qos"
+    reason: "M* and MA topos do not support qos"
     conditions_logical_operator: or
     conditions:
-      - "topo_type in ['bmc', 'm0', 'm1', 'mx']"
+      - "topo_type in ['bmc', 'm0', 'm1', 'mx', 'uma', 'lma']"
       - "macsec_en==True"
       # ipv6 mgmt ip is not supported, see fixture dut_disable_ipv6 in qos_sai_base.py
       - "is_mgmt_ipv6_only==True"
@@ -5255,9 +5255,9 @@ snmp/test_snmp_loopback.py::test_snmp_loopback:
 
 snmp/test_snmp_pfc_counters.py:
   skip:
-    reason: "M* topo does not support test_snmp_pfc_counters"
+    reason: "M* and MA topos do not support test_snmp_pfc_counters"
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1']"
+      - "topo_type in ['m0', 'mx', 'm1', 'uma', 'lma']"
 
 snmp/test_snmp_phy_entity.py:
   skip:
@@ -5280,10 +5280,10 @@ snmp/test_snmp_queue.py:
 snmp/test_snmp_queue_counters.py:
   skip:
     conditions_logical_operator: OR
-    reason: "Have an known issue on kvm testbed / Unsupported in M* and C0 topos / issue #17929 on Mellanox platform"
+    reason: "Have an known issue on kvm testbed / Unsupported in M*, MA and C0 topos / issue #17929 on Mellanox platform"
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/14007"
-      - "topo_type in ['m0', 'mx', 'm1', 'c0']"
+      - "topo_type in ['m0', 'mx', 'm1', 'c0', 'uma', 'lma']"
       - "https://github.com/sonic-net/sonic-mgmt/issues/17929 and asic_type in ['mellanox']"
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -563,7 +563,7 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_hostname):
                     add_asic_arg("{}", cmds.broadcom_cmd_misc, num),
             }
         )
-        if duthost.topo_type in ["mx", "m0", "m1"]:
+        if duthost.topo_type in ["mx", "m0", "m1", "uma", "lma"]:
             cmds_to_check.update(
                 {
                     "copy_config_cmds":


### PR DESCRIPTION
### Description of PR

Summary:
The UMA and LowerMgmtAggregator management aggregator topologies carry no QoS or buffer configuration, exactly as the existing M* management topologies do not. Tests that read queue, buffer, PFC or PFC watchdog state therefore fail on them for a reason unrelated to what they set out to verify.

Every entry touched here already skips for `m0` / `m1` / `mx` for precisely this reason. This adds `uma` and `lma` alongside them:

| Entry | Condition after this change |
| --- | --- |
| `qos` | `['bmc', 'm0', 'm1', 'mx', 'uma', 'lma']` |
| `pfcwd` | `['bmc', 'm0', 'm1', 'mx', 'uma', 'lma']` |
| `bgp/test_bgp_queue.py` | `['m0', 'mx', 'm1', 'uma', 'lma']` |
| `snmp/test_snmp_pfc_counters.py` | `['m0', 'mx', 'm1', 'uma', 'lma']` |
| `snmp/test_snmp_queue_counters.py` | `['m0', 'mx', 'm1', 'c0', 'uma', 'lma']` |

The "M*" wording in those reasons is widened to mention MA as well, so the intent stays readable.

`show_techsupport/test_techsupport.py` checks that QoS config files appear in the techsupport dump on topologies that have them. `uma` and `lma` are added to the same list, so the check is skipped where there is nothing to find rather than failing.

ADO number: 39354534

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Backport is requested to **msft-202603** via the `Request for msft-202603 branch` label, since that branch is not on the list above. That is the branch the uma/lma testbeds run.

Tracking issue/work item for backport/cherry-pick request: ADO number 39354534
Failure type: day-one issue - these topologies have never had QoS configuration.

### Tested branch

- [x] master
- [x] 202603
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: validated by this PR's own impacted-area kvmtest checks
- 202603: 20260310.15 - 42 skipped / 0 failed per box across all seven pfcwd modules and both snmp modules, plus 18 skipped for qos/test_buffer.py, 1 for bgp/test_bgp_queue.py and 3 pass / 1 skip for show_techsupport. Pre-test and post-test passed in the same runs (17 pass each side).

Executed on the msft-202603 line, image `20260310.15`, on one UMA and one LMA physical testbed (7050cx3).

Worth noting how this was validated. An earlier run only covered three of the six entries, so rather than assume the rest behaved the same I ran a second round specifically for the ones with no evidence. Both boxes returned identical results.

**Round 1** - `qos`, `bgp/test_bgp_queue.py`, `show_techsupport`:

| Module | UMA | LMA |
| --- | --- | --- |
| `qos/test_buffer.py` | 18 skipped | 18 skipped |
| `bgp/test_bgp_queue.py` | 1 skipped | 1 skipped |
| `show_techsupport/test_techsupport.py` | 3 pass, 1 skip | 3 pass, 1 skip |

**Round 2** - the `pfcwd` folder and the two snmp modules, which round 1 never exercised:

| Module | UMA | LMA |
| --- | --- | --- |
| `pfcwd/test_pfc_config.py` | 17 skipped | 17 skipped |
| `pfcwd/test_pfcwd_all_port_storm.py` | 2 skipped | 2 skipped |
| `pfcwd/test_pfcwd_cli.py` | 2 skipped | 2 skipped |
| `pfcwd/test_pfcwd_function.py` | 10 skipped | 10 skipped |
| `pfcwd/test_pfcwd_timer_accuracy.py` | 2 skipped | 2 skipped |
| `pfcwd/test_pfcwd_warm_reboot.py` | 6 skipped | 6 skipped |
| `pfcwd/test_xon_not_counted.py` | 1 skipped | 1 skipped |
| `snmp/test_snmp_pfc_counters.py` | 1 skipped | 1 skipped |
| `snmp/test_snmp_queue_counters.py` | 1 skipped | 1 skipped |
| **total** | **42 skipped, 0 failed** | **42 skipped, 0 failed** |

Pre-test and post-test passed in the same runs (17 pass each side), so the testbeds were healthy and the skips are the conditions firing rather than a collection problem.

### Approach

#### What is the motivation for this PR?

Bringing up nightly coverage on the UMA and LMA topologies. These modules cannot pass there and their failures crowd out real signal.

#### How did you do it?

Added `uma` and `lma` to the existing topology conditions. No new keys, no change to any other topology.

#### How did you verify/test it?

Ran every affected module on one UMA and one LMA physical testbed and confirmed each one skips rather than fails, with pre/post test green in the same runs. Numbers above.

#### Any platform specific information?

None. This is topology specific, not platform specific.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change needed.

