### PR TITLE
[snappi] Scope single-DUT snappi ports to the testbed's own chassis

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1922,6 +1922,17 @@ def get_snappi_ports_single_dut(duthosts,  # noqa: F811
                 port['asic_value'] = duthost.get_port_asic_instance(port['peer_port']).namespace
             else:
                 port['asic_value'] = None
+    # A DUT can be cabled to more than one snappi/ixia chassis; keep only the ports
+    # on the chassis this testbed drives (its ptf/api-server) so ports from another
+    # chassis do not leak in and create duplicate snappi Device names.
+    chassis_ips = {str(port['ip']).split('/')[0] for port in snappi_ports_all}
+    if len(chassis_ips) > 1:
+        ptf_ip = str(tbinfo['ptf_ip']).split('/')[0]
+        scoped_ports = [port for port in snappi_ports_all
+                        if str(port['ip']).split('/')[0] == ptf_ip]
+        logger.info('DUT {} peers snappi chassis {}; scoping to ptf {} ({} of {} ports)'.format(
+            duthost.hostname, sorted(chassis_ips), ptf_ip, len(scoped_ports), len(snappi_ports_all)))
+        snappi_ports_all = scoped_ports
     for index, port in enumerate(snappi_ports_all):
         port['port_id'] = str(index + 1)
     return snappi_ports_all


### PR DESCRIPTION
## Issue

On a testbed whose DUT is physically cabled to **more than one** snappi/ixia chassis, `get_snappi_ports_single_dut` collects ports from **every** peer chassis (`get_peer_snappi_chassis` returns all peers whose name contains `ixia`/`snappi`/`stc`). On the single-DUT path the collected list is never scoped to the testbed's own chassis, so ports that belong to a *different* testbed's chassis leak into the snappi `Config`.

That produces duplicate `Device` / `Ethernet` / `Ipv4` names, and IxNetwork rejects `set_config` with:

```
Device.name: "Device Port 0" is not unique, DeviceEthernet.name: "Ethernet Port 0" is not unique, ...
```

so every snappi test on that bed fails during setup, before any traffic runs. Testbeds whose DUT peers a single chassis are unaffected (that is the common case, which is why this went unnoticed).

## Fix

Before assigning `port_id`, keep only the ports on the chassis this testbed actually drives (matched by its `ptf` / api-server IP). It is guarded to only take effect when the DUT peers **more than one** chassis, so single-chassis testbeds get byte-for-byte identical behavior.

## Verification (real hardware)

Ran on a DUT cabled to two IXIA chassis:

- Collected **20 ports from 2 chassis**; the fix scoped it to **`kept=4 of 20`** (only the testbed's own chassis).
- `... is not unique` occurrences: **12 → 0**; `set_config` validation now passes.
- Single-chassis bed: `len(chassis_ips) == 1` → guard is `False` → no-op (no behavior change).
