### PR TITLE
Integrate lldp test case on the t2-isolated-d128s2 topology

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -156,7 +156,7 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
     # We use the MAC of mgmt port to generate chassis ID as LLDPD dose.
     # To be compatible with PR #3331, we keep using router MAC on T2 devices
     switch_mac = ""
-    if tbinfo["topo"]["type"] != "t2":
+    if tbinfo["topo"]["type"] != "t2" or "isolated" in tbinfo["topo"]["name"]:
         mgmt_alias = duthost.get_extended_minigraph_facts(tbinfo)["minigraph_mgmt_interface"]["alias"]
         switch_mac = duthost.get_dut_iface_mac(mgmt_alias)
     elif tbinfo["topo"]["type"] == "t2":
@@ -299,7 +299,7 @@ def get_expected_chassis_mac(duthost, asic, tbinfo):
     Returns:
         str: Expected chassis MAC address (lowercase)
     """
-    if tbinfo["topo"]["type"] == "t2":
+    if tbinfo["topo"]["type"] == "t2" and "isolated" not in tbinfo["topo"]["name"]:
         if duthost.is_multi_asic:
             asic_cfg = asic.config_facts(host=duthost.hostname, source="running")['ansible_facts']
             return asic_cfg['DEVICE_METADATA']['localhost']['mac'].lower()


### PR DESCRIPTION

### Description of PR
On T2 single ASIC switch, such as sn5640, the chassis mac should be get from interface mac.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- 202605: latest image
<img width="584" height="279" alt="image" src="https://github.com/user-attachments/assets/4b4cc90d-80a4-4176-bc61-db0ea6ebbe6f" />


### Approach
#### What is the motivation for this PR?
Run test on T2 single ASIC switch
#### How did you do it?
On T2 single ASIC switch, such as sn5640, the chassis mac should be get from interface mac
#### How did you verify/test it?
Validate pass on the 202605 image

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
