### PR TITLE
[everflow] Skip mirror-port queue drop check when QUEUE flex counter polling is disabled

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -448,6 +448,23 @@ def get_queue_counters(dut, asic_ns, port, queue):
     return -1
 
 
+def is_queue_counter_polling_enabled(duthost):
+    """
+    Check whether QUEUE flex counter polling is enabled on the DUT.
+
+    Only an explicit "disable" counts as off. If the key is missing we assume polling is on,
+    which matches the image default in init_cfg.json.j2 and keeps existing coverage intact.
+
+    Args:
+        duthost: DUT fixture
+    """
+    status = duthost.shell(
+        "sonic-db-cli CONFIG_DB hget 'FLEX_COUNTER_TABLE|QUEUE' FLEX_COUNTER_STATUS",
+        module_ignore_errors=True
+    )['stdout'].strip()
+    return status != "disable"
+
+
 def assert_no_tx_queue_drops_on_mirror_port(duthost, mirror_port):
     """
     Assert that there are no tx drops on the mirror port.
@@ -456,6 +473,16 @@ def assert_no_tx_queue_drops_on_mirror_port(duthost, mirror_port):
         duthost: DUT fixture
         mirror_port: The mirror port to check
     """
+    # Management devices have QUEUE flex counters disabled by minigraph.py, so
+    # "show queue counters" returns nothing and there is no drop data to check.
+    if not is_queue_counter_polling_enabled(duthost):
+        logging.warning("Skipping tx queue drop check on mirror port %s: QUEUE flex counter polling is "
+                        "disabled on %s (CONFIG_DB FLEX_COUNTER_TABLE|QUEUE FLEX_COUNTER_STATUS=disable). "
+                        "Port-level tx drops are still checked separately. If this device is not a "
+                        "management device, the disabled counter is unexpected and worth investigating.",
+                        mirror_port, duthost.hostname)
+        return
+
     cmd = f"show queue counters {mirror_port}"
     output = duthost.command(cmd)['stdout']
 


### PR DESCRIPTION
### Description of PR

`assert_no_tx_queue_drops_on_mirror_port` runs `show queue counters <mirror_port>` and fails the test when the port is absent from the output:

```python
if (not output) or mirror_port not in output:
    pytest_assert(False, f"Mirror port {mirror_port} not in queue counters output")
```

On any device where **QUEUE flex counter polling is disabled**, that command returns nothing, so the check can never pass. The failure message reads like a mirroring fault when the real cause is that there is no queue counter data to read.

Queue polling is disabled **by design on management devices**. `src/sonic-config-engine/minigraph.py` in sonic-buildimage does:

```python
mgmt_device_types = ['BmcMgmtToRRouter', 'MgmtToRRouter', 'MgmtTsToR']
mgmt_disabled_counters = ["BUFFER_POOL_WATERMARK", "PFCWD", "PG_DROP",
                          "PG_WATERMARK", "PORT_BUFFER_DROP", "QUEUE", "QUEUE_WATERMARK"]
...
if current_device and current_device['type'] in mgmt_device_types:
    results["FLEX_COUNTER_TABLE"] = {c: {"FLEX_COUNTER_STATUS": "disable"} for c in mgmt_disabled_counters}
```

with a dedicated unit test (`test_mgmt_device_disable_counters`) asserting it. So **every m0/mx testbed hits this, on any vendor and any ASIC** — it is not confined to one platform.

The existing call-site guard excluding `th2`/`td3` is about ASICs counting policer drops as TX drops — a separate concern, left untouched. Gating on ASIC name cannot express "this device has no queue counters", so the polling state is queried directly.

Summary: skip the mirror-port queue drop check when QUEUE flex counter polling is explicitly disabled.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/39312803

Reviewer start point: `tests/everflow/everflow_test_utilities.py`, `assert_no_tx_queue_drops_on_mirror_port`.

Dependencies: none.

cc @StormLiangMS @bingwang-ms — this touches the check added in #23269 / #27090.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Only 202605 is requested. `assert_no_tx_queue_drops_on_mirror_port` was introduced by #23269 and does not exist on 202311, 202405, 202411, 202505, 202511 or 202512, so those branches are unaffected. (202611 also carries the check but is not listed in this template; happy to add it if wanted.)

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39312803

Failure type: day-one issue — the check has never been able to pass on a management device since it was added; it is not a regression from a working state.

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

**202605: `SONiC.20260510.11` — ElasticTest test plan `6a8e8555c0a5d5aae841110c` — `FINISHED` / `SUCCESS`, 0 failures, 0 errors.**

Nokia-7215 (`Nokia-M0-7215`, armhf, marvell-prestera), m0 topology. Image pinned to the explicit `20260510.11` artifact so the code change is the only variable against the nightly baseline. Retries disabled so nothing is masked.

| | Before | After |
| --- | ---: | ---: |
| `test_everflow_dscp_with_policer` failures | **12** | **0** |

Collected 332, passed 83, skipped 249, failed 0, errored 0. The previously failing parametrizations now execute and pass rather than being skipped:

```
test_everflow_dscp_with_policer[erspan_ipv4-cli-downstream-m0_vlan_scenario]  success  181.6s
test_everflow_dscp_with_policer[erspan_ipv4-cli-downstream-m0_l3_scenario]    success  179.2s
test_everflow_dscp_with_policer[erspan_ipv4-cli-upstream-m0_vlan_scenario]    success  181.6s
```

They previously failed with `Mirror port EthernetNN not in queue counters output`. The remaining skips are pre-existing and unrelated (`ingress ACL w/ egress Mirroring not supported` and similar, which skip at setup in ~0.1 s).

DUT state confirming the condition under test:

```
$ counterpoll show
QUEUE_STAT                  default (10000)     disable
QUEUE_WATERMARK_STAT        default (60000)     disable

$ sonic-db-cli CONFIG_DB hgetall "FLEX_COUNTER_TABLE|QUEUE"
{'FLEX_COUNTER_STATUS': 'disable'}
```

The enabled/disabled split on this DUT matches `mgmt_disabled_counters` exactly — `ACL`, `PORT`, `RIF` enabled, all seven listed counters disabled — confirming the management-device path in `minigraph.py`.

**master was not separately executed.** `tests/everflow/everflow_test_utilities.py` is identical on master and 202605 at this function, and the change applies cleanly to both, so the 202605 run exercises the same code. Happy to run master as well if a reviewer would prefer it.

### Approach

#### What is the motivation for this PR?

The queue drop assertion is unsatisfiable on management devices, producing a guaranteed false failure with a misleading message on every m0/mx nightly. On our four Nokia-7215 lanes it accounted for 12 failures per m0 run.

#### How did you do it?

Added `is_queue_counter_polling_enabled()`, which reads `CONFIG_DB FLEX_COUNTER_TABLE|QUEUE FLEX_COUNTER_STATUS`, and an early return in `assert_no_tx_queue_drops_on_mirror_port()` when polling is explicitly disabled.

Only an explicit `"disable"` is treated as off. A missing key is assumed enabled, matching the `init_cfg.json.j2` default, so **coverage is unchanged anywhere polling is on**.

The skip is logged at `warning` level with the reason and an explicit pointer to investigate if it fires on a non-management device, so a wrongly disabled counter cannot hide silently.

#### How did you verify/test it?

See Test result above. Branch-specific evidence: 202605 / `SONiC.20260510.11` / plan `6a8e8555c0a5d5aae841110c`.

Worth noting for reviewers assessing coverage loss: **the port-level check still runs.** `assert_no_tx_drops_on_mirror_port` reads `TX_DRP` from PORT counters, and PORT polling remains enabled on management devices. Genuine mirror-port drops are still caught; only the per-queue breakdown is skipped, and that breakdown was never obtainable on these devices.

#### Any platform specific information?

Not platform specific. Triggered by device **type** (management devices), not vendor or ASIC. Observed on Nokia-7215 armhf and arm64, but applies to any m0/mx testbed.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case.

### Documentation

N/A — behaviour change is internal to a test utility and documented inline plus in the runtime warning.
