### PR TITLE
[autorestart][conftest]: Filter enum_dut_feature to only enabled features

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -531,7 +531,11 @@ def postcheck_critical_processes_status(duthost, feature_autorestart_states, up_
         check_all_critical_processes_status, duthost
     )
 
+    disabled_containers = get_disabled_container_list(duthost)
+
     for feature_name in list(feature_autorestart_states.keys()):
+        if feature_name in disabled_containers:
+            continue
         if feature_name in duthost.DEFAULT_ASIC_SERVICES:
             for asic in duthost.asics:
                 service_name = asic.get_service_name(feature_name)

--- a/tests/common/unit_tests/fixtures/unit_test_generate_dut_feature_list.py
+++ b/tests/common/unit_tests/fixtures/unit_test_generate_dut_feature_list.py
@@ -1,0 +1,139 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+
+CONFTEST_PATH = (Path(__file__).resolve().parents[3] / "conftest.py")
+
+
+def _load_generate_dut_feature_list(meta):
+    """
+    Extract features from generate_dut_feature_list from tests/conftest.py and run it in
+    an isolated namespace with get_testbed_metadata stubbed to return
+    meta data.
+
+    tests/conftest.py imports the full integration-test dependency tree
+    (paramiko, ansible device wrappers, etc.), so it cannot be imported
+    directly in a lightweight unit test.
+    """
+    source = CONFTEST_PATH.read_text()
+    tree = ast.parse(source)
+    func_node = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "generate_dut_feature_list"
+    )
+    module = ast.Module(body=[func_node], type_ignores=[])
+    code = compile(module, filename=str(CONFTEST_PATH), mode="exec")
+
+    namespace = {"get_testbed_metadata": lambda request: meta}
+    exec(code, namespace)
+    return namespace["generate_dut_feature_list"]
+
+
+def _run(meta, duts_selected, asics_selected):
+    generate_dut_feature_list = _load_generate_dut_feature_list(meta)
+    return generate_dut_feature_list(None, duts_selected, asics_selected)
+
+
+def test_disabled_features_filtered_with_asics():
+    """Disabled features must be dropped when asics are selected (BMC case)."""
+    meta = {
+        "dut1": {
+            "features": {
+                "bgp": "disabled",
+                "swss": "disabled",
+                "lldp": "enabled",
+                "pmon": "always_enabled",
+            }
+        }
+    }
+    result = _run(meta, ["dut1"], [["0"]])
+    assert result == [("dut1", "0", "lldp"), ("dut1", "0", "pmon")]
+
+
+def test_disabled_features_filtered_without_asics():
+    """Disabled features must be dropped when no asics are selected."""
+    meta = {
+        "dut1": {
+            "features": {
+                "bgp": "disabled",
+                "lldp": "enabled",
+                "telemetry": "enabled",
+            }
+        }
+    }
+    result = _run(meta, ["dut1"], [])
+    assert result == [("dut1", None, "lldp"), ("dut1", None, "telemetry")]
+
+
+def test_skip_feature_list_excluded():
+    """database, database-chassis and gbsyncd are always skipped."""
+    meta = {
+        "dut1": {
+            "features": {
+                "database": "enabled",
+                "database-chassis": "enabled",
+                "gbsyncd": "enabled",
+                "lldp": "enabled",
+            }
+        }
+    }
+    assert _run(meta, ["dut1"], []) == [("dut1", None, "lldp")]
+    assert _run(meta, ["dut1"], [["0"]]) == [("dut1", "0", "lldp")]
+
+
+def test_enabled_variants_included():
+    """Any status that does not contain 'disabled' is included."""
+    meta = {
+        "dut1": {
+            "features": {
+                "lldp": "enabled",
+                "pmon": "always_enabled",
+            }
+        }
+    }
+    result = _run(meta, ["dut1"], [])
+    assert result == [("dut1", None, "lldp"), ("dut1", None, "pmon")]
+
+
+def test_meta_none_returns_empty():
+    """When metadata is unavailable, an empty list is returned."""
+    assert _run(None, ["dut1"], [["0"]]) == []
+    assert _run(None, ["dut1"], []) == []
+
+
+def test_dut_without_features_key():
+    """A DUT lacking a 'features' key yields a single None-feature tuple."""
+    meta = {"dut1": {}}
+    assert _run(meta, ["dut1"], [["0"]]) == [("dut1", "0", None)]
+    assert _run(meta, ["dut1"], []) == [("dut1", None, None)]
+
+
+def test_multiple_asics_expand_features():
+    """Each enabled feature is emitted once per selected asic."""
+    meta = {
+        "dut1": {
+            "features": {
+                "bgp": "disabled",
+                "lldp": "enabled",
+            }
+        }
+    }
+    result = _run(meta, ["dut1"], [["0", "1"]])
+    assert result == [("dut1", "0", "lldp"), ("dut1", "1", "lldp")]
+
+
+def test_multiple_duts():
+    """Features are filtered independently per DUT."""
+    meta = {
+        "dut1": {"features": {"bgp": "disabled", "lldp": "enabled"}},
+        "dut2": {"features": {"swss": "enabled"}},
+    }
+    result = _run(meta, ["dut1", "dut2"], [])
+    assert result == [("dut1", None, "lldp"), ("dut2", None, "swss")]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2110,14 +2110,16 @@ def generate_dut_feature_list(request, duts_selected, asics_selected):
                 # Create tuple of dut and asic index
                 if "features" in meta[a_dut]:
                     for a_feature in list(meta[a_dut]["features"].keys()):
-                        if a_feature not in skip_feature_list:
+                        if a_feature not in skip_feature_list \
+                                and "disabled" not in meta[a_dut]["features"][a_feature]:
                             tuple_list.append((a_dut, a_asic, a_feature))
                 else:
                     tuple_list.append((a_dut, a_asic, None))
         else:
             if "features" in meta[a_dut]:
                 for a_feature in list(meta[a_dut]["features"].keys()):
-                    if a_feature not in skip_feature_list:
+                    if a_feature not in skip_feature_list \
+                            and "disabled" not in meta[a_dut]["features"][a_feature]:
                         tuple_list.append((a_dut, None, a_feature))
             else:
                 tuple_list.append((a_dut, None, None))


### PR DESCRIPTION
### Description of PR

Summary:
Filters `generate_dut_feature_list` in `tests/conftest.py` to only enumerate **enabled** features, matching the existing convention used in `generate_dut_container_list` (`if "disabled" in val["features"][feature]: continue`).

This is an alternative to #27269.

On a BMC, `enum_dut_feature` drops from 15 params to 5:

| Before | After |
| --- | --- |
| acms, bgp, dhcp_relay, gnmi, lldp, macsec, mux, otel, pmon, profiler, redfish, swss, syncd, teamd, telemetry | acms, gnmi, lldp, pmon, redfish, telemetry |

This removes the source of the `Unit bgp.service could not be found` crash and also skips other never-installed units. It's platform-agnostic — on a normal NPU those features are enabled so nothing changes.

Additionally, `postcheck_critical_processes_status` in `tests/autorestart/test_container_autorestart.py` iterated over all features in `feature_autorestart_states`, including disabled ones, calling `is_hiting_start_limit` on never-installed units. This now skips containers returned by `get_disabled_container_list`, matching the convention already used in `run_test_on_single_container`.

Fixes #27271

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202608

### Approach
#### What is the motivation for this PR?

On BMC platforms, `enum_dut_feature` enumerated features that are never installed as systemd units (e.g. `bgp`, `swss`, `syncd`, `teamd`). Tests parametrized over these features crashed with `Unit bgp.service could not be found`. The same class of failure occurred in `postcheck_critical_processes_status`, which iterated over disabled features.

#### How did you do it?

- Added a `"disabled" not in meta[a_dut]["features"][a_feature]` guard to both the ASIC and non-ASIC branches of `generate_dut_feature_list`, mirroring the existing disabled-feature filter already used by `generate_dut_container_list`.
- Added a `if feature_name in disabled_containers: continue` guard to `postcheck_critical_processes_status`, using `get_disabled_container_list`, matching `run_test_on_single_container`.

#### How did you verify/test it?

Confirmed `tests/conftest.py` and `tests/autorestart/test_container_autorestart.py` compile cleanly. On a BMC the `enum_dut_feature` parametrization drops from 15 to 5 enabled features, removing the never-installed units that caused the crash. On a normal NPU the affected features are enabled, so the enumerated list is unchanged.

Added unit tests in `tests/common/unit_tests/fixtures/unit_test_generate_dut_feature_list.py` covering disabled-feature filtering (with and without asics), `skip_feature_list` exclusion, enabled/always_enabled inclusion, `None` metadata, DUTs without a `features` key, and per-asic / per-DUT expansion. All 8 pass against the real conftest source:

```
PASS test_disabled_features_filtered_with_asics
PASS test_disabled_features_filtered_without_asics
PASS test_dut_without_features_key
PASS test_enabled_variants_included
PASS test_meta_none_returns_empty
PASS test_multiple_asics_expand_features
PASS test_multiple_duts
PASS test_skip_feature_list_excluded

8/8 passed
```

Run with:
```bash
python3 -m pytest --noconftest \
  tests/common/unit_tests/fixtures/unit_test_generate_dut_feature_list.py -v
```

#### Any platform specific information?

Platform-agnostic. Only affects platforms (such as BMC) where some features are marked `disabled` in testbed metadata.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A