### PR TITLE
[bgp/test_traffic_shift]: Enable test_traffic_shift on T2

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -1021,9 +1021,14 @@ def fetch_and_delete_pcap_file(bgp_pcap, log_dir, duthost, request):
 
 def get_tsa_chassisdb_config(duthost):
     """
-    @summary: Returns the dut's CHASSIS_APP_DB value for BGP_DEVICE_GLOBAL.STATE.tsa_enabled flag
+    @summary: Returns the dut's BGP_DEVICE_GLOBAL.STATE.tsa_enabled flag.
+              On modular chassis, reads from CHASSIS_APP_DB.
+              On fixed platforms, falls back to CONFIG_DB since CHASSIS_APP_DB does not exist.
     """
-    tsa_conf = duthost.shell('sonic-db-cli CHASSIS_APP_DB HGET \'BGP_DEVICE_GLOBAL|STATE\' tsa_enabled')['stdout']
+    if duthost.get_facts().get("modular_chassis"):
+        tsa_conf = duthost.shell('sonic-db-cli CHASSIS_APP_DB HGET \'BGP_DEVICE_GLOBAL|STATE\' tsa_enabled')['stdout']
+    else:
+        tsa_conf = duthost.shell('sonic-db-cli CONFIG_DB HGET \'BGP_DEVICE_GLOBAL|STATE\' tsa_enabled')['stdout']
     return tsa_conf
 
 

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -18,7 +18,7 @@ from tests.bgp.traffic_checker import get_traffic_shift_state, check_tsa_persist
 from tests.bgp.constants import TS_NORMAL, TS_MAINTENANCE, TS_NO_NEIGHBORS
 
 pytestmark = [
-    pytest.mark.topology('t1', 'm1', 'c0')
+    pytest.mark.topology('t1', 'm1', 'c0', 't2')
 ]
 
 logger = logging.getLogger(__name__)
@@ -85,8 +85,9 @@ def test_TSA(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
         # For T2 - TSA command sets up policies where only loopback address on the iBGP peers on the same linecard
         # are exchanged between the asics. Also, since bgpmon is iBGP as well, routes learnt from other asics on other
         # linecards are also not going to be advertised to bgpmon.
-        # So, cannot validate all routes are send to bgpmon on T2.
-        if tbinfo['topo']['type'] != 't2':
+        # So, cannot validate all routes are send to bgpmon on modular chassis T2.
+        # Fixed UpperT2 platforms are not modular chassis, bgpmon is eBGP so all routes should be visible.
+        if not (tbinfo['topo']['type'] == 't2' and duthost.facts.get('modular_chassis')):
             pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost,
                                                              bgpmon_setup_teardown['namespace']) == [],
                           "Not all routes are announced to bgpmon")
@@ -146,7 +147,7 @@ def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrho
     # Verify DUT is in normal state.
     pytest_assert(wait_until(30, 5, 0, lambda: TS_NORMAL == get_traffic_shift_state(duthost, "TSC no-stats")),
                   "DUT is not in normal state")
-    if tbinfo['topo']['type'] != 't2':
+    if not (tbinfo['topo']['type'] == 't2' and duthost.facts.get('modular_chassis')):
         pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost, bgpmon_setup_teardown['namespace']) == [],
                       "Not all routes are announced to bgpmon")
 
@@ -272,7 +273,7 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
         # Verify DUT is in maintenance state.
         pytest_assert(wait_until(30, 5, 0, lambda: TS_MAINTENANCE == get_traffic_shift_state(duthost, "TSC no-stats")),
                       "DUT is not in maintenance state")
-        if tbinfo['topo']['type'] != 't2':
+        if not (tbinfo['topo']['type'] == 't2' and duthost.facts.get('modular_chassis')):
             pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost,
                                                              bgpmon_setup_teardown['namespace']) == [],
                           "Not all routes are announced to bgpmon")
@@ -348,7 +349,7 @@ def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsk
         # Verify DUT is in maintenance state.
         pytest_assert(wait_until(30, 5, 0, lambda: TS_MAINTENANCE == get_traffic_shift_state(duthost, "TSC no-stats")),
                       "DUT is not in maintenance state")
-        if tbinfo['topo']['type'] != 't2':
+        if not (tbinfo['topo']['type'] == 't2' and duthost.facts.get('modular_chassis')):
             pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost,
                                                              bgpmon_setup_teardown['namespace']) == [],
                           "Not all routes are announced to bgpmon")

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -757,6 +757,12 @@ bgp/test_startup_tsa_tsb_service.py::test_user_init_tsb_on_sup_while_service_run
     conditions:
       - "'t2_single_node' in topo_name or topo_type in ['lrh', 'urh']"
 
+bgp/test_traffic_shift.py:
+  skip:
+    reason: "test_traffic_shift is explicitly disabled on chassis T2"
+    conditions:
+      - "topo_type in ['t2'] and is_chassis==True"
+
 bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away:
   skip:
     reason: "Test is flaky and causing PR test to fail unnecessarily"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
Some of the TSA tests currently running for T2 topology, cannot run on UpperT2 because of fixed chassis and no supervisor node. Test_traffic_shift can run on UpperT2 as the test covers scenario where there is no supervisor node.
Addressed following changes as part of this PR:

1. Enabled test_traffic_test on T2 topo
2. In case of test_traffic_shift_lc, replaced CHASSIS_APP_DB with CONFIG_DB for UpperT2 case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
3. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
Tested on Cisco 8223 platform:
[test_traffic_shift.log](https://github.com/user-attachments/files/31487803/test_traffic_shift.log)


### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
