### PR TITLE
fix(dhcp_relay): stabilize VPP stress packet counting

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -54,53 +54,65 @@ class DHCPStressTest(DHCPTest):
 
     # Simulate client coming on VLAN and broadcasting a DHCPDISCOVER message
     def client_send_packet_stress(self):
-        server_ports = "|".join(["eth{}".format(idx) for idx in self.receive_port_indices])
-        tcpdump_cmd = (
-            "tcpdump --buffer-size=102400 --immediate-mode -U "
-            "-i any -n -q -l "
-            "'inbound and udp and (port 67 or port 68) and (udp[249:2] = 0x01{})' "
-            "| grep --line-buffered -w -E '{}' > /tmp/dhcp_stress_test_{}.log"
-        ).format(self.packet_type_hex, server_ports, self.packet_type)
-        tcpdump_proc = subprocess.Popen(tcpdump_cmd, shell=True)
-        if self.packet_type == "discover" or self.packet_type == "request":
-            dhcp_packet = self.create_packet(self.dest_mac_address, self.client_udp_src_port)
-        else:
-            dhcp_packet = self.create_packet()
-        end_time = time.time() + self.packets_send_duration
-        xid = 0
-        while time.time() < end_time:
-            dhcp_packet[scapy.BOOTP].xid = xid
-            xid += 1
-            testutils.send_packet(self, self.send_port_indices[0], dhcp_packet)
-            time.sleep(1/self.client_packets_per_sec)
+        capture_filter = "inbound and udp and (port 67 or port 68) and (udp[249:2] = 0x01{})".format(
+            self.packet_type_hex
+        )
+        capture_log_files = [
+            "/tmp/dhcp_stress_test_{}_eth{}.log".format(self.packet_type, port_index)
+            for port_index in self.receive_port_indices
+        ]
+        capture_outputs = []
+        tcpdump_procs = []
+        try:
+            for port_index, log_file in zip(self.receive_port_indices, capture_log_files):
+                capture_output = open(log_file, "w")
+                capture_outputs.append(capture_output)
+                tcpdump_procs.append(subprocess.Popen([
+                    "tcpdump", "--buffer-size=102400", "--immediate-mode", "-U",
+                    "-i", "eth{}".format(port_index), "-n", "-q", "-l", capture_filter
+                ], stdout=capture_output, stderr=subprocess.DEVNULL))
 
-        # Wait until tcpdump stops receiving packets (idle for 5s, max 120s)
-        log_file = "/tmp/dhcp_stress_test_{}.log".format(self.packet_type)
-        last_size = 0
-        idle_count = 0
-        deadline = time.time() + 120
-        while idle_count < 5 and time.time() < deadline:
-            time.sleep(1)
-            try:
-                current_size = os.path.getsize(log_file)
-            except OSError:
-                current_size = 0
-            if current_size == last_size:
-                idle_count += 1
+            if self.packet_type == "discover" or self.packet_type == "request":
+                dhcp_packet = self.create_packet(self.dest_mac_address, self.client_udp_src_port)
             else:
-                idle_count = 0
-            last_size = current_size
+                dhcp_packet = self.create_packet()
+            end_time = time.time() + self.packets_send_duration
+            xid = 0
+            while time.time() < end_time:
+                dhcp_packet[scapy.BOOTP].xid = xid
+                xid += 1
+                testutils.send_packet(self, self.send_port_indices[0], dhcp_packet)
+                time.sleep(1/self.client_packets_per_sec)
 
-        pids = subprocess.check_output("pgrep tcpdump", shell=True).split()
-        for pid in pids:
-            os.kill(int(pid), signal.SIGINT)
-        tcpdump_proc.wait()
+            # Wait until tcpdump stops receiving packets (idle for 5s, max 120s)
+            last_size = 0
+            idle_count = 0
+            deadline = time.time() + 120
+            while idle_count < 5 and time.time() < deadline:
+                time.sleep(1)
+                current_size = sum(os.path.getsize(log_file) for log_file in capture_log_files)
+                if current_size == last_size:
+                    idle_count += 1
+                else:
+                    idle_count = 0
+                last_size = current_size
+        finally:
+            for tcpdump_proc in tcpdump_procs:
+                if tcpdump_proc.poll() is None:
+                    tcpdump_proc.send_signal(signal.SIGINT)
+            for tcpdump_proc in tcpdump_procs:
+                tcpdump_proc.wait()
+            for capture_output in capture_outputs:
+                capture_output.close()
 
-        wc_cmd = "wc -l /tmp/dhcp_stress_test_{}.log".format(self.packet_type)
-        wc_output = subprocess.check_output(wc_cmd, shell=True)
-        line_cnt = wc_output.decode().split()[0]
-        os.remove("/tmp/dhcp_stress_test_{}.log".format(self.packet_type))
-        subprocess.check_output("echo {} > /tmp/dhcp_stress_test_{}".format(line_cnt, self.packet_type), shell=True)
+        line_count = 0
+        for log_file in capture_log_files:
+            with open(log_file) as capture_log:
+                line_count += sum(1 for _ in capture_log)
+            os.remove(log_file)
+
+        with open("/tmp/dhcp_stress_test_{}".format(self.packet_type), "w") as result_file:
+            result_file.write(str(line_count))
 
     def runTest(self):
         self.client_send_packet_stress()

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -20,6 +20,8 @@ pytestmark = [
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
 DEFAULT_DHCP_SERVER_PORT = 67
+DEFAULT_PACKET_RATE_PER_SEC = 10000
+VPP_KVM_PACKET_RATE_PER_SEC = 25
 
 
 def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist,
@@ -121,7 +123,7 @@ def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_du
     testing_mode, duthost = testing_config
     packets_send_duration = 120
     is_vpp_kvm = duthost.facts.get("asic_type") == "vpp" and "kvm" in duthost.facts.get("platform", "")
-    client_packets_per_sec = 1000 if is_vpp_kvm else 10000
+    client_packets_per_sec = VPP_KVM_PACKET_RATE_PER_SEC if is_vpp_kvm else DEFAULT_PACKET_RATE_PER_SEC
 
     for dhcp_relay in dut_dhcp_relay_data:
         client_port_name = str(dhcp_relay['client_iface']['name'])


### PR DESCRIPTION
### Description of PR

Summary:
Stabilize the DHCP relay stress test on VPP KVM by using reliable per-interface packet capture and a load that a freshly started VPP relay can sustain.

Fixes # N/A

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: day-one test-harness limitation

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master, `SONiC.master-28316.1197637-b08d3e010`: target case passed through the normal fixture path at 25 pps.
- master, `SONiC.master.1192522-1ff6c6584`: target case passed at 25 pps. The original 1000 pps setting reproduced relay saturation with 61,346 packets entering the DUT and 2,808 packets relayed.
- The repaired packet-counting path also passed four consecutive focused runs.

### Approach
#### What is the motivation for this PR?

`dhcp_relay.test_dhcp_relay_stress::test_dhcp_relay_stress[offer-sonic-relay-agent]` flakes on `t0-vpp` because the PTF-side packet counter uses `tcpdump -i any` followed by interface-name filtering. That can duplicate packets at lower load and drop packets at higher load. The VPP-specific 1000 pps setting also exceeds the forwarding capacity of a freshly started `sonic-relay-agent`.

The saturation reproduces on both a representative failing image and an older image with prior passing fleet results, so it is not caused by a specific SONiC image regression.

#### How did you do it?

- Capture directly on each intended PTF interface instead of capturing on `any` and filtering text output.
- Track and stop only the tcpdump processes started by the test.
- Sum the per-interface capture counts.
- Use 25 pps for VPP KVM while retaining 10000 pps for other platforms.

#### How did you verify/test it?

The target case passed on both tested VPP images with the corrected capture implementation and 25 pps rate. At 1000 pps, both images reproduced the same relay saturation behavior, including when DUT capture was moved from `PortChannel101` to physical member `Ethernet112`.

#### Any platform specific information?

The packet-rate change applies only when the DUT is VPP on KVM. Other platforms retain the existing 10000 pps rate.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
