### PR TITLE
[copp] Fix libssl-dev install conflict with FIPS libssl3t64 on trixie

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -245,22 +245,27 @@ def _install_nano_bookworm(dut, creds, syncd_docker_name):
     if output["stdout"] == "copp":
         http_proxy = creds.get('proxy_env', {}).get('http_proxy', '')
         https_proxy = creds.get('proxy_env', {}).get('https_proxy', '')
+        # Skip libssl-dev on FIPS trixie images, where it conflicts with the pre-installed "+fips" libssl3t64.
+        libssl3_fips = dut.command(
+            "docker exec {} bash -c \"dpkg -s libssl3t64 2>/dev/null | grep -q '+fips' && echo fips || echo plain\""
+            .format(syncd_docker_name))["stdout"].strip() == "fips"
+        ssl_pkgs = "" if libssl3_fips else "libssl-dev "
         # Change the permission of /tmp to 1777 to workaround issue sonic-net/sonic-buildimage#16034
         cmd = '''docker exec -e http_proxy={0} -e https_proxy={1} {2} bash -c " \
                 mkdir -p /var/tmp_build \
                 && rm -rf /var/lib/apt/lists/* \
                 && apt-get update \
-                && apt-get install -y python3-pip build-essential libssl-dev libffi-dev \
+                && apt-get install -y python3-pip build-essential {5}libffi-dev \
                 python3-dev python3-setuptools wget libnanomsg-dev python-is-python3 \
                 && TMPDIR=/var/tmp_build pip3 install --no-cache-dir cffi \
                 && TMPDIR=/var/tmp_build pip3 install --no-cache-dir nnpy \
                 && rm -rf /var/tmp_build \
                 && mkdir -p /opt && cd /opt && wget {3} \
                 && mkdir ptf && cd ptf && wget {4} && touch __init__.py \
-                && apt-get -y purge build-essential libssl-dev libffi-dev python3-dev \
+                && apt-get -y purge build-essential {5}libffi-dev python3-dev \
                 python3-setuptools wget \
                 " '''.format(http_proxy, https_proxy, syncd_docker_name,
-                             _PTF_NN_AGENT_URL, _PTF_AFPACKET_URL)
+                             _PTF_NN_AGENT_URL, _PTF_AFPACKET_URL, ssl_pkgs)
         dut.command(cmd)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
On images with ENABLE_FIPS=y, the syncd container's Debian trixie
already has libssl3t64 pre-installed at a "+fips" build. The
_install_nano_bookworm() build-dep install for ptf_nn_agent then tries to
apt-get install libssl-dev, which pins an exact non-FIPS version of
libssl3t64, causing apt's solver to fail with "Unable to correct problems,
you have held broken packages" and breaking test_copp.py for all
downstream tests (copp_testbed fixture failure).

Root cause on the image side (sonic-buildimage):
- https://github.com/Azure/sonic-buildimage/commit/f0de49320661594ca0198d98bf50f8f78cf7b00d
  ("[fips] Upgrade OpenSSL to 3.5.6-1~deb13u2 for trixie" (#28860)) bumped
  FIPS_OPENSSL_VERSION to the exact "+fips" version seen in the failure log

Detect whether libssl3t64 is a "+fips" build and skip installing
libssl-dev in that case (libffi-dev is unaffected and still installed
unconditionally, since cffi still needs it to build).

Verified on image, where FIPS-enabled - test_copp.py now passes past the copp_testbed fixture.


Test **failure before** a change:
```
msg = non-zero return code
invocation = {'module_args': {'_raw_params': 'docker exec -e http_proxy= -e https_proxy= syncd bash -c "                  mkdir -p /var/tmp_build                  && rm -rf /var/lib/apt/lists/*                  && apt-get update                  && apt-get install -y python3-pip build-essential libssl-dev libffi-dev                  python3-dev python3-setuptools wget libnanomsg-dev python-is-python3                  && TMPDIR=/var/tmp_build pip3 install --no-cache-dir cffi                  && TMPDIR=/var/tmp_build pip3 install --no-cache-dir nnpy                  && rm -rf /var/tmp_build                  && mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/9d41838d634c479fc24fac7a527ec5ee2d0ce8eb/ptf_nn/ptf_nn_agent.py                  && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/9d41838d634c479fc24fac7a527ec5ee2d0ce8eb/src/ptf/afpacket.py && touch __init__.py                  && apt-get -y purge build-essential libssl-dev libffi-dev python3-dev                  python3-setuptools wget                  " ', '_uses_shell': False, 'expand_argument_vars': True, 'stdin_add_newline': True, 'strip_empty_ends': True, 'cmd': None, 'argv': None, 'chdir': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}
exception = (traceback unavailable)
_ansible_no_log = False
stdout =
Get:1 http://deb.debian.org/debian trixie InRelease [140 kB]
Get:2 http://deb.debian.org/debian trixie-updates InRelease [47.3 kB]
Get:3 http://deb.debian.org/debian trixie-backports InRelease [54.0 kB]
Get:4 http://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
Get:5 http://deb.debian.org/debian trixie/contrib Sources [62.2 kB]
Get:6 http://deb.debian.org/debian trixie/non-free-firmware Sources [7061 B]
Get:7 http://deb.debian.org/debian trixie/main Sources [14.1 MB]
Get:8 http://deb.debian.org/debian trixie/main amd64 Packages [13.3 MB]
Get:9 http://deb.debian.org/debian trixie/contrib amd64 Packages [65.0 kB]
Get:10 http://deb.debian.org/debian trixie/non-free-firmware amd64 Packages [7503 B]
Get:11 http://deb.debian.org/debian trixie-updates/main Sources [1840 B]
Get:12 http://deb.debian.org/debian trixie-updates/main amd64 Packages [4412 B]
Get:13 http://deb.debian.org/debian trixie-backports/main amd64 Packages [318 kB]
Get:14 http://deb.debian.org/debian trixie-backports/contrib amd64 Packages [7960 B]
Get:15 http://deb.debian.org/debian trixie-backports/non-free-firmware amd64 Packages [6480 B]
Get:16 http://deb.debian.org/debian-security trixie-security/non-free-firmware Sources [696 B]
Get:17 http://deb.debian.org/debian-security trixie-security/contrib Sources [1564 B]
Get:18 http://deb.debian.org/debian-security trixie-security/main Sources [220 kB]
Get:19 http://deb.debian.org/debian-security trixie-security/main amd64 Packages [244 kB]
Get:20 http://deb.debian.org/debian-security trixie-security/non-free-firmware amd64 Packages [544 B]
Get:21 http://deb.debian.org/debian-security trixie-security/contrib amd64 Packages [3148 B]
Fetched 28.7 MB in 19s (1476 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
python3-pip is already the newest version (25.1.1+dfsg-1).
python3-setuptools is already the newest version (78.1.1-0.1).
wget is already the newest version (1.25.0-2).
libnanomsg-dev is already the newest version (1.1.5+dfsg-1.1+b1).
python-is-python3 is already the newest version (3.13.3-1).
Solving dependencies...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 libssl-dev : Depends: libssl3t64 (= 3.5.6-1~deb13u2) but 3.5.6-1~deb13u2+fips is to be installedstderr =
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
E: Unable to correct problems, you have held broken packages.
E: The following information from --solver 3.0 may provide additional context:
   Unable to satisfy dependencies. Reached two conflicting decisions:
   1. libssl3t64:amd64=3.5.6-1~deb13u2 is not selected for install
   2. libssl3t64:amd64=3.5.6-1~deb13u2 is selected as a downgrade because:
      1. libssl-dev:amd64=3.5.6-1~deb13u2 is selected for install
      2. libssl-dev:amd64 Depends libssl3t64 (= 3.5.6-1~deb13u2)
```

Test **passed after** the change:
```
"rc": 0, 
"cmd": ["docker", "exec", "-e", "http_proxy=", "-e", "https_proxy=", "syncd", "bash", "-c", 
"                  mkdir -p /var/tmp_build                  && rm -rf /var/lib/apt/lists/*                  && apt-get update                  
&& apt-get install -y python3-pip build-essential libffi-dev                  
python3-dev python3-setuptools wget libnanomsg-dev python-is-python3                 
 && TMPDIR=/var/tmp_build pip3 install --no-cache-dir cffi                  
&& TMPDIR=/var/tmp_build pip3 install --no-cache-dir nnpy                  && rm -rf /var/tmp_build                  
&& mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/9d41838d634c479fc24fac7a527ec5ee2d0ce8eb/ptf_nn/ptf_nn_agent.py                  
&& mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/9d41838d634c479fc24fac7a527ec5ee2d0ce8eb/src/ptf/afpacket.py 
&& touch __init__.py                  && apt-get -y purge build-essential libffi-dev python3-dev                  
python3-setuptools wget                  "], 
"start": "2026-08-25 12:18:18.961570", "end": "2026-08-25 12:19:53.775405"
```


<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [X] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
Fix failed test

#### How did you do it?
Updated the installation cmd

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Test passed after the change

