### PR TITLE
tests/autorestart: improve test_supervisor_listener_syslog_reconnects robustness

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -792,8 +792,8 @@ def test_supervisor_listener_syslog_reconnects(
     )
 
     # Skip if this container has no supervisord-managed rsyslogd (e.g. sflow, telemetry)
-    rsyslogd_check_pre = duthost.command(
-        "docker exec {} supervisorctl status rsyslogd".format(container_name),
+    rsyslogd_check_pre = duthost.shell(
+        "docker exec {} supervisorctl status rsyslogd 2>/dev/null; true".format(container_name),
         module_ignore_errors=True
     )
     pytest_require(
@@ -861,11 +861,11 @@ def test_supervisor_listener_syslog_reconnects(
         time.sleep(2)
         status_mid, pid_mid = get_program_info(duthost, container_name, "supervisor-proc-exit-listener")
         pytest_assert(
-            status_mid == "RUNNING",
-            "Listener is not RUNNING while /dev/log is absent in '{}': "
-            "status='{}', pid={}".format(container_name, status_mid, pid_mid)
+            status_mid == "RUNNING" and pid_mid == listener_pid,
+            "Listener is not RUNNING (or restarted) while /dev/log is absent in '{}': "
+            "status='{}', pid={} (was {})".format(container_name, status_mid, pid_mid, listener_pid)
         )
-        logger.info("PASS: listener stayed RUNNING while /dev/log was absent (pid={})".format(pid_mid))
+        logger.info("PASS: listener stayed RUNNING (same pid={}) while /dev/log was absent".format(pid_mid))
 
         # Step 7: restart rsyslogd to restore /dev/log
         logger.info("Restarting rsyslogd to restore /dev/log")

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -792,8 +792,8 @@ def test_supervisor_listener_syslog_reconnects(
     )
 
     # Skip if this container has no supervisord-managed rsyslogd (e.g. sflow, telemetry)
-    rsyslogd_check_pre = duthost.shell(
-        "docker exec {} supervisorctl status rsyslogd 2>/dev/null; true".format(container_name),
+    rsyslogd_check_pre = duthost.command(
+        "docker exec {} supervisorctl status rsyslogd".format(container_name),
         module_ignore_errors=True
     )
     pytest_require(


### PR DESCRIPTION
## Why I did it
The Step 6 assertion in `test_supervisor_listener_syslog_reconnects` only checked `status == "RUNNING"` after stopping rsyslogd. If the listener crashed and supervisord silently restarted it, the test would still pass. Adding a PID check catches that case.

## How I did it
One commit, one file (`tests/autorestart/test_container_autorestart.py`):

- Step 6: add `pid_mid == listener_pid` to verify the listener was not restarted (same PID), not merely that it is currently RUNNING after a potential silent restart.

## How to verify it
```
pytest tests/autorestart/test_container_autorestart.py::test_supervisor_listener_syslog_reconnects
```