### PR TITLE
Set 365-day validity on telemetry/restapi certs in deploy_certs.yml

### DIFF
--- a/ansible/deploy_certs.yml
+++ b/ansible/deploy_certs.yml
@@ -10,6 +10,7 @@
       -x509 \
       -sha256 \
       -nodes \
+      -days 365 \
       -newkey rsa:2048 \
       -keyout "{{ server_key }}"
       -subj "/CN={{ cert_subject }}"
@@ -21,6 +22,7 @@
       -x509 \
       -sha256 \
       -nodes \
+      -days 365 \
       -newkey rsa:2048 \
       -keyout "{{ dsmsroot_key }}"
       -subj "/CN={{ root_subject }}"


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #27406

`ansible/deploy_certs.yml` generates the streaming-telemetry server cert, the `dsmsroot` CA cert and (via the same include from `roles/testbed/prepare/tasks/setup_restapi_certs.yml`) the RESTAPI cert with `openssl req -x509` and no `-days` flag, so they get openssl's 30-day default validity. It is the only cert-generation path in the repo without an explicit validity — `tests/common/helpers/gnmi_utils.py` (825/1825 days), `tests/restapi/conftest.py` (825/1825 days), `tests/telemetry/telemetry_utils.py` (`_TELEMETRY_CERT_VALIDITY_DAYS = 365`) and `tests/gnmi/test_gnmi_2038.py` (4800+ days) all set one.

On testbeds that are deployed once and reused (rather than re-running `deploy-mg` before every run), the deployed certs under `/etc/sonic/telemetry/` expire after 30 days and any telemetry/gNMI test that consumes them without regenerating — e.g. `test_telemetry_cert_rotation.py::test_telemetry_post_cert_del`, whose first request goes through `create_gnmi_config` and reuses the on-disk `streamingtelemetryserver.cer` / `dsmsroot.cer` — fails on `SSLV3_ALERT_CERTIFICATE_EXPIRED`.

This PR adds `-days 365` to both `openssl req -x509` invocations, matching `_TELEMETRY_CERT_VALIDITY_DAYS` in `telemetry_utils.py`. These are self-signed lab certs regenerated on every deploy, so 365 days is a ceiling on their lifetime, not a rotation policy change.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #27406
Failure type: day-one issue (the missing `-days` dates back to the file's creation in #2903)

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

The certs are generated on the sonic-mgmt host by the `openssl req -x509` command in `ansible/deploy_certs.yml`, so the result is deterministic and identical on every branch; `ansible/deploy_certs.yml` is byte-identical (sha256 `ef3fb7c550f6c1a0...`) on master, 202505, 202511 and 202605, so the same two-line patch applies to each. Verified by executing the patched command and checking the resulting cert:

```
$ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
    -keyout streamingtelemetryserver.key -subj "/CN=ndastreamingservertest" \
    -out streamingtelemetryserver.cer
$ openssl x509 -in streamingtelemetryserver.cer -noout -dates
notBefore=Aug 31 22:50:48 2026 GMT
notAfter=Aug 31 22:50:48 2027 GMT     # exactly +365 days (30 days without the patch)
```

- master: patched command verified as above; `pre-commit run --files ansible/deploy_certs.yml` passes
- 202505: `ansible/deploy_certs.yml` identical to master (same sha256); same verification applies
- 202511: `ansible/deploy_certs.yml` identical to master (same sha256); same verification applies
- 202605: `ansible/deploy_certs.yml` identical to master (same sha256); same verification applies

No test case is changed by this PR; the cert-lifecycle tests (`tests/telemetry/test_telemetry_cert_rotation.py`) mint their own certs and are unaffected.

### Approach
#### What is the motivation for this PR?

Telemetry/gNMI tests intermittently fail on long-lived testbeds when the certs deployed by `deploy_certs.yml` silently expire after openssl's 30-day default validity.

#### How did you do it?

Added `-days 365` to both `openssl req -x509` invocations in `ansible/deploy_certs.yml`.

#### How did you verify/test it?

Confirmed `deploy_certs.yml` is the sole `openssl req -x509` call in the repo without `-days`; traced the include wiring (`config_sonic_basedon_testbed.yml`, `roles/testbed/prepare/tasks/setup_{telemetry,restapi}_certs.yml`) and that `create_gnmi_config` points `GNMI|certs` at exactly these deployed files. Executed the patched openssl command and confirmed `notAfter` = generation time + 365 days (see Test result); `pre-commit run --files ansible/deploy_certs.yml` passes.

#### Any platform specific information?

None — framework cert generation, platform-agnostic.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
