### PR TITLE
system_health: use selected DUT in module fixtures

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -72,15 +72,17 @@ DEFAULT_LED_CONFIG = {
 
 
 @pytest.fixture(autouse=True, scope="module")
-def check_image_version(duthost):
+def check_image_version(duthosts, enum_rand_one_per_hwsku_hostname):
     """Skip the test for unsupported images."""
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     pytest_require(parse_version(duthost.kernel_version) > parse_version('4.9.0'),
                    "Test not supported for 201911 images. Skipping the test")
     yield
 
 
 @pytest.fixture(autouse=True, scope='module')
-def config_reload_after_tests(duthost):
+def config_reload_after_tests(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     yield
     config_reload(duthost)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Fix `system_health/test_system_health.py` module fixtures to use the same
  enum-selected DUT as the test cases. On dualtor, default `duthost` can resolve
  to the peer DUT, causing teardown to reload/validate a different DUT than the
  one tested.
Fixes #27391 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change. https://github.com/aristanetworks/sonic-qual.msft/issues/1420
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/aristanetworks/sonic-qual.msft/issues/1420

Failure type: day-one issue

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
- 202605: SONiC.branch.202605-ars.111785e8-buildimage.84d74ca1aa3b233d1198b3eae18e79c420893493-nightly-2026.08.19.14.40

***Test Results before Fix :*** 
  [test_system_health_iteration_1.log](https://github.com/user-attachments/files/31479405/test_system_health_iteration_1.log)
  [test_system_health_iteration_1.xml](https://github.com/user-attachments/files/31479408/test_system_health_iteration_1.xml)

***Test Results after Fix :*** 
    Ran 10 iterations  and the right DUT was selected 
     Sharing results of 1 iteration 
    [test_system_health.log](https://github.com/user-attachments/files/31479618/test_system_health.log)
    [test_system_health.xml](https://github.com/user-attachments/files/31479624/test_system_health.xml)


### Approach
#### What is the motivation for this PR?
`system_health` tests select a DUT using
  `duthosts[enum_rand_one_per_hwsku_hostname]`, but module-scoped fixtures used
  the default `duthost`. On dualtor testbeds, this can make teardown run on a
  different DUT than the test case used.

#### How did you do it?
 Updated `check_image_version` and `config_reload_after_tests` to resolve the DUT
  from `duthosts[enum_rand_one_per_hwsku_hostname]`.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Tested the 202605 fix on a dualtor testbed by running `system_health/test_system_health.py`
  10 times without reproducing the teardown flakiness.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A