### PR TITLE
[202511] snappi/pfcwd: gate post-restart traffic on lossless PG readiness and enable the basic PFCWD tests on VOQ/Broadcom-DNX (#25950)

### DIFF
--- a/tests/common/broadcom_data.py
+++ b/tests/common/broadcom_data.py
@@ -2,6 +2,10 @@ def is_broadcom_device(dut):
     return dut.facts["asic_type"] == "broadcom"
 
 
+def is_broadcom_dnx_device(dut):
+    return dut.facts.get("platform_asic") == "broadcom-dnx"
+
+
 LOSSY_ONLY_HWSKUS = ['Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8',
                      'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']
 NO_QOS_HWSKUS = ['Arista-7050CX3-32C-C28S16', 'Arista-7050CX3-32C-S128',

--- a/tests/common/nexthop_data.py
+++ b/tests/common/nexthop_data.py
@@ -1,0 +1,41 @@
+def is_nexthop_device(dut):
+    """Return True if the device is a Nexthop platform."""
+    return "nexthop" in dut.facts["platform"].lower()
+
+
+class NexthopPlatform:
+    """
+    Query Nexthop platform capabilities.
+
+    Capabilities default to supported; a platform opts out by listing the
+    capability in _UNSUPPORTED, keyed by hwsku prefix. A SKU absent from the
+    table is treated as supporting the capability.
+    """
+
+    # hwsku-prefix -> set of capabilities that platform does NOT support
+    _UNSUPPORTED = {
+        "NH-5010": {"warm_reboot", "fast_reboot"},
+    }
+
+    def __init__(self, dut):
+        self.dut = dut
+        self.hwsku = dut.facts["hwsku"]
+        self.platform = dut.facts["platform"]
+
+    @property
+    def is_nexthop(self):
+        return is_nexthop_device(self.dut)
+
+    def _unsupported(self):
+        caps = set()
+        for prefix, unsupported in self._UNSUPPORTED.items():
+            if self.hwsku.startswith(prefix):
+                caps |= unsupported
+        return caps
+
+    def supports(self, capability):
+        # Non-Nexthop boxes aren't described by this table; report True so a
+        # caller that forgot to guard with is_nexthop doesn't wrongly skip.
+        if not self.is_nexthop:
+            return True
+        return capability not in self._unsupported()

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -22,13 +22,14 @@ import json
 import re
 from netaddr import IPNetwork
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
+from tests.common.broadcom_data import is_broadcom_dnx_device
 from ipaddress import IPv6Network, IPv6Address
 import ipaddress
 from random import getrandbits
 from tests.common.portstat_utilities import parse_portstat
 from collections import defaultdict
 from tests.conftest import parse_override
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
@@ -762,6 +763,34 @@ def get_pfcwd_restore_time(host_ans, intf, asic_value=None):
     return None
 
 
+def get_pfcwd_timers(host_ans, intf, asic_value=None):
+    """
+    Get PFC watchdog timers for a given interface, skipping the test if they are
+    not configured.
+
+    PFC watchdog config is only populated when 'default_pfcwd_status' is enabled
+    on the DUT; otherwise the timers read back as None and any pfcwd test cannot
+    run. Reusable by any pfcwd test that needs the timers.
+
+    Args:
+        host_ans: Ansible host instance of the device
+        intf (str): interface name
+        asic_value: asic value of the host
+
+    Returns:
+        dict with 'poll_interval', 'detection_time' and 'restoration_time' in seconds.
+    """
+    timers = {
+        'poll_interval': get_pfcwd_poll_interval(host_ans, asic_value),
+        'detection_time': get_pfcwd_detect_time(host_ans, intf, asic_value),
+        'restoration_time': get_pfcwd_restore_time(host_ans, intf, asic_value),
+    }
+    pytest_require(None not in timers.values(),
+                   "PFC watchdog is not configured on {} port {}: {}; skipping test"
+                   .format(host_ans.hostname, intf, timers))
+    return {key: val / 1000.0 for key, val in timers.items()}
+
+
 def get_pfcwd_stats(duthost, port, prio, asic_value=None):
     """
     Get PFC watchdog statistics for given interface:prio
@@ -831,6 +860,47 @@ def stop_pfcwd(duthost, asic_value=None):
         duthost.shell('sudo ip netns exec {} pfcwd stop'.format(asic_value))
 
 
+def _set_credit_watchdog(duthost, enable, asic_value=None):
+    """
+    Enable/disable the VOQ credit watchdog by setting the SWITCH_TABLE:switch 'credit_watchdog'
+    field in APPL_DB, which SwitchOrch maps to the SAI_SWITCH_ATTR_CREDIT_WD switch attribute.
+
+    Args:
+        duthost (AnsibleHost): Device Under Test (DUT)
+        enable (bool): True to enable the watchdog, False to disable it
+        asic_value (str): asic namespace to target (e.g. 'asic0'). None targets the
+            default namespace, or every asic namespace on a multi-asic DUT.
+    """
+    if not is_broadcom_dnx_device(duthost):
+        logger.info("Credit watchdog not applicable on platform %s; skipping",
+                    duthost.facts.get("platform_asic"))
+        return
+    if asic_value:
+        namespaces = [asic_value]
+    elif duthost.is_multi_asic:
+        namespaces = [asic.namespace for asic in duthost.frontend_asics]
+    else:
+        namespaces = ['']
+    value = "1" if enable else "0"
+    for ns in namespaces:
+        # 'credit_watchdog' is the exact SWITCH_TABLE field SwitchOrch consumes and maps
+        # to SAI_SWITCH_ATTR_CREDIT_WD (sonic-swss #4658; on images without that support
+        # SwitchOrch logs 'Unsupported switch attribute' and the write is a no-op).
+        pyscript = (
+            "from swsscommon.swsscommon import SonicDBConfig, DBConnector, ProducerStateTable; "
+            # Namespaced redis is reached via unix socket and needs the global db config;
+            # the default namespace keeps the existing TCP connection unchanged.
+            + ("SonicDBConfig.load_sonic_global_db_config(); "
+               "db = DBConnector('APPL_DB', 0, False, '{}'); ".format(ns) if ns
+               else "db = DBConnector('APPL_DB', 0, True); ")
+            + "p = ProducerStateTable(db, 'SWITCH_TABLE'); "
+              "p.set('switch', [('credit_watchdog', '{}')])".format(value)
+        )
+        duthost.shell('sudo python3 -c "{}"'.format(pyscript))
+        logger.info("%s VOQ credit watchdog via APPL_DB SWITCH_TABLE credit_watchdog=%s (namespace: %s)",
+                    'Enabled' if enable else 'Disabled', value, ns or 'default')
+
+
 def disable_packet_aging(duthost, asic_value=None):
     """
     Disable packet aging feature
@@ -845,20 +915,11 @@ def disable_packet_aging(duthost, asic_value=None):
         duthost.command("docker cp /tmp/packets_aging.py syncd:/")
         duthost.command("docker exec syncd python /packets_aging.py disable")
         duthost.command("docker exec syncd rm -rf /packets_aging.py")
-    elif "platform_asic" in duthost.facts and duthost.facts["platform_asic"] == "broadcom-dnx":
-        # if asic_value is present, disable packet aging for specific asic_value.
-        if (asic_value):
-            try:
-                duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog disable"'.format(asic_value))
-            except Exception:
-                duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog disable"'.format(asic_value[-1]))
-        else:
-            # Disabling packet aging for all asics on given DUT.
-            for asic_value in duthost.facts['asics_present']:
-                try:
-                    duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog disable"'.format(asic_value))
-                except Exception:
-                    duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog disable"'.format(asic_value[-1]))
+    elif is_broadcom_dnx_device(duthost):
+        _set_credit_watchdog(duthost, enable=False, asic_value=asic_value)
+    else:
+        logger.info("Packet aging disable not needed on this platform (%s)",
+                    duthost.facts.get("platform_asic"))
 
 
 def enable_packet_aging(duthost, asic_value=None):
@@ -875,20 +936,11 @@ def enable_packet_aging(duthost, asic_value=None):
         duthost.command("docker cp /tmp/packets_aging.py syncd:/")
         duthost.command("docker exec syncd python /packets_aging.py enable")
         duthost.command("docker exec syncd rm -rf /packets_aging.py")
-    elif "platform_asic" in duthost.facts and duthost.facts["platform_asic"] == "broadcom-dnx":
-        # if asic_value is present, enable packet aging for specific asic_value.
-        if (asic_value):
-            try:
-                duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog enable"'.format(asic_value))
-            except Exception:
-                duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog enable"'.format(asic_value[-1]))
-        else:
-            # Enabling packet aging for all asics on given DUT.
-            for asic_value in duthost.facts['asics_present']:
-                try:
-                    duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog enable"'.format(asic_value))
-                except Exception:
-                    duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog enable"'.format(asic_value[-1]))
+    elif is_broadcom_dnx_device(duthost):
+        _set_credit_watchdog(duthost, enable=True, asic_value=asic_value)
+    else:
+        logger.info("Packet aging enable not needed on this platform (%s)",
+                    duthost.facts.get("platform_asic"))
 
 
 def get_ipv6_addrs_in_subnet(subnet, number_of_ip, exclude_ips=None):
@@ -1063,6 +1115,7 @@ def check_tx_drp_counts(
     raw_out = duthost.shell(cmd)["stdout"]
 
     raw_json_str = re.sub(r"^(?:(?!{).)*\n", "", raw_out, count=1)
+    stats = {}
     try:
         stats = json.loads(raw_json_str)
     except Exception as e:
@@ -1076,7 +1129,7 @@ def check_tx_drp_counts(
     details = {} if verbose else None
 
     for p in ports:
-        pytest_assert(p in stats, f"Port {p} not found in portstat output")
+        pytest_assert(p in stats, f"Port {p} missing from portstat output")
         tx_drp_raw = stats[p].get("TX_DRP")
         pytest_assert(tx_drp_raw is not None, f"TX_DRP field missing for port {p}")
         try:
@@ -1242,7 +1295,7 @@ def config_capture_settings(api,
     for port_name in port_names:
         port = ixnet_session.Vport.find(Name=port_name)
         if not port:
-            raise ValueError(f"Port '{port_name}' not found in IxNetwork session")
+            raise ValueError(f"Port '{port_name}' missing from IxNetwork session")
 
         port.Capture.HardwareEnabled = True  # enables data plane capture
         port.Capture.Filter.CaptureFilterEnable = True

--- a/tests/ixia/files/helper.py
+++ b/tests/ixia/files/helper.py
@@ -1,4 +1,5 @@
 from tests.common.broadcom_data import is_broadcom_device
+from tests.common.nexthop_data import NexthopPlatform
 from tests.common.helpers.assertions import pytest_require
 
 
@@ -15,5 +16,8 @@ def skip_warm_reboot(duthost, reboot_type):
     """
     SKIP_LIST = ["td2"]
     asic_type = duthost.get_asic_name()
-    pytest_require(not (is_broadcom_device(duthost) and asic_type in SKIP_LIST and "warm" in reboot_type),
-                   "Warm reboot is not supported on {}".format(asic_type))
+    skip_reboot = (is_broadcom_device(duthost) and asic_type in SKIP_LIST and "warm" in reboot_type) or \
+                  (reboot_type in ("warm", "fast") and
+                   not NexthopPlatform(duthost).supports("{}_reboot".format(reboot_type)))
+    pytest_require(not skip_reboot,
+                   "{} reboot is not supported on {}".format(reboot_type, asic_type))

--- a/tests/snappi_tests/conftest.py
+++ b/tests/snappi_tests/conftest.py
@@ -61,18 +61,18 @@ def start_pfcwd_after_test(duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture(autouse=True, scope="module")
-def enable_packet_aging_after_test(duthosts, rand_one_dut_hostname):
+def enable_packet_aging_after_test(duthosts):
     """
     Ensure that packet aging is enabled after tests
 
     Args:
         duthosts (pytest fixture) : list of DUTs
-        rand_one_dut_hostname (pytest fixture): DUT hostname
 
     Yields:
         N/A
     """
     yield
 
-    duthost = duthosts[rand_one_dut_hostname]
-    enable_packet_aging(duthost)
+    # Tests disable aging on both ingress and egress DUTs; restore every frontend DUT.
+    for duthost in duthosts.frontend_nodes:
+        enable_packet_aging(duthost)

--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -7,6 +7,7 @@ from tests.common.broadcom_data import is_broadcom_device
 from tests.common.helpers.assertions import pytest_require
 from tests.common.cisco_data import is_cisco_device
 from tests.common.nokia_data import is_nokia_device
+from tests.common.nexthop_data import NexthopPlatform
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.common.config_reload import config_reload
 from tests.common.reboot import reboot
@@ -36,19 +37,27 @@ def skip_warm_reboot(duthost, reboot_type):
     """
     SKIP_LIST = ["td2", "jr2", "j2c+"]
     asic_type = duthost.get_asic_name()
-    reboot_case_supported = True
+    # Each branch states the check it actually applied, so the skip log points at
+    # the real gate instead of a generic vendor-wide claim.
+    skip_reason = None
     if (reboot_type == "fast") and asic_type in ["jr2", "j2c+"]:
-        reboot_case_supported = False
+        skip_reason = "Reboot type {} is not supported on {} asics".format(reboot_type, asic_type)
     elif (reboot_type == "warm" or reboot_type == "fast") and is_cisco_device(duthost):
-        reboot_case_supported = False
+        skip_reason = "Reboot type {} is not supported on Cisco switches".format(reboot_type)
     elif (reboot_type == "warm" or reboot_type == "fast") and is_nokia_device(duthost):
-        reboot_case_supported = False
+        skip_reason = "Reboot type {} is not supported on Nokia switches".format(reboot_type)
+    elif reboot_type in ("warm", "fast") and \
+            not NexthopPlatform(duthost).supports("{}_reboot".format(reboot_type)):
+        skip_reason = "Reboot type {} is not supported on hwsku {}".format(
+            reboot_type, duthost.facts['hwsku'])
     elif is_broadcom_device(duthost) and asic_type in SKIP_LIST and "warm" in reboot_type:
-        reboot_case_supported = False
-    msg = "Reboot type {} is {} supported on {} switches".format(
-            reboot_type, "" if reboot_case_supported else "not", duthost.facts['asic_type'])
-    logger.info(msg)
-    pytest_require(reboot_case_supported, msg)
+        skip_reason = "Reboot type {} is not supported on {} asics".format(reboot_type, asic_type)
+    if skip_reason is None:
+        logger.info("Reboot type %s is supported on %s (hwsku %s)",
+                    reboot_type, duthost.hostname, duthost.facts['hwsku'])
+    else:
+        logger.info(skip_reason)
+    pytest_require(skip_reason is None, skip_reason or "")
 
 
 def skip_ecn_tests(duthost):

--- a/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
@@ -2,12 +2,17 @@ import time
 from math import ceil
 import logging
 
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.broadcom_data import is_broadcom_device
+from tests.common.cisco_data import is_cisco_device
+from tests.common.nexthop_data import is_nexthop_device
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                              # noqa: F401
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
-    get_pfcwd_poll_interval, get_pfcwd_detect_time, get_pfcwd_restore_time, \
-    enable_packet_aging, start_pfcwd, sec_to_nanosec, get_pfcwd_stats                             # noqa: F401
+    get_pfcwd_timers, disable_packet_aging, enable_packet_aging, \
+    start_pfcwd, sec_to_nanosec, get_pfcwd_stats, get_pfcwd_poll_interval    # noqa: F401
+from tests.common.helpers.pfcwd_helper import update_pfc_poll_interval
+from tests.common.config_reload import pfcwd_feature_enabled
 from tests.common.snappi_tests.port import select_ports, select_tx_port                           # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp                                 # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
@@ -26,6 +31,8 @@ DATA_PKT_SIZE = 1024
 SNAPPI_POLL_DELAY_SEC = 2
 DEVIATION = 0.3
 UDP_PORT_START = 5000
+# Keep poll well below detection_time so a sub-detection pause can't trip pfcwd in one poll.
+PFCWD_POLL_INTERVAL_MS = 100
 
 
 def run_pfcwd_basic_test(api,
@@ -70,114 +77,128 @@ def run_pfcwd_basic_test(api,
     ingress_duthost = tx_port["duthost"]
     pytest_assert(testbed_config is not None, 'Fail to get L2/3 testbed config')
 
-    if (egress_duthost.is_multi_asic):
-        enable_packet_aging(egress_duthost, rx_port['asic_value'])
-        enable_packet_aging(ingress_duthost, tx_port['asic_value'])
-        start_pfcwd(egress_duthost, rx_port['asic_value'])
-        start_pfcwd(ingress_duthost, tx_port['asic_value'])
-    else:
-        enable_packet_aging(egress_duthost)
-        enable_packet_aging(ingress_duthost)
-        start_pfcwd(egress_duthost)
-        start_pfcwd(ingress_duthost)
+    # Skip early, before touching the DUT, if pfcwd is neither running nor startable.
+    cfg = egress_duthost.get_running_config_facts()
+    pytest_require(bool(cfg.get('PFC_WD')) or pfcwd_feature_enabled(egress_duthost),
+                   "PFC watchdog cannot be started on {}; skipping".format(egress_duthost.hostname))
 
-    ini_stats = {}
-    for prio in prio_list:
-        ini_stats.update(get_stats(egress_duthost, rx_port['peer_port'], prio))
+    orig_poll_interval_ms = {}
+    try:
+        for duthost, asic_value in ((egress_duthost, rx_port['asic_value']),
+                                    (ingress_duthost, tx_port['asic_value'])):
+            # Disable packet aging only on Nexthop (VOQ/DNX) DUTs; others keep it enabled.
+            packet_aging = disable_packet_aging if is_nexthop_device(duthost) else enable_packet_aging
+            packet_aging(duthost, asic_value)
+            start_pfcwd(duthost, asic_value)
+            if is_nexthop_device(duthost) and duthost not in orig_poll_interval_ms:
+                # `pfcwd interval` is host-global: once per DUT, else a repeat DUT re-reads our own override.
+                orig_poll_interval_ms[duthost] = get_pfcwd_poll_interval(duthost, asic_value)
+                update_pfc_poll_interval(duthost, PFCWD_POLL_INTERVAL_MS)
 
-    # Set appropriate pfcwd loss deviation - these values are based on empirical testing
-    DEVIATION = 0.35 if egress_duthost.facts['asic_type'] in ["broadcom"] or \
-        ingress_duthost.facts['asic_type'] in ["broadcom"] else 0.3
-    if "cisco-8000" in (egress_duthost.facts['asic_type'],
-                        ingress_duthost.facts['asic_type']):
-        DEVIATION = 0.5
+        # Must run after the setup loop above so the timers reflect what the DUT runs with.
+        timers = get_pfcwd_timers(egress_duthost, dut_port, rx_port['asic_value'])
+        poll_interval_sec = timers['poll_interval']
+        detect_time_sec = timers['detection_time']
+        restore_time_sec = timers['restoration_time']
 
-    poll_interval_sec = get_pfcwd_poll_interval(egress_duthost, rx_port['asic_value']) / 1000.0
-    detect_time_sec = get_pfcwd_detect_time(host_ans=egress_duthost, intf=dut_port,
-                                            asic_value=rx_port['asic_value']) / 1000.0
-    restore_time_sec = get_pfcwd_restore_time(host_ans=egress_duthost, intf=dut_port,
-                                              asic_value=rx_port['asic_value']) / 1000.0
+        ini_stats = {}
+        for prio in prio_list:
+            ini_stats.update(get_stats(egress_duthost, rx_port['peer_port'], prio))
 
-    """ Warm up traffic is initially sent before any other traffic to prevent pfcwd
-    fake alerts caused by idle links (non-incremented packet counters) during pfcwd detection periods """
-    warm_up_traffic_dur_sec = WARM_UP_TRAFFIC_DUR
-    warm_up_traffic_delay_sec = 0
+        # Set appropriate pfcwd loss deviation - these values are based on empirical testing
+        if is_cisco_device(egress_duthost) or is_cisco_device(ingress_duthost):
+            DEVIATION = 0.5
+        elif is_broadcom_device(egress_duthost) or is_broadcom_device(ingress_duthost):
+            DEVIATION = 0.35
+        else:
+            DEVIATION = 0.3
 
-    if trigger_pfcwd:
-        """ Large enough to trigger PFC watchdog """
-        pfc_storm_dur_sec = ceil(detect_time_sec + poll_interval_sec + 0.1)
+        """ Warm up traffic is initially sent before any other traffic to prevent pfcwd
+        fake alerts caused by idle links (non-incremented packet counters) during pfcwd detection periods """
+        warm_up_traffic_dur_sec = WARM_UP_TRAFFIC_DUR
+        warm_up_traffic_delay_sec = 0
 
-        flow1_delay_sec = restore_time_sec / 2 + WARM_UP_TRAFFIC_DUR
-        flow1_dur_sec = pfc_storm_dur_sec
+        if trigger_pfcwd:
+            """ Large enough to trigger PFC watchdog """
+            pfc_storm_dur_sec = ceil(detect_time_sec + poll_interval_sec + 0.1)
 
-        """ Start data traffic 2 after PFC is restored """
-        flow2_delay_sec = pfc_storm_dur_sec + restore_time_sec + \
-            poll_interval_sec + WARM_UP_TRAFFIC_DUR
-        flow2_dur_sec = 1
+            flow1_delay_sec = restore_time_sec / 2 + WARM_UP_TRAFFIC_DUR
+            flow1_dur_sec = pfc_storm_dur_sec
 
-        flow1_max_loss_rate = 1
-        flow1_min_loss_rate = 1 - DEVIATION
+            """ Start data traffic 2 after PFC is restored """
+            flow2_delay_sec = pfc_storm_dur_sec + restore_time_sec + \
+                poll_interval_sec + WARM_UP_TRAFFIC_DUR
+            flow2_dur_sec = 1
 
-    else:
-        pfc_storm_dur_sec = detect_time_sec * 0.5
-        flow1_delay_sec = pfc_storm_dur_sec * 0.1 + WARM_UP_TRAFFIC_DUR
-        flow1_dur_sec = ceil(pfc_storm_dur_sec)
+            flow1_max_loss_rate = 1
+            flow1_min_loss_rate = 1 - DEVIATION
 
-        """ Start data traffic 2 after the completion of data traffic 1 """
-        flow2_delay_sec = flow1_delay_sec + flow1_dur_sec + WARM_UP_TRAFFIC_DUR + 0.1
-        flow2_dur_sec = 1
+        else:
+            pfc_storm_dur_sec = detect_time_sec * 0.5
+            flow1_delay_sec = pfc_storm_dur_sec * 0.1 + WARM_UP_TRAFFIC_DUR
+            flow1_dur_sec = ceil(pfc_storm_dur_sec)
 
-        flow1_max_loss_rate = 0
-        flow1_min_loss_rate = 0
+            """ Start data traffic 2 after the completion of data traffic 1 """
+            flow2_delay_sec = flow1_delay_sec + flow1_dur_sec + WARM_UP_TRAFFIC_DUR + 0.1
+            flow2_dur_sec = 1
 
-    exp_dur_sec = flow2_delay_sec + flow2_dur_sec + 1
-    cisco_platform = "Cisco" in egress_duthost.facts['hwsku']
-    number_of_streams = get_number_of_streams(egress_duthost, tx_port, rx_port)
+            flow1_max_loss_rate = 0
+            flow1_min_loss_rate = 0
 
-    """ Generate traffic config """
-    __gen_traffic(testbed_config=testbed_config,
-                  port_config_list=port_config_list,
-                  port_id=0,
-                  pause_flow_name=PAUSE_FLOW_NAME,
-                  pause_flow_dur_sec=pfc_storm_dur_sec,
-                  data_flow_name_list=[WARM_UP_TRAFFIC_NAME,
-                                       DATA_FLOW1_NAME, DATA_FLOW2_NAME],
-                  data_flow_delay_sec_list=[
-                      warm_up_traffic_delay_sec, flow1_delay_sec, flow2_delay_sec],
-                  data_flow_dur_sec_list=[
-                      warm_up_traffic_dur_sec, flow1_dur_sec, flow2_dur_sec],
-                  data_pkt_size=DATA_PKT_SIZE,
-                  prio_list=prio_list,
-                  prio_dscp_map=prio_dscp_map,
-                  traffic_rate=49.99 if cisco_platform else 100.0,
-                  number_of_streams=number_of_streams)
+        exp_dur_sec = flow2_delay_sec + flow2_dur_sec + 1
+        cisco_platform = "Cisco" in egress_duthost.facts['hwsku']
+        number_of_streams = get_number_of_streams(egress_duthost, tx_port, rx_port)
 
-    flows = testbed_config.flows
+        """ Generate traffic config """
+        __gen_traffic(testbed_config=testbed_config,
+                      port_config_list=port_config_list,
+                      port_id=0,
+                      pause_flow_name=PAUSE_FLOW_NAME,
+                      pause_flow_dur_sec=pfc_storm_dur_sec,
+                      data_flow_name_list=[WARM_UP_TRAFFIC_NAME,
+                                           DATA_FLOW1_NAME, DATA_FLOW2_NAME],
+                      data_flow_delay_sec_list=[
+                          warm_up_traffic_delay_sec, flow1_delay_sec, flow2_delay_sec],
+                      data_flow_dur_sec_list=[
+                          warm_up_traffic_dur_sec, flow1_dur_sec, flow2_dur_sec],
+                      data_pkt_size=DATA_PKT_SIZE,
+                      prio_list=prio_list,
+                      prio_dscp_map=prio_dscp_map,
+                      traffic_rate=49.99 if cisco_platform else 100.0,
+                      number_of_streams=number_of_streams)
 
-    all_flow_names = [flow.name for flow in flows]
+        flows = testbed_config.flows
 
-    flow_stats = __run_traffic(api=api,
-                               config=testbed_config,
-                               all_flow_names=all_flow_names,
-                               exp_dur_sec=exp_dur_sec)
+        all_flow_names = [flow.name for flow in flows]
 
-    fin_stats = {}
-    for prio in prio_list:
-        fin_stats.update(get_stats(egress_duthost, rx_port['peer_port'], prio))
+        flow_stats = __run_traffic(api=api,
+                                   config=testbed_config,
+                                   all_flow_names=all_flow_names,
+                                   exp_dur_sec=exp_dur_sec)
 
-    loss_packets = 0
-    for k in fin_stats.keys():
-        logger.info('Parameter:{}, Initial Value:{}, Final Value:{}'.format(k, ini_stats[k], fin_stats[k]))
-        if 'DROP' in k:
-            loss_packets += (int(fin_stats[k]) - int(ini_stats[k]))
+        fin_stats = {}
+        for prio in prio_list:
+            fin_stats.update(get_stats(egress_duthost, rx_port['peer_port'], prio))
 
-    logger.info('Total PFCWD drop packets before and after the test:{}'.format(loss_packets))
+        loss_packets = 0
+        for k in fin_stats.keys():
+            logger.info('Parameter:{}, Initial Value:{}, Final Value:{}'.format(k, ini_stats[k], fin_stats[k]))
+            if 'DROP' in k:
+                loss_packets += (int(fin_stats[k]) - int(ini_stats[k]))
 
-    __verify_results(rows=flow_stats,
-                     data_flow_name_list=[DATA_FLOW1_NAME, DATA_FLOW2_NAME],
-                     data_flow_min_loss_rate_list=[flow1_min_loss_rate, 0],
-                     data_flow_max_loss_rate_list=[flow1_max_loss_rate, 0],
-                     loss_packets=loss_packets)
+        logger.info('Total PFCWD drop packets before and after the test:{}'.format(loss_packets))
+
+        __verify_results(rows=flow_stats,
+                         data_flow_name_list=[DATA_FLOW1_NAME, DATA_FLOW2_NAME],
+                         data_flow_min_loss_rate_list=[flow1_min_loss_rate, 0],
+                         data_flow_max_loss_rate_list=[flow1_max_loss_rate, 0],
+                         loss_packets=loss_packets)
+    finally:
+        # Restore the pre-test poll interval overridden above (runtime-only config).
+        # get_pfcwd_poll_interval may return None, in which case there is nothing to restore.
+        for duthost, orig in orig_poll_interval_ms.items():
+            if orig:
+                update_pfc_poll_interval(duthost, orig)
 
 
 def get_stats(duthost, port, prio):

--- a/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -16,6 +16,7 @@ from tests.common.reboot import reboot                              # noqa: F401
 from tests.common.utilities import wait_until                       # noqa: F401
 from tests.common.config_reload import config_reload
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
+from tests.common.helpers.dut_utils import restart_service_with_startlimit_guard
 from tests.snappi_tests.pfcwd.files.pfcwd_basic_helper import run_pfcwd_basic_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import reboot_duts, \
@@ -25,6 +26,101 @@ pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 WAIT_TIME = 600
 INTERVAL = 40
+# Dedicated (smaller) poll interval for the lossless-PG readiness probe: the
+# APPL_DB query is cheap, and a warm restart can reprogram the PG within
+# seconds — polling at INTERVAL would quantize readiness to 40s boundaries.
+PG_READY_INTERVAL = 5
+
+
+def _lossless_pg_range(lossless_prio_list):     # noqa: F811
+    """BUFFER_PG_TABLE key suffix for the lossless priorities, e.g. [3, 4] -> '3-4'.
+
+    buffermgrd keys the lossless PG entry with the contiguous 'min-max' range of the
+    configured lossless priorities ('min' alone for a single priority), matching how
+    they are listed in BUFFER_PG. SONiC qos profiles use contiguous lossless
+    priorities; a non-contiguous set would need one probe per sub-range.
+    """
+    prios = sorted(int(p) for p in lossless_prio_list)
+    return '{}-{}'.format(prios[0], prios[-1]) if len(prios) > 1 else str(prios[0])
+
+
+def _wait_lossless_pg_ready(duthost, snappi_ports, lossless_prio_list):     # noqa: F811
+    """Block until lossless BUFFER_PG is reprogrammed on every test port of ``duthost``.
+
+    A port is ready once ``BUFFER_PG_TABLE:<port>:<lossless range>`` (derived from the
+    testbed's lossless priorities, e.g. ``3-4``) is present in APPL_DB, i.e.
+    buffermgr/orchagent have re-pushed lossless buffer/PG state after the swss
+    restart. ``critical_services_fully_started`` only reflects systemd-level health
+    and does not guarantee QoS has been reapplied to SAI. ``asic.sonic_db_cli`` targets
+    APPL_DB explicitly and adds ``-n <namespace>`` scoping on multi-asic DUTs.
+    """
+    pg_range = _lossless_pg_range(lossless_prio_list)
+
+    def _lossless_pg_ready(port):
+        asic = duthost.get_port_asic_instance(port)
+        cmd = "{} APPL_DB EXISTS 'BUFFER_PG_TABLE:{}:{}'".format(asic.sonic_db_cli, port, pg_range)
+        return duthost.shell(cmd, verbose=False)['stdout'].strip() == '1'
+
+    ports_on_duthost = [port for port in snappi_ports if port['duthost'] is duthost]
+    for snappi_port in ports_on_duthost:
+        peer_port = snappi_port['peer_port']
+        pytest_assert(
+            wait_until(WAIT_TIME, PG_READY_INTERVAL, 0, _lossless_pg_ready, peer_port),
+            "Lossless BUFFER_PG {} not programmed on {}:{} after swss restart".format(
+                pg_range, duthost.hostname, peer_port))
+
+
+def restart_swss_and_wait_ready(snappi_ports, restart_service, lossless_prio_list):     # noqa: F811
+    """Restart swss on each DUT carrying a snappi test port, then wait until it is
+    ready to carry lossless traffic again.
+
+    On multi-asic DUTs a random per-asic ``swss@<id>`` instance is restarted and
+    BGP re-establishment is additionally gated; on single-asic DUTs ``restart_service``
+    is restarted through ``restart_service_with_startlimit_guard``, which also guards the
+    systemd start-rate-limit that repeated restarts can trip. In both cases we wait on
+    critical services, interface up-state and the lossless BUFFER_PG row (see
+    ``_lossless_pg_ready``) on every test port before returning.
+    """
+    duthosts = list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]))
+    # Derived from one DUT and applied to both: this test's topologies pair DUTs of
+    # the same platform, so the asic-count is assumed to match across them.
+    is_multi_asic = snappi_ports[0]['duthost'].is_multi_asic
+
+    ports_dict = defaultdict(list)
+    if is_multi_asic:
+        for port in snappi_ports:
+            ports_dict[port['peer_device']].append(port['asic_value'])
+        for k in ports_dict.keys():
+            ports_dict[k] = list(set(ports_dict[k]))
+        logger.info('Port dictionary:{}'.format(ports_dict))
+
+    for duthost in duthosts:
+        # Record current state of critical services (and BGP neighbors on multi-asic).
+        up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established") if is_multi_asic else None
+        duthost.critical_services_fully_started()
+
+        if is_multi_asic:
+            asic = random.sample(ports_dict[duthost.hostname], 1)[0]
+            asic_index = int(re.match(r"asic(\d+)", asic).group(1))
+            asic_inst = duthost.asic_instance(asic_index)
+            # asic_instance resolves the per-asic systemd unit (swss@<id>) and docker name
+            # (swss<id>) separately, which the startlimit-guard helper cannot.
+            logger.info("Issuing a restart of {} on {} of dut {}".format(restart_service, asic, duthost.hostname))
+            asic_inst.reset_service(restart_service)
+            asic_inst.restart_service(restart_service)
+        else:
+            logger.info("Issuing a restart of service {} on the dut {}".format(restart_service, duthost.hostname))
+            restart_service_with_startlimit_guard(duthost, restart_service)
+
+        logger.info("Wait until the system is stable")
+        pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
+                      "Not all critical services are fully started")
+        pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, check_interface_status_of_up_ports, duthost),
+                      "Not all interfaces are up.")
+        if is_multi_asic:
+            pytest_assert(wait_until(
+                WAIT_TIME, INTERVAL, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"))
+        _wait_lossless_pg_ready(duthost, snappi_ports, lossless_prio_list)
 
 
 @pytest.fixture(autouse=True, scope='module')
@@ -39,7 +135,8 @@ def save_restore_config(tgen_port_info):          # noqa: F811
     dest = f'~/{timestamp}'
 
     for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
-        duthost.shell(f"sudo mkdir {dest}; sudo cp /etc/sonic/config*.json {dest}")
+        duthost.shell(f"sudo mkdir {dest}")
+        duthost.shell(f"sudo cp /etc/sonic/config*.json {dest}")
         duthost.shell("sudo config save -y")
 
     yield
@@ -270,43 +367,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
     lossless_prio = random.sample(lossless_prio_list, 1)
     lossless_prio = int(lossless_prio[0])
 
-    if (snappi_ports[0]['duthost'].is_multi_asic):
-        ports_dict = defaultdict(list)
-        for port in snappi_ports:
-            ports_dict[port['peer_device']].append(port['asic_value'])
-
-        for k in ports_dict.keys():
-            ports_dict[k] = list(set(ports_dict[k]))
-
-        logger.info('Port dictionary:{}'.format(ports_dict))
-        for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
-            up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
-            # Record current state of critical services.
-            duthost.critical_services_fully_started()
-
-            asic_list = ports_dict[duthost.hostname]
-            asic = random.sample(asic_list, 1)[0]
-            asic_id = re.match(r"(asic)(\d+)", asic).group(2)
-            proc = 'swss@' + asic_id
-            logger.info("Issuing a restart of service {} on the dut {}".format(proc, duthost.hostname))
-            duthost.command("sudo systemctl reset-failed {}".format(proc))
-            duthost.command("sudo systemctl restart {}".format(proc))
-            logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
-                          "Not all critical services are fully started")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, check_interface_status_of_up_ports, duthost),
-                          "Not all interfaces are up.")
-            pytest_assert(wait_until(
-                WAIT_TIME, INTERVAL, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"))
-
-    else:
-        for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
-            logger.info("Issuing a restart of service {} on the dut {}".format(restart_service, duthost.hostname))
-            duthost.command("systemctl reset-failed {}".format(restart_service))
-            duthost.command("systemctl restart {}".format(restart_service))
-            logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
-                          "Not all critical services are fully started")
+    restart_swss_and_wait_ready(snappi_ports, restart_service, lossless_prio_list)
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
@@ -357,44 +418,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
     testbed_config, port_config_list, snappi_ports = tgen_port_info
     logger.info('Ports:{}'.format(snappi_ports))
 
-    if (snappi_ports[0]['duthost'].is_multi_asic):
-        ports_dict = defaultdict(list)
-        for port in snappi_ports:
-            ports_dict[port['peer_device']].append(port['asic_value'])
-
-        for k in ports_dict.keys():
-            ports_dict[k] = list(set(ports_dict[k]))
-
-        logger.info('Port dictionary:{}'.format(ports_dict))
-        for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
-            up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
-            # Record current state of critical services.
-            duthost.critical_services_fully_started()
-
-            asic_list = ports_dict[duthost.hostname]
-            asic = random.sample(asic_list, 1)[0]
-            asic_id = re.match(r"(asic)(\d+)", asic).group(2)
-            proc = 'swss@' + asic_id
-
-            logger.info("Issuing a restart of service {} on the dut {}".format(proc, duthost.hostname))
-            duthost.command("sudo systemctl reset-failed {}".format(proc))
-            duthost.command("sudo systemctl restart {}".format(proc))
-            logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
-                          "Not all critical services are fully started")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, check_interface_status_of_up_ports, duthost),
-                          "Not all interfaces are up.")
-            pytest_assert(wait_until(
-                WAIT_TIME, INTERVAL, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"))
-
-    else:
-        for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
-            logger.info("Issuing a restart of service {} on the dut {}".format(restart_service, duthost.hostname))
-            duthost.command("systemctl reset-failed {}".format(restart_service))
-            duthost.command("systemctl restart {}".format(restart_service))
-            logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
-                          "Not all critical services are fully started")
+    restart_swss_and_wait_ready(snappi_ports, restart_service, lossless_prio_list)
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports


### PR DESCRIPTION
Manual cherry-pick of #25950 to `202511` (mssonicbld reported a conflict: label `Cherry Pick Conflict_202511`).

### Description of PR

Same as #25950: fixes intermittent snappi PFCWD basic-test failures across an in-test `swss` restart by waiting for the lossless PG buffer profile to be re-programmed before resuming traffic, and adds the platform handling needed to run these tests on Broadcom DNX / VOQ.

### Conflict resolution

Two small conflicts, both mechanical:

- `tests/common/snappi_tests/common_helpers.py`: 202511 carries extra imports (`IPv6Address`, `getrandbits`) in the same import block the PR touches — resolved as a union, and `pytest_require` added to the existing `tests.common.helpers.assertions` import.
- `tests/snappi_tests/conftest.py`: 202511 does not have master's GCU/`pytest_addoption` code adjacent to the fixture — applied only the PR's actual change (restore packet aging on all `duthosts.frontend_nodes` in `enable_packet_aging_after_test`).

Everything else applied cleanly; the resulting diff is equivalent to the original PR.

### Backport dependency

The DNX/VOQ packet-aging path writes the APPL_DB `SWITCH_TABLE:switch credit_watchdog` knob, honored by SwitchOrch only with sonic-net/sonic-swss#4658. That dependency is now **included in 202511** (cherry-picked via sonic-net/sonic-swss#4835), so this backport is unblocked.

### Type of change

- [x] Bug fix
- [x] Test case improvement

cc @vmittal-msft — could you help approve/merge this 202511 cherry-pick? The original PR already has `Approved for 202511 branch`.
