### PR TITLE
[202511][gnmi] Skip gNOI warm reboot test

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2631,7 +2631,7 @@ gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_halt:
 
 gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm:
   skip:
-    reason: "Warm reboot should only run on t0 topology but not on dualtor"
+    reason: "Warm reboot is unsupported on this topology/release, or exceeds the timeout on Arista-7060CX-32S-D48C8 in 202511"
     conditions_logical_operator: or
     conditions:
       - "topo_type not in ['t0']"
@@ -2639,6 +2639,7 @@ gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm:
       - "'isolated' in topo_name"
       - "release in ['202412']"
       - "'f2' in topo_name"
+      - "hwsku in ['Arista-7060CX-32S-D48C8']"
 
 ###############################################
 #####       golden_config_infra           #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2631,7 +2631,7 @@ gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_halt:
 
 gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm:
   skip:
-    reason: "Warm reboot is unsupported on this topology/release, or exceeds the timeout on Arista-7060CX-32S-D48C8 in 202511"
+    reason: "Warm reboot is unsupported on this topology or release"
     conditions_logical_operator: or
     conditions:
       - "topo_type not in ['t0']"
@@ -2639,7 +2639,7 @@ gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm:
       - "'isolated' in topo_name"
       - "release in ['202412']"
       - "'f2' in topo_name"
-      - "hwsku in ['Arista-7060CX-32S-D48C8']"
+      - "release in ['202511']"
 
 ###############################################
 #####       golden_config_infra           #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2631,7 +2631,7 @@ gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_halt:
 
 gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm:
   skip:
-    reason: "Warm reboot is unsupported on this topology or release"
+    reason: "Skip gNOI warm reboot on unsupported topologies and releases that use CLI warm reboot"
     conditions_logical_operator: or
     conditions:
       - "topo_type not in ['t0']"

--- a/tests/gnmi/test_gnoi_system_reboot.py
+++ b/tests/gnmi/test_gnoi_system_reboot.py
@@ -148,7 +148,7 @@ def test_gnoi_system_reboot_warm(duthosts, rand_one_dut_hostname, localhost):
 
     # Wait for critical processes before ending
     # Warm reboot takes longer for containers to restart; use an extended timeout
-    wait_critical_processes(duthost, timeout=600)
+    wait_critical_processes(duthost, timeout=360)
 
     # Wait for gNMI container to be running
     wait_until(120, 10, 0, is_gnmi_container_running, duthost)

--- a/tests/gnmi/test_gnoi_system_reboot.py
+++ b/tests/gnmi/test_gnoi_system_reboot.py
@@ -148,7 +148,7 @@ def test_gnoi_system_reboot_warm(duthosts, rand_one_dut_hostname, localhost):
 
     # Wait for critical processes before ending
     # Warm reboot takes longer for containers to restart; use an extended timeout
-    wait_critical_processes(duthost, timeout=360)
+    wait_critical_processes(duthost, timeout=600)
 
     # Wait for gNMI container to be running
     wait_until(120, 10, 0, is_gnmi_container_running, duthost)


### PR DESCRIPTION
### Description of PR

Summary:

Skip the gNOI `test_gnoi_system_reboot_warm` test for the `202511` release.
Warm reboot remains supported on 202511 through the CLI path; this change only
disables the gNOI invocation.

The timeout fix in #25124 was not accepted for 202511 and was included in
202605 instead. This branch-specific skip prevents the known warm-reboot
critical-process timeout from repeatedly failing 202511 nightly runs.

Related issue: #25956

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

Tracking issue/work item for backport/cherry-pick request: #25956
Failure type: release maintenance; 202511 uses CLI warm reboot instead of gNOI

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- 202511: `SONiC.202511.1200020-fde92d26c` -
  [Elastictest plan](https://elastictest.org/scheduler/testplan/6a8ce4cd51f39cced790fa6b):
  exact gNOI warm-reboot node collected once and skipped once, with zero
  failures or errors; no reboot RPC ran.

### Approach

#### What is the motivation for this PR?

`test_gnoi_system_reboot_warm` failed 5/5 times on three
`Arista-7060CX-32S-D48C8` DUTs in a `SONiC.20251110.45` nightly. The WARM
reboot RPC and SSH recovery succeeded, but the test exhausted its 360-second
critical-process timeout while `snmpd` and `snmp-subagent` were still starting.

#25124 raises the timeout to 600 seconds and is included in 202605, but its
202511 backport was rejected as too late. The lower-risk maintenance action is
to skip the gNOI test for the 202511 release rather than carry the timeout
change. Warm reboot itself remains supported through the CLI path.

#### How did you do it?

Added `release in ['202511']` to the existing conditional-mark entry for
`gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm`. No test logic
or timeout is changed.

#### How did you verify/test it?

- Parsed `tests_mark_conditions.yaml` with `yaml.safe_load`.
- Evaluated the conditional-mark plugin directly for the exact pytest node:
  `release=202511` adds the skip and `release=202605` does not.
- Ran the exact node from public PR #27296 on a public 202511 T0 KVM:
  [Elastictest plan](https://elastictest.org/scheduler/testplan/6a8ce4cd51f39cced790fa6b).
- Image: `SONiC.202511.1200020-fde92d26c`; DUT facts reported
  `release: 202511`.
- Result: 1 collected, 1 skipped, 0 failures, 0 errors in 15.78 seconds.
- Skip reason before reviewer clarification: `Warm reboot is unsupported on
  this topology or release`. The wording is updated to clarify that 202511 uses
  CLI warm reboot instead of gNOI; the validated condition is unchanged.
- The retained module log contains no `System.Reboot`, `gnoi_request`, or
  `RPC_COMPLETION` runtime invocation, confirming the test body did not run.
- Verified the final PR diff changes only the conditional-mark YAML.
- `git diff --check` passed.

No internal sonic-mgmt branch or physical NIGHTLY plan is used for this
public-only change.

#### Any platform specific information?

N/A. The condition is release-wide for 202511.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
