### PR TITLE
[202511] snappi: create the stats log directory before writing to it (#26819)

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -7,6 +7,7 @@ import logging
 import re
 import pandas as pd
 from datetime import datetime
+from pathlib import Path
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi_tests.common_helpers import config_capture_settings, get_egress_queue_count, \
@@ -1501,6 +1502,8 @@ def run_traffic_and_collect_stats(rx_duthost,
         flow_list.append(item.replace(' ', '_').lower())
     results = list(df_t.columns)
     fname = fname + '-' + datetime.now().strftime('%Y-%m-%d-%H-%M')
+    # Callers compose fname from nested log dirs that may not exist yet.
+    Path(fname).parent.mkdir(parents=True, exist_ok=True)
     with open(fname+'.txt', 'w') as f:
         f.write('Captured data for {} iterations at {} seconds interval \n'.format(m, stats_interval))
         test_stats = {}


### PR DESCRIPTION
Manual cherry-pick of #26819 to `202511` — mssonicbld reported a conflict (`Cherry Pick Conflict_202511`) and asked for a manual cherry-pick PR. The PR is already `Approved for 202511 branch` and `Tested for 202511 branch`.

### Description of PR

Same as #26819: `run_traffic_and_collect_stats()` writes its stats file into a directory the caller composes (e.g. `logs/snappi_tests/pfcwd/...`) but never creates, so on a fresh tree it raises `FileNotFoundError` after the traffic run has already completed. Fix: create the parent directory before writing.

### Conflict resolution

Single conflict in the import block of `tests/common/snappi_tests/traffic_generation.py`: the surrounding import lines differ between master and 202511. Resolved by adding only the PR's actual change (`from pathlib import Path`); the `mkdir` hunk applied cleanly. Resulting diff is identical to the original (3 insertions).

### Type of change

- [x] Bug fix

cc @vmittal-msft — could you help approve/merge this 202511 cherry-pick?
