### PR TITLE
[platform_tests]: Handle BMC platforms in show platform fan and pcieinfo tests

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -460,7 +460,8 @@ def check_fan_status(duthost, cmd):
     fans = verify_show_platform_fan_output(duthost, fan_status_output_lines)
 
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-    if not fans and config_facts['DEVICE_METADATA']['localhost'].get('switch_type', '') == 'dpu':
+    if not fans and (config_facts['DEVICE_METADATA']['localhost'].get('switch_type', '') == 'dpu'
+                     or duthost.is_bmc()):
         return True
     if duthost.facts["asic_type"] == "vs":
         return True
@@ -700,6 +701,8 @@ def test_show_platform_pcieinfo(duthosts, enum_rand_one_per_hwsku_hostname):
     @summary: Verify output of `show platform pcieinfo`
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if duthost.is_bmc():
+        pytest.skip("PCIe config (pcie.yaml) is not provided on the BMC, skip the case on BMC")
 
     cmd = "show platform pcieinfo -c"
 


### PR DESCRIPTION
### Description of PR
Summary:
Fixes #27358

`test_show_platform_fan` and `test_show_platform_pcieinfo` in `platform_tests/cli/test_show_platform.py` fail on BMC platforms (e.g. `arm64-nokia_bmc_h6_128-r0` on a `bmc` topology):

- On BMC, `show platform fan` returns `Fan Not detected` — fans are not managed by the BMC. `check_fan_status` only accepted an empty fan list for `dpu`/`vs` devices, so the test polled the full timeout and then failed.
- On BMC, `show platform pcieinfo` has no `/usr/share/sonic/platform/pcie.yaml`, so the command errors out.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Two `show platform` CLI tests fail on BMC platforms because the BMC does not own fan management and does not provide a PCIe config file. Neither test previously handled BMC devices.

#### How did you do it?
- `test_show_platform_fan`: extended the existing "no fans is expected" branch in `check_fan_status` to also cover BMC devices (`duthost.is_bmc()`), alongside the existing `dpu`/`vs` handling. On BMC, `Fan Not detected` yields an empty fan list, which is now treated as a valid pass rather than a failure — so the test provides real coverage instead of being skipped.
- `test_show_platform_pcieinfo`: added a `duthost.is_bmc()` guard to skip the case on BMC, since the PCIe config (`pcie.yaml`) is not provided there.

`duthost.is_bmc()` returns True when `router_type == 'NetworkBmc'`, so non-BMC platforms are unaffected.

#### How did you verify/test it?
Compiled the module to confirm syntax. On a BMC testbed (`vms77-bmc-7220-1`, platform `arm64-nokia_bmc_h6_128-r0`), `show platform fan` returns `Fan Not detected` and pcieinfo errors on the missing config; with this change the fan case passes and the pcieinfo case is skipped. Non-BMC platforms retain their previous behavior.

#### Any platform specific information?
Affects BMC platforms only (`router_type == 'NetworkBmc'`).

#### Supported testbed topology if it's a new test case?
N/A — existing test cases.

### Documentation
N/A