### PR TITLE
[202512][pipeline]: Set up Python for pre-test checks

### DIFF
--- a/.azure-pipelines/dependency-check.yml
+++ b/.azure-pipelines/dependency-check.yml
@@ -1,7 +1,7 @@
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.x'
+    versionSpec: '3.10'
   displayName: 'Set up Python 3'
 
 - script: |

--- a/.azure-pipelines/dependency-check.yml
+++ b/.azure-pipelines/dependency-check.yml
@@ -1,10 +1,15 @@
 steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.x'
+  displayName: 'Set up Python 3'
+
 - script: |
     set -x
 
-    pip3 install natsort
+    python -m pip install natsort
 
-    python3 ./.azure-pipelines/dependency_check/dependency_check.py tests
+    python ./.azure-pipelines/dependency_check/dependency_check.py tests
     if [[ $? -ne 0 ]]; then
       echo "##vso[task.complete result=Failed;]Condition check failed."
       exit 1

--- a/.azure-pipelines/markers-check.yml
+++ b/.azure-pipelines/markers-check.yml
@@ -1,10 +1,15 @@
 steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.x'
+  displayName: 'Set up Python 3'
+
 - script: |
     set -x
 
-    pip3 install natsort
+    python -m pip install natsort
 
-    python3 ./.azure-pipelines/markers_check/markers_check.py tests
+    python ./.azure-pipelines/markers_check/markers_check.py tests
     if [[ $? -ne 0 ]]; then
       echo "##vso[task.complete result=Failed;]Markers check fails."
       exit 1

--- a/.azure-pipelines/markers-check.yml
+++ b/.azure-pipelines/markers-check.yml
@@ -1,7 +1,7 @@
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.x'
+    versionSpec: '3.10'
   displayName: 'Set up Python 3'
 
 - script: |

--- a/.azure-pipelines/meta-check.yml
+++ b/.azure-pipelines/meta-check.yml
@@ -1,8 +1,13 @@
 steps:
-- script: |
-    pip3 install ipaddr natsort
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.x'
+  displayName: 'Set up Python 3'
 
-    python3 ./ansible/scripts/meta/meta_validator.py -r errors -c .azure-pipelines/meta_validator.yml
+- script: |
+    python -m pip install ipaddr natsort
+
+    python ./ansible/scripts/meta/meta_validator.py -r errors -c .azure-pipelines/meta_validator.yml
     if [[ $? -ne 0 ]]; then
       echo "##vso[task.complete result=Failed;]Meta check fails."
       exit 1

--- a/.azure-pipelines/meta-check.yml
+++ b/.azure-pipelines/meta-check.yml
@@ -5,7 +5,7 @@ steps:
   displayName: 'Set up Python 3'
 
 - script: |
-    python -m pip install ipaddr natsort
+    python -m pip install ipaddr natsort PyYAML six
 
     python ./ansible/scripts/meta/meta_validator.py -r errors -c .azure-pipelines/meta_validator.yml
     if [[ $? -ne 0 ]]; then

--- a/.azure-pipelines/meta-check.yml
+++ b/.azure-pipelines/meta-check.yml
@@ -1,7 +1,7 @@
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.x'
+    versionSpec: '3.10'
   displayName: 'Set up Python 3'
 
 - script: |

--- a/.azure-pipelines/pre-commit-check.yml
+++ b/.azure-pipelines/pre-commit-check.yml
@@ -15,7 +15,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.x'
+    versionSpec: '3.10'
   displayName: 'Set up Python 3'
 
 - script: |

--- a/.azure-pipelines/pre-commit-check.yml
+++ b/.azure-pipelines/pre-commit-check.yml
@@ -13,10 +13,15 @@ steps:
   clean: true
   displayName: 'checkout sonic-mgmt repo'
 
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.x'
+  displayName: 'Set up Python 3'
+
 - script: |
     set -x
-    sudo pip install pre-commit
-    pre-commit install-hooks
+    python -m pip install pre-commit
+    python -m pre_commit install-hooks
   displayName: 'Prepare pre-commit check'
 
 - script: |
@@ -24,7 +29,7 @@ steps:
     CHANGED_FILES=$(git diff --name-only HEAD^ HEAD)
     FILTERED_FILES=$(echo "$CHANGED_FILES" | grep -v '^tests/common2')
     if [ -n "$FILTERED_FILES" ]; then
-      out=`pre-commit run --color never --files $FILTERED_FILES`
+      out=`python -m pre_commit run --color never --files $FILTERED_FILES`
       RC=$?
     else
       out="No files outside tests/common2 to check."
@@ -75,7 +80,7 @@ steps:
          docker container.
       2. Ensure that the `pre-commit` package is installed:
       ```
-      sudo pip install pre-commit
+      python3 -m pip install pre-commit
       ```
       3. Go to repository root folder
       4. Install the pre-commit hooks:


### PR DESCRIPTION
### Description of PR

Summary:
Provision Python through Azure's `UsePythonVersion` task before running pre-test analysis jobs. This prevents Markers, Dependency, Meta, and Static Analysis checks from failing when the hosted agent image does not include system `pip`/`pip3`.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): PR #27144
Failure type: other

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] N/A

### Test result

- 202512: YAML parsing passed for all four modified templates; targeted pre-commit checks passed.

### Approach
#### What is the motivation for this PR?

Azure pre-test jobs on PR #27144 failed before executing their analysis because the hosted agents had Python 3 but no `pip` or `pip3` commands. The templates currently assume those commands are installed by the base agent image.

#### How did you do it?

Added `UsePythonVersion@0` to the four affected templates and replaced direct `pip`/`pip3` usage with `python -m pip`. The static-analysis template also invokes pre-commit through `python -m pre_commit`, avoiding reliance on the scripts directory being present in `PATH`.

#### How did you verify/test it?

- Parsed all four modified YAML files with PyYAML.
- Ran pre-commit against all four modified templates; every applicable hook passed.
- Ran `git diff --check`.

#### Any platform specific information?

Not applicable.

#### Supported testbed topology if it's a new test case?

Not applicable.

### Documentation

Updated the pre-commit installation instructions embedded in the pipeline failure comment.