### PR TITLE
[secure_boot]: Test unsigned kernel module rejection

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -202,6 +202,7 @@ t0:
   - platform_tests/mellanox/test_hw_management_service.py
   - platform_tests/mellanox/test_psu_power_threshold.py
   - platform_tests/mellanox/test_reboot_cause.py
+  - platform_tests/secure_boot/test_secure_boot.py
   - platform_tests/sfp/test_sfpshow.py
   - platform_tests/sfp/test_sfputil.py
   - platform_tests/sfp/test_show_intf_xcvr.py

--- a/tests/common/helpers/grub_console.py
+++ b/tests/common/helpers/grub_console.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import shlex
+import sys
+import time
+
+import pexpect
+
+
+GRUB_MENU_READY = "The highlighted entry will be executed"
+KEY_UP = "\x1b[A"
+KEY_DOWN = "\x1b[B"
+GRUB_CONSOLE_SCRIPT_PATH = "/tmp/sonic_grub_console.py"
+
+
+def start_grub_entry_selection(
+    vmhost,
+    serial_port,
+    current_index,
+    target_index,
+    menu_pattern=GRUB_MENU_READY,
+    menu_occurrence=1,
+    wait_pattern=None,
+    wait_pattern_occurrence=1,
+    acknowledge_wait_pattern=False,
+    timeout=180,
+    log_path="/tmp/sonic_grub_console.log",
+):
+    """Start a VM-host process that selects a GRUB entry through serial."""
+    vmhost.copy(src=os.path.abspath(__file__), dest=GRUB_CONSOLE_SCRIPT_PATH)
+    wait_option = (
+        ""
+        if wait_pattern is None
+        else "--wait-pattern {} --wait-pattern-occurrence {} ".format(
+            shlex.quote(wait_pattern),
+            int(wait_pattern_occurrence),
+        )
+    )
+    acknowledge_option = (
+        "--acknowledge-wait-pattern " if acknowledge_wait_pattern else ""
+    )
+    command = (
+        "rm -f {log}; "
+        "nohup timeout {process_timeout} python3 {script} "
+        "--port {port} --current-index {current_index} "
+        "--target-index {target_index} "
+        "--menu-pattern {menu_pattern} --menu-occurrence {menu_occurrence} "
+        "{wait_option}{acknowledge_option}"
+        "--timeout {timeout} "
+        "> {log} 2>&1 < /dev/null & echo $!"
+    ).format(
+        log=shlex.quote(log_path),
+        process_timeout=int(timeout) + 10,
+        script=shlex.quote(GRUB_CONSOLE_SCRIPT_PATH),
+        port=int(serial_port),
+        current_index=int(current_index),
+        target_index=int(target_index),
+        menu_pattern=shlex.quote(menu_pattern),
+        menu_occurrence=int(menu_occurrence),
+        wait_option=wait_option,
+        acknowledge_option=acknowledge_option,
+        timeout=int(timeout),
+    )
+    result = vmhost.shell(command)
+    process_id = result["stdout"].strip()
+    if not process_id.isdigit():
+        raise RuntimeError(
+            "Failed to start GRUB console selection: {}".format(result)
+        )
+    return process_id, log_path
+
+
+def _connect(port, timeout):
+    last_error = None
+    for attempt in range(10):
+        try:
+            return pexpect.spawn(
+                "telnet",
+                ["127.0.0.1", str(port)],
+                timeout=timeout,
+                logfile=sys.stdout,
+                encoding="utf-8",
+                codec_errors="replace",
+            )
+        except OSError as error:
+            last_error = error
+            if attempt == 9:
+                break
+            time.sleep(1)
+    raise RuntimeError(
+        "Failed to connect to the serial console: {}".format(last_error)
+    )
+
+
+def select_grub_entry(
+    port,
+    current_index,
+    target_index,
+    menu_pattern=GRUB_MENU_READY,
+    menu_occurrence=1,
+    wait_pattern=None,
+    wait_pattern_occurrence=1,
+    acknowledge_wait_pattern=False,
+    timeout=180,
+):
+    """Select a zero-based entry when the requested GRUB menu appears."""
+    console = _connect(port, timeout)
+    try:
+        if wait_pattern:
+            for unused in range(wait_pattern_occurrence):
+                console.expect(wait_pattern)
+            if acknowledge_wait_pattern:
+                time.sleep(1)
+                console.sendline()
+        for unused in range(menu_occurrence):
+            console.expect_exact(menu_pattern)
+        time.sleep(0.5)
+
+        offset = target_index - current_index
+        key = KEY_DOWN if offset > 0 else KEY_UP
+        for unused in range(abs(offset)):
+            console.send(key)
+        console.sendline()
+        time.sleep(1)
+    finally:
+        console.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Select a GRUB entry through a Telnet serial console"
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        required=True,
+        help="Local Telnet serial-console port",
+    )
+    parser.add_argument(
+        "--current-index",
+        type=int,
+        required=True,
+        help="Initially highlighted entry index",
+    )
+    parser.add_argument(
+        "--target-index",
+        type=int,
+        required=True,
+        help="Entry index to select",
+    )
+    parser.add_argument(
+        "--menu-pattern",
+        default=GRUB_MENU_READY,
+        help="Exact output that indicates the GRUB menu is ready",
+    )
+    parser.add_argument(
+        "--menu-occurrence",
+        type=int,
+        default=1,
+        help="Select the entry when this occurrence of the GRUB menu appears",
+    )
+    parser.add_argument(
+        "--wait-pattern",
+        help=(
+            "Wait for this regular expression before looking for the GRUB "
+            "menu"
+        ),
+    )
+    parser.add_argument(
+        "--wait-pattern-occurrence",
+        type=int,
+        default=1,
+        help="Wait for this occurrence of the prerequisite pattern",
+    )
+    parser.add_argument(
+        "--acknowledge-wait-pattern",
+        action="store_true",
+        help="Press Enter after matching the prerequisite pattern",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=180,
+        help="Console interaction timeout",
+    )
+    args = parser.parse_args()
+
+    select_grub_entry(
+        port=args.port,
+        current_index=args.current_index,
+        target_index=args.target_index,
+        menu_pattern=args.menu_pattern,
+        menu_occurrence=args.menu_occurrence,
+        wait_pattern=args.wait_pattern,
+        wait_pattern_occurrence=args.wait_pattern_occurrence,
+        acknowledge_wait_pattern=args.acknowledge_wait_pattern,
+        timeout=args.timeout,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/common/helpers/secure_boot.py
+++ b/tests/common/helpers/secure_boot.py
@@ -1,0 +1,52 @@
+import shlex
+
+import pytest
+
+
+def require_secure_boot(duthost):
+    """Skip the test unless UEFI Secure Boot is enabled."""
+    secure_boot_state = duthost.command("mokutil --sb-state", module_ignore_errors=True)
+    if secure_boot_state["rc"] != 0 or "SecureBoot enabled" not in secure_boot_state["stdout"]:
+        pytest.skip("Secure Boot is not enabled")
+
+
+def get_installed_images(duthost):
+    """Return all SONiC images reported in the installer's Available section."""
+    output = duthost.command("sonic-installer list")["stdout"]
+    installed_images = []
+    reading_available = False
+
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if line == "Available:":
+            reading_available = True
+        elif reading_available and line:
+            installed_images.append(line)
+
+    return installed_images
+
+
+def get_inactive_image(installed_images, current_image):
+    """Return an installed image other than the running image."""
+    inactive_images = [image for image in installed_images if image != current_image]
+    if not inactive_images:
+        pytest.skip("--secure_boot_second_image_url or an installed inactive image is required")
+    return inactive_images[0]
+
+
+def get_current_image(duthost):
+    """Return the currently running SONiC image."""
+    return duthost.image_facts()["ansible_facts"]["ansible_image_facts"]["current"]
+
+
+def restore_image_selection(duthost, image):
+    """Set an image as both the default and next boot selection."""
+    quoted_image = shlex.quote(image)
+    duthost.command(
+        "sudo sonic-installer set-default {}".format(quoted_image),
+        module_ignore_errors=True,
+    )
+    duthost.command(
+        "sudo sonic-installer set-next-boot {}".format(quoted_image),
+        module_ignore_errors=True,
+    )

--- a/tests/platform_tests/secure_boot/test_secure_boot.py
+++ b/tests/platform_tests/secure_boot/test_secure_boot.py
@@ -1,0 +1,136 @@
+import shlex
+
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.secure_boot import require_secure_boot
+
+
+pytestmark = [
+    pytest.mark.topology("t0"),
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.skip_check_dut_health,
+]
+
+UNSIGNED_MODULE_PATH = "/tmp/secure_boot_unsigned_test.ko"
+SIGNATURE_REJECTION_MESSAGES = (
+    "key was rejected by service",
+    "loading of unsigned module is rejected",
+    "module verification failed",
+    "required key not available",
+)
+
+
+# Select a module that matches the running kernel but is not currently loaded.
+def _find_unloaded_kernel_module(duthost):
+    command = r"""
+loaded_modules=$(awk '{print $1}' /proc/modules | tr '-' '_')
+find /lib/modules/"$(uname -r)" -type f \
+    \( -name '*.ko' -o -name '*.ko.xz' -o -name '*.ko.gz' -o -name '*.ko.zst' \) |
+while read -r module; do
+    module_name=$(modinfo -F name "$module" 2>/dev/null | tr '-' '_')
+    if [ -n "$module_name" ] && ! printf '%s\n' "$loaded_modules" | grep -Fxq "$module_name"; then
+        printf '%s\n' "$module"
+        break
+    fi
+done
+"""
+    return duthost.shell(command)["stdout"].strip()
+
+
+# Copy the selected module to a temporary uncompressed file that can be modified.
+def _copy_uncompressed_module(duthost, source_path):
+    quoted_source = shlex.quote(source_path)
+    quoted_destination = shlex.quote(UNSIGNED_MODULE_PATH)
+
+    if source_path.endswith(".xz"):
+        command = "xz -dc {} > {}".format(quoted_source, quoted_destination)
+    elif source_path.endswith(".gz"):
+        command = "gzip -dc {} > {}".format(quoted_source, quoted_destination)
+    elif source_path.endswith(".zst"):
+        command = "zstd -dc {} > {}".format(quoted_source, quoted_destination)
+    else:
+        command = "cp {} {}".format(quoted_source, quoted_destination)
+
+    duthost.shell(command)
+
+
+# Remove the appended Linux module signature without changing the module payload.
+def _remove_module_signature(duthost):
+    command = r"""
+python3 - <<'PY'
+import struct
+
+module_path = "/tmp/secure_boot_unsigned_test.ko"
+signature_magic = b"~Module signature appended~\n"
+signature_header_size = 12
+
+with open(module_path, "rb") as module_file:
+    module_data = module_file.read()
+
+signature_count = 0
+while module_data.endswith(signature_magic):
+    header_offset = len(module_data) - len(signature_magic) - signature_header_size
+    signature_length = struct.unpack(">I", module_data[header_offset + 8:header_offset + 12])[0]
+    unsigned_module_size = header_offset - signature_length
+    if unsigned_module_size <= 0:
+        raise RuntimeError("Selected kernel module has an invalid signature length")
+    module_data = module_data[:unsigned_module_size]
+    signature_count += 1
+
+if signature_count == 0:
+    raise RuntimeError("Selected kernel module does not contain an appended signature")
+
+with open(module_path, "wb") as module_file:
+    module_file.write(module_data)
+PY
+"""
+    duthost.shell(command)
+
+
+# Verify that the running Secure Boot kernel refuses the unsigned module.
+def test_unsigned_kernel_module_is_rejected(duthost):
+    """Verify that Secure Boot prevents an unsigned kernel module from loading."""
+    require_secure_boot(duthost)
+
+    source_path = _find_unloaded_kernel_module(duthost)
+    pytest_assert(source_path, "No unloaded kernel module is available for the Secure Boot test")
+    module_name = duthost.command(
+        "modinfo -F name {}".format(shlex.quote(source_path))
+    )["stdout"].strip()
+
+    try:
+        _copy_uncompressed_module(duthost, source_path)
+
+        # Removing the signature keeps the module compatible with the running kernel
+        # while making it untrusted by the Secure Boot chain of trust.
+        _remove_module_signature(duthost)
+
+        dmesg_before = duthost.command("sudo dmesg --notime")["stdout"]
+        load_result = duthost.command(
+            "sudo insmod {}".format(shlex.quote(UNSIGNED_MODULE_PATH)),
+            module_ignore_errors=True,
+        )
+        dmesg_after = duthost.command("sudo dmesg --notime")["stdout"]
+
+        new_dmesg = dmesg_after[len(dmesg_before):] if dmesg_after.startswith(dmesg_before) else dmesg_after
+        rejection_output = "{}\n{}\n{}".format(
+            load_result["stdout"],
+            load_result["stderr"],
+            new_dmesg,
+        ).lower()
+
+        pytest_assert(load_result["rc"] != 0, "The kernel loaded an unsigned module")
+        pytest_assert(
+            any(message in rejection_output for message in SIGNATURE_REJECTION_MESSAGES),
+            "The module load failed without evidence of signature enforcement: {}".format(rejection_output),
+        )
+    finally:
+        duthost.command(
+            "sudo rmmod {}".format(shlex.quote(module_name)),
+            module_ignore_errors=True,
+        )
+        duthost.command(
+            "rm -f {}".format(shlex.quote(UNSIGNED_MODULE_PATH)),
+            module_ignore_errors=True,
+        )


### PR DESCRIPTION
### Description of PR

Summary:
Add a KVM Secure Boot test that removes every appended signature from a module built for the running kernel and verifies that the kernel rejects loading it.

ADO: 39396827

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `SONiC-OS-feature_sb-prune-db-certs.0-83f2141a3` - passed on `vms-kvm-t0` with UEFI Secure Boot enabled.

### Approach
#### What is the motivation for this PR?

Automatically verify that Secure Boot enforcement prevents unsigned kernel code from loading.

#### How did you do it?

Copy a module matching the running kernel, strip all appended Linux module signatures, attempt to load the resulting module, and require a Secure Boot signature-rejection error. The test restores and removes temporary artifacts during cleanup.

#### How did you verify/test it?

Ran the test end-to-end on the KVM `vms-kvm-t0` topology with Secure Boot enabled.

#### Any platform specific information?

The initial implementation supports the SONiC VS KVM platform and skips unsupported platforms or systems where Secure Boot is disabled.

#### Supported testbed topology if it's a new test case?

`t0` using a UEFI Secure Boot-enabled KVM DUT.

### Documentation

The Secure Boot test plan is tracked in PR #27301.