### PR TITLE
Removing XFAIL for pfcwd IPv6 tests for Cisco-8000

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4064,7 +4064,7 @@ pfcwd/test_pfcwd_.*\[IPv6.*:
    xfail:
      reason: "Xfail due to https://github.com/sonic-net/sonic-mgmt/issues/21082"
      conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/21082 and asic_type in ['mellanox', 'cisco-8000']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/21082 and asic_type in ['mellanox']"
 
 pfcwd/test_pfcwd_all_port_storm.py:
    skip:


### PR DESCRIPTION
Summary:
Fixes # (issue)
All pfcwd ipv6 tests for Cisco are passing ok now - due to various fixes went in last many months. Noticably
https://github.com/sonic-net/sonic-mgmt/pull/23147
https://github.com/sonic-net/sonic-mgmt/pull/25438

They were marked as XFAIL because of this issue
https://github.com/sonic-net/sonic-mgmt/issues/21082

Removing the XFAIL now.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
https://github.com/sonic-net/sonic-mgmt/issues/21082

Failure type: regression 

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605
- [ ] N/A

### Test result
pfcwd IPv6 test results 
DUT: cmono-t0-2-dut (cisco-8000) · Date: 2026-08-18 · 16 pfcwd IPv6 tests

✅ PASS (7)

test_pfc_config::test_high_detect_time_cfg

test_pfc_config::test_high_restore_time_cfg

test_pfc_config::test_low_detect_time_cfg

test_pfc_config::test_low_restore_time_cfg

test_pfc_config::test_invalid_action_cfg

test_pfc_config::test_invalid_detect_time_cfg

test_pfc_config::test_invalid_restore_time_cfg

🟡 XPASS — xfail marker but passed (8, all issue #21082)

test_pfcwd_all_port_storm::test_all_port_storm_restore

test_pfcwd_cli::test_pfcwd_show_stat

test_pfcwd_function::test_pfcwd_actions

test_pfcwd_function::test_pfcwd_mmu_change

test_pfcwd_function::test_pfcwd_multi_port

test_pfcwd_function::test_pfcwd_port_toggle

test_pfcwd_timer_accuracy::test_pfcwd_timer_accuracy

test_pfcwd_function::test_pfcwd_no_traffic


Need this PR also into 202605 - https://github.com/sonic-net/sonic-mgmt/pull/25438

### Approach
#### What is the motivation for this PR?
Have pfcwd ipv6 tests also running for Cisco-8000

#### How did you do it?
Removed XFAIL and tested

#### How did you verify/test it?
Ran all pfcwd ipv6 tests on Cisco-8000 T0 

#### Any platform specific information?
Removed XFAIL for Cisco-8000 only

#### Supported testbed topology if it's a new test case?

### Documentation
