### PR TITLE
fix(dualtor): reset mux start limit before recovery

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1753,6 +1753,8 @@ def validate_active_active_dualtor_setup(
                 "config mux mode active all failed on device {}".format(duthost.hostname)
             )
 
+    # Clear a potentially exhausted systemd start budget before recovery.
+    duthosts.shell("systemctl reset-failed mux.service")
     duthosts.shell("systemctl restart mux.service")
     # verify both ToRs are active
     for duthost in duthosts:


### PR DESCRIPTION
### Description of PR

Summary:
Clear the systemd failure state before the active-active dualtor setup fixture restarts `mux.service`. Repeated mux starts can exhaust `StartLimitBurst`, causing the recovery restart to fail immediately and leaving subsequent tests with inconsistent mux state.

ADO: https://dev.azure.com/msazure/One/_workitems/edit/39396866/

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/39396866/
Failure type: regression

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: `python3 -m py_compile tests/common/dualtor/dual_tor_utils.py` and targeted static checks passed.
- 202605: The patch applies cleanly. Affected pre-fix image `SONiC.20260510.11`: https://elastictest.org/scheduler/testplan/6a893ae024f9645a147a50e5
- 202605 validation: https://elastictest.org/scheduler/testplan/6a8fb653d025e08c23cc53f6 using internal branch `austinpham/39396866-reset-mux-start-limit-internal-202605`.

### Approach
#### What is the motivation for this PR?

The affected active-active normal-operation run first logged:

```text
Failed to start mux.service - MUX Cable Container
```

Later fixture recovery attempts failed with:

```text
Job for mux.service failed because start of the service was attempted too often.
To force a start use "systemctl reset-failed mux.service"
```

The existing recovery in `shutdown_tor_heartbeat` already handles the same `mux.service` start-rate limit, but `validate_active_active_dualtor_setup` directly restarts the service without clearing the exhausted systemd start budget. Its recovery therefore fails and subsequent tests cascade.

#### How did you do it?

Run `systemctl reset-failed mux.service` immediately before the shared active-active setup fixture restarts `mux.service`.

#### How did you verify/test it?

The updated module compiles and passes targeted static checks. The patch also applies cleanly to `202605`.

#### Any platform specific information?

Active-active dualtor topologies using `mux.service`.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.
