### PR TITLE
[dhcp_relay] Skip the stress tests on sonic-vpp t0 KVM

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1243,22 +1243,22 @@ dhcp_relay/test_dhcp_relay.py::test_interface_binding:
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_restart_with_stress:
   skip:
-    reason: "Skip due to flaky issue"
+    reason: "1. Skip due to flaky issue
+             2. Unstable on sonic-vpp KVM, same low-performance reason as the vs skip below"
+    conditions_logical_operator: or
     conditions:
-      - "asic_type in ['vs']"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/16450"
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16450"
+      - "asic_type in ['vpp'] and topo_name in ['t0']"
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress:
   skip:
     reason: "1. Need to skip for platform armhf-nokia_ixs7215_52x-r0 due to buffer issues
-             2. Need to skip for KVM due to low performance"
+             2. Need to skip for KVM due to low performance
+             3. Unstable on sonic-vpp KVM; xfail did not keep PR checks green"
     conditions_logical_operator: or
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - "asic_type in ['vs']"
-  xfail:
-    reason: "DHCP relay stress test is unstable on t0-vpp"
-    conditions:
       - "asic_type in ['vpp'] and topo_name in ['t0']"
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[discover:


### PR DESCRIPTION
### Description of PR
Summary:
`dhcp_relay/test_dhcp_relay_stress.py` fails consistently on the `t0-vpp` PR check and is currently blocking unrelated PRs in both sonic-mgmt and sonic-buildimage. This extends the existing KVM skip to sonic-vpp on t0.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The module fails every time it runs on `t0-vpp`, and because ElasticTest uses `stop whole test plan`, one failing module fails the entire job. Observed across three independent PRs:

| PR | Repo | Attempts | Failing module |
|---|---|---|---|
| #29152 | sonic-buildimage | **3 of 3** | `dhcp_relay/test_dhcp_relay_stress.py` |
| #29166 | sonic-buildimage | 1 | same |
| #29162 | sonic-buildimage | 1 | same |

Both cases in this module are already skipped on **vs** KVM — *"Need to skip for KVM due to low performance"* and *"Skip due to flaky issue"*. sonic-vpp is a software data plane running on the same KVM infrastructure, so it has the same performance profile, but the conditions only ever matched `asic_type in ['vs']`.

#### How did you do it?

Two changes, both scoped to `asic_type == 'vpp'` **and** `topo_name == 't0'`:

1. `test_dhcp_relay_stress` — there was already an
   `xfail: "asic_type in ['vpp'] and topo_name in ['t0']"` for this, but the job still reports the module as failed, so xfail is not sufficient to keep the check green. Converted it to a `skip` on the same condition.
2. `test_dhcp_relay_restart_with_stress` — this one had **no** vpp handling at all. Its skip fires only on `asic_type in ['vs']`, so it runs unguarded on t0-vpp. Added the same vpp condition.

The pre-existing `vs` and `armhf-nokia_ixs7215_52x-r0` conditions are unchanged. I rewrote the first entry's implicit AND (`vs` AND issue-16450) as a single explicit condition so the new vpp arm could be OR'd alongside it without altering the original meaning.

#### How did you verify/test it?

Resolved both entries against the real yaml for five platform/topology combinations to confirm nothing outside vpp-t0 changes:

| Scenario | restart_with_stress | stress |
|---|---|---|
| `vs` + t0 | skip (unchanged) | skip (unchanged) |
| **`vpp` + t0** | **skip (new)** | **skip (new)** |
| `vpp` + t1-lag | runs | runs |
| `broadcom` + t0 | runs | runs |
| `armhf-nokia_ixs7215_52x-r0` | runs (unchanged) | skip (unchanged) |

`check-conditional-mark-sort` and `check-yaml` both pass.

#### Any platform specific information?

Only sonic-vpp on t0 is affected. Physical platforms and vpp t1-lag are untouched, so no coverage is lost anywhere the tests currently pass.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
No documentation change needed.