### PR TITLE
[minigraph]: Rank connection graph above platform default port speed

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -52,7 +52,7 @@ EXAMPLES = '''
 RETURN = '''
       ansible_facts{
         port_alias: [Ethernet0, Ethernet4, ....],
-        port_speed: {'Ethernet0':'40000', 'Ethernet4':'40000', ......]
+        port_speed: {'Ethernet0':'40000', 'Ethernet4':'40000', ......},
         port_speed_is_platform_default: True when port_speed came from platform.json/hwsku.json
       }
 '''

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -53,6 +53,7 @@ RETURN = '''
       ansible_facts{
         port_alias: [Ethernet0, Ethernet4, ....],
         port_speed: {'Ethernet0':'40000', 'Ethernet4':'40000', ......]
+        port_speed_is_platform_default: True when port_speed came from platform.json/hwsku.json
       }
 '''
 
@@ -85,6 +86,9 @@ class SonicPortAliasMap():
 
     def __init__(self, hwsku):
         self.hwsku = hwsku
+        # platform.json/hwsku.json carry a speed for every port, so those are platform defaults
+        # rather than the explicit per-port overrides port_config.ini optionally provides.
+        self.speed_is_platform_default = False
         return
 
     def get_platform_type(self):
@@ -145,6 +149,7 @@ class SonicPortAliasMap():
         hwsku_json_path = os.path.join(platform_dir, self.hwsku, HWSKU_JSON)
 
         (ports, _, _) = parse_platform_json_file(hwsku_json_path, platform_json_path)
+        self.speed_is_platform_default = True
 
         aliases = []
         front_panel_aliases = []
@@ -390,6 +395,7 @@ def main():
                                             'port_name_map': portmap,
                                             'port_alias_map': aliasmap,
                                             'port_speed': portspeed,
+                                            'port_speed_is_platform_default': False,
                                             'front_panel_asic_ifnames': [],
                                             'front_panel_asic_ids': [],
                                             'asic_if_names': [],
@@ -509,6 +515,7 @@ def main():
                                         'port_name_map': portmap,
                                         'port_alias_map': aliasmap,
                                         'port_speed': portspeed,
+                                        'port_speed_is_platform_default': allmap.speed_is_platform_default,
                                         'front_panel_asic_ifnames': front_panel_asic_ifnames_list,
                                         'front_panel_asic_ifs_asic_id': front_panel_asic_ifs_asic_id_list,
                                         'asic_if_names': asic_ifnames_list,

--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -28,12 +28,15 @@
 {% if subtype is defined and subtype == 'SmartSwitch' and intf[8:]|int >= 224 %}
           <role>Dpc</role>
 {% endif %}
-{% if port_speed[port_alias[index]] is defined %}
+{# An explicit per-port speed wins, but a platform default must not override the connection graph. #}
+{% if port_speed[port_alias[index]] is defined and not (port_speed_is_platform_default | default(false)) %}
           <Speed>{{ port_speed[port_alias[index]] }}</Speed>
 {% elif (breakout_speed is defined) and (hwsku in breakout_speed) and (port_alias[index] in breakout_speed[hwsku].keys()) %}
           <Speed>{{ breakout_speed[hwsku][port_alias[index]] }}</Speed>
 {% elif device_conn[inventory_hostname][port_alias_map[port_alias[index]]] is defined %}
           <Speed>{{ device_conn[inventory_hostname][port_alias_map[port_alias[index]]]['speed'] }}</Speed>
+{% elif port_speed[port_alias[index]] is defined %}
+          <Speed>{{ port_speed[port_alias[index]] }}</Speed>
 {% else %}
           <Speed>{{ iface_speed }}</Speed>
 {% endif %}


### PR DESCRIPTION
### Description of PR

Summary:

`port_alias` exposes the `port_speed` fact, which `minigraph_device.j2` ranks above the
connection graph. That ordering dates to #3527, where `port_speed` was an explicit
*per-port override* -- populated only when a `port_config.ini` happened to carry a `speed`
column, which is rare, and deliberately authoritative when present.

#23534 added `platform.json`/`hwsku.json` support to `port_alias`. Those files declare a
speed for **every** port, so `port_speed` silently changed from a rare explicit override
into an always-present **platform default**, while keeping top priority in the chain. Any
DUT cabled below its platform default now gets the wrong speed — and consequently the
wrong FEC — written to `config_db`, and those ports stay oper-down after `deploy-mg`.

This is a regression: a platform default should not outrank the lab's physical cabling as
described by the connection graph.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
MSFT ADO: 39377087

Failure type: regression

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

<!-- TODO: fill in with real evidence, e.g.
- master: <image version> - deploy-mg on <testbed>, all ports oper-up at graph speed
- 202605: <image version> - <result or link>
-->

### Approach

#### What is the motivation for this PR?

After #23534, `deploy-mg` generates minigraphs that ignore the `BandWidth` column of the
lab connection graph whenever the DUT platform ships `platform.json` + `hwsku.json`.

Concrete failure: a `Mellanox-SN2700` DUT cabled at 40G to an Arista-7260QX-64 fanout — a
40G-only platform. `Mellanox-SN2700/hwsku.json` declares 100G, so `deploy-mg` produced
`speed 100000` / `fec rs` and 28 of 32 ports went down. Only the 4 uplink ports survived,
because VM-facing links carry an explicit `<Bandwidth>` in the PNG section while
server-facing links fall back to the `DeviceInfo` `<Speed>`.

Note `Mellanox-SN2700/port_config.ini` has no `speed` column at all, which is precisely why
this testbed worked before #23534: `port_speed` came back empty and the connection graph
was used. The same class of breakage applies to any hwsku cabled below its platform
default.

#### How did you do it?

`port_alias` now reports *where* the speeds came from, via a new
`port_speed_is_platform_default` fact:

- `port_config.ini` with an explicit `speed` column -> `False` (a real per-port override)
- `platform.json` / `hwsku.json` -> `True` (a platform default)

`minigraph_device.j2` consults the connection graph ahead of a platform default, while
explicit per-port speeds keep their original top priority:

| priority | before | after |
|---|---|---|
| 1 | `port_speed` (any source) | `port_speed` (explicit per-port only) |
| 2 | `breakout_speed` | `breakout_speed` |
| 3 | `device_conn` (connection graph) | `device_conn` (connection graph) |
| 4 | — | `port_speed` (platform default) |
| 5 | `iface_speed` | `iface_speed` |

The `port_speed` fact itself is unchanged, so `minigraph_png.j2` — which uses it for
multi-ASIC chassis-internal links, where the platform default *is* the correct value —
needs no modification. The new fact is read with `| default(false)`, so cached facts or
runs where the `port_alias` task was skipped (e.g. BMC topologies) fall back to the
previous behaviour.

#### How did you verify/test it?

- **202605**: verified on a `Mellanox-SN2700` T0 testbed cabled at 40G to an
  Arista-7260QX-64 fanout — i.e. below the 100G platform default declared in
  `Mellanox-SN2700/hwsku.json`, which is the condition that triggers the bug.

  `deploy-mg` completed cleanly and all 32 ports came up at the connection-graph
  speed (40G) with the matching FEC, instead of the 100G / `fec rs` that previously
  left 28 of 32 ports oper-down.

  A full warm upgrade test then passed on top of that configuration

#### Any platform specific information?

Affects any hwsku whose device directory contains both `platform.json` and
`<hwsku>/hwsku.json` with a non-empty `interfaces` key — that is the condition under which
`get_portconfig_path()` takes the JSON branch added by #23534. Platforms that still resolve
via `port_config.ini` are unaffected either way.

Observed on `Mellanox-SN2700`. Other hwskus cabled below their platform default are
affected by the same mechanism.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case. The change is topology-independent; it affects minigraph
generation for every topology that runs `deploy-mg`.

### Documentation

No documentation change required. The new `port_speed_is_platform_default` fact is
documented in the `RETURN` block of `ansible/library/port_alias.py`.
