### PR TITLE
[system_health]: Skip LED check on BMC platforms without system status LED support

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -507,9 +507,41 @@ def check_health_field_not_equal(duthost, field, unexpected):
     return not value or value != unexpected
 
 
+# Some platforms (e.g. certain BMC-based SKUs) do not implement
+# the system status LED chassis APIs. On those platforms 'show system-health summary'
+# exits non-zero with one of these markers. Treat that as "LED not supported" and
+# skip the LED check instead of failing the test.
+LED_UNSUPPORTED_MARKERS = [
+    "set_status_led is not implemented",
+    "get_status_led is not implemented",
+    "initizalize_system_led",   # upstream typo present in some platform APIs
+    "initialize_system_led",
+]
+
+
+def _system_health_summary(duthost):
+    """Run 'show system-health summary'.
+
+    Returns a tuple (supported, output):
+    - supported is False when the platform doesn't implement the system status
+      LED APIs (command exits non-zero with a known marker).
+    - output is the command stdout when supported, otherwise the combined
+      stdout/stderr for logging.
+    """
+    res = duthost.shell('show system-health summary', module_ignore_errors=True)
+    if res['rc'] != 0:
+        combined = "{}\n{}".format(res.get('stdout', ''), res.get('stderr', ''))
+        if any(marker in combined for marker in LED_UNSUPPORTED_MARKERS):
+            return False, combined
+        pytest_assert(
+            False,
+            "'show system-health summary' failed unexpectedly (rc={}): {}".format(res['rc'], combined))
+    return True, res['stdout']
+
+
 def _fetch_led_and_status(duthost):
     """Fetch system health summary and return (led_color_lower, status_dict)."""
-    summary = duthost.shell('show system-health summary')['stdout']
+    _, summary = _system_health_summary(duthost)
     # Use [\w ]+ to capture multi-word colors like "blinking green"
     led_res = re.findall(r"System status LED\s+([\w ]+)", summary)
     led_status = led_res[0].strip().lower() if led_res else ""
@@ -519,6 +551,14 @@ def _fetch_led_and_status(duthost):
 
 
 def check_system_health_led_info(duthost):
+    supported, output = _system_health_summary(duthost)
+    if not supported:
+        logger.warning(
+            "Skipping system status LED check: platform '%s' does not implement "
+            "the system status LED APIs ('show system-health summary' not supported). Output: %s",
+            duthost.facts.get('platform'), output)
+        return True
+
     led_cfg = get_system_health_config(duthost, "led_color", DEFAULT_LED_CONFIG)
     expected_normal = led_cfg["normal"].lower()
     not_normal = {color.lower() for key, color in led_cfg.items() if key != "normal"}

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -507,41 +507,9 @@ def check_health_field_not_equal(duthost, field, unexpected):
     return not value or value != unexpected
 
 
-# Some platforms (e.g. certain BMC-based SKUs) do not implement
-# the system status LED chassis APIs. On those platforms 'show system-health summary'
-# exits non-zero with one of these markers. Treat that as "LED not supported" and
-# skip the LED check instead of failing the test.
-LED_UNSUPPORTED_MARKERS = [
-    "set_status_led is not implemented",
-    "get_status_led is not implemented",
-    "initizalize_system_led",   # upstream typo present in some platform APIs
-    "initialize_system_led",
-]
-
-
-def _system_health_summary(duthost):
-    """Run 'show system-health summary'.
-
-    Returns a tuple (supported, output):
-    - supported is False when the platform doesn't implement the system status
-      LED APIs (command exits non-zero with a known marker).
-    - output is the command stdout when supported, otherwise the combined
-      stdout/stderr for logging.
-    """
-    res = duthost.shell('show system-health summary', module_ignore_errors=True)
-    if res['rc'] != 0:
-        combined = "{}\n{}".format(res.get('stdout', ''), res.get('stderr', ''))
-        if any(marker in combined for marker in LED_UNSUPPORTED_MARKERS):
-            return False, combined
-        pytest_assert(
-            False,
-            "'show system-health summary' failed unexpectedly (rc={}): {}".format(res['rc'], combined))
-    return True, res['stdout']
-
-
 def _fetch_led_and_status(duthost):
     """Fetch system health summary and return (led_color_lower, status_dict)."""
-    _, summary = _system_health_summary(duthost)
+    summary = duthost.shell('show system-health summary')['stdout']
     # Use [\w ]+ to capture multi-word colors like "blinking green"
     led_res = re.findall(r"System status LED\s+([\w ]+)", summary)
     led_status = led_res[0].strip().lower() if led_res else ""
@@ -551,12 +519,12 @@ def _fetch_led_and_status(duthost):
 
 
 def check_system_health_led_info(duthost):
-    supported, output = _system_health_summary(duthost)
-    if not supported:
+    # BMC platforms do not implement the system status LED chassis APIs, so
+    # 'show system-health summary' fails on them. Skip the LED check there.
+    if duthost.is_bmc():
         logger.warning(
-            "Skipping system status LED check: platform '%s' does not implement "
-            "the system status LED APIs ('show system-health summary' not supported). Output: %s",
-            duthost.facts.get('platform'), output)
+            "Skipping system status LED check: BMC platform '%s' does not implement "
+            "the system status LED APIs.", duthost.facts.get('platform'))
         return True
 
     led_cfg = get_system_health_config(duthost, "led_color", DEFAULT_LED_CONFIG)


### PR DESCRIPTION
### Description of PR
Summary:
Fixes #27360

`test_service_checker` and `test_service_checker_with_process_exit` fail on BMC platforms (e.g. `Nokia-7220-Th6p` BMC topology) because BMC devices do not implement the system status LED chassis APIs. On those platforms `show system-health summary` exits non-zero (`chassis.set_status_led is not implemented` / `AttributeError: 'Chassis' object has no attribute 'initizalize_system_led'`), causing `check_system_health_led_info` to raise `RunAnsibleModuleFail`.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202608

### Approach
#### What is the motivation for this PR?
BMC devices don't implement the system status LED APIs. The LED check should be skipped on BMC platforms rather than failing the whole test, while behavior on all other platforms stays unchanged.

#### How did you do it?
`check_system_health_led_info` now returns early (with a warning) when `duthost.is_bmc()` is `True`. Non-BMC platforms are unaffected.

#### How did you verify/test it?
Verified the module compiles (`python -m py_compile`). On BMC platforms the LED check is skipped with a warning; on all other platforms the existing LED verification runs as before.

#### Any platform specific information?
Scoped to BMC devices (detected via `DEVICE_METADATA.localhost.type == 'NetworkBmc'`), e.g. `Nokia-7220-Th6p` BMC topology. No behavior change for non-BMC platforms.

#### Supported testbed topology if it's a new test case?
N/A — existing test cases.

### Documentation
N/A