### PR TITLE
[202512][process_monitoring]: Fix BGP recovery wait

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -31,13 +31,21 @@ CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_RESTART_THRESHOLD_SECS = 180
 POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 600
+# config_reload adds 120 seconds to these values for its BGP convergence check.
+CONFIG_RELOAD_WAIT_SECS = 120
+LT2_CONFIG_RELOAD_WAIT_SECS = 480
+
+
+def get_config_reload_wait(tbinfo):
+    return LT2_CONFIG_RELOAD_WAIT_SECS if tbinfo["topo"]["type"] == "lt2" else CONFIG_RELOAD_WAIT_SECS
 
 
 @pytest.fixture(autouse=True, scope='module')
-def config_reload_after_tests(duthosts, rand_one_dut_hostname):
+def config_reload_after_tests(duthosts, rand_one_dut_hostname, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     yield
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True,
+                  wait=get_config_reload_wait(tbinfo), wait_for_bgp=True)
 
 
 @pytest.fixture(autouse=True, scope='module')
@@ -548,7 +556,8 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_ven
     yield
 
     logger.info("Executing the config reload...")
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True,
+                  wait=get_config_reload_wait(tbinfo), wait_for_bgp=True)
     logger.info("Executing the config reload was done!")
 
     ensure_all_critical_processes_running(duthost, containers_in_namespaces)


### PR DESCRIPTION
This manually backports #26933.

202512 predates the database-specific recovery branch, so the topology-specific wait is applied only to the two equivalent reload paths present on this branch. LT2 uses wait=480, yielding config_reload's 600-second BGP convergence window, while non-LT2 remains effectively unchanged at wait=120.

Red-team review found the backport faithful and no blocking issues; modular chassis already enforce a 600-second base wait.

Tests: py_compile; flake8 --max-line-length=120 on the changed file; git diff --check.