### PR TITLE
Use dataclasses.replace for auto-derived to_version in perform_gnoi_upgrade

### DIFF
--- a/tests/common/helpers/upgrade_helpers.py
+++ b/tests/common/helpers/upgrade_helpers.py
@@ -3,7 +3,7 @@ import logging
 import ipaddress
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from six.moves.urllib.parse import urlparse
 import tests.common.fixtures.grpc_fixtures  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
@@ -376,9 +376,7 @@ def perform_gnoi_upgrade(
     pytest_assert(res.get("rc", 1) == 0, f"Downloaded file not found or empty on DUT: {cfg.dut_image_path}")
 
     # ---- 2b) Extract target version from the image binary if not provided ----
-    # Empty/None to_version means "always use the version extracted from the image".
-    target_version = cfg.to_version
-    if not target_version:
+    if not cfg.to_version:
         ver_result = duthost.shell(
             "sonic_installer binary_version {} 2>&1".format(cfg.dut_image_path)
             + " | grep 'SONiC-OS-' | awk -F'SONiC-OS-' '{print $2}'",
@@ -391,13 +389,13 @@ def perform_gnoi_upgrade(
                 cfg.dut_image_path, ver_result.get("stderr", "")
             ),
         )
-        target_version = "SONiC-OS-{}".format(extracted_version)
-        logger.info("Extracted target version from image: %s", target_version)
+        cfg = replace(cfg, to_version="SONiC-OS-{}".format(extracted_version))
+        logger.info("Extracted target version from image: %s", cfg.to_version)
 
     # ---- 3) SetPackage (via wrapper) ----
     setpkg_resp = ptf_gnoi.system_set_package(
         local_path=cfg.dut_image_path,
-        version=target_version,
+        version=cfg.to_version,
         activate=True,
     )
     logger.info("SetPackage response: %s", setpkg_resp)
@@ -441,8 +439,8 @@ def perform_gnoi_upgrade(
     images = _get_images_from_sonic_installer_list(duthost)
     logger.info("sonic-installer list parsed: %s", images)
     pytest_assert(
-        images.get("current") == target_version,
-        f"Current image mismatch after reboot. current={images.get('current')} expected={target_version}. full={images}"
+        images.get("current") == cfg.to_version,
+        f"Current image mismatch after reboot. current={images.get('current')} expected={cfg.to_version}. full={images}"
     )
 
     return {"transfer_resp": transfer_resp, "setpkg_resp": setpkg_resp}


### PR DESCRIPTION
### What

Rebind `cfg` via `dataclasses.replace()` in `perform_gnoi_upgrade` instead of
carrying the auto-derived target version in a separate local variable.

### Why

`GnoiUpgradeConfig` is declared `@dataclass(frozen=True)`. When a caller does not
supply `--target_version`, `cfg.to_version` is `None` and the helper derives the
version from the transferred image via `sonic_installer binary_version`.

Master currently stores that derived value in a local `target_version`, which
works, but leaves `cfg.to_version` still set to `None` for the remainder of the
function. Any code that reads the config object rather than the local sees a
stale `None`. Rebinding `cfg` with `replace()` keeps the config object itself
authoritative, so `cfg.to_version` is correct everywhere downstream.

### Background

Without a derived version, `system_set_package()` omits the `version` field
entirely (`ptf_gnoi.py` only sets it under `if version:`), and the gNOI server
rejects the request:

```
tests.common.ptf_grpc.PtfGrpcError: grpcurl failed: rc=67 stdout=''
stderr='ERROR:
  Code: InvalidArgument
  Message: version is missing in package request' msg='non-zero return code'
```

### How I did test it

No behavioural change to the SetPackage request itself — the same derived
version string is sent. Verified `perform_gnoi_upgrade` compiles and flake8 is
clean. The gNOI upgrade path requires real hardware and was not executed here.
