### PR TITLE
[process_monitoring] Skip auto-restart processes (bmcweb/sonic-dbus-bridge) from expected alerts on BMC

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -53,6 +53,33 @@ BMC_UNSUPPORTED_CRITICAL_PROCESSES = {
 }
 
 
+# Critical processes whose container supervisord.conf sets `autorestart=true`.
+# When killed, supervisord restarts them immediately, so they never stay down
+# long enough for the supervisor-proc-exit-listener to emit a
+# "Process '<name>' is not running" alert into syslog. They are still killed to
+# exercise the kill/restart path, but must be excluded from the expected
+# alerting messages. Keyed by container name:
+#   - otel: the 'otel' process autorestarts
+#   - redfish: 'bmcweb' / 'sonic-dbus-bridge' autorestart (BMC platforms only)
+AUTORESTART_CRITICAL_PROCESSES = {
+    "otel": ["otel"],
+    "redfish": ["sonic-dbus-bridge", "bmcweb"],
+}
+
+
+def _is_autorestart_process(container_name, critical_process):
+    """Return True if the given critical process is configured with
+    autorestart=true and therefore never emits a "not running" alert when killed.
+
+    Matches against the base container name, tolerating a namespace/ASIC suffix
+    (e.g. 'otel0') that may be appended for multi-ASIC platforms.
+    """
+    for base_container, processes in AUTORESTART_CRITICAL_PROCESSES.items():
+        if container_name.startswith(base_container) and critical_process in processes:
+            return True
+    return False
+
+
 def _filter_bmc_unsupported(duthost, container_name, critical_process_list):
     """Remove processes that are not supported on BMC devices from the given list.
 
@@ -368,8 +395,13 @@ def get_expected_alerting_messages_supervisor(duthost, containers_in_namespaces)
                 # TODO: Should remove the following two lines once the issue was solved in the image.
                 if "syncd" in container_name_in_namespace and critical_process == "dsserve":
                     continue
-                # Skip 'otel' process since it would autorestart
-                if "otel" in container_name_in_namespace and critical_process == "otel":
+                # Skip processes configured with autorestart=true (e.g. 'otel', and
+                # the redfish container's 'bmcweb' / 'sonic-dbus-bridge'). They are
+                # restarted immediately when killed, so they never emit a
+                # "not running" alert into syslog.
+                if _is_autorestart_process(container_name_in_namespace, critical_process):
+                    logger.info("Skipping autorestart process '{}' in container '{}' from expected alerts"
+                                .format(critical_process, container_name_in_namespace))
                     continue
                 logger.info("Generating the regex of expected alerting message for process '{}' in container '{}'"
                             .format(critical_process, container_name_in_namespace))
@@ -379,6 +411,10 @@ def get_expected_alerting_messages_supervisor(duthost, containers_in_namespaces)
             for critical_group in critical_group_list:
                 group_program_info = get_group_program_info(duthost, container_name_in_namespace, critical_group)
                 for program_name in group_program_info:
+                    if _is_autorestart_process(container_name_in_namespace, program_name):
+                        logger.info("Skipping autorestart process '{}' in container '{}' from expected alerts"
+                                    .format(program_name, container_name_in_namespace))
+                        continue
                     logger.info("Generating the regex of expected alerting message for process '{}' in container '{}'"
                                 .format(program_name, container_name_in_namespace))
                     expected_alerting_messages.append(".*Process '{}' is not running in namespace '{}'.*"


### PR DESCRIPTION
### Description of PR
Summary:
Fixes #27354

`test_monitoring_critical_processes` fails on BMC platforms. The test kills the `redfish` container's critical processes (`bmcweb`, `sonic-dbus-bridge`) and expects a `Process '<name>' is not running` alert in syslog. But both are configured with `autorestart=true` in their container's `supervisord.conf`, so supervisord restarts them immediately after they are killed — they never stay down long enough for `supervisor-proc-exit-listener` to emit the alert. LogAnalyzer then reports them as missing (`expected_missing_match: 2`).

The `otel` process already had the same problem and was handled with a hardcoded skip; this PR generalizes that handling.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202608

### Approach
#### What is the motivation for this PR?
Make `test_monitoring_critical_processes` pass on BMC platforms, where `bmcweb` and `sonic-dbus-bridge` auto-restart and therefore never emit "not running" syslog alerts.

#### How did you do it?
Added a static `AUTORESTART_CRITICAL_PROCESSES` map (keyed by container name: `otel` → `otel`; `redfish` → `bmcweb`, `sonic-dbus-bridge`) and a `_is_autorestart_process()` helper (tolerates a namespace/ASIC suffix). In `get_expected_alerting_messages_supervisor`, these processes are skipped from the expected alerting messages, in both the process and group loops. This folds the previously hardcoded `otel` skip into the same list. The processes are still killed, so the kill/restart path is still exercised.

#### How did you verify/test it?
- `python -m py_compile` and `flake8 --max-line-length=120` pass on the modified file.
- Root cause confirmed in sonic-buildimage: `bmcweb`, `sonic-dbus-bridge`, and `otel` all set `autorestart=true`; alerting processes `lldpd`/`lldpmgrd` set `autorestart=false`.

#### Any platform specific information?
The `redfish` container (bmcweb, sonic-dbus-bridge) only exists on BMC platforms.

#### Supported testbed topology if it's a new test case?
N/A — existing test, `bmc`/`any` topology.

### Documentation
N/A