### PR TITLE
[gnmi] Migrate COUNTERS_DB tests to managed pyGNMI

### DIFF
--- a/tests/gnmi/test_gnmi_countersdb.py
+++ b/tests/gnmi/test_gnmi_countersdb.py
@@ -3,55 +3,108 @@ import logging
 import pytest
 import re
 
-from .helper import gnmi_get, gnmi_subscribe_polling, gnmi_subscribe_streaming_sample, get_namespace, \
-                     apply_cert_config
+from .helper import get_namespace
 from tests.common import config_reload
+from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.pygnmi_client import PygnmiClientCallError, PygnmiClientError, SubscribeMode
 from tests.common.utilities import wait_until
 
 
 logger = logging.getLogger(__name__)
 
 CFG_DB_PATH = "/etc/sonic/config_db.json"
-ORIG_CFG_DB = "/etc/sonic/orig_config_db.json"
+CFG_DB_BACKUP = "/etc/sonic/config_db.json.gnmi_countersdb_backup"
 
 pytestmark = [
     pytest.mark.topology('any'),
     pytest.mark.disable_loganalyzer,
-    pytest.mark.usefixtures("setup_gnmi_ntp_client_server", "setup_gnmi_server",
-                            "setup_gnmi_rotated_server", "check_dut_timestamp")
+    pytest.mark.usefixtures("setup_gnmi_ntp_client_server", "check_dut_timestamp"),
 ]
 
 
-def _load_new_cfg(duthost, data):
+def _iter_response_text(value):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            yield str(key)
+            yield from _iter_response_text(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _iter_response_text(item)
+    elif value is not None:
+        yield str(value)
+
+
+def _iter_updates(value):
+    if isinstance(value, dict):
+        updates = value.get("update")
+        if isinstance(updates, list):
+            yield from (update for update in updates if isinstance(update, dict))
+        for item in value.values():
+            yield from _iter_updates(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _iter_updates(item)
+
+
+def _response_has_update(value, text):
+    for update in _iter_updates(value):
+        update_value = update.get("val")
+        if update_value is None or update_value == "" or update_value == {} or update_value == []:
+            continue
+        path = str(update.get("path") or "")
+        if text in path or any(text in item for item in _iter_response_text(update_value)):
+            return True
+    return False
+
+
+def _assert_responses_contain(result, text, expected):
+    pytest_assert(len(result) == expected, (
+        "Expected {} responses, got {}: {}"
+    ).format(expected, len(result), result))
+    pytest_assert(all(_response_has_update(response, text) for response in result), (
+        "Expected '{}' in every response: {}"
+    ).format(text, result))
+
+
+def _countersdb_prefix(duthost):
+    return "sonic-db:COUNTERS_DB/{}".format(get_namespace(duthost))
+
+
+def _load_new_cfg(duthost, grpc_env, data):
     duthost.copy(content=json.dumps(data, indent=4), dest=CFG_DB_PATH)
     config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True,
                   wait_for_bgp=True, yang_validate=False)
     # config reload restarts the gnmi container and drops the test cert/server setup;
-    # re-apply it so subsequent gnmi_get calls authenticate.
-    apply_cert_config(duthost)
+    # re-apply it so subsequent pygnmi calls authenticate.
+    grpc_env.reconfigure_after_reboot()
 
 
-def _get_buffer_queues_cnt(duthost, ptfhost, iface):
-    namespace_name = get_namespace(duthost)
-    path_list = ["/sonic-db:COUNTERS_DB/{}/COUNTERS_QUEUE_NAME_MAP".format(namespace_name)]
+def _get_buffer_queues_cnt(duthost, client, iface):
     try:
-        msg_list = gnmi_get(duthost, ptfhost, path_list)
-    except Exception:
+        result = client.get(
+            "COUNTERS_QUEUE_NAME_MAP",
+            prefix=_countersdb_prefix(duthost),
+        )
+    except PygnmiClientError:
         return 0
-    result = str(msg_list)
-    return len(re.findall(r'{}:\d+'.format(re.escape(iface)), result))
+    queue_pattern = re.compile(r'{}:\d+'.format(re.escape(iface)))
+    queues = set()
+    for text in _iter_response_text(result):
+        queues.update(queue_pattern.findall(text))
+    return len(queues)
 
 
-def _check_buffer_queues_cnt(duthost, ptfhost, iface):
-    return _get_buffer_queues_cnt(duthost, ptfhost, iface) > 0
+def _check_buffer_queues_cnt(duthost, client, iface):
+    return _get_buffer_queues_cnt(duthost, client, iface) > 0
 
 
-def test_gnmi_queue_buffer_cnt(duthosts, rand_one_dut_hostname, ptfhost):
+def test_gnmi_queue_buffer_cnt(rand_one_dut_hostname, gnmi_tls):  # noqa: F811
     """
     Check number of queue counters
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = gnmi_tls.duthost
+    client = gnmi_tls.pygnmi_client
     if duthost.is_supervisor_node():
         pytest.skip("Skipping test as no Ethernet0 frontpanel port on supervisor")
     logger.info('start gnmi output testing')
@@ -66,25 +119,17 @@ def test_gnmi_queue_buffer_cnt(duthosts, rand_one_dut_hostname, ptfhost):
     uc_list = re.findall(r"UC(\d+)", result["stdout"])
     for i in uc_list:
         # Read UC
-        path_list = [f"/sonic-db:COUNTERS_DB/{namespace_name}/COUNTERS_QUEUE_NAME_MAP/" + iface + ":" + str(i)]
-        msg_list = gnmi_get(duthost, ptfhost, path_list)
-        result = msg_list[0]
-        pytest_assert("oid" in result, (
+        path = "COUNTERS_QUEUE_NAME_MAP/" + iface + ":" + str(i)
+        result = client.get(path, prefix=_countersdb_prefix(duthost))
+        pytest_assert(_response_has_update(result, "oid"), (
             "OID not found in result. "
             "Result: {}"
         ).format(result))
 
     # Read invalid UC
-    path_list = [f"/sonic-db:COUNTERS_DB/{namespace_name}/COUNTERS_QUEUE_NAME_MAP/" + iface + ":abc"]
-    try:
-        msg_list = gnmi_get(duthost, ptfhost, path_list)
-    except Exception as e:
-        assert "GRPC error" in str(e), (
-            "Expected GRPC error, but got: {}. "
-        ).format(str(e))
-
-    else:
-        pytest.fail("Should fail for invalid path: " + path_list[0])
+    invalid_path = "COUNTERS_QUEUE_NAME_MAP/" + iface + ":abc"
+    with pytest.raises(PygnmiClientCallError):
+        client.get(invalid_path, prefix=_countersdb_prefix(duthost))
 
     # Verify the "create_only_config_db_buffers" optimization: with it enabled,
     # removing a BUFFER_QUEUE entry must reduce the number of queue counters in
@@ -95,8 +140,7 @@ def test_gnmi_queue_buffer_cnt(duthosts, rand_one_dut_hostname, ptfhost):
     admin_up_interfaces = [i for i, info in interfaces.items()
                            if pattern.match(i) and info['admin'] == 'up' and info['oper'] == 'up']
 
-    duthost.shell("sonic-cfggen -d --print-data > {}".format(ORIG_CFG_DB))
-    data = json.loads(duthost.shell("cat {}".format(ORIG_CFG_DB), verbose=False)['stdout'])
+    data = json.loads(duthost.shell("sonic-cfggen -d --print-data", verbose=False)['stdout'])
 
     if 'BUFFER_QUEUE' not in data or not data['BUFFER_QUEUE']:
         pytest.skip("Skipping test as BUFFER_QUEUE table is not present in config db")
@@ -137,39 +181,42 @@ def test_gnmi_queue_buffer_cnt(duthosts, rand_one_dut_hostname, ptfhost):
         else:
             is_single_queue = True
 
+    duthost.shell("cp {} {}".format(CFG_DB_PATH, CFG_DB_BACKUP))
     try:
         data['DEVICE_METADATA']["localhost"]["create_only_config_db_buffers"] = "true"
-        _load_new_cfg(duthost, data)
-        pytest_assert(wait_until(120, 20, 0, _check_buffer_queues_cnt, duthost, ptfhost, interface_to_check),
+        _load_new_cfg(duthost, gnmi_tls, data)
+        pytest_assert(wait_until(120, 20, 0, _check_buffer_queues_cnt, duthost, client, interface_to_check),
                       "Unable to get count of buffer queues from COUNTERS_QUEUE_NAME_MAP")
-        pre_del_cnt = _get_buffer_queues_cnt(duthost, ptfhost, interface_to_check)
+        pre_del_cnt = _get_buffer_queues_cnt(duthost, client, interface_to_check)
 
         # Remove a buffer queue, reload, and get the new number of queue counters.
         del data['BUFFER_QUEUE'][bq_entry]
-        _load_new_cfg(duthost, data)
+        _load_new_cfg(duthost, gnmi_tls, data)
         if not is_single_queue:
-            pytest_assert(wait_until(120, 20, 0, _check_buffer_queues_cnt, duthost, ptfhost, interface_to_check),
+            pytest_assert(wait_until(120, 20, 0, _check_buffer_queues_cnt, duthost, client, interface_to_check),
                           "Unable to get count of buffer queues from COUNTERS_QUEUE_NAME_MAP")
-        post_del_cnt = _get_buffer_queues_cnt(duthost, ptfhost, interface_to_check)
+        post_del_cnt = _get_buffer_queues_cnt(duthost, client, interface_to_check)
 
         pytest_assert(pre_del_cnt > post_del_cnt,
                       "Number of queue counters count differs from expected")
     finally:
-        data = json.loads(duthost.shell("cat {}".format(ORIG_CFG_DB), verbose=False)['stdout'])
-        _load_new_cfg(duthost, data)
+        duthost.shell("mv {} {}".format(CFG_DB_BACKUP, CFG_DB_PATH))
+        config_reload(duthost, config_source='config_db', safe_reload=True,
+                      check_intf_up_ports=True, wait_for_bgp=True,
+                      yang_validate=False)
 
 
-def test_gnmi_output(duthosts, rand_one_dut_hostname, ptfhost):
+def test_gnmi_output(rand_one_dut_hostname, gnmi_tls):  # noqa: F811
     """
     Read COUNTERS table
     Get table key from COUNTERS_PORT_NAME_MAP
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = gnmi_tls.duthost
+    client = gnmi_tls.pygnmi_client
     if duthost.is_supervisor_node():
         pytest.skip("Skipping test as no Ethernet0 frontpanel port on supervisor")
     logger.info('start gnmi output testing')
     # Get COUNTERS table key for Ethernet0
-    namespace_name = get_namespace(duthost)
     asic = duthost.get_port_asic_instance("Ethernet0")
     result = asic.run_sonic_db_cli_cmd("COUNTERS_DB hget COUNTERS_PORT_NAME_MAP Ethernet0")
     counter_key = result['stdout'].strip()
@@ -177,12 +224,11 @@ def test_gnmi_output(duthosts, rand_one_dut_hostname, ptfhost):
         "Invalid oid: {}."
     ).format(counter_key)
 
-    path_list = [f"/sonic-db:COUNTERS_DB/{namespace_name}/COUNTERS/" + counter_key]
-    msg_list = gnmi_get(duthost, ptfhost, path_list)
-    result = msg_list[0]
+    path = "COUNTERS/" + counter_key
+    result = client.get(path, prefix=_countersdb_prefix(duthost))
     logger.info("GNMI Server output")
     logger.info(result)
-    pytest_assert("SAI_PORT_STAT_IF_IN_ERRORS" in result, (
+    pytest_assert(_response_has_update(result, "SAI_PORT_STAT_IF_IN_ERRORS"), (
         "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi_output: {}."
     ).format(result))
 
@@ -190,48 +236,44 @@ def test_gnmi_output(duthosts, rand_one_dut_hostname, ptfhost):
 test_data_counters_port_name_map = [
     {
         "name": "Subscribe table for COUNTERS_PORT_NAME_MAP",
-        "path": "/sonic-db:COUNTERS_DB/",
         "port": "",
     },
     {
         "name": "Subscribe table field for COUNTERS_PORT_NAME_MAP",
-        "path": "/sonic-db:COUNTERS_DB/",
         "port": "/Ethernet0"
     }
 ]
 
 
 @pytest.mark.parametrize('test_data', test_data_counters_port_name_map)
-def test_gnmi_counterdb_polling_01(duthosts, rand_one_dut_hostname, ptfhost, test_data):
+def test_gnmi_counterdb_polling_01(rand_one_dut_hostname, gnmi_tls, test_data):  # noqa: F811
     '''
     Verify GNMI subscribe API
     Subscribe polling mode for COUNTERS_PORT_NAME_MAP
     '''
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = gnmi_tls.duthost
     if duthost.is_supervisor_node():
         pytest.skip("Skipping test as no Ethernet0 frontpanel port on supervisor")
     exp_cnt = 3
-    namespace_name = get_namespace(duthost)
-    path_list = [f"{test_data['path']}{namespace_name}/COUNTERS_PORT_NAME_MAP{test_data['port']}"]
-    msg, _ = gnmi_subscribe_polling(duthost, ptfhost, path_list, 1000, exp_cnt)
-    assert msg.count("oid") >= exp_cnt, (
-        "{}: {}. "
-        "Expected count of 'oid': {}"
-        "Actual count of 'oid': {}"
-    ).format(test_data["name"], msg, exp_cnt, msg.count("oid"))
+    path = "COUNTERS_PORT_NAME_MAP{}".format(test_data['port'])
+    result = list(gnmi_tls.pygnmi_client.subscribe(
+        path, mode=SubscribeMode.POLL,
+        poll_count=exp_cnt, poll_interval=1,
+        prefix=_countersdb_prefix(duthost),
+    ))
+    _assert_responses_contain(result, "oid", exp_cnt)
 
 
-def test_gnmi_counterdb_polling_02(duthosts, rand_one_dut_hostname, ptfhost):
+def test_gnmi_counterdb_polling_02(rand_one_dut_hostname, gnmi_tls):  # noqa: F811
     '''
     Verify GNMI subscribe API
     Subscribe polling mode for COUNTERS
     '''
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = gnmi_tls.duthost
     if duthost.is_supervisor_node():
         pytest.skip("Skipping test as no Ethernet0 frontpanel port on supervisor")
     exp_cnt = 3
     # Get COUNTERS table key for Ethernet0
-    namespace_name = get_namespace(duthost)
     asic = duthost.get_port_asic_instance("Ethernet0")
     result = asic.run_sonic_db_cli_cmd("COUNTERS_DB hget COUNTERS_PORT_NAME_MAP Ethernet0")
     counter_key = result['stdout'].strip()
@@ -241,67 +283,58 @@ def test_gnmi_counterdb_polling_02(duthosts, rand_one_dut_hostname, ptfhost):
     ).format(counter_key)
 
     # Subscribe table
-    counters_path = f"/sonic-db:COUNTERS_DB/{namespace_name}/COUNTERS/"
-    path_list = [counters_path]
-    msg, _ = gnmi_subscribe_polling(duthost, ptfhost, path_list, 1000, exp_cnt)
-    assert msg.count("SAI_PORT_STAT_IF_IN_ERRORS") >= exp_cnt, (
-        "Expected count of 'SAI_PORT_STAT_IF_IN_ERRORS' not met. "
-        "Expected count: {}"
-        "Actual count: {}"
-        "Message: {}"
-    ).format(exp_cnt, msg.count("SAI_PORT_STAT_IF_IN_ERRORS"), msg)
+    counters_path = "COUNTERS/"
+    result = list(gnmi_tls.pygnmi_client.subscribe(
+        counters_path, mode=SubscribeMode.POLL,
+        poll_count=exp_cnt, poll_interval=1,
+        prefix=_countersdb_prefix(duthost),
+    ))
+    _assert_responses_contain(result, "SAI_PORT_STAT_IF_IN_ERRORS", exp_cnt)
 
     # Subscribe table key
-    path_list = [counters_path + counter_key]
-    msg, _ = gnmi_subscribe_polling(duthost, ptfhost, path_list, 1000, exp_cnt)
-    assert msg.count("SAI_PORT_STAT_IF_IN_ERRORS") >= exp_cnt, (
-        "Expected count of 'SAI_PORT_STAT_IF_IN_ERRORS' not met. "
-        "Expected count: {}"
-        "Actual count: {}"
-        "Message: {}"
-    ).format(exp_cnt, msg.count("SAI_PORT_STAT_IF_IN_ERRORS"), msg)
+    result = list(gnmi_tls.pygnmi_client.subscribe(
+        counters_path + counter_key, mode=SubscribeMode.POLL,
+        poll_count=exp_cnt, poll_interval=1,
+        prefix=_countersdb_prefix(duthost),
+    ))
+    _assert_responses_contain(result, "SAI_PORT_STAT_IF_IN_ERRORS", exp_cnt)
     # Subscribe table field
-    path_list = [counters_path + counter_key + "/SAI_PORT_STAT_IF_IN_ERRORS"]
-    msg, _ = gnmi_subscribe_polling(duthost, ptfhost, path_list, 1000, exp_cnt)
-    assert msg.count("SAI_PORT_STAT_IF_IN_ERRORS") >= exp_cnt, (
-        "Expected count of 'SAI_PORT_STAT_IF_IN_ERRORS' not met. "
-        "Expected count: {}"
-        "Actual count: {}"
-        "Message: {}"
-    ).format(exp_cnt, msg.count("SAI_PORT_STAT_IF_IN_ERRORS"), msg)
+    result = list(gnmi_tls.pygnmi_client.subscribe(
+        counters_path + counter_key + "/SAI_PORT_STAT_IF_IN_ERRORS",
+        mode=SubscribeMode.POLL, poll_count=exp_cnt, poll_interval=1,
+        prefix=_countersdb_prefix(duthost),
+    ))
+    _assert_responses_contain(result, "SAI_PORT_STAT_IF_IN_ERRORS", exp_cnt)
 
 
 @pytest.mark.parametrize('test_data', test_data_counters_port_name_map)
-def test_gnmi_counterdb_streaming_sample_01(duthosts, rand_one_dut_hostname, ptfhost, test_data):
+def test_gnmi_counterdb_streaming_sample_01(rand_one_dut_hostname, gnmi_tls, test_data):  # noqa: F811
     '''
     Verify GNMI subscribe API
     Subscribe streaming sample mode for COUNTERS_PORT_NAME_MAP
     '''
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = gnmi_tls.duthost
     if duthost.is_supervisor_node():
         pytest.skip("Skipping test as no Ethernet0 frontpanel port on supervisor")
     exp_cnt = 3
-    namespace_name = get_namespace(duthost)
-    path_list = [f"{test_data['path']}{namespace_name}/COUNTERS_PORT_NAME_MAP{test_data['port']}"]
-    msg, _ = gnmi_subscribe_streaming_sample(duthost, ptfhost, path_list, 0, exp_cnt, origin="sonic-db")
-    assert msg.count("oid") >= exp_cnt, (
-        "Expected count of 'oid' not met. "
-        "Expected count: {}"
-        "Actual count: {}"
-        "Message: {}"
-    ).format(exp_cnt, msg.count("oid"), msg)
+    path = "COUNTERS_PORT_NAME_MAP{}".format(test_data['port'])
+    result = list(gnmi_tls.pygnmi_client.subscribe(
+        path, sample_interval=0,
+        count=exp_cnt, collect_seconds=30,
+        prefix=_countersdb_prefix(duthost),
+    ))
+    _assert_responses_contain(result, "oid", exp_cnt)
 
 
-def test_gnmi_counterdb_streaming_sample_02(duthosts, rand_one_dut_hostname, ptfhost):
+def test_gnmi_counterdb_streaming_sample_02(rand_one_dut_hostname, gnmi_tls):  # noqa: F811
     '''
     Verify GNMI subscribe API
     Subscribe streaming sample mode for COUNTERS
     '''
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = gnmi_tls.duthost
     if duthost.is_supervisor_node():
         pytest.skip("Skipping test as no Ethernet0 frontpanel port on supervisor")
     exp_cnt = 3
-    namespace_name = get_namespace(duthost)
     # Get COUNTERS table key for Ethernet0
     asic = duthost.get_port_asic_instance("Ethernet0")
     result = asic.run_sonic_db_cli_cmd("COUNTERS_DB hget COUNTERS_PORT_NAME_MAP Ethernet0")
@@ -312,11 +345,9 @@ def test_gnmi_counterdb_streaming_sample_02(duthosts, rand_one_dut_hostname, ptf
     ).format(counter_key)
 
     # Subscribe table field
-    path_list = [f"/sonic-db:COUNTERS_DB/{namespace_name}/COUNTERS/" + counter_key + "/SAI_PORT_STAT_IF_IN_ERRORS"]
-    msg, _ = gnmi_subscribe_streaming_sample(duthost, ptfhost, path_list, 0, exp_cnt, origin="sonic-db")
-    assert msg.count("SAI_PORT_STAT_IF_IN_ERRORS") >= exp_cnt, (
-        "Expected count of 'SAI_PORT_STAT_IF_IN_ERRORS' not met. "
-        "Expected count: {}"
-        "Actual count: {}"
-        "Message: {}"
-    ).format(exp_cnt, msg.count("SAI_PORT_STAT_IF_IN_ERRORS"), msg)
+    path = "COUNTERS/" + counter_key + "/SAI_PORT_STAT_IF_IN_ERRORS"
+    result = list(gnmi_tls.pygnmi_client.subscribe(
+        path, sample_interval=0, count=exp_cnt, collect_seconds=30,
+        prefix=_countersdb_prefix(duthost),
+    ))
+    _assert_responses_contain(result, "SAI_PORT_STAT_IF_IN_ERRORS", exp_cnt)


### PR DESCRIPTION
### Description of PR

Summary:

Migrate `gnmi/test_gnmi_countersdb.py` from the legacy unmanaged telemetry server and CLI/text clients to the managed `gnmi_tls` fixture and `PygnmiClient`.

The legacy module inherited `setup_gnmi_server`, which stopped Supervisor programs and launched `/usr/sbin/telemetry` through `nohup`. On images where the `gnmi` container uses the host PID namespace, that lifecycle could also stop the production telemetry service. The managed fixture configures `GNMI|gnmi` and `GNMI|certs`, restarts Supervisor-managed `gnmi-native`, couples the server and pyGNMI client configuration, and rolls ConfigDB back during teardown.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/39355711

Part of https://github.com/sonic-net/sonic-mgmt/issues/26384

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39355711

Failure type: regression after the gNMI container gained host PID namespace access

The original failure is on `SONiC.20251110.47`, so `202511` is the required backport branch. This migration depends on the requested `202511` backport of the managed `PygnmiClient` infrastructure from #26013. `tests/common/pygnmi_client.py` is not yet present on the current `202511` branch.

The same telemetry-absent / Monit `container_checker` teardown signature also occurs on `SONiC.20260510.12`. The current `internal-202605` base does not contain the complete prerequisites used by this master change. Standalone #27348 is not functional on current 202605; 202605 delivery requires the #23353, #26013, and #26467 commits/backports (or equivalent deliberately conflict-resolved release changes).

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master KVM image `SONiC.master.0-fe40965`, virtual T0:
  - Full migrated module run 1: 7 passed, 1 expected skip, 0 failures/errors in 292.52s.
  - Full migrated module run 2: 7 passed, 1 expected skip, 0 failures/errors in 332.59s.
  - The skipped queue-buffer mutation requires a `BUFFER_QUEUE` table, which the VS image does not provide.
  - All COUNTERS_DB GET, invalid-path, POLL, and STREAM/SAMPLE pyGNMI cases passed.
  - Fixture teardown completed, critical processes and YANG validation passed, `gnmi-native` remained Supervisor-managed, and Monit `container_checker` was OK.
- 202511 prerequisite: #26013 records 20/20 `PygnmiClient` tests passing on a physical 202511 image based on sonic-buildimage commit `d58ef239ed06`; its `202511` backport is still pending.
- 202511 target validation: run this migrated module on `SONiC.20251110.47` after the #26013 prerequisite lands.
- 202605 physical validation on `testbed-bjw2-can-720dt-8` (MX, `Arista-720DT-G48S4`), image `SONiC.20260510.12` (build commit `644c1a022f`):
  - Exact `internal-202605` base: `c113d8cc17c187dec6a7eec1639e5952a2ec908c`.
  - Validation stack, in dependency order:
    - #23353 merged source `2440e9f7c4323be78ee973b3d645da0231f2e7b2`, cherry-picked as `392e93ebf70fb8bac522bc1f457f7eeac704e616`.
    - #26013 merged source `6b9056e9d91948b949f345517ff65b55ada32395`, cherry-picked as `68e461337fd2fce7619540636c6e1d30f19f2a47`; the 202605 `grpc_fixtures.py` conflict was deliberately resolved by preserving the release fixture flow while adding the managed `PygnmiClient` and selected-DUT API.
    - #26467 merged source `610a2d5857c8287dde29ff67dbfb90634adbfbdc`, cherry-picked as `010a3be224ad9868de6f5002fc2ce0765d96a805`.
    - #27348 exact head `bfb25123e1ca267ec4ca5ea2de59af58ca2f9bdb`, cherry-picked as final validation head `6708583be66a468a5166a24e6645c271d65752c2`.
  - The resulting `tests/gnmi/test_gnmi_countersdb.py` blob is exactly `c54b20fa77593d29b513bc9f6a7448164e99057c`. Open backport PR #27343 was not included.
  - Fresh-workspace pretest: 11 passed, 3 expected skips, 0 failures/errors in 826.38s.
  - Full-module smoke: 7 passed, 1 expected skip, 0 failures/errors in 795.63s.
  - Five consecutive valid full-module runs: 7 passed, 1 expected skip, 0 failures/errors in 799.73s, 795.52s, 791.24s, 797.20s, and 796.56s.
  - Every module run collected all 8 cases. The queue-buffer mutation was the expected skip because `BUFFER_QUEUE` is absent from the rendered ConfigDB; all COUNTERS_DB GET, invalid-path, POLL, and STREAM/SAMPLE cases passed.
  - After the smoke and every evidence run, Monit `container_checker` was `OK` with last exit value 0, the `telemetry` container was running, and Supervisor-managed `gnmi-native` was `RUNNING`.
  - Five-run interval: 2026-08-31 05:07:57–06:16:36 UTC (15:07:57–16:16:36 Sydney, +10:00).
  - 202605 validation tracking: https://msazure.visualstudio.com/One/_workitems/edit/39480482 and https://msazure.visualstudio.com/One/_workitems/edit/39480484.
  - Delivery dependency: standalone #27348 is not functional on current 202605; the three prerequisite commits/backports above must be delivered first or incorporated equivalently in a deliberate release conflict resolution.
- Static: Python compilation, focused Flake8, collection of all eight cases, and `git diff --check` passed.

No public URL is available for the local KVM runs.

### Approach
#### What is the motivation for this PR?

The COUNTERS_DB module should use the repository's managed gRPC test environment rather than duplicate certificate/server lifecycle through an unmanaged `nohup` process. This removes the module's exposure to broad process-name cleanup and replaces CLI output parsing with native structured responses.

#### How did you do it?

- Replace `setup_gnmi_server` and rotated-certificate fixtures with function-scoped `gnmi_tls`.
- Use `gnmi_tls.pygnmi_client` for raw COUNTERS_DB GET, POLL, and STREAM/SAMPLE requests.
- Preserve per-ASIC namespace paths through the gNMI `sonic-db` prefix.
- Validate structured updates instead of counting CLI output strings.
- Reprovision the managed TLS server after the queue-buffer test reloads ConfigDB.
- Preserve and restore persistent `config_db.json` around that mutation.

#### How did you verify/test it?

Ran the entire eight-case module twice on a local T0 KVM with the managed TLS fixture and pyGNMI 0.8.15. Both runs completed without failures or errors, and post-run service health was clean.

On physical 202605 720DT MX hardware, a full-module smoke and five additional consecutive valid runs each collected all eight cases and completed with 7 passed, 1 expected capability skip, no failures/errors, and clean Monit/telemetry/`gnmi-native` post-run health.

#### Any platform specific information?

Raw COUNTERS_DB paths preserve the selected ASIC namespace. The queue-buffer mutation still depends on platforms exposing `BUFFER_QUEUE` in the rendered ConfigDB.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A

