### PR TITLE
[packet trimming]Fix packet trimming state restoration between retries

### DIFF
--- a/tests/packet_trimming/conftest.py
+++ b/tests/packet_trimming/conftest.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import copy
 
+from tests.common.config_reload import config_reload
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from tests.common.utilities import configure_packet_aging
 from tests.common.helpers.ptf_tests_helper import downstream_links, upstream_links, peer_links    # noqa F401
@@ -269,8 +270,16 @@ def setup_trimming(duthost, test_params, trim_counter_params, request):
 
     with allure.step("Restore original configuration"):
         logger.info("Restoring original configuration")
-        duthost.shell("sudo config load -y /etc/sonic/config_db_before_trimming_test.json")
-        duthost.shell("sudo config save -y")
+        duthost.shell(
+            "sudo cp /etc/sonic/config_db_before_trimming_test.json /etc/sonic/config_db.json"
+        )
+        config_reload(
+            duthost,
+            config_source="config_db",
+            safe_reload=True,
+            wait_for_bgp=True,
+            check_intf_up_ports=True
+        )
 
 
 @pytest.fixture(params=SRV6_TUNNEL_MODE)

--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -413,6 +413,14 @@ def create_blocking_scheduler(duthost):
         duthost.shell(cmd_create)
         logger.info(f"Successfully created blocking scheduler: {BLOCK_DATA_PLANE_SCHEDULER_NAME}")
 
+    pytest_assert(
+        wait_until(
+            60, 5, 0, get_scheduler_oid_by_attributes, duthost,
+            type=SCHEDULER_TYPE, weight=SCHEDULER_WEIGHT, pir=SCHEDULER_PIR
+        ),
+        f"Blocking scheduler {BLOCK_DATA_PLANE_SCHEDULER_NAME} was not programmed in ASIC_DB"
+    )
+
 
 def delete_blocking_scheduler(duthost):
     """


### PR DESCRIPTION
Restore the saved CONFIG_DB with replacement semantics and wait for services, interfaces, and BGP to recover. Verify that the blocking scheduler reaches ASIC_DB before starting packet trimming tests.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix packet-trimming retries inheriting stale DUT configuration and running
before the blocking scheduler is programmed in ASIC_DB.

The packet-trimming module previously restored its saved configuration using
`config load`, which merges configuration instead of replacing CONFIG_DB.
Entries created by the test but absent from the saved configuration could
therefore remain after teardown.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<img width="1281" height="713" alt="image" src="https://github.com/user-attachments/assets/570896e6-9190-4bd5-8c2b-27ad9b77abd9" />

<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
The packet-trimming module saves `CONFIG_DB` before setup and restores it during
teardown. The previous teardown used:

```
config load -y <saved-config>\n
config save -y
```

 config load  applies the saved configuration using merge semantics. It does
not remove entries created by the test when those entries are absent from the
saved configuration. As a result, packet-trimming-specific state could remain,
including:

•  SWITCH_TRIMMING 
• Test TC-to-DSCP maps
• Modified  PORT_QOS_MAP  entries
• Test buffer-profile settings
• Blocking scheduler configuration

If pytest retried the module, the retry could inherit this stale state. In the
observed failure, the retry subsequently failed to receive an expected trimmed
packet and could not find the blocking scheduler in ASIC_DB while SwSS was not
ready.

Scheduler creation is also asynchronous. Writing the scheduler to CONFIG_DB
does not guarantee that orchagent has already programmed its corresponding
object into ASIC_DB before traffic validation begins.

#### How did you do it?
• Restore the saved configuration as the complete
 /etc/sonic/config_db.json  instead of merging it into the current database.
• Use the common  config_reload  helper with  safe_reload=True .
• Wait for critical services, interfaces, and BGP sessions to recover before
teardown completes.
• After creating the blocking scheduler, poll ASIC_DB for a scheduler matching
the expected type, weight, and rate attributes.
• Fail during setup with a clear error if the scheduler does not reach ASIC_DB
within the timeout.
This ensures that subsequent modules or automatic retries start from a clean
and fully converged DUT state.

#### How did you verify/test it?
• Re-ran  `test_packet_trimming_asymmetric.py`  on an `NVIDIA/Mellanox SN5640`
using the `202511` branch and  `SONiC.20251110.47` .
• Confirmed that the packet-trimming test passed after applying the change.
• Confirmed that configuration restoration completed through the safe reload
path.
• Confirmed that setup waited for the blocking scheduler to appear in ASIC_DB.
• Validated the changed Python files and repository formatting checks.
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
The failure was reproduced on an NVIDIA/Mellanox Spectrum-5 SN5640, but the
configuration restoration issue is not platform-specific. Any platform can
retain test-created CONFIG_DB entries when a saved configuration is restored
using merge semantics.

The ASIC_DB scheduler readiness check uses the existing platform-aware
scheduler configuration and applies to all platforms supported by the packet
trimming tests.

#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
