### PR TITLE
[Mellanox] Fail on empty SFP sysfs reads in check_sysfs

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -163,10 +163,12 @@ def check_sysfs(dut, expected_module_temp_fault_value=['0']):
 
     logging.info("Check SFP related sysfs")
     for sfp_id, sfp_info in list(sysfs_facts['sfp_info'].items()):
-        # Skip when the sfp is missing
-        if not sfp_info["temp_fault"]:
+        # An absent module reads "0", so all values empty means the sysfs nodes are missing
+        if not any(sfp_info.values()):
             continue
 
+        assert '' not in sfp_info.values(), \
+            "SFP{} sysfs read returned an empty value: {}".format(sfp_id, sfp_info)
         assert sfp_info["temp_fault"] in expected_module_temp_fault_value, "SFP%d temp fault" % int(sfp_id)
         sfp_temp = float(sfp_info['temp']) if sfp_info['temp'] != '0' else 0
         sfp_temp_crit = float(


### PR DESCRIPTION
### Description of PR

Summary:
Fail on empty SFP sysfs reads in `check_sysfs` instead of skipping the cage or crashing on `float('')`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Tested branch
- [x] master

### Approach
#### What is the motivation for this PR?

An absent module reads "0" on all of its `module_temp_*` nodes, so an empty value means the sysfs read failed rather than the cage being empty. Skipping the cage when `temp_fault` was empty hid those failures, and an empty `temp_input` reached `float('')` and raised `ValueError: could not convert string to float: ''`.

#### How did you do it?

Skip only when all of the module's sysfs nodes are empty, and assert otherwise so a failed read is reported with the cage id and the values that were read.

#### How did you verify/test it?

Ran `platform_tests/mellanox/test_check_sysfs.py` on SN5640.

#### Any platform specific information?

Mellanox only.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
