### PR TITLE
[cherry-pick]: Handle empty cherry-picks as already included

### DIFF
--- a/.github/workflows/pr_cherrypick_prestep.yml
+++ b/.github/workflows/pr_cherrypick_prestep.yml
@@ -142,7 +142,17 @@ jobs:
           git checkout -b $branch --track origin/$branch
           git status | grep "working tree clean"
 
-          if ! git cherry-pick -s $sha; then
+          if ! cherry_pick_output=$(git cherry-pick -s "$sha" 2>&1); then
+            echo "$cherry_pick_output"
+            if echo "$cherry_pick_output" | grep -qiF "cherry-pick is now empty"; then
+              echo "Changes are already present in $branch branch."
+              git cherry-pick --abort
+              git status | grep "working tree clean"
+              gh pr edit "$pr_url" --remove-label "Cherry Pick Conflict_$branch" || true
+              gh pr edit "$pr_url" --add-label "Included in $branch branch"
+              gh pr comment "$pr_url" --body "No cherry-pick PR is needed for $branch because these changes are already present in the target branch. Added the \`Included in $branch branch\` label."
+              return 0
+            fi
             echo 'cherry-pick failed.'
             git cherry-pick --abort
             git status | grep "working tree clean"

--- a/.github/workflows/pr_cherrypick_prestep.yml
+++ b/.github/workflows/pr_cherrypick_prestep.yml
@@ -190,4 +190,3 @@ jobs:
           echo Begin to parse Branch: $branch
           cherry_pick
         done
-


### PR DESCRIPTION
… target branch

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Handle empty cherry-pick results in the pre-cherry-pick workflow as changes that are already present in the target branch, rather than reporting them as conflicts.
Fixes https://github.com/sonic-net/sonic-mgmt/issues/26280
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
When all changes from a PR are already present in a target release branch, `git cherry-pick` reports that the cherry-pick is empty. The workflow previously handled this as a cherry-pick conflict, which added a misleading conflict label.
#### How did you do it?
Detect the `cherry-pick is now empty` result and handle it separately by:

- Aborting the empty cherry-pick and verifying that the working tree is clean.
- Removing any existing `Cherry Pick Conflict_<branch>` label.
- Adding the `Included in <branch> branch` label.
- Posting a comment explaining that no cherry-pick PR is required.
- Returning successfully without creating a cherry-pick PR.

Other cherry-pick failures continue to use the existing conflict-handling flow.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Verified the workflow logic for these outcomes:

- An empty cherry-pick is recognized as already included.
- The repository is returned to a clean state.
- The included label and explanatory comment are added.
- A cherry-pick PR is not created.
- Non-empty cherry-pick failures still follow the conflict path.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
