### PR TITLE
[ci] temporarily switch from sonic-ubuntu-1c-2 to sonic-ubuntu-1c to help share the workload

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -2,7 +2,7 @@ parameters:
 - name: RUN_TEST_AGENT_POOL
   type: object
   default:
-    name: sonic-ubuntu-1c-2
+    name: sonic-ubuntu-1c     # temporarily switch from sonic-ubuntu-1c-2 to sonic-ubuntu-1c to help share the workload
 
 - name: PRE_TEST_AGENT_POOL
   type: object


### PR DESCRIPTION
### Description of PR

Summary:
Temporarily switch the default PR test agent pool from `sonic-ubuntu-1c-2` to `sonic-ubuntu-1c` to distribute the CI workload across available agents.

Fixes # N/A

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

Not applicable. This change only updates the Azure Pipelines agent pool used to run PR tests.

### Approach

#### What is the motivation for this PR?

The `sonic-ubuntu-1c-2` agent pool currently has a high workload. Using `sonic-ubuntu-1c` temporarily allows PR test jobs to share the available CI capacity and reduces pressure on the original pool.

#### How did you do it?

Updated the default `RUN_TEST_AGENT_POOL` in the PR test pipeline template from `sonic-ubuntu-1c-2` to `sonic-ubuntu-1c`.

#### How did you verify/test it?

Verified that the pipeline template references the intended agent pool.
The pipeline run will provide end-to-end validation.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A