### PR TITLE
[202605] [cacl][test] Expect dhcp_server docker0 syslog rule on tcp/2514

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -534,11 +534,11 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
                                    .format(v['IPv6Address'],
                                            docker_network['bridge']['IPv6Address']))
 
-        # dhcp_server uses bridge networking; its startup script adds an iptables
-        # rule to allow syslog (UDP 514) past caclmgrd's catch-all DROP.
-        if "dhcp_server" in docker_network['container']:
+        # dhcp_server forwards rsyslog to the host over docker0 (tcp/2514); caclmgrd adds this ACCEPT when enabled
+        feature_status, _ = duthost.get_feature_status()
+        if feature_status.get("dhcp_server") == "enabled":
             iptables_rules.append(
-                "-A INPUT -i docker0 -p udp -m udp --dport 514"
+                "-A INPUT -i docker0 -p tcp -m tcp --dport 2514"
                 " -m comment --comment dhcp_server_syslog -j ACCEPT")
 
     else:

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -175,7 +175,7 @@ def dummy_acl_rules(duthosts, enum_rand_one_per_hwsku_hostname):
         acl_entry = {}
 
         # Alternate between IPv4 and IPv6 addresses (should be 2 IPv4 for every IPv6)
-        src_ip = f"20.0.0.{1 + index}/32" if index % 3 else f"2001::{1 + index}/128"
+        src_ip = "20.0.0.{}/32".format(1 + index) if index % 3 else "2001::{}/128".format(1 + index)
 
         # Alternate between accept and drop for each rule
         action = "ACCEPT" if index % 2 else "DROP"
@@ -1047,17 +1047,17 @@ def verify_cacl_show_acl_rule(duthost, acl_file):
             if rule_conf_actual[ip_key] != rule_conf_expected["ip"]["config"]["source-ip-address"]:
                 actual = rule_conf_actual[ip_key]
                 expected = rule_conf_expected["ip"]["config"]["source-ip-address"]
-                rule_issues.append(f"  - {rule_name}: Expected IP {expected} does not match {actual}")
+                rule_issues.append("  - {}: Expected IP {} does not match {}".format(rule_name, expected, actual))
 
             if rule_conf_actual["action"] != rule_conf_expected["actions"]["config"]["forwarding-action"]:
                 actual = rule_conf_actual["action"]
                 expected = rule_conf_expected["actions"]["config"]["forwarding-action"]
-                rule_issues.append(f"  - {rule_name}: Expected action {expected} does not match {actual}")
+                rule_issues.append("  - {}: Expected action {} does not match {}".format(rule_name, expected, actual))
 
             if int(rule_conf_actual["priority"]) != (10000 - int(rule_conf_expected["config"]["sequence-id"])):
                 actual = int(rule_conf_actual["priority"])
                 expected = (10000 - int(rule_conf_expected["config"]["sequence-id"]))
-                rule_issues.append(f"  - {rule_name}: Expected priority {expected} does not match {actual}")
+                rule_issues.append("  - {}: Expected priority {} does not match {}".format(rule_name, expected, actual))
 
             if rule_issues:
                 rule_issues_str = '\n'.join(rule_issues)


### PR DESCRIPTION
### Description of PR

Summary:
Manual backport of https://github.com/sonic-net/sonic-mgmt/pull/26477 to `202605`, from exact source head `2e817d7bff02f6b42722bc1ef8f4390e008f9fa0`.

The CACL expectation now matches the `caclmgrd`-owned `dhcp_server` syslog exception: RELP over tcp/2514, gated by `FEATURE|dhcp_server`, instead of the former container-owned udp/514 rule.

The image prerequisite is satisfied by the current tagged `internal-202605` image, **SONiC.20260510.16**. Its exact internal buildimage source commit is `623030c3059377790723aa1207c7b52452061eb9`: `src/sonic-host-services` points to `e7426f90c619d84c2aa70898566c5261344d962f` (which contains the #426 merge), and `docker_image_ctl.j2` contains the tcp/2514 `DHCP_SERVER_SYSLOG_CHECK` wait logic from #29164. The earlier installed tag `20260510.12` predates these fixes and must not be used for validation.

Related root PR: https://github.com/sonic-net/sonic-mgmt/pull/26477
Underlying bug: https://github.com/sonic-net/sonic-buildimage/pull/27584

##### Work item tracking
- Microsoft ADO (number only): 39385803

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Manual backport to `202605`; no further backport is requested and no release-workflow labels should be applied to this PR.

### Approach
#### What is the motivation for this PR?

Keep the `202605` CACL regression expectation aligned with the product behavior after the prerequisite 202605 image deliveries.

#### How did you do it?

Applied the root PR's merged patch to current `origin/202605`. It applied without conflicts. The release branch's existing container-loop structure was preserved; no unrelated master test changes were pulled in.

Azure build 1201573 then exposed a release-branch static-analysis compatibility issue: flake8 6.0 on Python 3.12 mis-tokenizes literal IPv6 colons and leading diagnostic bullets inside four pre-existing f-strings. Those strings now use the release-native `str.format` style, preserving their generated values and messages.

#### How did you verify/test it?

- `git diff --check`: passed.
- `python3 -m py_compile tests/cacl/test_cacl_application.py`: passed.
- `pre-commit run --files tests/cacl/test_cacl_application.py`: passed, including AST and flake8 checks.
- Exact CI reproduction, `uvx --python 3.12 --from flake8==6.0.0 flake8 --max-line-length=120 tests/cacl/test_cacl_application.py`: passed after reproducing the five original E231/E221 errors before the fix.
- The root backport hunk's stable patch-id exactly matches the merged root patch; the follow-up changes only equivalent string formatting needed by release CI.

Repository PR CI passed. The current tagged image prerequisite was verified from the official `SONiC.20260510.16` artifact and its exact build source as described above. The original exact source head was previously validated on `SONiC.20260510.07` with the complete product series hand-patched: `cacl/test_cacl_application.py` passed 5 tests with 4 topology skips. A release-native functional rerun should use tag `20260510.16`, not the stale `20260510.12` image installed as an inactive image on the prior DUT.

#### Any platform specific information?

Host-namespace IPv4 INPUT rule; applies when the `dhcp_server` feature is enabled.

#### Supported testbed topology if it's a new test case?

N/A (existing test).

### Documentation

N/A.

### Tagged 202605 physical validation

Validated exact PR head `f73697f700579c01dbe3a1b4f02796be83c6c0f2` on a physical 720DT MX testbed using the current official tagged image.

- Image: `SONiC.20260510.16` (`build commit 623030c305`, built 2026-09-18).
- Testbed / DUT: `testbed-bjw-can-720dt-2` / `bjw-can-720dt-2`, Arista-720DT-G48S4, `mx`.
- Validation checkout: fresh `internal-202605` clone with the two exact #27285 commits cherry-picked.
- Matching `deploy-mg`: passed (`failed=0`, `unreachable=0`).
- `test_pretest.py`: 11 passed, 3 skipped, exit 0.
- Full `cacl/test_cacl_application.py`: all five applicable functional tests passed and four topology-inapplicable cases skipped, including `test_caclmgrd_syslog`. The run then reported an unrelated global `memory_utilization` teardown alarm (`monit:memory_usage` 19.6% to 36.9%), so the aggregate command exited 1.
- Focused `test_caclmgrd_syslog` rerun with only memory monitoring disabled: 1 passed, exit 0 in 165.06 seconds.

This confirms the tcp/2514 expectation and syslog/CACL behavior on the actual tagged image containing #426/#29415 and #29164. The memory teardown is tracked separately by the existing memory-utilization false-alarm work and is not a failure of this PR.
