### PR TITLE
[syslog]: Wait for rate-limit notification before log analysis

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -283,7 +283,8 @@ def verify_config_rate_limit_fail(duthost, service_name):
     pytest_assert('Error' in output, 'Error: config syslog rate limit for {}: {}'.format(service_name, output))
 
 
-def _wait_expected_logs_forwarded(duthost, start_marker, expect_log_regex, expect_log_matches, additional_files):
+def _wait_expected_logs_forwarded(duthost, start_marker, expect_log_regex, expect_log_matches, additional_files,
+                                  presence_log_regex=None):
     """Wait until every expected message has been forwarded into the host log files for
     this LogAnalyzer window before the window is closed.
 
@@ -319,6 +320,8 @@ def _wait_expected_logs_forwarded(duthost, start_marker, expect_log_regex, expec
                     return False
             elif not re.search(regex, captured):
                 return False
+        if presence_log_regex and not all(re.search(regex, captured) for regex in presence_log_regex):
+            return False
         return True
 
     return wait_until(SYSLOG_FORWARD_TIMEOUT, SYSLOG_FORWARD_INTERVAL, 0, _all_expected_present)
@@ -369,7 +372,7 @@ def verify_rate_limit_with_log_generator(duthost, service_name, log_marker, expe
         # and verifies the window, instead of racing that forwarding with a fixed sleep.
         # LogAnalyzer itself asserts the messages on exit, so this is only a wait.
         _wait_expected_logs_forwarded(duthost, loganalyzer._markers[-1], expect_log_regex,
-                                      expect_log_matches, additional_files)
+                                      expect_log_matches, additional_files, presence_log_regex)
 
     if presence_log_regex:
         presence_analyzer.analyze(presence_marker)


### PR DESCRIPTION
### Description of PR

Summary:
Fix intermittent `test_syslog_rate_limit` failures where the generated-message count is satisfied but the separate rsyslog rate-limit notification is not yet available when `LogAnalyzer` begins verification.

The count-aware forwarding wait added in #26288 keeps the main analyzer window open until all expected generated messages reach the host logs. The rate-limit notification is validated by a second analyzer because its count varies, but the existing wait does not include that notification. On loaded testbeds, analysis can therefore begin while the notification is still being forwarded, producing `expected_missing_match: 1` even though rate limiting worked.

This change extends the existing forwarding poll to wait for every `presence_log_regex` before either analyzer closes.
Result in the local:
<img width="907" height="328" alt="image" src="https://github.com/user-attachments/assets/dac022a1-92da-42ba-9999-0b6172d99fe7" />


### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`test_syslog_rate_limit` can fail after capturing the expected 100 generated messages because the rate-limit notification follows a separate asynchronous forwarding path and may arrive later. The presence analyzer is closed immediately after the main analyzer, so it can miss a valid notification that is still in flight.

#### How did you do it?
Pass `presence_log_regex` into `_wait_expected_logs_forwarded()` and require every presence pattern to appear before the wait returns. The check uses the same marker-scoped log window and existing log-file set, preserving support for redirected logs such as `/var/log/stpd.log`.

The healthy path remains unchanged: the wait returns as soon as both the expected generated-message count and notification are present.

#### How did you verify/test it?
Static validation on the external `master` patch:
- `python3 -m py_compile tests/syslog/test_syslog_rate_limit.py`
- `flake8 --max-line-length=120 tests/syslog/test_syslog_rate_limit.py`
- `git diff --check`

Validated the equivalent change on the `202512` branch using `vms13-lt2-nh4210-1` (`lt2-u32d128`, image `20251210.12`):

```
tests/syslog/test_syslog_rate_limit.py::test_syslog_rate_limit
1 passed in 412.59s
```

#### Any platform specific information?
Observed on an NH-4210 testbed under elevated log load, but the asynchronous forwarding race is platform-independent.

#### Supported testbed topology if it's a new test case?
N/A -- existing test case fix.

### Documentation
N/A -- test-only change.
