### PR TITLE
fix(memory_checker): ensure Monit monitors test container

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -243,6 +243,8 @@ def test_setup_and_cleanup(memory_checker_dut_and_container, request):
     backup_monit_config_files(duthost)
     customize_monit_config_files(duthost, container, *request.param)
     restart_monit_service(duthost)
+    logger.info("Ensuring Monit monitors %s", container.memory_service_name)
+    duthost.shell("sudo monit monitor {}".format(container.memory_service_name))
 
     yield
 


### PR DESCRIPTION
### Description of PR

Summary:
Ensure the memory checker explicitly enables monitoring for its target service after restarting Monit. Without this, `container_memory_gnmi` can remain `Not monitored`, causing `test_memory_checker` to wait 700 seconds and fail even though the GNMI container is healthy.

Fixes # N/A

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: intermittent PR-test flake

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `SONiC.master.1200798-5b575d9a0`, `vms-kvm-four-asic-t1-lag`
  - Unmodified test with `container_memory_gnmi` forced to `Not monitored`: failed with `Failed to wait for one monit cycle to be ok for gnmi`.
  - Patched test under the same forced precondition: passed 3 consecutive runs.
  - Each passing log confirmed `sudo monit monitor container_memory_gnmi` executed successfully before the readiness check.

Representative fleet failures:

- [Testplan 6a8e2cf3c02c8a580dfebf96](https://elastictest.org/scheduler/testplan/6a8e2cf3c02c8a580dfebf96): sonic-buildimage PR #29171, image `SONiC.master-29171.1202504-78a262911`; initial attempt failed with the target signature and retry passed.
- [Testplan 6a8e225ec02c8a580dfebf84](https://elastictest.org/scheduler/testplan/6a8e225ec02c8a580dfebf84): sonic-mgmt PR #26861, image `SONiC.master.1200798-5b575d9a0`; initial attempt failed with the target signature and retry passed.
- [Testplan 6a8e2a4eae6f9bbcd6a888cf](https://elastictest.org/scheduler/testplan/6a8e2a4eae6f9bbcd6a888cf): sonic-mgmt PR #26883, image `SONiC.master.1200798-5b575d9a0`; initial attempt failed with the target signature and retry passed.

### Approach
#### What is the motivation for this PR?

`restart_monit_service()` accepts intentionally disabled services in the `Not monitored` state. That is correct globally, but the memory checker requires its selected container memory service to be actively monitored. When `container_memory_gnmi` remains unmonitored after the restart, the test cannot observe an `OK` cycle and eventually times out.

#### How did you do it?

After restarting Monit in the test fixture, explicitly enable monitoring for the selected container memory service. The command is idempotent when the service is already monitored.

#### How did you verify/test it?

The fleet signature was reproduced locally by forcing `container_memory_gnmi` to `Not monitored` before running the test. The unmodified test failed with the same assertion seen in PR telemetry. The patched test passed three consecutive runs from that same precondition, and the logs confirmed the new command executed.

#### Any platform specific information?

Validated on the four-ASIC VS platform with `t1-8-lag`. The fix uses generic Monit behavior and is not platform-specific.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
