### PR TITLE
[conditional_mark] Fix inert t0-vpp xfail for test_dhcp_relay_stress

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1259,7 +1259,7 @@ dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress:
   xfail:
     reason: "DHCP relay stress test is unstable on t0-vpp"
     conditions:
-      - "asic_type in ['vpp'] and topo_name in ['t0']"
+      - "asic_type in ['vpp'] and topo_name in ['t0-vpp']"
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[discover:
   skip:


### PR DESCRIPTION
### Description of PR
Summary:
Fixes an inert `xfail` condition added in https://github.com/sonic-net/sonic-mgmt/pull/27220 — it never evaluates to `True`, so `dhcp_relay/test_dhcp_relay_stress.py` still fails and aborts the whole `t0-vpp` test plan.

Follow-up to https://github.com/sonic-net/sonic-mgmt/pull/27220.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

https://github.com/sonic-net/sonic-mgmt/pull/27220 added an `xfail` for `test_dhcp_relay_stress` on the `t0-vpp` testbed:

```yaml
- "asic_type in ['vpp'] and topo_name in ['t0']"
```

The intent is correct, but the condition can never be true, so the `xfail` is never attached and the flake continues to abort the plan.

`conditional_mark` exposes **two distinct** topology variables (`tests/common/plugins/conditional_mark/__init__.py`):

```python
results['topo_type'] = tbinfo['topo']['type']   # regex-normalized family
results['topo_name'] = tbinfo['topo']['name']   # raw topo: field, verbatim
```

and they are derived differently in `tests/common/testbed.py`:

```python
topo = tb.pop("topo")                            # raw string from vtestbed.yaml
tb["topo"]["name"] = topo                        # verbatim
tb["topo"]["type"] = self.get_testbed_type(topo) # ^(wan|t0|t1|...) regex
```

`ansible/vtestbed.yaml` declares `conf-name: vms-kvm-vpp-t0` with **`topo: t0-vpp`**, so:

| variable | value |
|---|---|
| `topo_name` | `t0-vpp` |
| `topo_type` | `t0` |

`'t0-vpp' in ['t0']` is `False`, the `and` short-circuits, and the mark is skipped. An unmatched condition is silently a no-op, so nothing errors — the only symptom is that the flake never stops.

#### How did you do it?

One-line change to use the exact topo name:

```diff
-      - "asic_type in ['vpp'] and topo_name in ['t0']"
+      - "asic_type in ['vpp'] and topo_name in ['t0-vpp']"
```

`topo_type in ['t0']` would also work for this testbed, but it additionally matches `dualtor-vpp` and `dualtor-aa-vpp` (both normalize to `topo_type == 't0'`), which is broader than https://github.com/sonic-net/sonic-mgmt/pull/27220 intended and broader than what has been observed. Using the exact `topo_name` also matches how every other `topo_name in [...]` entry in this file is written (e.g. `t0-isolated-d96u32s2`, `dualtor-aa-56`, `t1-32-lag`).

#### How did you verify/test it?

Evaluated both the old and the new condition through the plugin's **own** evaluator (`evaluate_condition`, `__init__.py`), with facts derived from `ansible/vtestbed.yaml` using `TestbedInfo.get_testbed_type`:

```
conf-name                 topo_name        topo_type   asic_type   OLD      NEW
----------------------------------------------------------------------------------
vms-kvm-vpp-t1-lag        t1-lag-vpp       t1          vpp         False    False
vms-kvm-vpp-t1            t1-vpp           t1          vpp         False    False
vms-kvm-vpp-t0            t0-vpp           t0          vpp         False    True    <== TARGET
vms-kvm-dual-vpp-t0-1     dualtor-vpp      t0          vpp         False    False
vms-kvm-dual-vpp-t0-2     dualtor-aa-vpp   t0          vpp         False    False
```

Exactly one testbed changes behaviour — `vms-kvm-vpp-t0`, `False -> True` — and no other testbed is newly matched.

Also ran the repo-shipped `check-conditional-mark-sort` pre-commit hook (exit 0) and confirmed the YAML still parses.

Supporting evidence that the mark is currently inert: build [1200113](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1200113) on https://github.com/sonic-net/sonic-mgmt/pull/27249 aborted `impacted-area-kvmtest-t0-vpp` on **four** consecutive attempts, always on the same case:

```
Error type: RUN_TEST_CASE_FAILED
dhcp_relay/test_dhcp_relay_stress.py|||2 failed for RUN_TEST_CASE_FAILED, stop whole test plan

test_dhcp_relay_stress[offer-sonic-relay-agent]
Failed: Mismatch: DUT count = 55661, PTF count = 10786.
```

Historically this module aborts **389 of 483** `t0-vpp` test plans (**80.5%**, 2026-08-11 → 2026-08-25), which is what https://github.com/sonic-net/sonic-mgmt/pull/27220 set out to suppress.

#### Any platform specific information?

`asic_type: vpp` (sonic-vpp), `t0-vpp` KVM testbed only. No change in behaviour on any other platform or topology.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case.

### Documentation
No documentation change needed.
