### PR TITLE
[vxlan] Skip v4-outer encap types for test_vxlan_ecmp and test_vxlan_crm on v6-only topos

### DIFF
--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -59,6 +59,7 @@ import pytest
 import copy
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
+from tests.common.utilities import is_ipv6_only_topology
 from tests.ptf_runner import ptf_runner
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 
@@ -195,6 +196,9 @@ def fixture_setUp(duthosts,
     platform = duthosts[rand_one_dut_hostname].facts['platform']
     if platform in ['x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0'] and encap_type in ['v4_in_v6', 'v6_in_v6']:
         pytest.skip("Skipping test. v6 underlay is not supported on Mlnx 2700")
+
+    if is_ipv6_only_topology(tbinfo) and ecmp_utils.get_outer_layer_version(encap_type) == 'v4':
+        pytest.skip("Skipping test with IPv4 encap type. IPv4 underlay/BGP peers are not available on v6-only topology")
 
     # Should I keep the temporary files copied to DUT?
     ecmp_utils.Constants['KEEP_TEMP_FILES'] = \


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_vxlan_ecmp.py and test_vxlan_crm.py fails on IPv6-only topology for v4_in_v4/v6_in_v4 encap types - there are no IPv4 BGP peers to select interfaces from.
Introduced the skip for tests with these encap types and v6-only topology.

Traceback of tests v4_in_v4/v6_in_v4:
```
def select_required_interfaces(
            self, duthost, number_of_required_interfaces, minigraph_data, af, topo="T1"):
        '''
        Pick the required number of interfaces to use for tests.
        These interfaces will be selected based on if they are currently
        running a established BGP.  The interfaces will be picked from those that face
        the neighbors of the specified topology (i.e., T0 if topo == "T1" or T1 if topo == "T0").
        '''
        neigh_topo = "T1" if topo == "T0" else "T0"
        bgp_interfaces = self.get_all_interfaces_running_bgp(
            duthost,
            minigraph_data,
            neigh_topo)
    
        # Randomly pick the interface from the above list
        list_of_bgp_ips = []
        for neigh_ip_address in bgp_interfaces:
            if isinstance(ip_address(neigh_ip_address), self.IP_TYPE[af]):
                list_of_bgp_ips.append(neigh_ip_address)
    
        ret_interface_list = []
        available_number = len(list_of_bgp_ips)
        # Confirm there are enough interfaces (basicaly more than or equal
        # to the number of vnets).
        if available_number <= number_of_required_interfaces+1:
>           raise RuntimeError(
                "There are not enough interfaces needed to perform the test. "
                "We need atleast {} interfaces, but only {} are "
                "available.".format(
                    number_of_required_interfaces+1, available_number))
E           RuntimeError: There are not enough interfaces needed to perform the test. We need atleast 2 interfaces, but only 0 are available.
```
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [X] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 
- 202605: 20260531.42 - <test result or link>
-->
- master: tests_vxlan_ecmp/crm[v4_in_v4/v6_in_v4] skipped

### Approach
#### What is the motivation for this PR?
Regression stabilization

#### How did you do it?
Skip not supported parametrized tests

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Test executed after change on v6-only topo

#### Supported testbed topology if it's a new test case?
V6-only topologies


