### PR TITLE
[202605][cherry-pick] UT2 golden_config uses stale port_config on deploy-mg (#26967)

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -879,10 +879,12 @@
       # golden config for lt2/ft2 modifies the PORT table. To support lt2-isolated
       # which have some interfaces disabled, apply the minigraph config first so that
       # golden config inherits the same admin_status settings
+      # t2_single_node golden_config needs port_config from generated minigraph so
+      # that golden config does not inherit stale admin_status from old minigraph
       - name: Apply minigraph prior to generating golden_config_db.json
         become: true
         shell: config load_minigraph -y
-        when: "'lt2' in topo or 'ft2' in topo"
+        when: "'lt2' in topo or 'ft2' in topo or 't2_single_node' in topo"
 
       - name: Extract port speeds and hwsku from lab CSV files for PORT override
         delegate_to: localhost


### PR DESCRIPTION
Load minigraph before golden_config generation on UT2 to prevent stale port_config being set in golden_config
Manual backport of #26967

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #26965 (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
202605 no longer see stale ports after change

### Approach
#### What is the motivation for this PR?
For UT2 config reload needs to run before creating the golden_config to prevent stale port_config being set in golden_config.

This is because `generate_ut2_golden_config_db` in generate_golden_config is actually calling `sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data`, but sonic-cfggen does not get port config from the xml, but the running-config:
https://github.com/sonic-net/sonic-buildimage/blob/202605/src/sonic-config-engine/minigraph.py#L2064
Since the running-config at this moment is not the new generated minigraph, but the original minigraph we get the port config of the older minigraph into the golden config.

#### How did you do it?
Similar to LT2, let config reload run before generating the golden_config.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

Re-ran deploy-mg on 202605 UT2 ctn dut
```
./testbed-cli.sh deploy-mg <testbedname> lab password.txt -vvv
```