### PR TITLE
[202511] snappi: read IxNetwork API credentials from ansible inventory (#24994)

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -60,22 +60,41 @@ def snappi_api_serv_port(tbinfo, duthosts, rand_one_dut_hostname):
 
 @pytest.fixture(scope='module')
 def snappi_api(snappi_api_serv_ip,
-               snappi_api_serv_port):
+               snappi_api_serv_port,
+               duthosts,
+               rand_one_dut_hostname):
     """
     Fixture for session handle,
     for creating snappi objects and making API calls.
     Args:
         snappi_api_serv_ip (pytest fixture): snappi_api_serv_ip fixture
         snappi_api_serv_port (pytest fixture): snappi_api_serv_port fixture.
+        duthosts (pytest fixture): The duthosts fixture.
+        rand_one_dut_hostname (pytest fixture): hostname of a random DUT.
     """
     location = "https://" + snappi_api_serv_ip + ":" + str(snappi_api_serv_port)
     # TODO: Currently extension is defaulted to ixnetwork.
     # Going forward, we should be able to specify extension
     # from command line while running pytest.
     api = snappi.api(location=location, ext="ixnetwork")
-    # TODO - Uncomment to use. Prefer to use environment vars to retrieve this information
-    # api._username = "<please mention the username if other than default username>"
-    # api._password = "<please mention the password if other than default password>"
+
+    # Read IxNetwork credentials from the DUT's ansible inventory variable
+    # `snappi_api_server.user` / `.password` (same source as the rest_port
+    # read by snappi_api_serv_port). When a key is absent the value stays
+    # None and the snappi library default applies, preserving behavior for
+    # testbeds that don't define these keys.
+    duthost = duthosts[rand_one_dut_hostname]
+    snappi_api_server = (duthost.host.options['variable_manager']
+                         ._hostvars[duthost.hostname]
+                         .get('snappi_api_server', {}))
+    snappi_api_serv_user = snappi_api_server.get('user')
+    snappi_api_serv_password = snappi_api_server.get('password')
+
+    if snappi_api_serv_user:
+        api._username = snappi_api_serv_user
+    if snappi_api_serv_password:
+        api._password = snappi_api_serv_password
+
     yield api
 
     if getattr(api, 'assistant', None) is not None:


### PR DESCRIPTION
Manual cherry-pick of #24994 to `202511` — mssonicbld reported a conflict (`Cherry Pick Conflict_202511`). The original PR is already `Approved for 202511 branch` (202605 is done via #26205).

### Description of PR

Same as #24994: read the IxNetwork API server credentials from the DUT's ansible inventory (`snappi_api_server.user` / `.password`) instead of the hardcoded commented-out placeholders in `snappi_api`. When the keys are absent the snappi library defaults apply, so testbeds without these inventory keys are unaffected.

### Conflict resolution

Single conflict in `tests/common/snappi_tests/snappi_fixtures.py`: on master the `snappi_api` fixture had since gained the STC/grpc (`ptf_image_name`) branch and a `tbinfo` parameter, which 202511 does not have. Applied only this PR's actual change onto the 202511 shape of the fixture:

- added the `duthosts` and `rand_one_dut_hostname` fixture parameters (and docstring entries)
- replaced the commented-out `api._username` / `api._password` TODO block with the inventory credential read (at the fixture's base indentation, since 202511 has no if/else branch)

Functionally identical to the original change.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)

cc @vmittal-msft — could you help approve/merge this 202511 cherry-pick?
