### PR TITLE
[kubesonic] Add Nokia-BMC-H6-128 to node-ip removal allowlist

### DIFF
--- a/tests/kubesonic/test_k8s_join_disjoin.py
+++ b/tests/kubesonic/test_k8s_join_disjoin.py
@@ -197,7 +197,8 @@ def is_the_sku_need_to_remove_node_ip_param(duthost):
         "Arista-7060CX-32S-C32",
         "Arista-7060X6-64PE-B-C512S2",
         "Mellanox-SN5640-C512S2",
-        "Mellanox-SN5640-C448O16"
+        "Mellanox-SN5640-C448O16",
+        "Nokia-BMC-H6-128"
     )
 
 


### PR DESCRIPTION
### Description of PR
Summary: Fixes k8s node joining failure for the `Nokia-BMC-H6-128` SKU in `test_k8s_join_disjoin.py`.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202608

### Approach
#### What is the motivation for this PR?
On the `Nokia-BMC-H6-128` SKU, `test_kubesonic_join_and_disjoin` fails at the join step:
```
Error from server (NotFound): nodes not found
Failed: Failed to join duthost to k8s cluster
```
The DUT's kubelet config contains `--node-ip=::`, which makes kubelet prefer an IPv6 address. Since the testbed communicates with the k8s (minikube) master over IPv4, the node never registers and the 120s join poll times out.

#### How did you do it?
Added the `Nokia-BMC-H6-128` hwsku to the `is_the_sku_need_to_remove_node_ip_param` allowlist, so `remove_node_ip_param()` rewrites `--node-ip=::` to the DUT management IP for this SKU.

#### How did you verify/test it?
Validated the file parses and the SKU is now matched. Should be run on a `Nokia-BMC-H6-128` DUT to confirm the join succeeds.

#### Any platform specific information?
Specific to the `Nokia-BMC-H6-128` SKU whose kubelet config sets `--node-ip=::`.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A