### PR TITLE
[dhcp_relay] Exercise sonic dhcp4relay on standby ToR

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -341,6 +341,7 @@ dualtor:
   - arp/test_arp_dualtor.py
   - arp/test_arp_extended.py
   - decap/test_subnet_decap.py
+  - dhcp_relay/test_dhcp_relay.py
   - dualtor/test_ipinip.py
   - dualtor/test_mux_port_iptables_entries.py
   - dualtor/test_orchagent_slb.py

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -341,7 +341,6 @@ dualtor:
   - arp/test_arp_dualtor.py
   - arp/test_arp_extended.py
   - decap/test_subnet_decap.py
-  - dhcp_relay/test_dhcp_relay.py
   - dualtor/test_ipinip.py
   - dualtor/test_mux_port_iptables_entries.py
   - dualtor/test_orchagent_slb.py

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -4,7 +4,6 @@ import ipaddress
 import binascii
 import os
 import logging
-import time
 
 # Packet Test Framework imports
 import ptf
@@ -1208,46 +1207,27 @@ class DHCPTest(DataplaneBaseTest):
         if self.agent_relay_mode == "discard" or self.dhcpv4_disable_flag or self.max_hop_count == self.MAX_HOP_COUNT:
             # Expected result: No packet sent
             num_expected_packets = 0
-
-        standby_mask = Mask(pkt)
-        self.set_common_ignored_mask_fields(standby_mask)
-        standby_mask.set_do_not_care_scapy(scapy.Ether, "src")
-        standby_mask.set_do_not_care_scapy(scapy.Ether, "dst")
-        standby_mask.set_do_not_care_scapy(scapy.IP, "src")
-        standby_mask.set_do_not_care_scapy(scapy.BOOTP, "giaddr")
-        standby_mask.set_do_not_care_scapy(scapy.DHCP, "options")
-
-        captured_count = 0
-        standby_count = 0
-        timeout = ptf.ptfutils.default_timeout
-        last_matched_packet_time = time.time()
-        while time.time() - last_matched_packet_time <= timeout:
-            result = testutils.dp_poll(self, device_number=0, timeout=timeout)
-            if not isinstance(result, self.dataplane.PollSuccess):
-                break
-
-            matched = False
-            if (result.port in self.server_port_indices
-                    and ptf.dataplane.match_exp_pkt(mask, result.packet)):
-                captured_count += 1
-                matched = True
-            elif (result.port in self.standby_server_port_indices
-                  and ptf.dataplane.match_exp_pkt(
-                      standby_mask, result.packet)):
-                standby_count += 1
-                matched = True
-
-            if matched:
-                last_matched_packet_time = time.time()
-
+        captured_count = testutils.count_matched_packets_all_ports(
+            self, mask, self.server_port_indices)
         self.assertTrue(captured_count == num_expected_packets,
                         "Failed: %s packet counts are not equal %d != %d"
                         % (packet_type, captured_count, num_expected_packets))
-        self.assertEqual(
-            standby_count,
-            0,
-            "Failed: standby ToR relayed {} matching {} packet(s)".format(
-                standby_count, packet_type))
+
+        if self.standby_server_port_indices:
+            standby_mask = Mask(pkt)
+            self.set_common_ignored_mask_fields(standby_mask)
+            standby_mask.set_do_not_care_scapy(scapy.Ether, "src")
+            standby_mask.set_do_not_care_scapy(scapy.Ether, "dst")
+            standby_mask.set_do_not_care_scapy(scapy.IP, "src")
+            standby_mask.set_do_not_care_scapy(scapy.BOOTP, "giaddr")
+            standby_mask.set_do_not_care_scapy(scapy.DHCP, "options")
+            standby_count = testutils.count_matched_packets_all_ports(
+                self, standby_mask, self.standby_server_port_indices)
+            self.assertEqual(
+                standby_count,
+                0,
+                "Failed: standby ToR relayed {} matching {} packet(s)".format(
+                    standby_count, packet_type))
 
     def check_pkt_on_client_side(self, mask, pkt, packet_type):
         logger.info("Expect receiving relayed {} packet from port {}".format(packet_type, self.client_port_index))

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -147,6 +147,10 @@ class DHCPTest(DataplaneBaseTest):
         # These are the interfaces we are injected into that link to out leaf switches
         self.server_port_indices = ast.literal_eval(
             self.test_params['leaf_port_indices'])
+        self.standby_server_port_indices = []
+        if 'standby_leaf_port_indices' in self.test_params:
+            self.standby_server_port_indices = ast.literal_eval(
+                self.test_params['standby_leaf_port_indices'])
         self.num_dhcp_servers = int(self.test_params['num_dhcp_servers'])
 
         self.assertTrue(self.num_dhcp_servers > 0,
@@ -1208,6 +1212,22 @@ class DHCPTest(DataplaneBaseTest):
         self.assertTrue(captured_count == num_expected_packets,
                         "Failed: %s packet counts are not equal %d != %d"
                         % (packet_type, captured_count, num_expected_packets))
+
+        if self.standby_server_port_indices:
+            standby_mask = Mask(pkt)
+            self.set_common_ignored_mask_fields(standby_mask)
+            standby_mask.set_do_not_care_scapy(scapy.Ether, "src")
+            standby_mask.set_do_not_care_scapy(scapy.Ether, "dst")
+            standby_mask.set_do_not_care_scapy(scapy.IP, "src")
+            standby_mask.set_do_not_care_scapy(scapy.BOOTP, "giaddr")
+            standby_mask.set_do_not_care_scapy(scapy.DHCP, "options")
+            standby_count = testutils.count_matched_packets_all_ports(
+                self, standby_mask, self.standby_server_port_indices)
+            self.assertEqual(
+                standby_count,
+                0,
+                "Failed: standby ToR relayed {} matching {} packet(s)".format(
+                    standby_count, packet_type))
 
     def check_pkt_on_client_side(self, mask, pkt, packet_type):
         logger.info("Expect receiving relayed {} packet from port {}".format(packet_type, self.client_port_index))

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -4,6 +4,7 @@ import ipaddress
 import binascii
 import os
 import logging
+import time
 
 # Packet Test Framework imports
 import ptf
@@ -1207,12 +1208,7 @@ class DHCPTest(DataplaneBaseTest):
         if self.agent_relay_mode == "discard" or self.dhcpv4_disable_flag or self.max_hop_count == self.MAX_HOP_COUNT:
             # Expected result: No packet sent
             num_expected_packets = 0
-        captured_count = testutils.count_matched_packets_all_ports(
-            self, mask, self.server_port_indices)
-        self.assertTrue(captured_count == num_expected_packets,
-                        "Failed: %s packet counts are not equal %d != %d"
-                        % (packet_type, captured_count, num_expected_packets))
-
+        standby_mask = None
         if self.standby_server_port_indices:
             standby_mask = Mask(pkt)
             self.set_common_ignored_mask_fields(standby_mask)
@@ -1220,14 +1216,39 @@ class DHCPTest(DataplaneBaseTest):
             standby_mask.set_do_not_care_scapy(scapy.Ether, "dst")
             standby_mask.set_do_not_care_scapy(scapy.IP, "src")
             standby_mask.set_do_not_care_scapy(scapy.BOOTP, "giaddr")
-            standby_mask.set_do_not_care_scapy(scapy.DHCP, "options")
-            standby_count = testutils.count_matched_packets_all_ports(
-                self, standby_mask, self.standby_server_port_indices)
-            self.assertEqual(
-                standby_count,
-                0,
-                "Failed: standby ToR relayed {} matching {} packet(s)".format(
-                    standby_count, packet_type))
+            if pkt.haslayer(scapy.DHCP):
+                standby_mask.set_do_not_care_scapy(scapy.DHCP, "options")
+
+        # Classify both port sets in a single drain: dp_poll consumes every packet it
+        # returns, so counting the active ports first would discard the standby copies
+        # this check exists to detect.
+        captured_count = 0
+        standby_count = 0
+        timeout = ptf.ptfutils.default_timeout
+        last_matched_packet_time = time.time()
+        while time.time() - last_matched_packet_time <= timeout:
+            result = testutils.dp_poll(self, device_number=0, timeout=timeout)
+            if not isinstance(result, self.dataplane.PollSuccess):
+                break
+
+            if (result.port in self.server_port_indices
+                    and ptf.dataplane.match_exp_pkt(mask, result.packet)):
+                captured_count += 1
+                last_matched_packet_time = time.time()
+            elif (standby_mask is not None
+                    and result.port in self.standby_server_port_indices
+                    and ptf.dataplane.match_exp_pkt(standby_mask, result.packet)):
+                standby_count += 1
+                last_matched_packet_time = time.time()
+
+        self.assertEqual(
+            standby_count,
+            0,
+            "Failed: standby ToR relayed {} matching {} packet(s)".format(
+                standby_count, packet_type))
+        self.assertTrue(captured_count == num_expected_packets,
+                        "Failed: %s packet counts are not equal %d != %d"
+                        % (packet_type, captured_count, num_expected_packets))
 
     def check_pkt_on_client_side(self, mask, pkt, packet_type):
         logger.info("Expect receiving relayed {} packet from port {}".format(packet_type, self.client_port_index))

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -4,6 +4,7 @@ import ipaddress
 import binascii
 import os
 import logging
+import time
 
 # Packet Test Framework imports
 import ptf
@@ -1207,27 +1208,46 @@ class DHCPTest(DataplaneBaseTest):
         if self.agent_relay_mode == "discard" or self.dhcpv4_disable_flag or self.max_hop_count == self.MAX_HOP_COUNT:
             # Expected result: No packet sent
             num_expected_packets = 0
-        captured_count = testutils.count_matched_packets_all_ports(
-            self, mask, self.server_port_indices)
+
+        standby_mask = Mask(pkt)
+        self.set_common_ignored_mask_fields(standby_mask)
+        standby_mask.set_do_not_care_scapy(scapy.Ether, "src")
+        standby_mask.set_do_not_care_scapy(scapy.Ether, "dst")
+        standby_mask.set_do_not_care_scapy(scapy.IP, "src")
+        standby_mask.set_do_not_care_scapy(scapy.BOOTP, "giaddr")
+        standby_mask.set_do_not_care_scapy(scapy.DHCP, "options")
+
+        captured_count = 0
+        standby_count = 0
+        timeout = ptf.ptfutils.default_timeout
+        last_matched_packet_time = time.time()
+        while time.time() - last_matched_packet_time <= timeout:
+            result = testutils.dp_poll(self, device_number=0, timeout=timeout)
+            if not isinstance(result, self.dataplane.PollSuccess):
+                break
+
+            matched = False
+            if (result.port in self.server_port_indices
+                    and ptf.dataplane.match_exp_pkt(mask, result.packet)):
+                captured_count += 1
+                matched = True
+            elif (result.port in self.standby_server_port_indices
+                  and ptf.dataplane.match_exp_pkt(
+                      standby_mask, result.packet)):
+                standby_count += 1
+                matched = True
+
+            if matched:
+                last_matched_packet_time = time.time()
+
         self.assertTrue(captured_count == num_expected_packets,
                         "Failed: %s packet counts are not equal %d != %d"
                         % (packet_type, captured_count, num_expected_packets))
-
-        if self.standby_server_port_indices:
-            standby_mask = Mask(pkt)
-            self.set_common_ignored_mask_fields(standby_mask)
-            standby_mask.set_do_not_care_scapy(scapy.Ether, "src")
-            standby_mask.set_do_not_care_scapy(scapy.Ether, "dst")
-            standby_mask.set_do_not_care_scapy(scapy.IP, "src")
-            standby_mask.set_do_not_care_scapy(scapy.BOOTP, "giaddr")
-            standby_mask.set_do_not_care_scapy(scapy.DHCP, "options")
-            standby_count = testutils.count_matched_packets_all_ports(
-                self, standby_mask, self.standby_server_port_indices)
-            self.assertEqual(
-                standby_count,
-                0,
-                "Failed: standby ToR relayed {} matching {} packet(s)".format(
-                    standby_count, packet_type))
+        self.assertEqual(
+            standby_count,
+            0,
+            "Failed: standby ToR relayed {} matching {} packet(s)".format(
+                standby_count, packet_type))
 
     def check_pkt_on_client_side(self, mask, pkt, packet_type):
         logger.info("Expect receiving relayed {} packet from port {}".format(packet_type, self.client_port_index))

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -594,29 +594,40 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
 
 @pytest.fixture()
-def enable_sonic_dhcpv4_relay_agent(rand_selected_dut, request):
+def enable_sonic_dhcpv4_relay_agent(rand_selected_dut, duthosts, tbinfo, request):
     """
-    Fixture to enable the DHCP relay feature flag and restart the service.
+    Enable SONiC DHCPv4 relay on every ToR that receives client traffic.
+
+    Classic dual-ToR tests must run dhcp4relay on both ToRs so their existing
+    standby counter assertions exercise dhcp4relay rather than ISC dhcrelay.
+    Active-active has no standby suppression requirement, so retain the
+    selected-DUT behavior there.
     """
     if "skip_config_dhcpv4_relay_agent" in request.keywords:
         yield
         return
-
-    duthost = rand_selected_dut
 
     if "dut_dhcp_relay_data" in request.fixturenames:
         dut_dhcp_relay_data = request.getfixturevalue("dut_dhcp_relay_data")
     else:
         dut_dhcp_relay_data = None
 
+    duthosts_to_configure = [rand_selected_dut]
+    topo_name = tbinfo["topo"]["name"]
+    if "dualtor" in topo_name and "dualtor-aa" not in topo_name:
+        duthosts_to_configure = duthosts.frontend_nodes
+
+    configured_duthosts = []
     try:
         if request.getfixturevalue("relay_agent") == "sonic-relay-agent":
-            sonic_dhcpv4_flag_config_and_unconfig(duthost, True)
-            sonic_dhcp_relay_config(duthost, dut_dhcp_relay_data, True)
+            for duthost in duthosts_to_configure:
+                sonic_dhcpv4_flag_config_and_unconfig(duthost, True)
+                configured_duthosts.append(duthost)
+                sonic_dhcp_relay_config(duthost, dut_dhcp_relay_data, True)
         yield
     finally:
         # Cleanup: disable the feature flag
-        if request.getfixturevalue("relay_agent") == "sonic-relay-agent":
+        for duthost in configured_duthosts:
             sonic_dhcpv4_flag_config_and_unconfig(duthost, False)
             sonic_dhcp_relay_unconfig(duthost, dut_dhcp_relay_data)
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -27,7 +27,7 @@ from tests.common.dhcp_relay_utils import restart_dhcp_service, wait_dhcp_relay_
 from tests.common.dhcp_relay_utils import enable_sonic_dhcpv4_relay_agent  # noqa: F401
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0'),
+    pytest.mark.topology('t0', 'm0', 'dualtor'),
     pytest.mark.device_type('vs'),
     pytest.mark.parametrize("relay_agent", ["isc-relay-agent", "sonic-relay-agent"]),
 ]

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -9,6 +9,7 @@ from _pytest.outcomes import OutcomeException
 from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmon_counters, restart_dhcpmon_in_debug
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder         # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 from tests.common.gcu_utils import generate_tmpfile, create_checkpoint, \
     apply_patch, expect_op_success, delete_tmpfile, \
@@ -254,6 +255,11 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                 loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="dhcpmon counter")
                 marker = loganalyzer.init()
                 loganalyzer.expect_regex = [expected_agg_counter_message]
+
+            standby_uplink_port_indices = []
+            if testing_mode == DUAL_TOR_MODE and relay_agent == "sonic-relay-agent":
+                standby_uplink_port_indices = dhcp_relay['standby_uplink_port_indices']
+
             # Run the DHCP relay test on the PTF host
             ptf_runner(ptfhost,
                        "ptftests",
@@ -266,6 +272,7 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                                "other_client_port": repr(dhcp_relay['other_client_ports']),
                                "client_iface_alias": str(dhcp_relay['client_iface']['alias']),
                                "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+                               "standby_leaf_port_indices": repr(standby_uplink_port_indices),
                                "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs']),
                                "server_ip": dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'],
                                "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Configure `sonic-relay-agent` on both ToRs in classic active-standby dual-ToR tests and directly assert that no matching client request is relayed through standby-ToR uplinks. This exercises dhcp4relay instead of leaving the standby ToR on ISC dhcrelay.

Related issue: sonic-net/sonic-dhcp-relay#139
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other — test coverage gap

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
- `python3 -m py_compile tests/dhcp_relay/test_dhcp_relay.py tests/ptftests/py3/dhcp_relay_test.py`: passed
- `git diff --check`: passed
- The classic dual-ToR `test_dhcp_relay_default[sonic-relay-agent]` now checks active relay counts and zero matching packets on standby uplinks. It is expected to fail on an unfixed image and pass after the sonic-dhcp-relay fix is installed.

### Approach
#### What is the motivation for this PR?
The fixture previously enabled dhcp4relay only on the selected active ToR. Standby assertions therefore continued validating ISC's iptables path and could not detect dhcp4relay raw-socket suppression regressions.

#### How did you do it?
For classic active-standby dual-ToR topologies, configure and clean up `sonic-relay-agent` on both frontend ToRs. Pass the standby ToR uplink indices to PTF and reject matching relayed client packets there while preserving the existing active-uplink count and Option 82 checks. Single-ToR and dual-ToR active-active behavior remains unchanged.

#### How did you verify/test it?
Validated Python syntax and patch formatting. The focused dual-ToR run requires an image containing the corresponding sonic-dhcp-relay fix for green evidence.
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
No. The regression concerns Linux AF_PACKET/netfilter ordering and dual-ToR mux state handling.

#### Supported testbed topology if it's a new test case?
Classic dual-ToR active-standby. This improves existing tests rather than adding a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A