### PR TITLE
[vxlan] Cleanup VNET route precedence resources (#27101)

### DIFF
--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -320,14 +320,87 @@ class Test_VNET_BGP_route_Precedence():
     '''
         Class for all the tests where VNET and BGP learnt routes are tested.
     '''
+    @pytest.fixture(autouse=True)
+    def _cleanup_test_resources(self):
+        self._test_vnet_routes = []
+        self._test_bgp_routes = []
+        self._test_bgp_profiles = set()
+        yield
+
+        # Test bodies intentionally exercise failure paths. Keep cleanup outside
+        # the body so an assertion/xfail does not contaminate following cases.
+        cleanup_errors = []
+        for routes in list(reversed(getattr(self, "_test_vnet_routes", []))):
+            try:
+                self.remove_vnet_route(routes)
+            except Exception as err:
+                message = "Failed to cleanup VNET route {}: {}".format(routes, err)
+                Logger.warning(message, exc_info=True)
+                cleanup_errors.append(message)
+
+        for tor, routes, routes_adv in list(reversed(getattr(self, "_test_bgp_routes", []))):
+            try:
+                self.remove_bgp_route_from_neighbor_tor(tor, routes, routes_adv)
+            except Exception as err:
+                message = "Failed to cleanup BGP route {}: {}".format(routes_adv, err)
+                Logger.warning(message, exc_info=True)
+                cleanup_errors.append(message)
+
+        for profile in list(getattr(self, "_test_bgp_profiles", set())):
+            try:
+                self.remove_bgp_profile(profile)
+            except Exception as err:
+                message = "Failed to cleanup BGP profile {}: {}".format(profile, err)
+                Logger.warning(message, exc_info=True)
+                cleanup_errors.append(message)
+
+        if hasattr(self, "duthost"):
+            try:
+                self.wait_for_route_checks_pass(vnet_check=True)
+            except Exception as err:
+                message = "Route check still failing after per-test cleanup: {}".format(err)
+                Logger.warning(message, exc_info=True)
+                cleanup_errors.append(message)
+
+        if cleanup_errors:
+            pytest.fail("Per-test cleanup failed:\n{}".format("\n".join(cleanup_errors)))
+
+    def _track_vnet_route(self, routes):
+        if hasattr(self, "_test_vnet_routes") and routes not in self._test_vnet_routes:
+            self._test_vnet_routes.append(routes)
+
+    def _untrack_vnet_route(self, routes):
+        if hasattr(self, "_test_vnet_routes") and routes in self._test_vnet_routes:
+            self._test_vnet_routes.remove(routes)
+
+    def _track_bgp_route(self, tor, routes, routes_adv):
+        if hasattr(self, "_test_bgp_routes"):
+            for entry_tor, entry_routes, entry_routes_adv in self._test_bgp_routes:
+                if entry_tor is tor and entry_routes == routes and entry_routes_adv == routes_adv:
+                    return
+            self._test_bgp_routes.append((tor, routes, routes_adv))
+
+    def _untrack_bgp_route(self, tor, routes, routes_adv):
+        if not hasattr(self, "_test_bgp_routes"):
+            return
+        for index, entry in enumerate(self._test_bgp_routes):
+            entry_tor, entry_routes, entry_routes_adv = entry
+            if entry_tor is tor and entry_routes == routes and entry_routes_adv == routes_adv:
+                del self._test_bgp_routes[index]
+                return
+
     def create_bgp_profile(self, name, community):
         # sonic-db-cli APPL_DB HSET "BGP_PROFILE_TABLE:FROM_SDN_SLB_ROUTES" "community_id" "1234:1235"
         self.duthost.shell("sonic-db-cli APPL_DB HSET 'BGP_PROFILE_TABLE:{}' 'community_id' '{}'"
                            .format(name, community))
+        if hasattr(self, "_test_bgp_profiles"):
+            self._test_bgp_profiles.add(name)
 
     def remove_bgp_profile(self, name):
         # sonic-db-cli APPL_DB DEL "BGP_PROFILE_TABLE:FROM_SDN_SLB_ROUTES"
         self.duthost.shell("sonic-db-cli APPL_DB DEL 'BGP_PROFILE_TABLE:{}' ".format(name))
+        if hasattr(self, "_test_bgp_profiles"):
+            self._test_bgp_profiles.discard(name)
 
     def generate_vnet_routes(self, encap_type, num_routes, postfix='', nhcount=4, fixed_route=False, nh_prefix="202"):
         nexthops = []
@@ -352,8 +425,8 @@ class Test_VNET_BGP_route_Precedence():
                 routes_adv[vnet][f"{prefix_offset}.131.131.0"] = f"{prefix_offset}.131.131.0"
                 return routes_adv, routes_prefix
             else:
-                routes_prefix[vnet][f"dcfa:{prefix_offset}:131::"] = nexthops.copy()
-                routes_adv[vnet][f"dcfa:{prefix_offset}:131::"] = f"dcfa:{prefix_offset}:131::"
+                routes_prefix[vnet][f"dcfa:{prefix_offset}:131::"] = nexthops.copy()  # noqa: E231
+                routes_adv[vnet][f"dcfa:{prefix_offset}:131::"] = f"dcfa:{prefix_offset}:131::"  # noqa: E231
                 return routes_adv, routes_prefix
         count = 0
         if self.prefix_type == 'v4':
@@ -366,7 +439,7 @@ class Test_VNET_BGP_route_Precedence():
                     return routes_adv, routes_prefix
         else:
             for i in range(1, 250):
-                key = f"dc4a:{prefix_offset}:{i}::"
+                key = f"dc4a:{prefix_offset}:{i}::"  # noqa: E231
                 routes_prefix[vnet][key] = nexthops.copy()
                 routes_adv[vnet][key] = key
                 count = count + 1
@@ -376,17 +449,19 @@ class Test_VNET_BGP_route_Precedence():
 
     def remove_vnet_route(self, routes):
         routes_copy = routes.copy()
-        if routes in self.vxlan_test_setup['active_routes']:
-            self.vxlan_test_setup['active_routes'].remove(routes)
         ecmp_utils.set_routes_in_dut(self.duthost,
                                      routes_copy,
                                      self.prefix_type,
                                      'DEL',
                                      bfd=False,
                                      mask=self.prefix_mask)
+        if routes in self.vxlan_test_setup['active_routes']:
+            self.vxlan_test_setup['active_routes'].remove(routes)
+        self._untrack_vnet_route(routes)
 
     def add_monitored_vnet_route(self, routes, routes_adv, profile, monitor_type):
         self.vxlan_test_setup['active_routes'].append(routes)
+        self._track_vnet_route(routes)
         if monitor_type == 'custom':
             for vnet in routes:
                 for prefix in routes[vnet]:
@@ -444,6 +519,7 @@ class Test_VNET_BGP_route_Precedence():
         return
 
     def add_bgp_route_to_neighbor_tor(self, tor, routes, routes_adv):
+        self._track_bgp_route(tor, routes, routes_adv)
         if self.prefix_type == 'v4':
             type = 'ipv4'
             type1 = 'ip'
@@ -502,6 +578,7 @@ class Test_VNET_BGP_route_Precedence():
                         ]
                 tor['host'].run_command_list(cmds)
                 Logger.info("Route %s removed from :%s", prefix, tor['host'].hostname)
+        self._untrack_bgp_route(tor, routes, routes_adv)
 
     def get_asic_db_bfd_session_id(self):
         cmd = "python /tmp/bfd_notifier.py"


### PR DESCRIPTION
### Description of PR

Summary:
Cherry-pick of #27101 to the **202605** branch.

Track VNET routes, neighbor BGP routes, and BGP profiles created by each VNET/BGP route precedence test so the autouse cleanup fixture can remove any resources left behind by failures. Keep route cleanup registered until DUT deletion succeeds and fail the test if post-test cleanup or route consistency checks still report an error.

Original PR: https://github.com/sonic-net/sonic-mgmt/pull/27101
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/27100

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?

`tests/vxlan/test_vnet_bgp_route_precedence.py` is heavily parameterized and creates temporary VNET routes, BGP routes on neighbor TORs, and BGP profiles. If a test case fails before its normal cleanup path, those resources can remain configured and cause later parameters to fail route consistency checks due to stale state. This is a cherry-pick of #27101 into 202605.

#### How did you do it?

Cherry-picked commit `518d3b4b98ffa69f71f7d067012880f60019e5ef` from #27101.

The automatic cherry-pick failed the `Run pre-commit check` stage: flake8 (running under Python 3.12 in the 202605 pipeline) reported `E231 missing whitespace after ':'` on three **pre-existing** IPv6-address f-strings in `generate_vnet_routes()` (lines 428, 429, 442), which the fixture insertion shifted into the changed file. Under Python 3.12, PEP 701 tokenizes f-strings, so pycodestyle sees the literal `:` characters inside the IPv6 literals (e.g. `f"dcfa:{prefix_offset}:131::"`). Inserting whitespace there would corrupt the IPv6 addresses, so the correct fix is to suppress the false positive with `# noqa: E231`, matching existing repo precedent (e.g. the IPv6 f-strings in `tests/ecmp/test_ecmp_balance.py`).

#### How did you verify/test it?

Reproduced the exact pre-commit failure locally with `flake8==6.0.0` (the pinned pre-commit version) under Python 3.12 — the same 14 E231 errors on lines 428/429/442. After adding `# noqa: E231` to those three lines, `flake8==6.0.0` on Python 3.12 passes with no errors, and `python -m py_compile` plus flake8 on Python 3.11 also pass. The `# noqa` comments are the only delta from the original PR; there is no functional change to the test logic.

- 202605: pre-commit (flake8 6.0.0 / py3.12) - PASSED

#### Any platform specific information?

No. This is a generic sonic-mgmt test cleanup improvement.

#### Supported testbed topology if it's a new test case?

N/A - cherry-pick of an existing test improvement.

### Documentation

No documentation changes needed.