### PR TITLE
[smartswitch]: Increase DPU upgrade temporary swap

### DIFF
--- a/ansible/library/test_upgrade_dpu_sonic_image.py
+++ b/ansible/library/test_upgrade_dpu_sonic_image.py
@@ -95,6 +95,71 @@ def test_get_installed_images_normalizes_leading_slash():
         True, "SONiC-OS-20251110.34", "SONiC-OS-20251110.34")
 
 
+def test_install_image_uses_larger_temporary_swap_when_supported(monkeypatch):
+    """Supported installers should create 3 GiB swap on DPUs below 8 GiB memory."""
+    upgrade = make_upgrade()
+    commands = []
+    upgrade.disk_used_pcent = 90
+    upgrade.connect_to_dpu = lambda *_: object()
+    upgrade.scp_image_to_dpu = lambda *_: True
+    upgrade.get_installed_images = lambda *_: (
+        True, "SONiC-OS-20251110.34", "SONiC-OS-20260510.10")
+    upgrade.get_host_path_size_mb = lambda *_: 4000
+    upgrade.get_host_avail_mb = lambda *_: 10000
+
+    def execute_command(_, __, command, **kwargs):
+        commands.append(command)
+        if command == "sudo sonic-installer install --help":
+            return True, "--skip-package-migration --total-mem-threshold --swap-mem-size", ""
+        if command == "sudo sonic-installer list":
+            return True, "Current: SONiC-OS-20251110.34\nNext: SONiC-OS-20260510.10", ""
+        if command.startswith("sudo sh -c 'stat"):
+            return True, str(upgrade_module.DPU_MIN_INITRD_BYTES), ""
+        return True, "", ""
+
+    upgrade.execute_command = execute_command
+    upgrade.prepare_image_for_reboot = lambda *_: True
+    monkeypatch.setattr(upgrade_module.os.path, "getsize", lambda _: 1024)
+
+    assert upgrade.install_image_on_dpu(object(), "169.254.200.1") is True
+    assert (
+        "sudo sonic-installer install /tmp/downloaded-sonic-image "
+        "--skip-package-migration --total-mem-threshold 8192 --swap-mem-size 3072 -y"
+    ) in commands
+
+
+def test_install_image_omits_swap_options_when_unsupported(monkeypatch):
+    """Older installers should continue upgrading without unsupported swap options."""
+    upgrade = make_upgrade()
+    commands = []
+    upgrade.connect_to_dpu = lambda *_: object()
+    upgrade.scp_image_to_dpu = lambda *_: True
+    upgrade.get_installed_images = lambda *_: (
+        True, "SONiC-OS-20251110.34", "SONiC-OS-20260510.10")
+    upgrade.get_host_path_size_mb = lambda *_: 4000
+    upgrade.get_host_avail_mb = lambda *_: 10000
+
+    def execute_command(_, __, command, **kwargs):
+        commands.append(command)
+        if command == "sudo sonic-installer install --help":
+            return True, "--skip-package-migration", ""
+        if command == "sudo sonic-installer list":
+            return True, "Current: SONiC-OS-20251110.34\nNext: SONiC-OS-20260510.10", ""
+        if command.startswith("sudo sh -c 'stat"):
+            return True, str(upgrade_module.DPU_MIN_INITRD_BYTES), ""
+        return True, "", ""
+
+    upgrade.execute_command = execute_command
+    upgrade.prepare_image_for_reboot = lambda *_: True
+    monkeypatch.setattr(upgrade_module.os.path, "getsize", lambda _: 1024)
+
+    assert upgrade.install_image_on_dpu(object(), "169.254.200.1") is True
+    assert (
+        "sudo sonic-installer install /tmp/downloaded-sonic-image "
+        "--skip-package-migration -y"
+    ) in commands
+
+
 def test_prepare_image_for_reboot_maps_uboot_image_to_physical_slot():
     """U-Boot selection must use the physical slot rather than the compact image list."""
     upgrade = make_upgrade()

--- a/ansible/library/upgrade_dpu_sonic_image.py
+++ b/ansible/library/upgrade_dpu_sonic_image.py
@@ -79,6 +79,9 @@ REBOOT_TIMEOUT = 600
 REBOOT_POLL_INTERVAL = 30
 # Extra /host headroom (MB) required beyond the image size before a DPU install
 DPU_INSTALL_MARGIN_MB = 500
+# Use a 3 GiB temporary swap file when the DPU has less than 8 GiB of memory.
+DPU_TOTAL_MEM_THRESHOLD_MB = 8192
+DPU_SWAP_MEM_SIZE_MB = 3072
 # Minimum plausible initrd size (bytes); anything smaller means a corrupt image
 DPU_MIN_INITRD_BYTES = 1024 * 1024
 # Max wait for a chassis-module state transition to clear (startup/shutdown no-op while set)
@@ -464,19 +467,29 @@ class UpgradeDpuSonicImageModule(object):
             return False
         self.log("[DPU {}] /host free {}M >= required {}M".format(dpu_ip, avail_mb, required_mb))
 
-        # Check for --skip-package-migration support
-        skip_param = ""
+        # Use optional installer features only when the running image supports them.
+        install_options = []
         ok, help_out, _ = self.execute_command(ssh, dpu_ip, "sudo sonic-installer install --help")
         if "skip-package-migration" in help_out:
-            skip_param = "--skip-package-migration"
+            install_options.append("--skip-package-migration")
             self.log("[DPU {}] Using --skip-package-migration".format(dpu_ip))
+        if "total-mem-threshold" in help_out and "swap-mem-size" in help_out:
+            install_options.extend([
+                "--total-mem-threshold", str(DPU_TOTAL_MEM_THRESHOLD_MB),
+                "--swap-mem-size", str(DPU_SWAP_MEM_SIZE_MB),
+            ])
+            self.log("[DPU {}] Using {} MiB temporary swap below {} MiB total memory".format(
+                dpu_ip, DPU_SWAP_MEM_SIZE_MB, DPU_TOTAL_MEM_THRESHOLD_MB))
+        else:
+            self.log("[DPU {}] Installer does not support configurable temporary swap".format(dpu_ip))
 
         # Install the image
         self.log("[DPU {}] Running sonic-installer install (timeout={}s)".format(
             dpu_ip, LONG_CMD_TIMEOUT))
         ok, out, err = self.execute_command(
             ssh, dpu_ip,
-            "sudo sonic-installer install {} {} -y".format(DPU_IMAGE_PATH, skip_param),
+            "sudo sonic-installer install {} {} -y".format(
+                DPU_IMAGE_PATH, " ".join(install_options)),
             timeout=LONG_CMD_TIMEOUT,
             get_pty=True
         )


### PR DESCRIPTION
### Description of PR

Summary:
Increase temporary swap used by DPU SONiC image installation to 3 GiB on systems with less than 8 GiB total memory.

Fixes # N/A

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: 16 focused unit tests passed.

### Approach
#### What is the motivation for this PR?

DPU image installation can require more temporary memory than the default 1 GiB swap allocation provides.

#### How did you do it?

When supported by the running `sonic-installer`, pass `--total-mem-threshold 8192 --swap-mem-size 3072` to create 3 GiB temporary swap on DPUs with less than 8 GiB total memory. Older installers that do not expose both options retain the existing command.

#### How did you verify/test it?

Added unit coverage that verifies the exact installer command when the options are supported and confirms unsupported installers omit the options.

#### Any platform specific information?

The change applies to any DPU image whose `sonic-installer install --help` advertises both temporary-swap options.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

No user-facing documentation change is required.
