### PR TITLE
[pfcwd] Fix all-port storm traffic and cleanup

### DIFF
--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -3,6 +3,8 @@ import os
 import pathlib
 import re
 import json
+import shlex
+import uuid
 
 from jinja2 import Template
 from tests.common.errors import MissingInputError
@@ -82,6 +84,10 @@ class PFCStorm(object):
         self.pfc_frames_number = kwargs.pop('pfc_frames_number', 100000)
         self.send_pfc_frame_interval = kwargs.pop('send_pfc_frame_interval', 0)
         self.pfc_send_period = kwargs.pop('pfc_send_period', None)
+        self._pfc_gen_id = uuid.uuid4().hex
+        self._pfc_gen_pid_file = "/tmp/pfc_storm_{}.pid".format(self._pfc_gen_id)
+        self._pfc_gen_uses_pid = False
+        self._pfc_gen_stop_scheduled = False
         self.peer_info = kwargs.pop('peer_info')
         self._validate_params(expected_args=['pfc_fanout_interface', 'peerdevice'])
         if 'hwsku' not in self.peer_info:
@@ -341,6 +347,108 @@ class PFCStorm(object):
                 self.inventory, **self.extra_vars
                 )
 
+    def _get_arista_pfc_process_args(self):
+        priority = self.pfc_queue_idx if getattr(
+            self, "pfc_asym", False) else 1 << self.pfc_queue_idx
+        interfaces = self.peer_info['pfc_fanout_interface'].replace(
+            "Ethernet", "et").replace("/", "_")
+        args = [
+            "python3", self.pfc_gen_file, "-c", self.pfc_gen_chip_name,
+            "-p", str(priority), "-i", interfaces,
+        ]
+        if not getattr(self, "pfc_asym", False):
+            args.extend(["-r", self.ip_addr])
+        return args
+
+    def _start_deferred_arista_storm(self):
+        process = " ".join(
+            shlex.quote(arg) for arg in self._get_arista_pfc_process_args())
+        defer_time = getattr(self, "pfc_storm_defer_time", None)
+        if defer_time:
+            process = "sleep {} && exec {}".format(
+                shlex.quote(str(defer_time)), process)
+        else:
+            process = "exec {}".format(process)
+
+        launch_script = (
+            "cd {directory} || exit 1; "
+            "PFC_STORM_ID={identity} nohup sh -c {process} >/dev/null 2>&1 & "
+            "echo $! > {pid_file}"
+        ).format(
+            directory=shlex.quote(self._PFC_GEN_DIR['eos']),
+            identity=shlex.quote(self._pfc_gen_id),
+            process=shlex.quote(process),
+            pid_file=shlex.quote(self._pfc_gen_pid_file))
+        result = self.peer_device.shell(
+            "sudo -n sh -c {}".format(shlex.quote(launch_script)),
+            module_ignore_errors=True)
+        if result.get('rc') != 0:
+            raise RuntimeError(
+                "Failed to schedule PFC storm on {}".format(
+                    self.peer_info['peerdevice']))
+        self._pfc_gen_uses_pid = True
+        self._pfc_gen_stop_scheduled = False
+
+    def _stop_deferred_arista_storm(self, force=False):
+        if self._pfc_gen_stop_scheduled and not force:
+            return
+
+        pid_file = shlex.quote(self._pfc_gen_pid_file)
+        stop_script = "pid=$(cat {pid_file} 2>/dev/null) || exit 0; ".format(
+            pid_file=pid_file)
+        defer_time = None if force else getattr(
+            self, "pfc_storm_stop_defer_time", None)
+        if defer_time:
+            stop_script += "sleep {}; ".format(shlex.quote(str(defer_time)))
+        stop_script += (
+            "if ! tr '\\0' '\\n' < /proc/\"$pid\"/environ 2>/dev/null | "
+            "grep -Fqx {identity}; then "
+            "current=$(cat {pid_file} 2>/dev/null || true); "
+            "[ \"$current\" != \"$pid\" ] || rm -f {pid_file}; "
+            "exit 0; fi; "
+            "kill -TERM \"$pid\" 2>/dev/null || true; "
+            "elapsed=0; "
+            "while kill -0 \"$pid\" 2>/dev/null; do "
+            "[ \"$elapsed\" -ge 120 ] && exit 124; "
+            "sleep 1; elapsed=$((elapsed + 1)); "
+            "done; "
+            "current=$(cat {pid_file} 2>/dev/null || true); "
+            "[ \"$current\" != \"$pid\" ] || rm -f {pid_file}"
+        ).format(
+            identity=shlex.quote("PFC_STORM_ID={}".format(self._pfc_gen_id)),
+            pid_file=pid_file)
+
+        if defer_time:
+            launch_script = "nohup sh -c {} >/dev/null 2>&1 &".format(
+                shlex.quote(stop_script))
+            command = "sudo -n sh -c {}".format(shlex.quote(launch_script))
+        else:
+            command = "sudo -n sh -c {}".format(shlex.quote(stop_script))
+
+        result = self.peer_device.shell(command, module_ignore_errors=True)
+        if result.get('rc') != 0:
+            raise RuntimeError(
+                "Failed to stop PFC storm on {}".format(
+                    self.peer_info['peerdevice']))
+        self._pfc_gen_stop_scheduled = True
+
+    def wait_for_deferred_storm_stop(self):
+        """Wait until this handle's scheduled EOS storm has fully stopped."""
+        if not getattr(self, "_pfc_gen_uses_pid", False):
+            return
+
+        timeout = int(getattr(self, "pfc_storm_stop_defer_time", 0) or 0) + 130
+        wait_script = "while [ -e {} ]; do sleep 1; done".format(
+            shlex.quote(self._pfc_gen_pid_file))
+        result = self.peer_device.shell(
+            "timeout {} sh -c {}".format(timeout, shlex.quote(wait_script)),
+            module_ignore_errors=True)
+        if result.get('rc') != 0:
+            self._pfc_gen_stop_scheduled = False
+            self._stop_deferred_arista_storm(force=True)
+        self._pfc_gen_uses_pid = False
+        self._pfc_gen_stop_scheduled = False
+
     def start_storm(self):
         """
         Starts PFC storm on the fanout interfaces
@@ -352,12 +460,43 @@ class PFCStorm(object):
                     .format(self.peer_info['peerdevice'],
                             self.peer_info['pfc_fanout_interface'],
                             self.pfc_queue_idx))
-        self._run_pfc_gen_template()
+        if self.pfc_gen_chip_name and self.peer_device.os == 'eos' and (
+                getattr(self, "pfc_storm_defer_time", None) or
+                getattr(self, "pfc_storm_stop_defer_time", None)):
+            self._start_deferred_arista_storm()
+        else:
+            self._run_pfc_gen_template()
 
     def stop_storm(self):
         """
         Stops PFC storm on the fanout interfaces
         """
+        if self.pfc_gen_chip_name and self.peer_device.os == 'eos' and \
+                getattr(self, "_pfc_gen_uses_pid", False):
+            self._stop_deferred_arista_storm()
+            return
+
+        if self.pfc_gen_chip_name and self.peer_device.os == 'eos' and \
+                not getattr(self, "pfc_storm_defer_time", None) and \
+                not getattr(self, "pfc_storm_stop_defer_time", None):
+            process = " ".join(self._get_arista_pfc_process_args())
+            pattern = "^{}$".format(re.escape(process))
+            wait_command = (
+                "while true; do pgrep -f {pattern} >/dev/null; rc=$?; "
+                "case $rc in 0) sleep 1 ;; 1) exit 0 ;; *) exit $rc ;; esac; "
+                "done"
+            ).format(pattern=shlex.quote(pattern))
+            command = "sudo -n pkill -TERM -f {pattern} >/dev/null 2>&1 || true; " \
+                      "sudo -n timeout 120 sh -c {wait}".format(
+                          pattern=shlex.quote(pattern), wait=shlex.quote(wait_command))
+            result = self.peer_device.shell(
+                command, module_ignore_errors=True)
+            if result.get('rc') != 0:
+                raise RuntimeError(
+                    "Timed out stopping PFC storm on {}".format(
+                        self.peer_info['peerdevice']))
+            return
+
         self._prepare_stop_template()
         if self.asic_type == 'vs':
             return

--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -566,18 +566,19 @@ numprocs=1
 
 @contextlib.contextmanager
 def send_background_traffic(duthost, ptfhost, storm_hndle, selected_test_ports, test_ports_info, pkt_count=100000):
-    """Send background traffic, stop the background traffic when the context finish """
-    if is_mellanox_device(duthost) or is_cisco_device(duthost):
-        background_traffic_params = _prepare_background_traffic_params(duthost, storm_hndle,
-                                                                       selected_test_ports,
-                                                                       test_ports_info,
-                                                                       pkt_count)
-        background_traffic_log = _send_background_traffic(ptfhost, background_traffic_params)
-        # Ensure the background traffic is running before moving on
-        time.sleep(1)
-    yield
-    if is_mellanox_device(duthost) or is_cisco_device(duthost):
-        _stop_background_traffic(ptfhost, background_traffic_log)
+    """Send background traffic and always stop it when the context exits."""
+    background_traffic_log = None
+    try:
+        if is_mellanox_device(duthost) or is_cisco_device(duthost):
+            background_traffic_params = _prepare_background_traffic_params(duthost, storm_hndle,
+                                                                           selected_test_ports,
+                                                                           test_ports_info,
+                                                                           pkt_count)
+            background_traffic_log = _send_background_traffic(ptfhost, background_traffic_params)
+        yield
+    finally:
+        if background_traffic_log:
+            _stop_background_traffic(ptfhost, background_traffic_log)
 
 
 def _prepare_background_traffic_params(duthost, queues, selected_test_ports, test_ports_info, pkt_count):
@@ -597,12 +598,15 @@ def _prepare_background_traffic_params(duthost, queues, selected_test_ports, tes
 
     router_mac = duthost.get_dut_iface_mac(selected_test_ports[0])
 
+    if not isinstance(queues, (list, tuple, set)):
+        queues = [queues]
+
     ptf_params = {'router_mac': router_mac,
                   'src_ports': src_ports,
                   'dst_ports': dst_ports,
                   'src_ips': src_ips,
                   'dst_ips': dst_ips,
-                  'queues': queues,
+                  'queues': list(queues),
                   'bidirection': False,
                   'pkt_count': pkt_count}
 
@@ -610,18 +614,44 @@ def _prepare_background_traffic_params(duthost, queues, selected_test_ports, tes
 
 
 def _send_background_traffic(ptfhost, ptf_params):
-    timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+    timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H:%M:%S.%f')
     log_file = "/tmp/pfc_wd_background_traffic.PfcWdBackgroundTrafficTest.{}.log".format(timestamp)
-    ptf_runner(ptfhost, "ptftests", "pfc_wd_background_traffic.PfcWdBackgroundTrafficTest", "/root/ptftests",
-               params=ptf_params, log_file=log_file, is_python3=True, async_mode=True)
+    started = False
+    try:
+        ptf_runner(ptfhost, "ptftests", "pfc_wd_background_traffic.PfcWdBackgroundTrafficTest", "/root/ptftests",
+                   params=ptf_params, log_file=log_file, is_python3=True, async_mode=True)
 
-    return log_file
+        for _ in range(30):
+            result = ptfhost.shell(
+                f"grep -q 'Start to send the background traffic' {log_file}",
+                module_ignore_errors=True)
+            if result.get("rc") == 0:
+                started = True
+                return log_file
+            time.sleep(1)
+
+        raise RuntimeError(f"PFCWD background traffic did not start: {log_file}")
+    finally:
+        if not started:
+            _stop_background_traffic(ptfhost, log_file)
 
 
 def _stop_background_traffic(ptfhost, background_traffic_log):
-    pids = ptfhost.shell(f"pgrep -f {background_traffic_log}")["stdout_lines"]
+    process_pattern = background_traffic_log.replace("/pfc_", "/[p]fc_", 1)
+    result = ptfhost.shell(f"pgrep -f '{process_pattern}'", module_ignore_errors=True)
+    if result.get("rc") not in (0, 1):
+        raise RuntimeError(f"Failed to query PFCWD background traffic: {background_traffic_log}")
+    pids = result.get("stdout_lines", [])
     for pid in pids:
         ptfhost.shell(f"kill -9 {pid}", module_ignore_errors=True)
+    for _ in range(20):
+        result = ptfhost.shell(f"pgrep -f '{process_pattern}'", module_ignore_errors=True)
+        if result.get("rc") == 1:
+            return
+        if result.get("rc") != 0:
+            raise RuntimeError(f"Failed to query PFCWD background traffic: {background_traffic_log}")
+        time.sleep(0.5)
+    raise RuntimeError(f"Failed to stop PFCWD background traffic: {background_traffic_log}")
 
 
 def has_neighbor_device(setup_pfc_test):

--- a/tests/common/unit_tests/unit_test_pfcwd_all_port_storm.py
+++ b/tests/common/unit_tests/unit_test_pfcwd_all_port_storm.py
@@ -1,0 +1,388 @@
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.common.helpers import pfcwd_helper
+from tests.common.helpers.pfc_storm import PFCStorm
+from tests.pfcwd import test_pfcwd_all_port_storm as all_port_storm
+from tests.pfcwd.test_pfcwd_all_port_storm import configure_vlan_neighbors
+
+
+def test_background_traffic_is_stopped_after_test_failure():
+    dut = MagicMock()
+    ptfhost = MagicMock()
+
+    with patch.object(pfcwd_helper, "is_mellanox_device", return_value=True), \
+            patch.object(pfcwd_helper, "_prepare_background_traffic_params", return_value={}), \
+            patch.object(pfcwd_helper, "_send_background_traffic", return_value="/tmp/pfc_test.log"), \
+            patch.object(pfcwd_helper, "_stop_background_traffic") as stop:
+        with pytest.raises(RuntimeError, match="test failure"):
+            with pfcwd_helper.send_background_traffic(dut, ptfhost, None, [], {}):
+                raise RuntimeError("test failure")
+
+    stop.assert_called_once_with(ptfhost, "/tmp/pfc_test.log")
+
+
+def test_background_traffic_params_normalize_scalar_queue():
+    dut = MagicMock()
+    dut.get_dut_iface_mac.return_value = "00:11:22:33:44:55"
+    params = pfcwd_helper._prepare_background_traffic_params(
+        dut, 3, ["Ethernet0"], {
+            "Ethernet0": {
+                "rx_port_id": [4],
+                "test_port_id": 0,
+                "test_neighbor_addr": "10.0.0.1",
+                "rx_neighbor_addr": "10.0.0.5",
+            },
+        }, 500)
+
+    assert params["queues"] == [3]
+
+
+def test_background_traffic_waits_for_start_marker():
+    ptfhost = MagicMock()
+    ptfhost.shell.side_effect = [
+        {"rc": 1, "stdout_lines": []},
+        {"rc": 0, "stdout_lines": []},
+    ]
+
+    with patch.object(pfcwd_helper, "ptf_runner") as runner, \
+            patch.object(pfcwd_helper.time, "sleep") as sleep:
+        log_file = pfcwd_helper._send_background_traffic(ptfhost, {})
+
+    assert log_file.startswith(
+        "/tmp/pfc_wd_background_traffic.PfcWdBackgroundTrafficTest.")
+    assert runner.call_args.kwargs["log_file"] == log_file
+    assert runner.call_args.kwargs["async_mode"] is True
+    assert ptfhost.shell.call_count == 2
+    sleep.assert_called_once_with(1)
+
+
+def test_background_traffic_cleans_up_when_start_probe_raises():
+    ptfhost = MagicMock()
+    ptfhost.shell.side_effect = RuntimeError("probe failed")
+
+    with patch.object(pfcwd_helper, "ptf_runner"), \
+            patch.object(pfcwd_helper, "_stop_background_traffic") as stop:
+        with pytest.raises(RuntimeError, match="probe failed"):
+            pfcwd_helper._send_background_traffic(ptfhost, {})
+
+    assert stop.call_count == 1
+
+
+def test_stop_background_traffic_uses_self_safe_pattern():
+    ptfhost = MagicMock()
+    ptfhost.shell.side_effect = [
+        {"rc": 0, "stdout_lines": ["101", "102"]},
+        {"rc": 0},
+        {"rc": 0},
+        {"rc": 1, "stdout_lines": []},
+    ]
+
+    pfcwd_helper._stop_background_traffic(
+        ptfhost, "/tmp/pfc_wd_background_traffic.test.log")
+
+    assert "'/tmp/[p]fc_wd_background_traffic.test.log'" in \
+        ptfhost.shell.call_args_list[0].args[0]
+    assert ptfhost.shell.call_args_list[1].args[0] == "kill -9 101"
+    assert ptfhost.shell.call_args_list[2].args[0] == "kill -9 102"
+    assert "pgrep -f" in ptfhost.shell.call_args_list[3].args[0]
+
+
+def test_configure_vlan_neighbors_assigns_and_cleans_unique_addresses():
+    duthost = MagicMock()
+    duthost.facts = {"asic_type": "mellanox"}
+    duthost.get_ip_in_range.return_value = {
+        "ansible_facts": {
+            "generated_ips": ["192.168.0.3/21", "192.168.0.4/21"],
+        },
+    }
+    ptfhost = MagicMock()
+    test_ports = {
+        "Ethernet24": _vlan_port_info(6),
+        "Ethernet28": _vlan_port_info(7),
+    }
+    vlan = {"addr": "192.168.0.1", "prefix": 21, "dev": "Vlan1000"}
+
+    with configure_vlan_neighbors(duthost, ptfhost, test_ports, vlan, "IPv4"):
+        assert test_ports["Ethernet24"]["test_neighbor_addr"] == "192.168.0.3"
+        assert test_ports["Ethernet28"]["test_neighbor_addr"] == "192.168.0.4"
+
+    commands = [call.args[0] for call in ptfhost.command.call_args_list]
+    assert "ip address replace 192.168.0.3/21 dev eth6" in commands
+    assert "arping -i eth6 -S 192.168.0.3 -c 3 -w 5 192.168.0.1" in commands
+    assert "ip address del 192.168.0.3/21 dev eth6" in commands
+    assert "ip neigh del 192.168.0.1 dev eth6" in commands
+    dut_commands = [call.args[0] for call in duthost.command.call_args_list]
+    assert "ip neigh del 192.168.0.3 dev Vlan1000" in dut_commands
+    assert "ip neigh del 192.168.0.4 dev Vlan1000" in dut_commands
+    assert test_ports["Ethernet24"]["test_neighbor_addr"] == "192.168.0.2"
+    assert test_ports["Ethernet28"]["test_neighbor_addr"] == "192.168.0.2"
+
+
+def test_configure_vlan_neighbors_preserves_unique_destination():
+    duthost = MagicMock()
+    duthost.facts = {"asic_type": "mellanox"}
+    duthost.get_ip_in_range.return_value = {
+        "ansible_facts": {
+            "generated_ips": ["192.168.0.4/21", "192.168.0.5/21"],
+        },
+    }
+    ptfhost = MagicMock()
+    test_ports = {
+        "Ethernet24": _vlan_port_info(6),
+        "Ethernet28": _vlan_port_info(7),
+        "Ethernet32": {
+            **_vlan_port_info(8),
+            "test_neighbor_addr": "192.168.0.3",
+        },
+    }
+    vlan = {"addr": "192.168.0.1", "prefix": 21, "dev": "Vlan1000"}
+
+    with configure_vlan_neighbors(duthost, ptfhost, test_ports, vlan, "IPv4"):
+        assert test_ports["Ethernet32"]["test_neighbor_addr"] == "192.168.0.3"
+
+    commands = [call.args[0] for call in ptfhost.command.call_args_list]
+    assert all("eth8" not in command for command in commands)
+
+
+def test_configure_vlan_neighbors_cleans_single_unique_destination():
+    duthost = MagicMock()
+    duthost.facts = {"asic_type": "mellanox"}
+    ptfhost = MagicMock()
+    test_ports = {
+        "Ethernet24": _vlan_port_info(6),
+        "Ethernet28": {
+            **_vlan_port_info(7),
+            "test_neighbor_addr": "192.168.0.3",
+        },
+    }
+    vlan = {"addr": "192.168.0.1", "prefix": 21, "dev": "Vlan1000"}
+
+    with configure_vlan_neighbors(duthost, ptfhost, test_ports, vlan, "IPv4"):
+        pass
+
+    commands = [call.args[0] for call in ptfhost.command.call_args_list]
+    assert "ip address replace 192.168.0.2/21 dev eth6" in commands
+    assert "ip address del 192.168.0.2/21 dev eth6" in commands
+    assert all("eth7" not in command for command in commands)
+
+
+def test_configure_vlan_neighbors_configures_every_unique_cisco_port():
+    duthost = MagicMock()
+    duthost.facts = {"asic_type": "cisco-8000"}
+    ptfhost = MagicMock()
+    test_ports = {
+        "Ethernet24": _vlan_port_info(6),
+        "Ethernet28": {
+            **_vlan_port_info(7),
+            "test_neighbor_addr": "192.168.0.3",
+        },
+    }
+    vlan = {"addr": "192.168.0.1", "prefix": 21, "dev": "Vlan1000"}
+
+    with configure_vlan_neighbors(duthost, ptfhost, test_ports, vlan, "IPv4"):
+        pass
+
+    commands = [call.args[0] for call in ptfhost.command.call_args_list]
+    assert "ip address replace 192.168.0.2/21 dev eth6" in commands
+    assert "ip address replace 192.168.0.3/21 dev eth7" in commands
+    assert "ip address del 192.168.0.2/21 dev eth6" in commands
+    assert "ip address del 192.168.0.3/21 dev eth7" in commands
+    assert "sysctl -w net.ipv4.conf.all.arp_ignore=1" in commands
+    assert "sysctl -w net.ipv4.conf.all.arp_ignore=0" in commands
+    duthost.get_ip_in_range.assert_not_called()
+    assert not any("ip neigh del" in call.args[0]
+                   for call in duthost.command.call_args_list)
+
+
+def test_configure_vlan_neighbors_uses_explicit_ipv6_source_and_cleans_up():
+    duthost = MagicMock()
+    duthost.facts = {"asic_type": "mellanox"}
+    duthost.get_ip_in_range.return_value = {
+        "ansible_facts": {
+            "generated_ips": ["fc02:1000::3/64", "fc02:1000::4/64"],
+        },
+    }
+    ptfhost = MagicMock()
+    test_ports = {
+        "Ethernet24": _vlan_port_info(6, "fc02:1000::2"),
+        "Ethernet28": _vlan_port_info(7, "fc02:1000::2"),
+    }
+    vlan = {"addr": "fc02:1000::1", "prefix": 64, "dev": "Vlan1000"}
+
+    with configure_vlan_neighbors(duthost, ptfhost, test_ports, vlan, "IPv6"):
+        pass
+
+    commands = [call.args[0] for call in ptfhost.command.call_args_list]
+    assert "ip -6 address replace fc02:1000::3/64 dev eth6 nodad" in commands
+    assert "ping -6 -I eth6 -I fc02:1000::3 -c 3 -W 2 fc02:1000::1" in commands
+    assert "ip -6 address del fc02:1000::3/64 dev eth6" in commands
+    assert "ip -6 neigh del fc02:1000::1 dev eth6" in commands
+    dut_commands = [call.args[0] for call in duthost.command.call_args_list]
+    assert "ip -6 neigh del fc02:1000::3 dev Vlan1000" in dut_commands
+
+
+def test_configure_vlan_neighbors_cleans_up_after_arp_failure():
+    duthost = MagicMock()
+    duthost.facts = {"asic_type": "mellanox"}
+    duthost.get_ip_in_range.return_value = {
+        "ansible_facts": {
+            "generated_ips": ["192.168.0.3/21", "192.168.0.4/21"],
+        },
+    }
+    ptfhost = MagicMock()
+    ptfhost.command.side_effect = lambda command, **_kwargs: (
+        (_ for _ in ()).throw(RuntimeError("ARP failed"))
+        if command.startswith("arping ") else None)
+    test_ports = {
+        "Ethernet24": _vlan_port_info(6),
+        "Ethernet28": _vlan_port_info(7),
+    }
+    vlan = {"addr": "192.168.0.1", "prefix": 21, "dev": "Vlan1000"}
+
+    with pytest.raises(RuntimeError, match="ARP failed"):
+        with configure_vlan_neighbors(duthost, ptfhost, test_ports, vlan, "IPv4"):
+            pass
+
+    commands = [call.args[0] for call in ptfhost.command.call_args_list]
+    assert "ip address del 192.168.0.3/21 dev eth6" in commands
+    assert "ip neigh del 192.168.0.1 dev eth6" in commands
+    assert test_ports["Ethernet24"]["test_neighbor_addr"] == "192.168.0.2"
+
+
+def test_all_port_storm_selects_ports_from_every_fanout():
+    dut = MagicMock()
+    dut.facts = {"asic_type": "mellanox"}
+    storm = MagicMock()
+    storm.peer_params = {
+        "fanout-1": {"intfs": "Ethernet1"},
+        "fanout-2": {"intfs": "Ethernet2"},
+    }
+    storm.fanout_graph = {
+        "fanout-1": {"device_conn": {"Ethernet1": {"peerport": "Ethernet0"}}},
+        "fanout-2": {"device_conn": {"Ethernet2": {"peerport": "Ethernet4"}}},
+    }
+    storm.storm_handle = {
+        "fanout-1": MagicMock(pfc_queue_idx=3),
+        "fanout-2": MagicMock(pfc_queue_idx=3),
+    }
+    setup = {
+        "test_ports": {"Ethernet0": {}, "Ethernet4": {}},
+        "vlan": None,
+        "ip_version": "IPv4",
+    }
+    test = all_port_storm.TestPfcwdAllPortStorm()
+
+    with patch.object(all_port_storm, "configure_vlan_neighbors",
+                      return_value=contextlib.nullcontext()), \
+            patch.object(all_port_storm, "send_background_traffic",
+                         return_value=contextlib.nullcontext()) as traffic, \
+            patch.object(test, "run_test") as run_test:
+        test.test_all_port_storm_restore(
+            {"dut": dut}, "dut", storm, setup, MagicMock(),
+            None, None, None, {})
+
+    assert traffic.call_args.args[3] == ["Ethernet0", "Ethernet4"]
+    assert run_test.call_args_list[0].kwargs["selected_test_ports"] == [
+        "Ethernet0", "Ethernet4"]
+
+
+def test_arista_backpressure_stop_waits_for_generator_cleanup():
+    storm = PFCStorm.__new__(PFCStorm)
+    storm.pfc_gen_chip_name = "Tomahawk2"
+    storm.pfc_gen_file = "pfc_gen_brcm_xgs.py"
+    storm.pfc_queue_idx = 3
+    storm.ip_addr = "10.3.146.96"
+    storm.peer_info = {
+        "peerdevice": "fanout-1",
+        "pfc_fanout_interface": "Ethernet1/1,Ethernet2/1",
+    }
+    storm.peer_device = MagicMock()
+    storm.peer_device.os = "eos"
+    storm.peer_device.shell.return_value = {"rc": 0}
+
+    storm.stop_storm()
+
+    command = storm.peer_device.shell.call_args.args[0]
+    assert "sudo -n pkill -TERM" in command
+    assert "sudo -n timeout 120" in command
+    assert "case $rc in 0) sleep 1 ;; 1) exit 0 ;; *) exit $rc" in command
+    assert r"python3\ pfc_gen_brcm_xgs\.py\ \-c\ Tomahawk2\ \-p\ 8" in command
+
+
+def test_deferred_arista_storm_uses_pid_and_waits_for_cleanup():
+    storm = _arista_storm()
+    storm.pfc_storm_defer_time = 5
+    storm.pfc_storm_stop_defer_time = 7
+    storm._pfc_gen_id = "test-id"
+    storm._pfc_gen_pid_file = "/tmp/pfc_storm_test.pid"
+    storm._prepare_start_template = MagicMock()
+    storm.peer_device.shell.side_effect = [{"rc": 0}, {"rc": 0}, {"rc": 0}]
+
+    storm.start_storm()
+    start_command = storm.peer_device.shell.call_args_list[0].args[0]
+    assert "PFC_STORM_ID=test-id nohup" in start_command
+    assert "sleep 5 && exec python3" in start_command
+    assert "echo $! > /tmp/pfc_storm_test.pid" in start_command
+
+    storm.stop_storm()
+    stop_command = storm.peer_device.shell.call_args_list[1].args[0]
+    assert "pid=$(cat /tmp/pfc_storm_test.pid" in stop_command
+    assert "sleep 7" in stop_command
+    assert "grep -Fqx" in stop_command
+    assert "PFC_STORM_ID=test-id" in stop_command
+    assert "kill -TERM" in stop_command
+    assert "nohup sh -c" in stop_command
+
+    storm.wait_for_deferred_storm_stop()
+    wait_command = storm.peer_device.shell.call_args_list[2].args[0]
+    assert "while [ -e /tmp/pfc_storm_test.pid ]" in wait_command
+    assert storm._pfc_gen_uses_pid is False
+    assert storm._pfc_gen_stop_scheduled is False
+
+
+def test_deferred_arista_storm_retries_cleanup_after_wait_timeout():
+    storm = _arista_storm()
+    storm.pfc_storm_stop_defer_time = 7
+    storm._pfc_gen_id = "test-id"
+    storm._pfc_gen_pid_file = "/tmp/pfc_storm_test.pid"
+    storm._pfc_gen_uses_pid = True
+    storm._pfc_gen_stop_scheduled = True
+    storm.peer_device.shell.side_effect = [{"rc": 124}, {"rc": 0}]
+
+    storm.wait_for_deferred_storm_stop()
+
+    retry_command = storm.peer_device.shell.call_args_list[1].args[0]
+    assert "sleep 7" not in retry_command
+    assert "kill -TERM" in retry_command
+    assert "nohup sh -c" not in retry_command
+    assert storm._pfc_gen_uses_pid is False
+    assert storm._pfc_gen_stop_scheduled is False
+
+
+def _arista_storm():
+    storm = PFCStorm.__new__(PFCStorm)
+    storm.asic_type = "mellanox"
+    storm.pfc_gen_chip_name = "Tomahawk2"
+    storm.pfc_gen_file = "pfc_gen_brcm_xgs.py"
+    storm.pfc_queue_idx = 3
+    storm.ip_addr = "10.3.146.96"
+    storm.peer_info = {
+        "peerdevice": "fanout-1",
+        "pfc_fanout_interface": "Ethernet1/1,Ethernet2/1",
+    }
+    storm.peer_device = MagicMock()
+    storm.peer_device.os = "eos"
+    storm._pfc_gen_uses_pid = False
+    storm._pfc_gen_stop_scheduled = False
+    return storm
+
+
+def _vlan_port_info(port_id, neighbor="192.168.0.2"):
+    return {
+        "test_port_type": "vlan",
+        "test_neighbor_addr": neighbor,
+        "test_port_id": port_id,
+    }

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -1,6 +1,7 @@
-import ipaddress
+import contextlib
 import logging
 import os
+from collections import defaultdict
 import pytest
 
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      # noqa: F401
@@ -180,105 +181,90 @@ def set_storm_params(duthost, fanout_graph, fanouthosts, peer_params):
     return storm_hndle
 
 
-def resolve_arp(duthost, ptfhost, test_ports_info, vlan, ip_version):
-    """
-    Populate ARP info for DUT vlan ports.
-
-    For Cisco-8000: assign a unique IP to each PTF port within the vlan subnet
-    so that background traffic creates independent egress flows on each server port.
-
-    For other platforms: uses the single test_neighbor_addr from the first VLAN port
-
-    Args:
-        duthost: DUT host instance
-        ptfhost: ptf host instance
-        test_ports_info: test ports information (modified in place for Cisco)
-        vlan: vlan info dict with 'addr' and 'prefix'
-        ip_version: "IPv4" or "IPv6"
-    """
-    # In T1, T2 topology there are no VLANs - nothing to resolve
+@contextlib.contextmanager
+def configure_vlan_neighbors(duthost, ptfhost, test_ports_info, vlan, ip_version):
+    """Configure independent PTF neighbors for VLAN ports and clean them up."""
     if vlan is None:
+        yield
         return
 
-    if duthost.facts['asic_type'] == 'cisco-8000':
-        # Assign unique IPs to each VLAN port starting from gateway + 1
-        vlan_addr = vlan['addr']
-        prefix = vlan['prefix']
-        if ip_version == "IPv4":
-            base_ip = ipaddress.IPv4Address(vlan_addr) + 1
-            # Set arp_ignore=1 so each PTF interface only responds to ARP for its own IP.
-            # Without this, Linux's weak host model causes all interfaces to respond to
-            # ARP requests for any local IP, polluting the DUT's ARP table.
+    vlan_ports = [
+        (port, info) for port, info in test_ports_info.items()
+        if info.get('test_port_type') == 'vlan'
+    ]
+    if not vlan_ports:
+        yield
+        return
+
+    original_neighbors = {
+        port: info['test_neighbor_addr'] for port, info in vlan_ports
+    }
+    neighbor_ports = defaultdict(list)
+    for port, info in vlan_ports:
+        neighbor_ports[info['test_neighbor_addr']].append((port, info))
+    duplicate_ports = [
+        item for ports in neighbor_ports.values() if len(ports) > 1
+        for item in ports
+    ]
+    configure_all_ports = duthost.facts['asic_type'] == 'cisco-8000'
+    ports_to_configure = vlan_ports if configure_all_ports else duplicate_ports or vlan_ports[:1]
+    configured = []
+    generated_ports = {port for port, _info in duplicate_ports}
+    restore_arp_settings = configure_all_ports and ip_version == "IPv4"
+    try:
+        if duplicate_ports:
+            generated_ips = duthost.get_ip_in_range(
+                num=len(duplicate_ports),
+                prefix="{}/{}".format(vlan['addr'], vlan['prefix']),
+                exclude_ips=[vlan['addr']] + list(original_neighbors.values())
+            )['ansible_facts']['generated_ips']
+            pytest_assert(
+                len(generated_ips) == len(duplicate_ports),
+                "Failed to generate unique neighbors for duplicate VLAN ports")
+            for (port, info), address in zip(duplicate_ports, generated_ips):
+                info['test_neighbor_addr'] = address.split('/')[0]
+
+        if restore_arp_settings:
             ptfhost.command("sysctl -w net.ipv4.conf.all.arp_ignore=1")
             ptfhost.command("sysctl -w net.ipv4.conf.all.arp_announce=2")
-        else:
-            base_ip = ipaddress.IPv6Address(vlan_addr) + 1
 
-        idx = 0
-        for port, port_info in test_ports_info.items():
-            if port_info['test_port_type'] == 'vlan':
-                unique_ip = str(base_ip + idx)
-                port_info['test_neighbor_addr'] = unique_ip
-                ptf_port = f"eth{port_info['test_port_id']}"
-                if ip_version == "IPv4":
-                    ptfhost.command(f"ifconfig {ptf_port} {unique_ip} netmask "
-                                    f"{ipaddress.IPv4Network(f'0.0.0.0/{prefix}').netmask}")
-                else:
-                    ptfhost.command(f"ip -6 addr add {unique_ip}/{prefix} dev {ptf_port}")
-                idx += 1
-
-        # Resolve ARP/NDP after all IPs are configured so each arping gets a single response
-        if ip_version == "IPv4":
-            for port, port_info in test_ports_info.items():
-                if port_info['test_port_type'] == 'vlan':
-                    duthost.command(f"docker exec -i swss arping {port_info['test_neighbor_addr']} -c 3")
-        else:
-            for port, port_info in test_ports_info.items():
-                if port_info['test_port_type'] == 'vlan':
-                    duthost.command(f"docker exec -i swss ping -6 -c 3 {port_info['test_neighbor_addr']}")
-    else:
-        # Original behavior: resolve ARP for the first VLAN port only
-        for port, port_info in test_ports_info.items():
-            if port_info['test_port_type'] == 'vlan':
-                neighbor_ip = port_info['test_neighbor_addr']
-                ptf_port = f"eth{port_info['test_port_id']}"
-                if ip_version == "IPv4":
-                    ptfhost.command(f"ifconfig {ptf_port} {neighbor_ip}")
-                    duthost.command(f"docker exec -i swss arping {neighbor_ip} -c 5")
-                else:
-                    ptfhost.command(f"ip -6 addr add {neighbor_ip}/{vlan['prefix']} dev {ptf_port}")
-                    duthost.command(f"docker exec -i swss ping -6 -c 5 {neighbor_ip}")
-                break
-
-
-def cleanup_ptf_ips(ptfhost, test_ports_info, vlan, ip_version):
-    """
-    Remove IPs configured on PTF ports by resolve_arp.
-
-    Args:
-        ptfhost: ptf host instance
-        test_ports_info: test ports information
-        vlan: vlan info dict with 'addr' and 'prefix'
-        ip_version: "IPv4" or "IPv6"
-    """
-    if vlan is None:
-        return
-
-    prefix = vlan['prefix']
-    for port, port_info in test_ports_info.items():
-        if port_info['test_port_type'] == 'vlan':
-            ptf_port = f"eth{port_info['test_port_id']}"
-            ip_addr = port_info['test_neighbor_addr']
+        for port, info in ports_to_configure:
+            neighbor_ip = info['test_neighbor_addr']
+            ptf_port = "eth{}".format(info['test_port_id'])
+            address = "{}/{}".format(neighbor_ip, vlan['prefix'])
             if ip_version == "IPv4":
-                ptfhost.command(f"ifconfig {ptf_port} 0.0.0.0", module_ignore_errors=True)
+                ptfhost.command("ip address replace {} dev {}".format(address, ptf_port))
+                configured.append((port, ptf_port, address))
+                ptfhost.command(
+                    "arping -i {port} -S {neighbor} -c 3 -w 5 {dut_ip}".format(
+                        port=ptf_port, neighbor=neighbor_ip, dut_ip=vlan['addr']))
             else:
-                ptfhost.command(f"ip -6 addr del {ip_addr}/{prefix} dev {ptf_port}",
-                                module_ignore_errors=True)
+                ptfhost.command("ip -6 address replace {} dev {} nodad".format(address, ptf_port))
+                configured.append((port, ptf_port, address))
+                ptfhost.command(
+                    "ping -6 -I {port} -I {neighbor} -c 3 -W 2 {dut_ip}".format(
+                        port=ptf_port, neighbor=neighbor_ip, dut_ip=vlan['addr']))
+        yield
+    finally:
+        family = "-6 " if ip_version == "IPv6" else ""
+        for port, ptf_port, address in configured:
+            ptfhost.command(
+                "ip {}address del {} dev {}".format(family, address, ptf_port),
+                module_ignore_errors=True)
+            ptfhost.command(
+                "ip {}neigh del {} dev {}".format(family, vlan['addr'], ptf_port),
+                module_ignore_errors=True)
+            if port in generated_ports:
+                duthost.command(
+                    "ip {}neigh del {} dev {}".format(
+                        family, address.split('/')[0], vlan['dev']),
+                    module_ignore_errors=True)
+        for port, neighbor in original_neighbors.items():
+            test_ports_info[port]['test_neighbor_addr'] = neighbor
 
-    if ip_version == "IPv4":
-        # Restore default arp_ignore/arp_announce settings
-        ptfhost.command("sysctl -w net.ipv4.conf.all.arp_ignore=0", module_ignore_errors=True)
-        ptfhost.command("sysctl -w net.ipv4.conf.all.arp_announce=0", module_ignore_errors=True)
+        if restore_arp_settings:
+            ptfhost.command("sysctl -w net.ipv4.conf.all.arp_ignore=0", module_ignore_errors=True)
+            ptfhost.command("sysctl -w net.ipv4.conf.all.arp_announce=0", module_ignore_errors=True)
 
 
 @pytest.mark.usefixtures('degrade_pfcwd_detection', 'stop_pfcwd', 'storm_test_setup_restore', 'start_background_traffic')  # noqa: E501
@@ -361,21 +347,19 @@ class TestPfcwdAllPortStorm(object):
 
         # get all the tested ports
         queues = []
+        selected_test_ports = []
         for peer in storm_hndle.peer_params.keys():
             fanout_intfs = storm_hndle.peer_params[peer]['intfs'].split(',')
             device_conn = storm_hndle.fanout_graph[peer]['device_conn']
+            if duthost.facts['asic_type'] != 'vs':
+                for intf in fanout_intfs:
+                    test_port = device_conn[intf]['peerport']
+                    if test_port in setup_pfc_test['test_ports']:
+                        selected_test_ports.append(test_port)
             queues.append(storm_hndle.storm_handle[peer].pfc_queue_idx)
         queues = list(set(queues))
-        selected_test_ports = []
-
-        if duthost.facts['asic_type'] != 'vs':
-            for intf in fanout_intfs:
-                test_port = device_conn[intf]['peerport']
-                if test_port in setup_pfc_test['test_ports']:
-                    selected_test_ports.append(test_port)
-        resolve_arp(duthost, ptfhost, setup_pfc_test['test_ports'],
-                    setup_pfc_test["vlan"], setup_pfc_test["ip_version"])
-        try:
+        with configure_vlan_neighbors(duthost, ptfhost, setup_pfc_test['test_ports'],
+                                      setup_pfc_test["vlan"], setup_pfc_test["ip_version"]):
             with send_background_traffic(duthost, ptfhost, queues, selected_test_ports,
                                          setup_pfc_test['test_ports'],
                                          pkt_count=500):
@@ -399,6 +383,3 @@ class TestPfcwdAllPortStorm(object):
                           stormed_ports_list=stormed_ports_list,
                           selected_test_ports=selected_test_ports,
                           tbinfo=tbinfo)
-        finally:
-            cleanup_ptf_ips(ptfhost, setup_pfc_test['test_ports'],
-                            setup_pfc_test["vlan"], setup_pfc_test["ip_version"])

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -512,6 +512,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
                     if self.storm_handle[port][queue]:
                         logger.info("--- Stop pfc storm on port {} queue {}".format(port, queue))
                         self.storm_handle[port][queue].stop_storm()
+                        self.storm_handle[port][queue].wait_for_deferred_storm_stop()
                     else:
                         logger.info("--- Disabling fake storm on port {} queue {}".format(port, queue))
                         PfcCmd.set_storm_status(self.dut, self.oid_map[(port, queue)], "disabled")
@@ -582,6 +583,10 @@ class TestPfcwdWb(SetupPfcwdFunc):
             if storm_deferred:
                 logger.info("Wait for all the deferred storms to start and stop ...")
                 join_all(self.storm_threads, self.max_wait)
+                for port_handles in self.storm_handle.values():
+                    for storm_handle in port_handles.values():
+                        if storm_handle:
+                            storm_handle.wait_for_deferred_storm_stop()
                 self.storm_threads = []
                 self.storm_handle = dict()
 


### PR DESCRIPTION
### Description of PR

Summary:

Fix PFCWD all-port-storm traffic setup and process cleanup. This is the root-cause follow-up to #25147: VLAN ports sharing one neighbor now receive independent traffic without relaxing the per-physical-port storm threshold.

ADO: 38421308

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): ADO 38421308
Failure type: regression

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: focused unit tests: 15 passed; `py_compile`, `flake8 --max-line-length=120`, and `git diff --check` passed.
- 202511: `SONiC.20251110.45` on `vms28-t0-4600c-04`; IPv6 then IPv4 physical testbed run: 2 passed in 19m04s.

### Approach
#### What is the motivation for this PR?

`test_pfcwd_all_port_storm.py` requires both PFC pause frames and queued egress traffic on each tested port. On non-dualtor T0 topologies, VLAN ports share one generated neighbor address, so traffic reaches only one server port. The test then fails its strict 75% per-port storm threshold even though the fanout sends PFC to every port.

The original failure also exposed cleanup races: background PTF traffic could survive exceptions, and EOS ASIC backpressure cleanup could overlap a later storm.

#### How did you do it?

- Assign unique temporary PTF neighbors to VLAN ports that share a destination, learn them through the correct physical PTF interfaces, and restore all modified state in a context manager.
- Preserve Cisco dual-ToR behavior by configuring every already-unique VLAN neighbor while avoiding deletion of topology-owned DUT neighbors.
- Collect tested ports from every fanout instead of only the final fanout in the loop.
- Wait for the PTF background sender startup marker and always terminate its exact log-scoped process.
- Track deferred EOS ASIC-backpressure generators by PID and unique process identity, wait for SIGTERM cleanup, and prevent a delayed stop from killing a later storm.

#### How did you verify/test it?

- Added focused regression coverage for exception cleanup, queue normalization, PTF startup/termination, IPv4 and IPv6 VLAN neighbors, Cisco unique neighbors, multi-fanout selection, and EOS immediate/deferred lifecycle.
- Ran the focused unit suite: 15 passed.
- Exercised the generated deferred start/stop commands against a real local shell lifecycle.
- Ran IPv6 and IPv4 all-port-storm tests sequentially on the target 202511 physical testbed: 2 passed.

#### Any platform specific information?

The traffic fix targets non-dualtor T0 topologies with shared VLAN neighbors. The lifecycle fix applies to EOS fanouts that use `pfc_gen_brcm_xgs.py` ASIC backpressure. Existing unique-neighbor dual-ToR behavior is preserved.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
