### PR TITLE
[console] Use mapped fanout ports in loopback test

### DIFF
--- a/tests/console/test_console_loopback.py
+++ b/tests/console/test_console_loopback.py
@@ -39,6 +39,16 @@ def _read_orig_console_port(host, line):
     return orig_baud, ("enable" if orig_fc_int == "1" else "disable")
 
 
+def _get_fanout_line(graph_facts, duthost, console_fanout, dut_line):
+    link = graph_facts['device_serial_link'][duthost.hostname][dut_line]
+    pytest_assert(
+        link['peerdevice'] == console_fanout.hostname,
+        "DUT '{}' line {} is wired to '{}', not selected console fanout '{}'".format(
+            duthost.hostname, dut_line, link['peerdevice'], console_fanout.hostname),
+    )
+    return str(link['peerport'])
+
+
 @pytest.mark.parametrize("baud_rate", ["9600", "115200"])
 @pytest.mark.parametrize("flow_control", ["enable", "disable"])
 def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flow_control,  # noqa: F811
@@ -69,8 +79,9 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
     if same_host:
         delay_factor = 1.6
     else:
-        console_fanout.command("config console flow_control {} {}".format(flow_control, target_line))
-        console_fanout.set_loopback(target_line, baud_rate, flow_control_bool)
+        fanout_line = _get_fanout_line(conn_graph_facts, duthost, console_fanout, target_line)
+        console_fanout.command("config console flow_control {} {}".format(flow_control, fanout_line))
+        console_fanout.set_loopback(fanout_line, baud_rate, flow_control_bool)
         delay_factor = 3.2
 
     dutip, dutuser, dutpass = get_host_ip_and_creds(duthost, creds)
@@ -99,7 +110,7 @@ def test_console_loopback_echo(setup_c0, creds, conn_graph_facts, baud_rate, flo
             duthost, target_line,
             error_msg="Target line {} is busy after exited reverse SSH session".format(target_line))
         if not same_host:
-            console_fanout.unset_loopback(target_line)
+            console_fanout.unset_loopback(fanout_line)
         # Restore pre-test CONFIG_DB state for this line.
         configure_console_line(duthost, target_line, orig_baud, orig_flow_control)
 
@@ -127,6 +138,8 @@ def test_console_loopback_pingpong(setup_c0, creds, conn_graph_facts, baud_rate,
         pytest.skip("Not enough console ports to run the ping-pong test on DUT '{}' (need at least 2, got {})".format(
             duthost.hostname, len(lines)))
     src_line, dst_line = lines[0], lines[1]
+    fanout_src_line = _get_fanout_line(conn_graph_facts, duthost, console_fanout, src_line)
+    fanout_dst_line = _get_fanout_line(conn_graph_facts, duthost, console_fanout, dst_line)
     flow_control_bool = (flow_control == "enable")
 
     # Capture pre-test CONFIG_DB state for both lines so we can restore on
@@ -136,7 +149,7 @@ def test_console_loopback_pingpong(setup_c0, creds, conn_graph_facts, baud_rate,
 
     configure_console_line(duthost, src_line, baud_rate, flow_control)
     configure_console_line(duthost, dst_line, baud_rate, flow_control)
-    console_fanout.bridge(src_line, dst_line, baud_rate, flow_control_bool)
+    console_fanout.bridge(fanout_src_line, fanout_dst_line, baud_rate, flow_control_bool)
 
     dutip, dutuser, dutpass = get_host_ip_and_creds(duthost, creds)
 
@@ -163,9 +176,9 @@ def test_console_loopback_pingpong(setup_c0, creds, conn_graph_facts, baud_rate,
             duthost, src_line,
             error_msg="Target line {} of dut is busy after exited reverse SSH session".format(src_line))
         wait_for_line_idle(
-            console_fanout, dst_line,
-            error_msg="Target line {} of fanout is busy after exited reverse SSH session".format(dst_line))
-        console_fanout.unbridge(src_line, dst_line)
+            duthost, dst_line,
+            error_msg="Target line {} of dut is busy after exited reverse SSH session".format(dst_line))
+        console_fanout.unbridge(fanout_src_line, fanout_dst_line)
         # Restore pre-test CONFIG_DB state for both lines.
         configure_console_line(duthost, src_line, orig_src_baud, orig_src_flow_control)
         configure_console_line(duthost, dst_line, orig_dst_baud, orig_dst_flow_control)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix `test_console_loopback` for c0 topologies where a DUT console line and its connected fanout line use different port numbers. The test now resolves the fanout port from `device_serial_link` instead of reusing the DUT port number.

Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

- master: flake8, syntax validation, mapping smoke test, and pytest collection passed (8 cases collected).
- Physical c0 validation on Nokia-7215-C1-G3 with SONiC image `20260310.19`: `8 passed, 0 failed, 0 skipped`.

### Approach
#### What is the motivation for this PR?

`*_serial_links.csv` records both the DUT line number and the connected fanout line number. These values are not always identical. The test selected DUT lines from the graph but incorrectly reused those numbers for fanout loopback and bridge operations, causing all data-path checks to time out when the fanout used different ports.

#### How did you do it?

Added a helper that resolves and validates each DUT line's fanout `peerport` from `device_serial_link`. Echo tests now loop back the mapped fanout port, and ping-pong tests bridge the two mapped fanout ports. Reverse-SSH session state checks remain on the corresponding DUT lines.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

Before the change, all 8 echo and ping-pong combinations failed on a c0 testbed whose DUT lines `1/2` mapped to different fanout lines. After the change, all 8 combinations passed at 9600 and 115200 baud with flow control enabled and disabled.

#### Any platform specific information?

Physically verified on Nokia-7215-C1-G3. The fix is graph-driven and not platform-specific.

#### Supported testbed topology if it's a new test case?

N/A. This fixes an existing test for c0 topology and preserves existing c0-lo behavior.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

N/A.
