### PR TITLE
[test_nbr_health]: Deduplicate converged cEOS health checks

### DIFF
--- a/tests/common/unit_tests/unit_test_nbr_health.py
+++ b/tests/common/unit_tests/unit_test_nbr_health.py
@@ -1,0 +1,169 @@
+"""
+Unit tests for tests/test_nbr_health.py::test_neighbors_health.
+
+Covers https://github.com/sonic-net/sonic-mgmt/issues/27339: on converged
+multi-VRF topologies several logical neighbors (nbrhosts entries) share one
+physical cEOS VM (same nbrhost.hostname, distinct EosHost objects).
+test_neighbors_health() must run check_snmp/check_eos_facts/
+check_eos_bgp_facts exactly once per physical hostname, not once per logical
+neighbor, while still failing the test if a check reports a problem.
+
+The real tests/test_nbr_health.py is loaded by file path via importlib, with
+lightweight stub modules injected into sys.modules for its
+tests.common.helpers.assertions / tests.common.devices.eos / .sonic
+imports. This avoids importing the real tests.common package (which pulls
+in ansible/paramiko), matching the isolation pattern used by
+tests/common/unit_tests/fixtures/unit_test_conn_graph_facts.py. Runs with
+only Python, pytest, and unittest.mock via:
+
+    python3 -m pytest --noconftest tests/common/unit_tests/unit_test_nbr_health.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "test_nbr_health.py"
+
+
+def _install_stub_modules():
+    """Inject fakes for test_nbr_health.py's tests.common.* imports."""
+    assertions_mod = types.ModuleType("tests.common.helpers.assertions")
+
+    def pytest_assert(condition, message=""):
+        if not condition:
+            pytest.fail(message)
+
+    assertions_mod.pytest_assert = pytest_assert
+
+    eos_mod = types.ModuleType("tests.common.devices.eos")
+
+    class EosHost:
+        def __init__(self, hostname, bgp_vrf=None):
+            self.hostname = hostname
+            self.bgp_vrf = bgp_vrf
+
+    eos_mod.EosHost = EosHost
+
+    sonic_mod = types.ModuleType("tests.common.devices.sonic")
+
+    class SonicHost:
+        pass
+
+    sonic_mod.SonicHost = SonicHost
+
+    sys.modules.update({
+        "tests": types.ModuleType("tests"),
+        "tests.common": types.ModuleType("tests.common"),
+        "tests.common.helpers": types.ModuleType("tests.common.helpers"),
+        "tests.common.helpers.assertions": assertions_mod,
+        "tests.common.devices": types.ModuleType("tests.common.devices"),
+        "tests.common.devices.eos": eos_mod,
+        "tests.common.devices.sonic": sonic_mod,
+    })
+
+
+def _load_target_module():
+    _install_stub_modules()
+    spec = importlib.util.spec_from_file_location("tests.test_nbr_health", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def nbr_health_module():
+    return _load_target_module()
+
+
+def _neighbor(mgmt_addr):
+    return {"mgmt_addr": mgmt_addr, "type": "SpineRouter"}
+
+
+def _run(module, nei_meta, nbrhosts, hostname="dut-1"):
+    duthost = MagicMock()
+    duthost.hostname = hostname
+    duthost.config_facts.return_value = {
+        "ansible_facts": {
+            "DEVICE_NEIGHBOR_METADATA": nei_meta,
+            "DEVICE_METADATA": {"localhost": {"type": "LeafRouter"}},
+        }
+    }
+    module.test_neighbors_health(
+        duthosts={hostname: duthost},
+        localhost=MagicMock(),
+        nbrhosts=nbrhosts,
+        eos={"snmp_rocommunity": "public"},
+        sonic={"snmp_rocommunity": "public"},
+        enum_frontend_dut_hostname=hostname,
+    )
+
+
+def test_same_physical_host_checked_once(nbr_health_module):
+    """Two logical VRF siblings, same hostname, different bgp_vrf: each
+    health helper is called exactly once."""
+    EosHost = nbr_health_module.EosHost
+    host_a = EosHost("VM0104", bgp_vrf="vrf-a")
+    host_b = EosHost("VM0104", bgp_vrf="vrf-b")
+    assert host_a is not host_b
+
+    nei_meta = {"vrf-a": _neighbor("10.250.0.1"), "vrf-b": _neighbor("10.250.0.1")}
+    nbrhosts = {"vrf-a": {"host": host_a}, "vrf-b": {"host": host_b}}
+
+    with patch.object(nbr_health_module, "check_snmp", return_value=None) as m_snmp, \
+            patch.object(nbr_health_module, "check_eos_facts", return_value=None) as m_facts, \
+            patch.object(nbr_health_module, "check_eos_bgp_facts", return_value=None) as m_bgp:
+        _run(nbr_health_module, nei_meta, nbrhosts)
+
+    assert m_snmp.call_count == 1
+    assert m_facts.call_count == 1
+    assert m_bgp.call_count == 1
+
+
+def test_different_physical_hosts_checked_independently(nbr_health_module):
+    """Two logical neighbors on two different physical hosts: each health
+    helper is called exactly twice, once per physical host."""
+    EosHost = nbr_health_module.EosHost
+    host_a = EosHost("VM0104")
+    host_b = EosHost("VM0105")
+
+    nei_meta = {"nbr-a": _neighbor("10.250.0.1"), "nbr-b": _neighbor("10.250.0.2")}
+    nbrhosts = {"nbr-a": {"host": host_a}, "nbr-b": {"host": host_b}}
+
+    with patch.object(nbr_health_module, "check_snmp", return_value=None) as m_snmp, \
+            patch.object(nbr_health_module, "check_eos_facts", return_value=None) as m_facts, \
+            patch.object(nbr_health_module, "check_eos_bgp_facts", return_value=None) as m_bgp:
+        _run(nbr_health_module, nei_meta, nbrhosts)
+
+    assert m_snmp.call_count == 2
+    assert m_facts.call_count == 2
+    assert m_bgp.call_count == 2
+
+
+def test_failure_propagates_despite_dedup(nbr_health_module):
+    """A failure from the single check run against a shared physical host
+    still fails test_neighbors_health(), even though the sibling VRF that
+    would have repeated the check is deduplicated."""
+    EosHost = nbr_health_module.EosHost
+    host_a = EosHost("VM0104", bgp_vrf="vrf-a")
+    host_b = EosHost("VM0104", bgp_vrf="vrf-b")
+
+    nei_meta = {"vrf-a": _neighbor("10.250.0.1"), "vrf-b": _neighbor("10.250.0.1")}
+    nbrhosts = {"vrf-a": {"host": host_a}, "vrf-b": {"host": host_b}}
+
+    with patch.object(nbr_health_module, "check_snmp", return_value=None) as m_snmp, \
+            patch.object(nbr_health_module, "check_eos_facts", return_value=None) as m_facts, \
+            patch.object(nbr_health_module, "check_eos_bgp_facts",
+                         return_value="vrf-a bgp not configured correctly") as m_bgp:
+        with pytest.raises(pytest.fail.Exception):
+            _run(nbr_health_module, nei_meta, nbrhosts)
+
+    # The failure was detected via the single check that ran on the shared
+    # physical host ...
+    assert m_bgp.call_count == 1
+    # ... even though the second logical sibling was deduplicated.
+    assert m_snmp.call_count == 1
+    assert m_facts.call_count == 1

--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -98,6 +98,11 @@ def test_neighbors_health(duthosts, localhost, nbrhosts, eos, sonic, enum_fronte
     """Check each neighbor device health"""
 
     fails = []
+    # Physical cEOS VMs already health-checked this run. On converged
+    # multi-VRF topologies, several logical neighbors (nbrhosts entries)
+    # share one physical EosHost VM (same nbrhost.hostname); skip repeating
+    # the device-wide checks for every logical sibling.
+    checked_eos_hosts = set()
     duthost = duthosts[enum_frontend_dut_hostname]
 
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
@@ -120,6 +125,12 @@ def test_neighbors_health(duthosts, localhost, nbrhosts, eos, sonic, enum_fronte
         nbrhost = nbrhosts[k]['host']
 
         if isinstance(nbrhost, EosHost):
+            if nbrhost.hostname in checked_eos_hosts:
+                logger.info("Skipping neighbor {}, physical host {} already checked"
+                            .format(k, nbrhost.hostname))
+                continue
+            checked_eos_hosts.add(nbrhost.hostname)
+
             failmsg = check_snmp(k, v['mgmt_addr'], localhost, eos['snmp_rocommunity'], True)
             if failmsg:
                 fails.append(failmsg)


### PR DESCRIPTION
### Description of PR

Summary:

Avoid repeated device-wide health checks for logical EOS neighbors that share the same physical cEOS VM on converged multi-VRF topologies.

`test_neighbors_health` currently iterates `DEVICE_NEIGHBOR_METADATA` per logical neighbor and runs SNMP, EOS facts, and all-VRF BGP checks each time. On converged topologies, multiple logical neighbors can map to the same physical cEOS VM, causing the same expensive checks to be repeated and making large topologies exceed the test timeout.

The change tracks physical EOS hosts by `nbrhost.hostname` and performs those device-wide checks once per physical VM. The existing `check_eos_bgp_facts()` behavior is preserved; on multi-VRF EOS hosts it already checks `show ip bgp summary vrf all` and validates all VRFs and peers.

Focused unit coverage verifies that shared physical hosts are checked once, different physical hosts are checked independently, and failures are still propagated when a logical sibling is skipped.

Fixes #27339

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A

Failure type: day-one scale/performance issue on converged multi-VRF topologies

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master:
  - `python3 -m pytest --noconftest tests/common/unit_tests/unit_test_nbr_health.py -v` -> **3 passed**
  - `python3 -m py_compile tests/test_nbr_health.py tests/common/unit_tests/unit_test_nbr_health.py` -> passed
  - `python3 -m flake8 --max-line-length=120 --select=E,W,F,C tests/test_nbr_health.py tests/common/unit_tests/unit_test_nbr_health.py` -> passed
  - `git diff --check` -> passed

A live converged multi-VRF testbed is required to reproduce the reported `Timeout >10000.0s`; that hardware-scale reproduction was not available locally.

### Approach

#### What is the motivation for this PR?

On converged multi-VRF cEOS topologies, several logical BGP neighbors can share one physical cEOS VM. `test_neighbors_health` currently runs the same physical-device health checks once for every logical neighbor, so runtime scales with the logical-neighbor count rather than the physical-VM count.

The repeated SNMP, EOS facts, and all-VRF BGP Ansible operations can make large converged topologies exceed the configured test timeout.

#### How did you do it?

Add a function-local `checked_eos_hosts` set in `test_neighbors_health()`.

For `EosHost` neighbors:

- use `nbrhost.hostname` as the physical cEOS VM identity;
- run the existing SNMP, EOS facts, and BGP checks only for the first logical neighbor mapped to that physical host;
- skip duplicate logical siblings and log which physical host was already checked.

The existing health-check helpers and failure messages are unchanged. `SonicHost` handling is also unchanged.

Added lightweight unit coverage that loads the real `tests/test_nbr_health.py` with stubbed SONiC framework imports so it can run with `--noconftest` and without Ansible.

#### How did you verify/test it?

Added three focused unit tests:

1. Two distinct logical EOS neighbors with the same physical hostname are health-checked once.
2. Two logical EOS neighbors with different physical hostnames are checked independently.
3. A health-check failure is still propagated even when another logical neighbor sharing the same physical host is deduplicated.

Result:

```text
3 passed in 0.01s
```

Also verified Python compilation, the repository-compatible flake8 checks, and `git diff --check`.

#### Any platform specific information?

The optimization is specific to the converged multi-VRF cEOS neighbor model. Existing non-converged EOS behavior remains equivalent, and SonicHost handling is unchanged.

#### Supported testbed topology if it's a new test case?

N/A — this is an improvement to the existing `test_neighbors_health` test.

### Documentation

No documentation change required.
