### PR TITLE
[202605] Fix SN4280 DPU reboot expectation after NPU crash (#26903)

### DIFF
--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -33,12 +33,25 @@ DUT_ABSENT_TIMEOUT_FOR_KERNEL_PANIC = 100
 DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION = 240
 MAX_COOL_OFF_TIME = 300
 EXTRA_DPU_ONLINE_TIMEOUT_FOR_WATCHDOG = 40
+SN4280_HWSKU_PREFIX = "Mellanox-SN4280"
 
 
 @pytest.fixture(params=["gnoi_based", "cli_based"])
 def invocation_type(request):
     """Parametrize reboot tests to run with both gNOI and CLI reboot paths."""
     return request.param
+
+
+def expects_dpu_reboot_after_npu_crash(duthost):
+    """Return whether DPUs are expected to reboot after an NPU crash/recovery."""
+    hwsku = duthost.facts.get('hwsku', '')
+    if hwsku.startswith(SN4280_HWSKU_PREFIX):
+        logging.info(
+            "Skipping DPU uptime reboot validation: %s keeps DPUs up during NPU crash recovery",
+            hwsku
+        )
+        return False
+    return True
 
 
 @pytest.mark.disable_loganalyzer
@@ -130,8 +143,10 @@ def test_dpu_status_post_switch_mem_exhaustion(duthosts, dpuhosts,
                                                  platform_api_conn,
                                                  num_dpu_modules)
 
-    logging.info("Recording DPU boot times before NPU memory exhaustion")
-    pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
+    pre_boot_times = None
+    if expects_dpu_reboot_after_npu_crash(duthost):
+        logging.info("Recording DPU boot times before NPU memory exhaustion")
+        pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
 
     logging.info("Starting memory exhaustion test on NPU by running \
                   a large process...")
@@ -178,8 +193,10 @@ def test_dpu_status_post_switch_kernel_panic(duthosts, dpuhosts,
                                                  platform_api_conn,
                                                  num_dpu_modules)
 
-    logging.info("Recording DPU boot times before NPU kernel panic")
-    pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
+    pre_boot_times = None
+    if expects_dpu_reboot_after_npu_crash(duthost):
+        logging.info("Recording DPU boot times before NPU kernel panic")
+        pre_boot_times = get_all_dpu_uptimes(dpuhosts, dpu_on_list)
 
     logging.info("Triggering kernel panic on NPU...")
     duthost.shell(kernel_panic_cmd, executable="/bin/bash")


### PR DESCRIPTION
### Description of PR

Summary:
Manual conflict-resolved backport of #26903 to `202605`.

SN4280 keeps DPUs up during NPU memory exhaustion and kernel panic recovery. These tests continue to verify post-recovery DPU status and connectivity, but skip the invalid uptime-based reboot assertion on SN4280.

Fixes #26455

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

The automatic cherry-pick of #26903 conflicts in `test_reload_dpu.py` because master contains adjacent DPU shutdown timing code that is not present on `202605`. The SN4280 release tests still need the platform-specific reboot expectation from the original fix.

#### How did you do it?

Re-applied only the functional diff from #26903 on top of the current `202605` branch:

- Added the SN4280 platform expectation helper.
- Gated DPU uptime collection for NPU memory exhaustion and NPU kernel panic tests.
- Preserved the existing `202605` implementation and excluded unrelated master-only code from the conflict.

#### How did you verify/test it?

- Changed-file pre-commit hooks passed.
- Python syntax compilation passed.
- The functional added/removed lines match #26903.

#### Any platform specific information?

Mellanox-SN4280 keeps DPUs up during NPU memory exhaustion and kernel panic recovery.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.