### PR TITLE
Update qos params for Arista-7060X6-64PE-B-O128

### DIFF
--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -456,19 +456,19 @@ qos_params:
         topo-lt2-o128:
             400000_500m:
                 hdrm_pool_size:
-                    dscps:
-                    - 3
-                    - 4
+                    dscps: [3, 4]
                     dst_port_id: 0
                     ecn: 1
                     margin: 4
-                    pgs:
-                    - 3
-                    - 4
+                    pgs: [3, 4]
                     pgs_num: 22
                     pkts_num_hdrm_full: 4474
                     pkts_num_hdrm_partial: 3326
                     pkts_num_trig_pfc: 108469
+                    pkts_num_trig_pfc_multi: [108469, 54252, 27143, 13588, 6811, 3423,
+                       1728, 881, 458, 246, 140, 87, 60, 47, 41, 37, 36, 35, 34,
+                       34, 34, 34]
+                    src_port_ids: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
                 lossy_queue_1:
                     dscp: 8
                     ecn: 1
@@ -548,7 +548,7 @@ qos_params:
                     pkts_num_margin: 4
                     pkts_num_trig_pfc: 108469
             cell_size: 254
-            hdrm_pool_wm_multiplier: 1
+            hdrm_pool_wm_multiplier: 2
             wrr:
                 ecn: 1
                 limit: 80


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #27397
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
Kusto ID: 8e934852-22c4-4fbe-99a9-ec33daae4e8d

### Approach
#### What is the motivation for this PR?
Large number of failures seen on the LT2-O128 topo in `qos/test_qos_sai.py`

#### How did you do it?
The failures are likely due to the headroom pool watermark multiplier being 1 instead of 2 upstream. Created a patch that updates the static qos params file to the latest values we have internally.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Tested by running the `qos/test_qos_sai.py` sonic-mgmt tests with the latest qos params and verified it was all passing.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
