### PR TITLE
Fix console stress input timeout

### DIFF
--- a/tests/common/connections/conserver_console_conn.py
+++ b/tests/common/connections/conserver_console_conn.py
@@ -1,6 +1,7 @@
 import logging
 import pexpect
 import os
+import select
 import time
 
 CONSERVER_CLI_PROMPT = "admin@[a-zA-Z0-9]{1,10}:~\\$"
@@ -80,12 +81,68 @@ class ConserverConsoleConn():
         self.console_cli.close(force=True)
         self.logger.debug("Conserver connection closed.")
 
+    def _sendline_with_timeout(self, cmd, timeout):
+        """Send one command line to conserver without an unbounded PTY write.
+
+        pexpect.sendline() can block inside os.write() before read_timeout is
+        applied. Use nonblocking partial writes so the DUT still receives one
+        logical command line, while the local write path is bounded by timeout.
+        """
+        child_fd = getattr(self.console_cli, "child_fd", None)
+        if child_fd is None:
+            self.console_cli.sendline(cmd)
+            return
+
+        def to_bytes(data):
+            """Convert console data to bytes using the pexpect encoding."""
+            if isinstance(data, bytes):
+                return data
+            encoding = getattr(self.console_cli, "encoding", None) or "utf-8"
+            return str(data).encode(encoding)
+
+        data = to_bytes(cmd) + to_bytes(self.console_cli.linesep)
+        write_start = time.monotonic()
+        deadline = write_start + timeout
+        sent = 0
+        was_blocking = os.get_blocking(child_fd)
+
+        os.set_blocking(child_fd, False)
+        try:
+            while sent < len(data):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    self.logger.info(
+                        "Timed out writing console command after %s seconds "
+                        "(%s/%s bytes sent)",
+                        timeout, sent, len(data)
+                    )
+                    raise TimeoutError(
+                        "Timed out writing console command after {} seconds "
+                        "({}/{} bytes sent)".format(timeout, sent, len(data))
+                    )
+
+                _, writable, _ = select.select([], [child_fd], [], remaining)
+                if not writable:
+                    continue
+
+                try:
+                    sent += os.write(child_fd, data[sent:])
+                except (BlockingIOError, InterruptedError):
+                    continue
+        finally:
+            os.set_blocking(child_fd, was_blocking)
+
+        self.logger.info(
+            "Console command write completed in %.1fs, %d bytes sent",
+            time.monotonic() - write_start, sent
+        )
+
     def send_command_timing(self, cmd, read_timeout=30, last_read=1.0):
         """Send command and read output until no data for 'last_read' seconds."""
         self.logger.debug("send_command_timing: cmd='%s'", cmd[:80])
 
         start_time = time.monotonic()
-        self.console_cli.sendline(cmd)
+        self._sendline_with_timeout(cmd, read_timeout)
 
         output = ""
         deadline = start_time + read_timeout

--- a/tests/common/unit_tests/connections/unit_test_conserver_console_conn.py
+++ b/tests/common/unit_tests/connections/unit_test_conserver_console_conn.py
@@ -1,9 +1,12 @@
 """Unit tests for the conserver console connection."""
 
 from importlib import import_module, util
+import os
 from pathlib import Path
 import sys
 import types
+
+import pytest
 
 
 MODULE_PATH = (
@@ -47,6 +50,7 @@ def make_connection():
     """Create a connection without invoking its I/O-heavy constructor."""
     connection = ConserverConsoleConn.__new__(ConserverConsoleConn)
     connection.console_cli = FakeConsoleCli()
+    connection.logger = MODULE.logging.getLogger(__name__)
     connection.default_timeout = 30
     connection.delay_factor = 1
     return connection
@@ -78,3 +82,38 @@ def test_send_command_keeps_max_loops_compatibility():
         "admin@[a-zA-Z0-9]{1,10}:~\\$",
         60,
     )
+
+
+def test_sendline_with_timeout_writes_complete_line():
+    """Write the complete command line when the pexpect child fd is writable."""
+    read_fd, write_fd = os.pipe()
+    connection = make_connection()
+    connection.console_cli.child_fd = write_fd
+    connection.console_cli.encoding = "utf-8"
+    try:
+        connection._sendline_with_timeout("show version", 1)
+        os.close(write_fd)
+        write_fd = None
+
+        assert os.read(read_fd, 1024) == b"show version\r\n"
+    finally:
+        os.close(read_fd)
+        if write_fd is not None:
+            os.close(write_fd)
+
+
+def test_sendline_with_timeout_restores_blocking_mode_on_timeout():
+    """Restore the pexpect fd blocking mode when a bounded write times out."""
+    read_fd, write_fd = os.pipe()
+    connection = make_connection()
+    connection.console_cli.child_fd = write_fd
+    try:
+        assert os.get_blocking(write_fd) is True
+
+        with pytest.raises(TimeoutError):
+            connection._sendline_with_timeout("show version", 0)
+
+        assert os.get_blocking(write_fd) is True
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

 Summary 

  `dut_console/test_console_stress.py::test_console_stress_input` can hang
  indefinitely while sending a single 100 KB command through the conserver
  console PTY.

  The existing `read_timeout` only applies after the command is sent. In the
  observed hang, pytest blocked in the write path before the read loop started,
  so the timeout never fired. This PR bounds the conserver console write path used
  by `send_command_timing()` and keeps the test objective unchanged. The test
  still sends the same 100 KB command and validates the payload with `md5sum`.

 Fixes #27398

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change. 
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):https://github.com/sonic-net/sonic-mgmt/issues/27398
Failure type: test infrastructure issue / flaky hang

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

202605: 
failure observed on SONiC image:
    - `SONiC.branch.202605-ars.d3ed3c17-buildimage.0fc772d2082790be95d4f09cc56470fc0243ac2c-nightly-2026.08.05.14.40`
    - Platform: `x86_64-arista_7050cx3_32c`
    - HwSKU: `Arista-7050CX3-32C-C32`
    - ASIC: `broadcom`
    - Kernel: `6.12.41+deb13-sonic-amd64`
    - Evidence:
      `dut_console/test_console_stress.py::test_console_stress_input[ldp207]`
      entered `send_command_timing()` for the 100 KB
      `echo -n ... | md5sum` command and did not produce junit XML until the
      hung process was killed.
Logs
[hung_section.txt](https://github.com/user-attachments/files/31485626/hung_section.txt)
[test_console_stress.log](https://github.com/user-attachments/files/31485627/test_console_stress.log)


### Approach

#### What is the motivation for this PR?
Prevent `test_console_stress_input` from hanging a test runner indefinitely
when writing a large command to the conserver console PTY. The hang blocks the
full test run and is not a DUT functional failure.

#### How did you do it?
Added a timeout-aware `_sendline_with_timeout()` helper in the conserver console
  connection path.

The helper writes the command line to the pexpect child fd using nonblocking
partial writes and `select.select()`. If the PTY write does not complete within
the existing `read_timeout`, it raises `TimeoutError` instead of blocking
forever. After the write, the existing read loop remains unchanged.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran the test multiple times without noticing hangs

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A