### PR TITLE
[conditional_mark] Skip snappi lacp/reboot and bgp rib route optimztn perf on 202605 branch

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5088,6 +5088,12 @@ snappi_tests/bgp/test_bgp_rib_in_convergence.py:
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/23857"
 
+snappi_tests/bgp/test_bgp_rib_route_optimztn_perf.py:
+  skip:
+    reason: "IxNetwork Error in L2/L3 Traffic Apply - https://github.com/sonic-net/sonic-mgmt/issues/23857"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23857"
+
 snappi_tests/bgp/test_bgp_scalability.py:
   xfail:
     reason: "IxNetwork Error in L2/L3 Traffic Apply - https://github.com/sonic-net/sonic-mgmt/issues/23857"
@@ -5136,9 +5142,9 @@ snappi_tests/ecn/test_red_accuracy_with_snappi:
 
 snappi_tests/lacp:
   skip:
-    reason: "Skipping dash on 2025 releases"
+    reason: "Skipping snappi lacp on 2025, 202605 and 202608 releases"
     conditions:
-      - "'2025' in release"
+      - "'2025' in release or '202605' in release or '202608' in release"
 
 snappi_tests/pfc/test_global_pause_with_snappi.py:
   skip:
@@ -5168,9 +5174,11 @@ snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_frwd_over_subs_40_09:
 
 snappi_tests/reboot:
   skip:
-    reason: "Skipping dash on 2025 releases"
+    reason: "Skipping snappi reboot on 2025 releases and while https://github.com/sonic-net/sonic-mgmt/issues/27415 is open"
+    conditions_logical_operator: or
     conditions:
       - "'2025' in release"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/27415"
 
 #######################################
 #####            snmp             #####


### PR DESCRIPTION
### Description of PR

Summary:
Suppress the following snappi suites:

| Test | Reason |
| --- | --- |
| `snappi_tests/reboot` | Issue #27415 is added to track this and used for skip. |
| `snappi_tests/lacp` | Will skip it on 202605/202608 only. Because #21720 reworks those cases to run with 3 TGEN ports on master, so later 2026 branch will be able to run them. |
| `snappi_tests/bgp` | `test_bgp_rib_route_optimztn_perf` is a new module, which hits the same IxNetwork "Error in L2/L3 Traffic Apply" problem in #23857. |

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch

- [x] master
- [ ] 202605

### Test result

Skipped on 202605 branch.

### Approach
#### What is the motivation for this PR?
snappi_tests/reboot, snappi_tests/lacp, snappi_tests/bgp are not ready yet in 202605 branch. skipping them for now.

#### How did you do it?
skip them using mark condition.

#### How did you verify/test it?

verified on local testbed.

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

N/A 

### Documentation

N/A
