### PR TITLE
[drop_packets] Improve drop counter failure diagnostics

### DIFF
--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -23,6 +23,10 @@ COMBINED_L2L3_DROP_COUNTER = False
 COMBINED_ACL_DROP_COUNTER = False
 
 
+def _parse_counter_value(value):
+    return int(str(value).replace(",", ""))
+
+
 def get_pkt_drops(duthost, cli_cmd, asic_index=None):
     """
     @summary: Parse output of "portstat" or "intfstat" commands and convert it to the dictionary.
@@ -66,7 +70,7 @@ def ensure_no_l3_drops(duthost, packets_count):
     unexpected_drops = {}
     for iface, value in list(intf_l3_counters.items()):
         try:
-            rx_err_value = int(value[RX_ERR])
+            rx_err_value = _parse_counter_value(value[RX_ERR])
         except ValueError as err:
             logger.info("Unable to verify L3 drops on iface {}, L3 counters may not be supported on this platform\n{}"
                         .format(iface, err))
@@ -83,7 +87,7 @@ def ensure_no_l2_drops(duthost, packets_count):
     unexpected_drops = {}
     for iface, value in list(intf_l2_counters.items()):
         try:
-            rx_drp_value = int(value[RX_DRP])
+            rx_drp_value = _parse_counter_value(value[RX_DRP])
         except ValueError as err:
             logger.warning("Unable to verify L2 drops on iface {}\n{}".format(iface, err))
             continue
@@ -109,21 +113,30 @@ def verify_drop_counters(duthosts, asic_index, dut_iface, get_cnt_cli_cmd, colum
     """ Verify drop counter incremented on specific interface """
     def _get_drops_across_all_duthosts():
         drop_list = []
+        unavailable_list = []
         for duthost in duthosts.frontend_nodes:
             pkt_drops = get_pkt_drops(duthost, get_cnt_cli_cmd)
             # we cannot assume the iface name will be same on all the devices for SONiC chassis
             # if the dut_iface is not found ignore this device
             if dut_iface not in pkt_drops:
                 continue
+            raw_value = pkt_drops[dut_iface][column_key]
             try:
-                drop_list.append(int(pkt_drops[dut_iface][column_key].replace(",", "")))
-            except ValueError:
-                # Catch error invalid literal for int() with base 10: 'N/A'
-                drop_list.append(0)
-        return drop_list
+                drop_list.append(_parse_counter_value(raw_value))
+            except ValueError as err:
+                unavailable_list.append({
+                    "host": duthost.hostname,
+                    "value": raw_value,
+                    "error": str(err),
+                })
+        return drop_list, unavailable_list
 
     def _check_drops_on_dut():
-        return packets_count in _get_drops_across_all_duthosts()
+        drop_list, unavailable_list = _get_drops_across_all_duthosts()
+        if packets_count in drop_list and unavailable_list:
+            logger.warning("Expected drops were observed, but some counter readings were unavailable: {}".format(
+                unavailable_list))
+        return packets_count in drop_list
 
     if not wait_until(25, 1, 0, _check_drops_on_dut):
         # We were seeing a few more drop counters than expected, so we are allowing a small margin of error
@@ -138,13 +151,14 @@ def verify_drop_counters(duthosts, asic_index, dut_iface, get_cnt_cli_cmd, colum
             if config_facts['DEVICE_METADATA']['localhost'].get('subtype', '') == 'DualToR':
                 DROP_MARGIN *= 2
         logger.info(f"The DROP_MARGIN is {DROP_MARGIN}")
-        actual_drop = _get_drops_across_all_duthosts()
+        actual_drop, unavailable_drop = _get_drops_across_all_duthosts()
         for drop in actual_drop:
             if drop >= packets_count and drop <= packets_count + DROP_MARGIN:
                 logger.warning("Actual drops {} exceeded expected drops {} on iface {}\n".format(
                     actual_drop, packets_count, dut_iface))
                 break
         else:
-            fail_msg = "'{}' drop counter was not incremented on iface {}. DUT {} == {}; Sent == {}".format(
-                column_key, dut_iface, column_key, actual_drop, packets_count)
+            fail_msg = "'{}' drop counter was not incremented on iface {}. DUT {} == {}; " \
+                       "unavailable readings == {}; Sent == {}".format(
+                           column_key, dut_iface, column_key, actual_drop, unavailable_drop, packets_count)
             pytest.fail(fail_msg)

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -349,14 +349,27 @@ def do_test(duthosts, weak_server):
             skip_counter_check = True
 
         asic_index = ports_info["asic_index"]
-        base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info, tx_dut_ports,
-                          skip_counter_check=skip_counter_check, drop_information=drop_information,
-                          weak_server=weak_server)
+        counter_failure = None
+        try:
+            base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info, tx_dut_ports,
+                              skip_counter_check=skip_counter_check, drop_information=drop_information,
+                              weak_server=weak_server)
+        # SafeThreadPoolExecutor wraps worker failures in RuntimeError.
+        except (RuntimeError, pytest.fail.Exception) as err:
+            counter_failure = err
 
         # Verify packets were not egresed the DUT
         if discard_group != "NO_DROPS":
             exp_pkt = expected_packet_mask(pkt, ip_ver=ip_ver)
-            testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=sniff_ports)
+            try:
+                testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=sniff_ports)
+            except (AssertionError, pytest.fail.Exception) as err:
+                if counter_failure is not None:
+                    pytest.fail("{}; packet was also observed at egress: {}".format(counter_failure, err))
+                raise
+
+        if counter_failure is not None:
+            raise counter_failure
 
     return do_counters_test
 


### PR DESCRIPTION
### Description of PR

Summary:

Harden `drop_packets/test_drop_counters.py` failure reporting so an intermittent counter failure preserves enough evidence to distinguish these states:

1. The expected drop counter is a real numeric zero.
2. The counter is unavailable or unparseable, for example `N/A`.
3. The packet was dropped but counted somewhere unexpected.
4. The packet was forwarded instead of dropped.

The current helper converts `N/A` to `0` and aborts before no-egress verification. As a result, failures such as `RX_DRP=[0]` cannot establish whether the DUT reported zero, the counter was unavailable, or the packet was forwarded.

This PR also normalizes comma-formatted values such as `1,000`, which previously caused valid counters to be treated as unparseable in the negative-counter checks.

Fixes # (issue): N/A

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: intermittent test-observability issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- Repository pre-commit hooks passed for both changed files, including Python AST and flake8 checks.
- Targeted helper checks passed for:
  - comma-formatted string values such as `1,000`;
  - numeric JSON counter values;
  - a real numeric zero versus an unavailable `N/A` value;
  - propagation of counter failures after no-egress verification;
  - combined reporting when counter verification and no-egress verification both fail.
- The intermittent scenario was investigated on `vms13-lt2-nh4210-1`, DUT `str4-nh4210-01`, image `SONiC.20251210.12`, Broadcom Tomahawk6:
  - fixed-port expired-TTL traffic on `Ethernet76` passed five valid repetitions;
  - one malformed-header repetition also passed;
  - an A/B stress experiment compared 12 immediate-send cycles after counter clear with 12 cycles gated on two stable zero reads;
  - all 24 A/B cycles reported exactly 1,000 `RX_DRP` packets and no packet egress.

The A/B result does not support adding a fixed sleep as a solution. This PR therefore improves state preservation and diagnostics without adding a timing workaround, platform skip, xfail, or wider counter tolerance.

### Approach

#### What is the motivation for this PR?

Intermittent `test_drop_counters.py` failures currently lose two pieces of evidence:

- `verify_drop_counters()` catches a conversion failure for values such as `N/A` and appends numeric `0`. The final failure is therefore indistinguishable from a genuine zero counter.
- `do_counters_test()` performs counter verification before `verify_no_packet_any()`. A counter assertion stops the test immediately, so the log cannot say whether the packet was correctly dropped, incorrectly forwarded, or never reached the expected ingress counter.

This makes an intermittent platform, counter-infrastructure, or packet-delivery problem impossible to classify from the nightly log alone.

#### How did you do it?

1. Added one counter-value parser that accepts strings with thousands separators and numeric JSON values.
2. Changed drop-counter polling to maintain separate collections for numeric readings and unavailable readings.
3. Included DUT hostname, raw counter value, and conversion error for every unavailable reading in the final assertion.
4. Added a warning when one DUT reports the expected value while another DUT reports an unavailable value, preserving mixed multi-DUT evidence without changing existing pass criteria.
5. Preserved the counter failure while still running no-egress verification.
6. Accounted for `SafeThreadPoolExecutor` wrapping worker assertions in `RuntimeError`.
7. If both checks fail, report the original counter failure together with the observed packet egress. If no egress is observed, re-raise the original counter failure unchanged.

The expected packet count, polling duration, drop margin, packet construction, platform selection, and skip behavior are unchanged.

#### How did you verify/test it?

Validated the parsing and exception-flow paths with focused mocks, then ran the repository pre-commit checks on both modified files. The associated `.12` hardware experiment verified that immediate versus readiness-gated counter clearing did not change the result, preventing an unsupported sleep-based workaround from being included.

#### Any platform specific information?

The motivating failures were observed on Nexthop NH-4210 (`NH-4210-F-O256`, Broadcom Tomahawk6), but the changed helpers are platform-independent and retain existing multi-DUT behavior.

#### Supported testbed topology if it's a new test case?

N/A; no new test case is added.

### Documentation

N/A; this changes internal test diagnostics and does not alter a user-facing interface.