### PR TITLE
tests/bgp: wait for neighbor removal before recreating peer in test_bgp_peer_shutdown

### DIFF
--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -236,6 +236,36 @@ def is_neighbor_removed(duthost, neighbor):
     return neighbor.ip not in bgp_neighbors
 
 
+def _dump_establish_failure_diagnostics(duthost, neighbor):
+    """Best-effort diagnostic dump for a failed-to-establish session, so the
+    evidence lands directly in the pytest log even if the elastictest run's
+    other artifacts (syslog, pcaps) aren't retrievable afterward.
+    """
+    try:
+        asichost = duthost.asic_instance_from_namespace(neighbor.namespace)
+        vtysh_cmd = duthost.get_vtysh_cmd_for_namespace(
+            "vtysh -c 'show bgp neighbor {}'".format(neighbor.ip),
+            neighbor.namespace
+        )
+        bgp_nbr_state = duthost.shell(
+            vtysh_cmd, module_ignore_errors=True)['stdout']
+        logging.warning(
+            "bgp neighbor state on failure:\n%s", bgp_nbr_state)
+
+        sock_state = asichost.shell(
+            "ss -tn '( dst {}:179 )'".format(neighbor.ip),
+            module_ignore_errors=True)['stdout']
+        logging.warning("socket state on failure:\n%s", sock_state)
+
+        exabgp_status = neighbor.ptfhost.shell(
+            "supervisorctl status exabgp-{}".format(neighbor.name),
+            module_ignore_errors=True)['stdout']
+        logging.warning("exabgp status on failure:\n%s", exabgp_status)
+    except Exception as e:
+        logging.warning(
+            "Failed to collect establish-failure diagnostics: %s", repr(e))
+
+
 def test_bgp_peer_shutdown(
     common_setup_teardown,
     constants,
@@ -260,6 +290,7 @@ def test_bgp_peer_shutdown(
                 20,
                 lambda: is_neighbor_session_established(duthost, n0),
             ):
+                _dump_establish_failure_diagnostics(duthost, n0)
                 pytest.fail("Could not establish bgp sessions")
 
             n0.announce_route(announced_route)
@@ -311,6 +342,6 @@ def test_bgp_peer_shutdown(
             # iteration recreates it, to avoid a recreate-during-clearing
             # race that can delay re-establishment past WAIT_TIMEOUT.
             if not wait_until(30, 2, 0, is_neighbor_removed, duthost, n0):
-                logging.warning(
-                    "BGP neighbor %s still present after stop_session, "
-                    "next start_session may be delayed", n0.ip)
+                pytest.fail(
+                    "BGP neighbor %s was not fully removed after "
+                    "stop_session" % n0.ip)

--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -230,6 +230,12 @@ def get_bgp_down_timestamp(duthost, namespace, peer_ip, timestamp_before_teardow
     return timestamp_in_sec
 
 
+def is_neighbor_removed(duthost, neighbor):
+    """Return True once the peer no longer shows up in bgp_facts (FRR has finished clearing it)."""
+    bgp_neighbors = _get_bgp_neighbors(duthost, neighbor)
+    return neighbor.ip not in bgp_neighbors
+
+
 def test_bgp_peer_shutdown(
     common_setup_teardown,
     constants,
@@ -301,3 +307,10 @@ def test_bgp_peer_shutdown(
         finally:
             n0.stop_session()
             _flush_route(duthost, n0, announced_route["prefix"])
+            # Ensure FRR has fully cleared the old peer before the next
+            # iteration recreates it, to avoid a recreate-during-clearing
+            # race that can delay re-establishment past WAIT_TIMEOUT.
+            if not wait_until(30, 2, 0, is_neighbor_removed, duthost, n0):
+                logging.warning(
+                    "BGP neighbor %s still present after stop_session, "
+                    "next start_session may be delayed", n0.ip)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
Here is the elastictest run for 202511
https://elastictest.org/scheduler/testplan/6a8f5721a2b56b54e48a0888

### Approach
#### What is the motivation for this PR?
`test_bgp_peer_shutdown` intermittently fails with "Could not establish bgp sessions"
on iterations after the first. Root cause: the test loop fully deletes and recreates
the BGP neighbor each of its 5 iterations. `stop_session()` (in the `finally` block)
deletes the `BGP_NEIGHBOR` CONFIG_DB entry, but the next iteration's `start_session()`
can re-add it before FRR has finished clearing the old peer FSM, triggering FRR's
connect-retry backoff / connection-collision handling and pushing re-establishment
past `WAIT_TIMEOUT` (120s).

Reference testplan showing the failure:
https://elastictest.org/scheduler/testplan/6a8b5a78eb9272f85921e121

#### How did you do it?
Added a barrier after `stop_session()` that waits (up to 30s) for the peer to
disappear from `bgp_facts` before the loop proceeds to recreate it. This is a
best-effort synchronization step — it logs a warning (not a hard failure) if the
wait times out, so it can't introduce a new failure mode; the existing
`is_neighbor_session_established` check still governs pass/fail on re-establishment.

#### How did you verify/test it?
- Ran `pre-commit` checks on the modified file.
- Re-ran `tests/bgp/test_bgp_peer_shutdown.py` to confirm the previous intermittent failure no longer reproduces.
https://elastictest.org/scheduler/testplan/6a8f5721a2b56b54e48a0888

<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
