### PR TITLE
[202605] Stop pytest when testbed becomes unreachable (#26803)

### DIFF
--- a/tests/common/helpers/host_failure_utils.py
+++ b/tests/common/helpers/host_failure_utils.py
@@ -1,0 +1,178 @@
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+DUTHOSTS_FIXTURE_FAILED_CACHE_KEY = "duthosts_fixture_failed"
+TESTBED_UNREACHABLE_STOP_REASON = (
+    "DUT/testbed is unreachable; stop the current pytest session"
+)
+TESTBED_UNREACHABLE_HANDLED_ATTR = "sonic_testbed_unreachable_handled"
+
+# An exception message may embed a whole ansible module result, the failure
+# signatures we look for are always in the leading part of the message.
+MAX_INSPECTED_MESSAGE_LENGTH = 8192
+
+# The two messages pytest-ansible raises for an unreachable host, see
+# ModuleDispatcherV213._raise_on_unreachable. They are method local literals
+# upstream, not an importable constant, so they have to be repeated here:
+# https://github.com/ansible/pytest-ansible/blob/9374c591579fffedc85e6bc1509be40c7b505d36/src/pytest_ansible/module_dispatcher/v213.py#L292-L313
+# They stay recognizable after the exception is wrapped by pytest_assert or a
+# parallel task runner, which is the only case these markers are needed for: a
+# directly raised AnsibleConnectionFailure is already matched by its "dark"
+# hosts, which is a documented attribute of the exception class.
+#
+# "in the inventory" is the token that carries the signal, so the leading
+# "Host" is deliberately not part of the marker: it adds no precision, and
+# omitting it keeps the match working if upstream ever says "Hosts".
+# A bare "host unreachable" must never be used: ICMP output embeds
+# "Destination Host Unreachable" and tests do put raw ping output into their
+# failure messages (tests/common/helpers/tacacs/tacacs_helper.py), which would
+# retire a healthy DUT when only the pinged peer is down.
+UNREACHABLE_MARKERS = (
+    "unreachable in the inventory",
+    "unreachable in the extra inventory",
+)
+# Reboot and sanity recovery detect a dead DUT by running wait_for from
+# localhost against the DUT ssh port, so the ansible connection itself succeeds
+# and the failure surfaces as a plain Exception that only carries text, see
+# wait_for_startup in tests/common/reboot.py. There is no
+# AnsibleConnectionFailure and no "dark" hosts to inspect for these, which is
+# why matching the message is the only signal available.
+# On their own these markers only mean a single connection attempt failed, so
+# they need an unhealthy DUT context to tell an unusable testbed from a
+# functional failure.
+CONNECTIVITY_FAILURE_MARKERS = (
+    "unable to connect to port 22",
+    "timeout when waiting for",
+    "no route to host",
+)
+
+
+def _iter_exception_chain(exc):
+    """Yield an exception and every exception it is chained to."""
+    pending = [exc]
+    seen = set()
+
+    while pending:
+        current = pending.pop()
+        if current is None or id(current) in seen:
+            continue
+        seen.add(id(current))
+        yield current
+
+        pending.append(getattr(current, "__cause__", None))
+        # __context__ is attached to any exception raised while another one was
+        # being handled, so honor an explicit "raise ... from None".
+        if not getattr(current, "__suppress_context__", False):
+            pending.append(getattr(current, "__context__", None))
+        # Exceptions collected by an ExceptionGroup, used by parallel runs.
+        nested = getattr(current, "exceptions", None)
+        if isinstance(nested, (list, tuple)):
+            pending.extend(nested)
+
+
+def _get_dark_hosts(exc):
+    """Return the hosts an ansible connection failure could not reach.
+
+    "dark" is the exception attribute pytest-ansible populates directly from
+    its result callback: AnsibleConnectionFailure(msg, dark=callback.unreachable).
+    The callback itself is a local of ModuleDispatcherV213._run and AdHocResult
+    only carries the contacted hosts, so this attribute is the only supported
+    way to read callback.unreachable, and it is exact rather than text matched.
+    """
+    dark = getattr(exc, "dark", None)
+    if isinstance(dark, dict):
+        return sorted(dark.keys())
+    return []
+
+
+def _get_message(exc):
+    try:
+        message = str(exc)
+    except Exception:
+        return ""
+    return message[:MAX_INSPECTED_MESSAGE_LENGTH].lower()
+
+
+def _is_unreachable_failure(exc, connection_failure_types):
+    # A connection failure is only conclusive when it names the hosts that were
+    # unreachable. ansible-core raises the same exception type for connection
+    # errors that do not mean the testbed became unusable.
+    if (connection_failure_types and
+            isinstance(exc, connection_failure_types) and
+            _get_dark_hosts(exc)):
+        return True
+
+    message = _get_message(exc)
+    if any(marker in message for marker in UNREACHABLE_MARKERS):
+        return True
+
+    # A DUT that never came back from a reboot always leaves the testbed unusable.
+    if "did not startup after reboot" in message:
+        return True
+
+    if not any(marker in message
+               for marker in CONNECTIVITY_FAILURE_MARKERS):
+        return False
+
+    # A bare "did not startup" is also used by functional assertions, it only
+    # means an unusable testbed when the DUT is unreachable as well.
+    reboot_failure = (
+        "dut not start" in message or
+        "did not startup" in message
+    )
+    sanity_recovery_failure = "recovery of sanity check failed" in message
+    return reboot_failure or sanity_recovery_failure
+
+
+def is_testbed_unreachable_exception(exc, connection_failure_types=None):
+    """Return whether an exception means the assigned testbed is unusable."""
+    return any(
+        _is_unreachable_failure(current, connection_failure_types)
+        for current in _iter_exception_chain(exc)
+    )
+
+
+def _get_unreachable_hosts(exc):
+    for current in _iter_exception_chain(exc):
+        hosts = _get_dark_hosts(current)
+        if hosts:
+            return hosts
+    return []
+
+
+def stop_on_testbed_unreachable(node, call, connection_failure_types=None):
+    """Flag and stop a pytest session after a testbed connectivity failure."""
+    if call.excinfo is None:
+        return False
+
+    exc = call.excinfo.value
+    if not is_testbed_unreachable_exception(exc, connection_failure_types):
+        return False
+
+    session = node.session
+    if not getattr(session, TESTBED_UNREACHABLE_HANDLED_ATTR, False):
+        setattr(session, TESTBED_UNREACHABLE_HANDLED_ATTR, True)
+        logger.error(
+            "Testbed connectivity failure detected in %s phase of %s: %r",
+            call.when,
+            getattr(node, "name", "unknown"),
+            exc,
+        )
+
+    node.config.cache.set(DUTHOSTS_FIXTURE_FAILED_CACHE_KEY, True)
+
+    unreachable_hosts = _get_unreachable_hosts(exc)
+    if unreachable_hosts:
+        reason = "{}: {}".format(
+            TESTBED_UNREACHABLE_STOP_REASON,
+            ", ".join(unreachable_hosts),
+        )
+    else:
+        reason = TESTBED_UNREACHABLE_STOP_REASON
+
+    if not session.shouldstop:
+        session.shouldstop = reason
+
+    return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,9 @@ from tests.common.cache import FactsCache
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 from pytest_ansible.errors import AnsibleConnectionFailure
+from ansible.errors import AnsibleConnectionFailure as AnsibleCoreConnectionFailure
 from tests.common.helpers.inventory_utils import trim_inventory
+from tests.common.helpers.host_failure_utils import stop_on_testbed_unreachable
 from tests.common.utilities import InterruptableThread
 from tests.common.plugins.ptfadapter.dummy_testutils import DummyTestUtils
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
@@ -100,6 +102,10 @@ logger = logging.getLogger(__name__)
 cache = FactsCache()
 
 HOST_FIXTURE_FAILED_RC = 15
+CONNECTION_FAILURE_TYPES = (
+    AnsibleConnectionFailure,
+    AnsibleCoreConnectionFailure,
+)
 CUSTOM_MSG_PREFIX = "sonic_custom_msg"
 GOLDEN_CONFIG_DB_PATH = "/etc/sonic/golden_config_db.json"
 GOLDEN_CONFIG_DB_PATH_ORI = "/etc/sonic/golden_config_db.json.origin.backup"
@@ -695,6 +701,11 @@ def pytest_sessionstart(session):
     for key in keys:
         logger.debug("reset existing key: {}".format(key))
         session.config.cache.set(key, None)
+
+    # A session killed before pytest_sessionfinish leaves these flags in the cache,
+    # reset them so that a later healthy run is not reported as a host failure.
+    session.config.cache.set("duthosts_fixture_failed", None)
+    session.config.cache.set("ptfhost_exception", None)
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -1494,11 +1505,25 @@ def log_custom_msg(item):
 # messages are logged at the latest possible stage in the test lifecycle.
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
+    # Check the raw exception here instead of pytest_exception_interact,
+    # which pytest skips for expected failures (xfail).
+    try:
+        stop_on_testbed_unreachable(
+            item,
+            call,
+            CONNECTION_FAILURE_TYPES,
+        )
+    except Exception as e:
+        # This hook runs for every test phase, a failure here would abort the
+        # whole session with an INTERNALERROR instead of reporting the test.
+        logger.exception("Failed to check testbed connectivity failure: {}".format(repr(e)))
 
     if call.when == 'setup':
         item.user_properties.append(('start', str(datetime.fromtimestamp(call.start))))
     elif call.when == 'teardown':
-        if item.nodeid == item.session.items[-1].nodeid:
+        # The remaining items never run once the session is stopped early, so this
+        # is the last chance to attach the custom messages to the test report.
+        if item.nodeid == item.session.items[-1].nodeid or item.session.shouldstop:
             log_custom_msg(item)
         item.user_properties.append(('end', str(datetime.fromtimestamp(call.stop))))
 


### PR DESCRIPTION
### Description of PR

Summary:
Manual conflict-resolved backport of #26803 to `202605`.

When a DUT/testbed becomes unreachable during a pytest session, finish the current item's teardown, stop before the next test item, and return `HOST_FIXTURE_FAILED_RC` (`15`) so ElasticTest retires the unhealthy testbed instead of producing cascaded failures.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/38927876

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

The automatic backport of #26803 conflicts with the current `202605` branch. Without this change, a DUT that becomes unreachable part way through a module can cause the remaining tests to continue and generate unrelated failures.

#### How did you do it?

Re-applied the final functional diff from #26803 onto the current `202605` branch:

- Added high-confidence detection for pytest-ansible and ansible-core connectivity failures, including wrapped exceptions and exception groups.
- Set `duthosts_fixture_failed` and `session.shouldstop` immediately after detecting an unusable testbed.
- Preserved current-item teardown and custom JUnit messages before stopping the remaining items.
- Reset stale host-failure cache flags at session start.

#### How did you verify/test it?

- Changed-file pre-commit hooks passed.
- Python syntax checks passed for both changed files.
- A focused smoke test covered positive and negative unreachable signatures, cache updates, stop reason, and stable DUT ordering.
- ElasticTest validation on the internal `202605` port confirmed: case 1 passed, case 2 triggered the unreachable stop, current-item teardown completed, cases 3-5 did not run, and pytest returned code `15`:
  https://elastictest.org/scheduler/testplan/6a8d6990d025e08c23cc4f42?testcase=host_failure_validation%2Ftest_stop_on_testbed_unreachable.py%7C%7C%7C2&type=console

#### Any platform specific information?

Platform independent.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.
