### PR TITLE
[dualtor-aa] add vlan multi-subnets support

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -1291,7 +1291,8 @@ class VMTopology(object):
                         (br_name, dut_iface_id, injected_iface_id))
         else:
             # Add flow from external iface to a VM and a ptf container
-            # Allow BGP, IPinIP, fragmented packets, ICMP, SNMP packets and layer2 packets from DUT to neighbors
+            # Allow BGP, IPinIP (both IPv4-in-IPv4 and IPv6-in-IPv4), fragmented packets, ICMP, SNMP packets
+            # and layer2 packets from DUT to neighbors
             # Block other traffic from DUT to EOS for EOS's stability,
             # Allow all traffic from DUT to PTF.
             bind_helper("ovs-ofctl add-flow %s table=0,priority=10,tcp,in_port=%s,tp_src=179,action=output:%s,%s" %
@@ -1311,6 +1312,9 @@ class VMTopology(object):
             bind_helper("ovs-ofctl add-flow %s table=0,priority=10,tcp6,in_port=%s,tp_src=22,action=output:%s,%s" %
                         (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             bind_helper("ovs-ofctl add-flow %s table=0,priority=10,ip,in_port=%s,nw_proto=4,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            # proto 41 is IPv6-in-IPv4, used by dualtor to tunnel IPv6 server traffic to the peer ToR
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=10,ip,in_port=%s,nw_proto=41,action=output:%s,%s" %
                         (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             bind_helper("ovs-ofctl add-flow %s table=0,priority=8,ip,in_port=%s,nw_frag=yes,action=output:%s,%s" %
                         (br_name, dut_iface_id, vm_iface_id, injected_iface_id))

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -189,7 +189,12 @@
           <Subnets>{{ vlan_param['prefix'] | ansible.utils.ipaddr('network') }}/{{ vlan_param['prefix'] | ansible.utils.ipaddr('prefix') }}</Subnets>
 {% endif %}
 {% if 'secondary_subnet' in vlan_param %}
-          <SecondarySubnets>{{ vlan_param['secondary_subnet'] | ansible.utils.ipaddr('network') }}/{{ vlan_param['secondary_subnet'] | ansible.utils.ipaddr('prefix') }}</SecondarySubnets>
+{%   set secondary_subnets = [vlan_param['secondary_subnet']] if vlan_param['secondary_subnet'] is string else vlan_param['secondary_subnet'] %}
+{%   set secondary_subnet_strs = [] %}
+{%   for subnet in secondary_subnets %}
+{%     set _ = secondary_subnet_strs.append((subnet | ansible.utils.ipaddr('network')) ~ '/' ~ (subnet | ansible.utils.ipaddr('prefix'))) %}
+{%   endfor %}
+          <SecondarySubnets>{{ secondary_subnet_strs | join(';') }}</SecondarySubnets>
 {% endif %}
 {% if 'mac' in vlan_param %}
           <MacAddress>{{ vlan_param['mac'] }}</MacAddress>
@@ -250,11 +255,14 @@
         </IPInterface>
 {% endif %}
 {%if 'secondary_subnet' in vlan_param %}
+{%   set secondary_subnets = [vlan_param['secondary_subnet']] if vlan_param['secondary_subnet'] is string else vlan_param['secondary_subnet'] %}
+{%   for subnet in secondary_subnets %}
         <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>{{ vlan }}</AttachTo>
-          <Prefix>{{ vlan_param['secondary_subnet'] }}</Prefix>
+          <Prefix>{{ subnet }}</Prefix>
         </IPInterface>
+{%   endfor %}
 {% endif %}
 {% endfor %}
 {% for vlan, vlan_param in vlan_configs.items() %}

--- a/ansible/templates/minigraph_filterleaf_dpg.j2
+++ b/ansible/templates/minigraph_filterleaf_dpg.j2
@@ -171,7 +171,12 @@
           <Tag>{{ vlan_param['tag'] }}</Tag>
           <Subnets>{{ vlan_param['prefix'] | ansible.utils.ipaddr('network') }}/{{ vlan_param['prefix'] | ansible.utils.ipaddr('prefix') }}</Subnets>
 {% if 'secondary_subnet' in vlan_param %}
-          <SecondarySubnets>{{ vlan_param['secondary_subnet'] | ansible.utils.ipaddr('network') }}/{{ vlan_param['secondary_subnet'] | ansible.utils.ipaddr('prefix') }}</SecondarySubnets>
+{%   set secondary_subnets = [vlan_param['secondary_subnet']] if vlan_param['secondary_subnet'] is string else vlan_param['secondary_subnet'] %}
+{%   set secondary_subnet_strs = [] %}
+{%   for subnet in secondary_subnets %}
+{%     set _ = secondary_subnet_strs.append((subnet | ansible.utils.ipaddr('network')) ~ '/' ~ (subnet | ansible.utils.ipaddr('prefix'))) %}
+{%   endfor %}
+          <SecondarySubnets>{{ secondary_subnet_strs | join(';') }}</SecondarySubnets>
 {% endif %}
 {% if 'mac' in vlan_param %}
           <MacAddress>{{ vlan_param['mac'] }}</MacAddress>
@@ -212,11 +217,14 @@
           <Prefix>{{ vlan_param['prefix'] }}</Prefix>
         </IPInterface>
 {%if 'secondary_subnet' in vlan_param %}
+{%   set secondary_subnets = [vlan_param['secondary_subnet']] if vlan_param['secondary_subnet'] is string else vlan_param['secondary_subnet'] %}
+{%   for subnet in secondary_subnets %}
         <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>{{ vlan }}</AttachTo>
-          <Prefix>{{ vlan_param['secondary_subnet'] }}</Prefix>
+          <Prefix>{{ subnet }}</Prefix>
         </IPInterface>
+{%   endfor %}
 {% endif %}
 {% endfor %}
 {% for vlan, vlan_param in vlan_configs.items() %}

--- a/ansible/vars/topo_dualtor-aa-56.yml
+++ b/ansible/vars/topo_dualtor-aa-56.yml
@@ -167,6 +167,17 @@ topology:
           prefix_v6: fc02:1000::1/64
           tag: 1000
           mac: 00:aa:bb:cc:dd:ee
+      one_vlan_b:
+        Vlan1000:
+          id: 1000
+          intfs: [0, 2, 4, 6, 8, 10, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 44, 46, 48, 50, 52, 54]
+          prefix: 192.168.0.1/21
+          prefix_v6: fc02:1000::1/64
+          secondary_subnet:
+            - 192.169.0.1/22
+            - 2001:db8:1000::1/64
+          tag: 1000
+          mac: 00:aa:bb:cc:dd:ee
       two_vlan_a:
         Vlan100:
           id: 100

--- a/ansible/vars/topo_dualtor-aa.yml
+++ b/ansible/vars/topo_dualtor-aa.yml
@@ -119,6 +119,17 @@ topology:
           prefix_v6: fc02:1000::1/64
           tag: 1000
           mac: 00:aa:bb:cc:dd:ee
+      one_vlan_b:
+        Vlan1000:
+          id: 1000
+          intfs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
+          prefix: 192.168.0.1/21
+          prefix_v6: fc02:1000::1/64
+          secondary_subnet:
+            - 192.169.0.1/22
+            - 2001:db8:1000::1/64
+          tag: 1000
+          mac: 00:aa:bb:cc:dd:ee
       two_vlan_a:
         Vlan100:
           id: 100

--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -262,7 +262,8 @@ def verify_and_report(tor_IO, verify, delay, allowed_disruption,
 def run_test(
     duthosts, activehost, ptfhost, ptfadapter, vmhost, action,
     tbinfo, tor_vlan_port, send_interval, traffic_direction,
-    stop_after, cable_type=CableType.active_standby, random_dst=None     # noqa: F811
+    stop_after, cable_type=CableType.active_standby, random_dst=None,     # noqa: F811
+    server_subnet=None
 ):
     io_ready = threading.Event()
 
@@ -270,7 +271,7 @@ def run_test(
     tor_IO = DualTorIO(
         activehost, peerhost, ptfhost, ptfadapter, vmhost, tbinfo,
         io_ready, tor_vlan_port=tor_vlan_port, send_interval=send_interval, cable_type=cable_type,
-        random_dst=random_dst
+        random_dst=random_dst, server_subnet=server_subnet
     )
     tor_IO.generate_traffic(traffic_direction)
 
@@ -369,7 +370,8 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
     def t1_to_server_io_test(activehost, tor_vlan_port=None,
                              delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.1,
                              stop_after=None, allow_disruption_before_traffic=False,
-                             allowed_duplication=None, merge_duplications_into_disruptions=False):
+                             allowed_duplication=None, merge_duplications_into_disruptions=False,
+                             server_subnet=None):
         """
         Helper method for `send_t1_to_server_with_action`.
         Starts sender and sniffer before performing the action on the tor host.
@@ -390,6 +392,8 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
             send_interval (int): Sleep duration between two sent packets
             stop_after (int): Wait time after which sender/sniffer threads are terminated
                 default - None: Early termination will not be performed
+            server_subnet (str): VLAN subnet whose server addresses to target, e.g. '2001:db8:1000::1/64'.
+                default - None: use the servers' MUX_CABLE addresses
         Returns:
             data_plane_test_report (dict): traffic test statistics (sent/rcvd/dropped)
         """
@@ -397,7 +401,7 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
         tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
                           action, tbinfo, tor_vlan_port, send_interval,
                           traffic_direction="t1_to_server", stop_after=stop_after,
-                          cable_type=cable_type)
+                          cable_type=cable_type, server_subnet=server_subnet)
 
         # If a delay is allowed but no numebr of allowed disruptions
         # is specified, default to 1 allowed disruption
@@ -438,7 +442,7 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
     def server_to_t1_io_test(activehost, tor_vlan_port=None,
                              delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
-                             stop_after=None, random_dst=None):
+                             stop_after=None, random_dst=None, server_subnet=None):
         """
         Helper method for `send_server_to_t1_with_action`.
         Starts sender and sniffer before performing the action on the tor host.
@@ -458,6 +462,8 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
             send_interval (int): Sleep duration between two sent packets
             stop_after (int): Wait time after which sender/sniffer threads are terminated
                 default - None: Early termination will not be performed
+            server_subnet (str): VLAN subnet whose server addresses to target, e.g. '192.169.0.1/22'.
+                default - None: use the servers' MUX_CABLE addresses
         Returns:
             data_plane_test_report (dict): traffic test statistics (sent/rcvd/dropped)
         """
@@ -465,7 +471,8 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
         tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
                           action, tbinfo, tor_vlan_port, send_interval,
                           traffic_direction="server_to_t1", stop_after=stop_after,
-                          cable_type=cable_type, random_dst=random_dst)
+                          cable_type=cable_type, random_dst=random_dst,
+                          server_subnet=server_subnet)
 
         # If a delay is allowed but no numebr of allowed disruptions
         # is specified, default to 1 allowed disruption
@@ -570,11 +577,12 @@ def send_server_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
     def server_to_server_io_test(activehost, test_mux_ports, delay=0,
                                  allowed_disruption=0, action=None,
-                                 verify=False, send_interval=0.01, stop_after=None):
+                                 verify=False, send_interval=0.01, stop_after=None,
+                                 server_subnet=None):
         tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
                           action, tbinfo, test_mux_ports, send_interval,
                           traffic_direction="server_to_server", stop_after=stop_after,
-                          cable_type=cable_type)
+                          cable_type=cable_type, server_subnet=server_subnet)
 
         # If a delay is allowed but no numebr of allowed disruptions
         # is specified, default to 1 allowed disruption

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -39,7 +39,7 @@ class DualTorIO:
 
     def __init__(self, activehost, standbyhost, ptfhost, ptfadapter, vmhost, tbinfo,
                  io_ready, tor_vlan_port=None, send_interval=0.01, cable_type=CableType.active_standby,
-                 random_dst=None):
+                 random_dst=None, server_subnet=None):
         self.tor_pc_intf = None
         self.tor_vlan_intf = tor_vlan_port
         self.duthost = activehost
@@ -54,6 +54,11 @@ class DualTorIO:
         self.tcp_sport = 1234
 
         self.cable_type = cable_type
+        # Target the servers' addresses in this VLAN subnet instead of their MUX_CABLE ones.
+        self.server_subnet = server_subnet
+        self.ip_version = ipaddress.ip_network(server_subnet, strict=False).version \
+            if server_subnet else 4
+        self.ip_layer = scapyall.IPv6 if self.ip_version == 6 else scapyall.IP
 
         if random_dst is None:
             # if random_dst is not set, default to true for active standby dualtor.
@@ -69,14 +74,28 @@ class DualTorIO:
 
         # Calculate valid range for T1 src/dst addresses
         mg_facts = self.duthost.get_extended_minigraph_facts(self.tbinfo)
-        prefix_len = mg_facts['minigraph_vlan_interfaces'][VLAN_INDEX]['prefixlen'] - 3
-        test_network = ipaddress.ip_address(
-            mg_facts['minigraph_vlan_interfaces'][VLAN_INDEX]['addr']) +\
-            (1 << (32 - prefix_len))
-        self.default_ip_range = str(ipaddress.ip_interface((str(test_network) + '/{0}'.format(prefix_len))
-                                                           .encode().decode()).network)
-        self.src_addr, mask = self.default_ip_range.split('/')
-        self.n_hosts = 2**(32 - int(mask))
+        # MUX_CABLE stores server addresses as /32 and /128, so the VLAN subnets are what
+        # give each server its host offset.
+        self.vlan_networks = [ipaddress.ip_interface('{}/{}'.format(intf['addr'], intf['prefixlen'])).network
+                              for intf in mg_facts['minigraph_vlan_interfaces']]
+        if self.ip_version == 6:
+            vlan_intf = next(intf for intf in mg_facts['minigraph_vlan_interfaces']
+                             if ipaddress.ip_address(intf['addr']).version == 6)
+            prefix_len = int(vlan_intf['prefixlen']) - 3
+            test_network = ipaddress.ip_address(vlan_intf['addr']) + (1 << (128 - prefix_len))
+            self.default_ip_range = str(ipaddress.ip_interface(
+                '{}/{}'.format(test_network, prefix_len)).network)
+            self.src_addr, mask = self.default_ip_range.split('/')
+            self.n_hosts = 2**(128 - int(mask))
+        else:
+            prefix_len = mg_facts['minigraph_vlan_interfaces'][VLAN_INDEX]['prefixlen'] - 3
+            test_network = ipaddress.ip_address(
+                mg_facts['minigraph_vlan_interfaces'][VLAN_INDEX]['addr']) +\
+                (1 << (32 - prefix_len))
+            self.default_ip_range = str(ipaddress.ip_interface((str(test_network) + '/{0}'.format(prefix_len))
+                                                               .encode().decode()).network)
+            self.src_addr, mask = self.default_ip_range.split('/')
+            self.n_hosts = 2**(32 - int(mask))
 
         self.tor_to_ptf_intf_map = mg_facts['minigraph_ptf_indices']
 
@@ -161,21 +180,70 @@ class DualTorIO:
         logger.info("Force stop the ptf sniffer process by sending SIGTERM")
         self.ptfhost.command("pkill -SIGTERM -f %s" % self.ptf_sniffer, module_ignore_errors=True)
 
+    def _base_tcp_packet(self, eth_dst, eth_src=None, ip_ttl=None):
+        """Build the template TCP packet for the configured address family."""
+        kwargs = dict(eth_dst=eth_dst, tcp_dport=TCP_DST_PORT, tcp_sport=self.tcp_sport)
+        if eth_src is not None:
+            kwargs['eth_src'] = eth_src
+        if self.ip_version == 6:
+            if ip_ttl is not None:
+                kwargs['ipv6_hlim'] = ip_ttl
+            return testutils.simple_tcpv6_packet(**kwargs)
+        if ip_ttl is not None:
+            kwargs['ip_ttl'] = ip_ttl
+        return testutils.simple_tcp_packet(**kwargs)
+
+    def _clear_checksums(self, packet):
+        packet[scapyall.TCP].chksum = None
+        # IPv6 has no header checksum, so scapy's IPv6 layer has no chksum field.
+        if self.ip_version == 4:
+            packet[scapyall.IP].chksum = None
+
+    def _server_address(self, mux_intf):
+        """
+        Resolve the address to use for a server, honouring `server_subnet` when set.
+
+        The mapped address keeps the host offset the server has within its VLAN subnet, so it
+        lands outside every cable's `srv_ip4_`/`srv_ip6_` and exercises muxorch's FDB
+        port-based classification instead of the subnet match.
+        """
+        server_key = 'server_ipv6' if self.ip_version == 6 else 'server_ipv4'
+        server_prefix = self.mux_cable_table[mux_intf][server_key]
+        server_ip = ipaddress.ip_interface(server_prefix).ip
+        if not self.server_subnet:
+            return str(server_ip)
+
+        target_network = ipaddress.ip_network(self.server_subnet, strict=False)
+        if server_ip.version != target_network.version:
+            raise ValueError("server_subnet {} family differs from server address {}"
+                             .format(self.server_subnet, server_prefix))
+
+        anchor = next((net for net in self.vlan_networks
+                       if net.version == server_ip.version and server_ip in net), None)
+        if anchor is None:
+            raise ValueError("server {} is not within any VLAN subnet".format(server_prefix))
+
+        offset = int(server_ip) - int(anchor.network_address)
+        mapped = target_network.network_address + offset
+        if mapped not in target_network:
+            raise ValueError("server {} maps outside server_subnet {}"
+                             .format(server_prefix, self.server_subnet))
+        return str(mapped)
+
     def _generate_vlan_servers(self):
         """
         Create mapping of server IPs to PTF interfaces
         """
         server_ip_list = []
 
-        for _, config in natsorted(list(self.mux_cable_table.items())):
-            server_ip_list.append(str(config['server_ipv4'].split("/")[0]))
+        for mux_intf, _ in natsorted(list(self.mux_cable_table.items())):
+            server_ip_list.append(self._server_address(mux_intf))
         logger.info("ALL server address:\n {}".format(server_ip_list))
 
         ptf_to_server_map = dict()
         for intf in natsorted(self.test_interfaces):
             ptf_intf = self.tor_to_ptf_intf_map[intf]
-            server_ip = str(self.mux_cable_table[intf]['server_ipv4'].split("/")[0])
-            ptf_to_server_map[ptf_intf] = server_ip
+            ptf_to_server_map[ptf_intf] = self._server_address(intf)
 
         logger.debug('VLAN intf to server IP map: {}'.format(json.dumps(ptf_to_server_map, indent=4, sort_keys=True)))
         return ptf_to_server_map
@@ -187,16 +255,19 @@ class DualTorIO:
         if self.cable_type == CableType.active_standby:
             return {}
 
+        soc_key = 'soc_ipv6' if self.ip_version == 6 else 'soc_ipv4'
         soc_ip_list = []
         for _, config in natsorted(list(self.mux_cable_table.items())):
-            if "soc_ipv4" in config:
-                soc_ip_list.append(str(config['soc_ipv4'].split("/")[0]))
+            if soc_key in config:
+                soc_ip_list.append(str(config[soc_key].split("/")[0]))
         logger.info("All soc address:\n {}".format(soc_ip_list))
 
         ptf_to_soc_map = dict()
         for intf in natsorted(self.test_interfaces):
+            if soc_key not in self.mux_cable_table[intf]:
+                continue
             ptf_intf = self.tor_to_ptf_intf_map[intf]
-            soc_ip = str(self.mux_cable_table[intf]['soc_ipv4'].split('/')[0])
+            soc_ip = str(self.mux_cable_table[intf][soc_key].split('/')[0])
             ptf_to_soc_map[ptf_intf] = soc_ip
 
         logger.debug('VLAN intf to soc IP map: {}'.format(json.dumps(ptf_to_soc_map, indent=4, sort_keys=True)))
@@ -300,12 +371,10 @@ class DualTorIO:
         # This way, when sending packets we continuously send for all servers/soc
         # instead of sending all packets for server/soc #1, then all packets for
         # server/soc #2, etc.
-        tcp_tx_packet_orig = testutils.simple_tcp_packet(
+        tcp_tx_packet_orig = self._base_tcp_packet(
             eth_dst=eth_dst,
             eth_src=eth_src,
-            ip_ttl=ip_ttl,
-            tcp_dport=TCP_DST_PORT,
-            tcp_sport=self.tcp_sport
+            ip_ttl=ip_ttl
         )
         tcp_tx_packet_orig = scapyall.Ether(convert_scapy_packet_to_bytes(tcp_tx_packet_orig))
         payload_suffix = "X" * 60
@@ -321,12 +390,11 @@ class DualTorIO:
                         0, ptf_t1_src_intf
                     )
                 packet[scapyall.Ether].src = eth_src
-                packet[scapyall.IP].src = self.random_host_ip()
-                packet[scapyall.IP].dst = server_ip
+                packet[self.ip_layer].src = self.random_host_ip()
+                packet[self.ip_layer].dst = server_ip
                 payload = str(i) + payload_suffix
                 packet.load = payload
-                packet[scapyall.TCP].chksum = None
-                packet[scapyall.IP].chksum = None
+                self._clear_checksums(packet)
                 self.packets_list.append((ptf_t1_src_intf, convert_scapy_packet_to_bytes(packet)))
 
         self.sent_pkt_dst_mac = self.dut_mac
@@ -377,10 +445,8 @@ class DualTorIO:
         # This way, when sending packets we continuously send for all servers/soc
         # instead of sending all packets for server/soc #1, then all packets for
         # server/soc #2, etc.
-        tcp_tx_packet_orig = testutils.simple_tcp_packet(
-            eth_dst=self.vlan_mac,
-            tcp_dport=TCP_DST_PORT,
-            tcp_sport=self.tcp_sport
+        tcp_tx_packet_orig = self._base_tcp_packet(
+            eth_dst=self.vlan_mac
         )
         tcp_tx_packet_orig = scapyall.Ether(convert_scapy_packet_to_bytes(tcp_tx_packet_orig))
         payload_suffix = "X" * 60
@@ -396,14 +462,13 @@ class DualTorIO:
                 payload = str(i) + payload_suffix
                 packet = tcp_tx_packet_orig.copy()
                 packet[scapyall.Ether].src = eth_src
-                packet[scapyall.IP].src = server_ip
+                packet[self.ip_layer].src = server_ip
                 if self.random_dst:
-                    packet[scapyall.IP].dst = self.random_host_ip()
+                    packet[self.ip_layer].dst = self.random_host_ip()
                 else:
-                    packet[scapyall.IP].dst = dst_ips[vlan_intf]
+                    packet[self.ip_layer].dst = dst_ips[vlan_intf]
                 packet.load = payload
-                packet[scapyall.TCP].chksum = None
-                packet[scapyall.IP].chksum = None
+                self._clear_checksums(packet)
                 self.packets_list.append((ptf_src_intf, convert_scapy_packet_to_bytes(packet)))
         self.sent_pkt_dst_mac = self.vlan_mac
         self.received_pkt_src_mac = [self.active_mac, self.standby_mac]
@@ -445,15 +510,24 @@ class DualTorIO:
             get_ovs_port_no_res = self.vmhost.shell("ovs-vsctl get Interface %s ofport" % vmhost_target_dut_port)
             vmhost_target_dut_port_no = get_ovs_port_no_res["stdout"].strip()
 
-            trace_command = ("ovs-appctl ofproto/trace {bridge} in_port={port},tcp,"
-                             "eth_src={eth_src},eth_dst={eth_dst},ip_src={ip_src},"
-                             "ip_dst={ip_dst},tp_src={{tp_src}},tp_dst={tp_dst}").format(
+            # OVS flow syntax differs per family: IPv6 uses tcp6 with ipv6_src/ipv6_dst.
+            if self.ip_version == 6:
+                flow_proto, src_key, dst_key = "tcp6", "ipv6_src", "ipv6_dst"
+            else:
+                flow_proto, src_key, dst_key = "tcp", "ip_src", "ip_dst"
+
+            trace_command = ("ovs-appctl ofproto/trace {bridge} in_port={port},{proto},"
+                             "eth_src={eth_src},eth_dst={eth_dst},{src_key}={ip_src},"
+                             "{dst_key}={ip_dst},tp_src={{tp_src}},tp_dst={tp_dst}").format(
                                  bridge=active_active_vmhost_bridge,
                                  port=active_active_vmhost_ptf_port,
+                                 proto=flow_proto,
+                                 src_key=src_key,
+                                 dst_key=dst_key,
                                  eth_src=packet[scapyall.Ether].src,
                                  eth_dst=packet[scapyall.Ether].dst,
-                                 ip_src=packet[scapyall.IP].src,
-                                 ip_dst=packet[scapyall.IP].dst,
+                                 ip_src=packet[self.ip_layer].src,
+                                 ip_dst=packet[self.ip_layer].dst,
                                  tp_dst=packet[scapyall.TCP].dport)
             sport_upper = min(65535, self.tcp_sport + 100)
             for tcp_sport in range(tcp_packet[scapyall.TCP].sport, sport_upper):
@@ -461,8 +535,7 @@ class DualTorIO:
                 if "output:%s" % vmhost_target_dut_port_no in trace_res["stdout"]:
                     packet[scapyall.TCP].sport = tcp_sport
                     self.tcp_sport = tcp_sport
-                    packet[scapyall.TCP].chksum = None
-                    packet[scapyall.IP].chksum = None
+                    self._clear_checksums(packet)
                     break
             else:
                 raise ValueError("Failed to generate packet destinated to target DUT %s" % self.duthost.hostname)
@@ -494,15 +567,13 @@ class DualTorIO:
         logger.info("-"*50)
 
         self.packets_list = []
-        tcp_tx_packet_orig = testutils.simple_tcp_packet(
-            eth_dst=self.vlan_mac,
-            tcp_dport=TCP_DST_PORT,
-            tcp_sport=self.tcp_sport
+        tcp_tx_packet_orig = self._base_tcp_packet(
+            eth_dst=self.vlan_mac
         )
         tcp_tx_packet_orig = scapyall.Ether(convert_scapy_packet_to_bytes(tcp_tx_packet_orig))
         tcp_tx_packet_orig[scapyall.Ether].src = src_mac
-        tcp_tx_packet_orig[scapyall.IP].src = src_ip
-        tcp_tx_packet_orig[scapyall.IP].dst = dst_ip
+        tcp_tx_packet_orig[self.ip_layer].src = src_ip
+        tcp_tx_packet_orig[self.ip_layer].dst = dst_ip
         tcp_tx_packet_orig = self._generate_upstream_packet_to_target_duthost(vlan_src_intf, tcp_tx_packet_orig)
 
         payload_suffix = "X" * 60
@@ -510,8 +581,7 @@ class DualTorIO:
             payload = str(i) + payload_suffix
             packet = tcp_tx_packet_orig.copy()
             packet.load = payload
-            packet[scapyall.TCP].chksum = None
-            packet[scapyall.IP].chksum = None
+            self._clear_checksums(packet)
             self.packets_list.append((src_ptf_port, convert_scapy_packet_to_bytes(packet)))
 
         self.sent_pkt_dst_mac = self.vlan_mac
@@ -528,6 +598,8 @@ class DualTorIO:
             raise Exception("host number {} is greater than number of hosts {}\
                 in the network {}".format(
                     host_number, self.n_hosts - 2, self.default_ip_range))
+        if self.ip_version == 6:
+            return str(ipaddress.ip_address(self.src_addr) + host_number)
         src_addr_n = struct.unpack(">I", socket.inet_aton(self.src_addr))[0]
         net_addr_n = src_addr_n & (2**32 - self.n_hosts)
         host_addr_n = net_addr_n + host_number
@@ -661,15 +733,15 @@ class DualTorIO:
 
     def get_server_address(self, packet):
         if self.traffic_direction == "t1_to_server":
-            server_addr = packet[scapyall.IP].dst
+            server_addr = packet[self.ip_layer].dst
         elif self.traffic_direction == "server_to_t1":
-            server_addr = packet[scapyall.IP].src
+            server_addr = packet[self.ip_layer].src
         elif self.traffic_direction == "t1_to_soc":
-            server_addr = packet[scapyall.IP].dst
+            server_addr = packet[self.ip_layer].dst
         elif self.traffic_direction == "soc_to_t1":
-            server_addr = packet[scapyall.IP].src
+            server_addr = packet[self.ip_layer].src
         elif self.traffic_direction == "server_to_server":
-            server_addr = packet[scapyall.IP].src
+            server_addr = packet[self.ip_layer].src
         return server_addr
 
     def get_test_results(self):

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -501,6 +501,40 @@ def pause_garp_service(ptfhost):
         ptfhost.shell("supervisorctl start garp_service")
 
 
+def _collapse_garp_addresses(values):
+    """Keep the single-value form so configs for single-subnet VLANs stay unchanged."""
+    if not values:
+        return ''
+    return values[0] if len(values) == 1 else values
+
+
+def _garp_subnet_targets(server_ip, vlan_intfs):
+    """Map a mux server address into every VLAN subnet of its own address family.
+
+    Returns (targets, gateways) index-paired for garp_service, so each announcement is
+    sent to the gateway of the subnet it belongs to.
+    """
+    anchor = next((intf for intf in vlan_intfs if server_ip and server_ip in intf.network), None)
+
+    if anchor is None:
+        # Server address sits outside every known VLAN subnet, announce it as-is.
+        targets = [str(server_ip)] if server_ip else []
+        gateways = [str(vlan_intfs[0].ip)] if vlan_intfs else []
+    else:
+        offset = int(server_ip) - int(anchor.network.network_address)
+        ordered = [anchor] + [intf for intf in vlan_intfs if intf.network != anchor.network]
+        targets, gateways = [], []
+        for intf in ordered:
+            candidate = intf.network.network_address + offset
+            # Subnets may differ in size, so the mapped host can fall outside a smaller one.
+            if candidate not in intf.network:
+                continue
+            targets.append(str(candidate))
+            gateways.append(str(intf.ip))
+
+    return _collapse_garp_addresses(targets), _collapse_garp_addresses(gateways)
+
+
 @pytest.fixture(scope='module', autouse=True)
 def run_garp_service(duthost, ptfhost, tbinfo, change_mac_addresses, request):
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
@@ -516,16 +550,18 @@ def run_garp_service(duthost, ptfhost, tbinfo, change_mac_addresses, request):
                 dut_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0]
             break
 
-        dst_ipv6 = ''
+        vlan_ipv4_intfs = []
+        vlan_ipv6_intfs = []
         for intf_details in list(vlan_intfs.values()):
             for key in list(intf_details.keys()):
                 try:
                     intf_ip = ip_interface(key)
-                    if intf_ip.version == 6:
-                        dst_ipv6 = intf_ip.ip
-                        break
                 except ValueError:
                     continue
+                if intf_ip.version == 6:
+                    vlan_ipv6_intfs.append(intf_ip)
+                else:
+                    vlan_ipv4_intfs.append(intf_ip)
             break
 
         ptf_indices = duthost.get_extended_minigraph_facts(tbinfo)["minigraph_ptf_indices"]
@@ -553,12 +589,14 @@ def run_garp_service(duthost, ptfhost, tbinfo, change_mac_addresses, request):
             ptf_port_index = ptf_indices[vlan_intf]
             server_ip = ip_interface(config['server_ipv4']).ip if config['server_ipv4'] else ''
             server_ipv6 = ip_interface(config['server_ipv6']).ip if config['server_ipv6'] else ''
+            target_ip, _ = _garp_subnet_targets(server_ip, vlan_ipv4_intfs)
+            target_ipv6, dst_ipv6 = _garp_subnet_targets(server_ipv6, vlan_ipv6_intfs)
 
             garp_config[ptf_port_index] = {
                                             'dut_mac': '{}'.format(dut_mac),
-                                            'dst_ipv6': '{}'.format(dst_ipv6),
-                                            'target_ip': '{}'.format(server_ip),
-                                            'target_ipv6': '{}'.format(server_ipv6)
+                                            'dst_ipv6': dst_ipv6,
+                                            'target_ip': target_ip,
+                                            'target_ipv6': target_ipv6
                                         }
 
         ptfhost.copy(src=os.path.join(SCRIPTS_SRC_DIR, GARP_SERVICE_PY), dest=OPT_DIR)

--- a/tests/common/fixtures/vlan_config_swap.py
+++ b/tests/common/fixtures/vlan_config_swap.py
@@ -173,6 +173,15 @@ def _inherit_servers_from_running(vlan_name, table, key, fallback_vlan):
     return entry.get(key, []) or []
 
 
+def _as_subnet_list(value):
+    """Topo yaml allows ``secondary_subnet`` to be a single prefix or a list of them."""
+    if not value:
+        return []
+    if isinstance(value, (list, tuple)):
+        return [subnet for subnet in value if subnet]
+    return [value]
+
+
 def _generate_config_patch_from_variant(duthost, localhost, tbinfo, variant_name, is_dualtor):
     """Build the (sub_vlans_info, config_patch) tuple for the requested variant."""
     topo_name = tbinfo["topo"]["name"]
@@ -250,7 +259,7 @@ def _generate_config_patch_from_variant(duthost, localhost, tbinfo, variant_name
     for vlan_name, vparams in variant.items():
         ipv4 = vparams.get("prefix")
         ipv6 = vparams.get("prefix_v6")
-        ipv4_secondary = vparams.get("secondary_subnet")
+        secondary_subnets = _as_subnet_list(vparams.get("secondary_subnet"))
         mac = vparams.get("mac") or default_mac
         intf_indices = vparams.get("intfs", []) or []
 
@@ -274,7 +283,7 @@ def _generate_config_patch_from_variant(duthost, localhost, tbinfo, variant_name
         sub_vlans_info.append({
             "vlan_name": vlan_name,
             "interface_ipv4": ipv4,
-            "interface_ipv4_secondary": ipv4_secondary,
+            "interface_ipv4_secondary": secondary_subnets,
             "interface_ipv6": ipv6,
             "members_with_ptf_idx": members_with_ptf_idx,
             "vlan_plan": variant_name,
@@ -299,12 +308,12 @@ def _generate_config_patch_from_variant(duthost, localhost, tbinfo, variant_name
             )
         if ipv4:
             config_patch += add_vlan_ip_patch(vlan_name, ipv4)
-        if ipv4_secondary:
+        for secondary_subnet in secondary_subnets:
             # Mark secondary:true so docker-dhcp-relay get_primary_addr picks
             # the primary for -pg <giaddr> (dhcrelay duplicate -iu trigger).
             config_patch.append({
                 'op': 'add',
-                'path': '/VLAN_INTERFACE/%s|%s' % (vlan_name, ipv4_secondary.replace('/', '~1')),
+                'path': '/VLAN_INTERFACE/%s|%s' % (vlan_name, secondary_subnet.replace('/', '~1')),
                 'value': {'secondary': 'true'},
             })
         if ipv6:

--- a/tests/dualtor_io/conftest.py
+++ b/tests/dualtor_io/conftest.py
@@ -39,6 +39,26 @@ def pytest_addoption(parser):
     dual_tor_io_group.addoption("--switchover_num_ports", type=int, default=8,
                                 help="Number of MUX ports to use in the bulk switchover impact test (default: 8).")
 
+    dual_tor_io_group.addoption("--server_subnet", type=str, default=None,
+                                help="Target the servers' addresses in this VLAN subnet instead of their "
+                                     "MUX_CABLE ones, e.g. '2001:db8:1000::1/64'. The subnet must already "
+                                     "be configured on the VLAN.")
+
+
+@pytest.fixture(scope="module")
+def server_subnet(request, duthosts):
+    """VLAN subnet whose server addresses the IO tests should target, or None."""
+    subnet = request.config.getoption("--server_subnet")
+    if not subnet:
+        return None
+
+    vlan_interfaces = duthosts[0].get_running_config_facts().get("VLAN_INTERFACE", {})
+    configured = {key for attrs in vlan_interfaces.values() for key in attrs}
+    if subnet not in configured:
+        pytest.skip("--server_subnet {} is not configured on the VLAN; configured keys: {}"
+                    .format(subnet, sorted(configured)))
+    return subnet
+
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_generate_tests(metafunc):

--- a/tests/dualtor_io/test_heartbeat_failure.py
+++ b/tests/dualtor_io/test_heartbeat_failure.py
@@ -64,7 +64,8 @@ def test_active_tor_heartbeat_failure_upstream(
 @pytest.mark.enable_active_active
 def test_active_tor_heartbeat_failure_downstream_active(
     toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa: F811
-    send_t1_to_server_with_action, shutdown_tor_heartbeat, cable_type           # noqa: F811
+    send_t1_to_server_with_action, shutdown_tor_heartbeat, cable_type,          # noqa: F811
+    server_subnet                                                              # noqa: F811
 ):
     """
     Send downstream traffic from T1 to the active ToR and stop the LinkProber module on the active ToR.
@@ -72,7 +73,8 @@ def test_active_tor_heartbeat_failure_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=lambda: shutdown_tor_heartbeat(upper_tor_host)
+        action=lambda: shutdown_tor_heartbeat(upper_tor_host),
+        server_subnet=server_subnet
     )
 
     if cable_type == CableType.active_standby:

--- a/tests/dualtor_io/test_link_drop.py
+++ b/tests/dualtor_io/test_link_drop.py
@@ -95,7 +95,7 @@ def drop_flow_upper_tor_active_active(active_active_ports, set_drop_active_activ
 def test_active_link_drop_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa: F811
     toggle_all_simulator_ports_to_upper_tor, drop_flow_upper_tor_all,   # noqa: F811
-    drop_flow_upper_tor_active_active, cable_type                       # noqa: F811
+    drop_flow_upper_tor_active_active, cable_type, server_subnet        # noqa: F811
 ):
     """
     Send traffic from servers to T1 and remove the flow between the servers and the active ToR.
@@ -107,7 +107,8 @@ def test_active_link_drop_upstream(
             verify=True,
             delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=3,
-            action=drop_flow_upper_tor_all
+            action=drop_flow_upper_tor_all,
+            server_subnet=server_subnet
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -122,7 +123,8 @@ def test_active_link_drop_upstream(
             verify=True,
             delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=1,
-            action=drop_flow_upper_tor_active_active
+            action=drop_flow_upper_tor_active_active,
+            server_subnet=server_subnet
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -137,7 +139,7 @@ def test_active_link_drop_upstream(
 def test_active_link_drop_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa: F811
     toggle_all_simulator_ports_to_upper_tor, drop_flow_upper_tor_all,   # noqa: F811
-    drop_flow_upper_tor_active_active, cable_type                       # noqa: F811
+    drop_flow_upper_tor_active_active, cable_type, server_subnet        # noqa: F811
 ):
     """
     Send traffic from the T1s to the servers via the active Tor and remove the flow between the
@@ -150,7 +152,8 @@ def test_active_link_drop_downstream_active(
             verify=True,
             delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=3,
-            action=drop_flow_upper_tor_all
+            action=drop_flow_upper_tor_all,
+            server_subnet=server_subnet
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -165,7 +168,8 @@ def test_active_link_drop_downstream_active(
             verify=True,
             delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=1,
-            action=drop_flow_upper_tor_active_active
+            action=drop_flow_upper_tor_active_active,
+            server_subnet=server_subnet
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -40,7 +40,8 @@ def link_down_downstream_active_duplication_setting(duthost, mux_config):   # no
 def test_active_link_down_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa: F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa: F811
-    shutdown_fanout_upper_tor_intfs, cable_type                         # noqa: F811
+    shutdown_fanout_upper_tor_intfs, cable_type,                        # noqa: F811
+    server_subnet                                                       # noqa: F811
 ):
     """
     Send traffic from server to T1 and shutdown the active ToR link.
@@ -49,7 +50,8 @@ def test_active_link_down_upstream(
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=1, action=shutdown_fanout_upper_tor_intfs
+            allowed_disruption=1, action=shutdown_fanout_upper_tor_intfs,
+            server_subnet=server_subnet
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -62,7 +64,8 @@ def test_active_link_down_upstream(
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
+            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs,
+            server_subnet=server_subnet
         )
 
         verify_tor_states(
@@ -78,7 +81,8 @@ def test_active_link_down_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa: F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa: F811
     shutdown_fanout_upper_tor_intfs, cable_type,                        # noqa: F811
-    link_down_downstream_active_duplication_setting                     # noqa: F811
+    link_down_downstream_active_duplication_setting,                    # noqa: F811
+    server_subnet                                                       # noqa: F811
 ):
     """
     Send traffic from T1 to active ToR and shutdown the active ToR link.
@@ -87,7 +91,8 @@ def test_active_link_down_downstream_active(
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
+            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs,
+            server_subnet=server_subnet
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -101,7 +106,8 @@ def test_active_link_down_downstream_active(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=1, allowed_duplication=allowed_duplication,
             action=shutdown_fanout_upper_tor_intfs,
-            merge_duplications_into_disruptions=merge_duplications
+            merge_duplications_into_disruptions=merge_duplications,
+            server_subnet=server_subnet
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -391,7 +397,7 @@ def config_interface_admin_status(duthost, ports, admin_status="up"):
 @pytest.mark.skip_active_standby
 def test_active_link_admin_down_config_reload_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,       # noqa: F811
-    cable_type, active_active_ports                                      # noqa: F811
+    cable_type, active_active_ports, server_subnet                       # noqa: F811
 ):
     if cable_type == CableType.active_active:
         try:
@@ -401,7 +407,8 @@ def test_active_link_admin_down_config_reload_upstream(
 
             send_server_to_t1_with_action(
                 lower_tor_host, verify=True, allowed_disruption=0,
-                action=lambda: config_reload(upper_tor_host, wait=0)
+                action=lambda: config_reload(upper_tor_host, wait=0),
+                server_subnet=server_subnet
             )
 
             verify_tor_states(
@@ -422,7 +429,7 @@ def test_active_link_admin_down_config_reload_upstream(
 @pytest.mark.skip_active_standby
 def test_active_link_admin_down_config_reload_downstream(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,       # noqa: F811
-    cable_type, active_active_ports                                      # noqa: F811
+    cable_type, active_active_ports, server_subnet                       # noqa: F811
 ):
     if cable_type == CableType.active_active:
         try:
@@ -443,7 +450,8 @@ def test_active_link_admin_down_config_reload_downstream(
                 upper_tor_host, verify=True,
                 stop_after=60,
                 allowed_disruption=0,
-                allow_disruption_before_traffic=True
+                allow_disruption_before_traffic=True,
+                server_subnet=server_subnet
             )
 
         finally:
@@ -455,7 +463,8 @@ def test_active_link_admin_down_config_reload_downstream(
 @pytest.mark.skip_active_standby
 def test_active_link_admin_down_config_reload_link_up_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa: F811
-    cable_type, active_active_ports, setup_loganalyzer                  # noqa: F811
+    cable_type, active_active_ports, setup_loganalyzer,                 # noqa: F811
+    server_subnet                                                       # noqa: F811
 ):
     """
     Send traffic from server to T1 and unshut the active-active mux ports.
@@ -490,7 +499,8 @@ def test_active_link_admin_down_config_reload_link_up_upstream(
                 upper_tor_host,
                 verify=True,
                 allowed_disruption=0,
-                action=lambda: config_interface_admin_status(upper_tor_host, active_active_ports, "up")
+                action=lambda: config_interface_admin_status(upper_tor_host, active_active_ports, "up"),
+                server_subnet=server_subnet
             )
 
             verify_tor_states(
@@ -509,7 +519,8 @@ def test_active_link_admin_down_config_reload_link_up_upstream(
 def test_active_link_admin_down_config_reload_link_up_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     cable_type, active_active_ports, setup_loganalyzer,                 # noqa F811
-    link_down_downstream_active_duplication_setting                     # noqa F811
+    link_down_downstream_active_duplication_setting,                    # noqa F811
+    server_subnet                                                       # noqa F811
 ):
     """
     Send traffic from T1 to standby ToR and unshut the active-active mux ports.
@@ -552,7 +563,8 @@ def test_active_link_admin_down_config_reload_link_up_downstream_standby(
                 allow_disruption_before_traffic=True,
                 allowed_duplication=allowed_duplication,
                 merge_duplications_into_disruptions=merge_duplications,
-                delay=MUX_SIM_ALLOWED_DISRUPTION_SEC
+                delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+                server_subnet=server_subnet
             )
 
             verify_tor_states(

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -24,7 +24,8 @@ from tests.common.helpers.assertions import pytest_assert
 
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology("dualtor"),
+    pytest.mark.skip_check_dut_health
 ]
 
 
@@ -37,16 +38,19 @@ def common_setup_teardown(validate_active_active_dualtor_setup):    # noqa: F811
 def test_normal_op_upstream(upper_tor_host, lower_tor_host,             # noqa: F811
                             send_server_to_t1_with_action,              # noqa: F811
                             toggle_all_simulator_ports_to_upper_tor,    # noqa: F811
-                            cable_type):                                # noqa: F811
+                            cable_type,                                 # noqa: F811
+                            server_subnet):                             # noqa: F811
     """Send upstream traffic and confirm no disruption or switchover occurs"""
     if cable_type == CableType.active_standby:
-        send_server_to_t1_with_action(upper_tor_host, verify=True, stop_after=60)
+        send_server_to_t1_with_action(upper_tor_host, verify=True, stop_after=60,
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host,
                           skip_tunnel_route=False)
 
     if cable_type == CableType.active_active:
-        send_server_to_t1_with_action(upper_tor_host, verify=True, stop_after=60)
+        send_server_to_t1_with_action(upper_tor_host, verify=True, stop_after=60,
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type,
@@ -57,18 +61,21 @@ def test_normal_op_upstream(upper_tor_host, lower_tor_host,             # noqa: 
 def test_normal_op_downstream_upper_tor(upper_tor_host, lower_tor_host,             # noqa: F811
                                         send_t1_to_server_with_action,              # noqa: F811
                                         toggle_all_simulator_ports_to_upper_tor,    # noqa: F811
-                                        cable_type):                                # noqa: F811
+                                        cable_type,                                 # noqa: F811
+                                        server_subnet):                             # noqa: F811
     """
     Send downstream traffic to the upper ToR and confirm no disruption or
     switchover occurs
     """
     if cable_type == CableType.active_standby:
-        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60)
+        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60,
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host)
 
     if cable_type == CableType.active_active:
-        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60)
+        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60,
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type)
@@ -78,18 +85,21 @@ def test_normal_op_downstream_upper_tor(upper_tor_host, lower_tor_host,         
 def test_normal_op_downstream_lower_tor(upper_tor_host, lower_tor_host,             # noqa: F811
                                         send_t1_to_server_with_action,              # noqa: F811
                                         toggle_all_simulator_ports_to_upper_tor,    # noqa: F811
-                                        cable_type):                                # noqa: F811
+                                        cable_type,                                 # noqa: F811
+                                        server_subnet):                             # noqa: F811
     """
     Send downstream traffic to the lower ToR and confirm no disruption or
     switchover occurs
     """
     if cable_type == CableType.active_standby:
-        send_t1_to_server_with_action(lower_tor_host, verify=True, stop_after=60)
+        send_t1_to_server_with_action(lower_tor_host, verify=True, stop_after=60,
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host)
 
     if cable_type == CableType.active_active:
-        send_t1_to_server_with_action(lower_tor_host, verify=True, stop_after=60)
+        send_t1_to_server_with_action(lower_tor_host, verify=True, stop_after=60,
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type)
@@ -100,7 +110,8 @@ def test_normal_op_active_server_to_active_server(upper_tor_host, lower_tor_host
                                                   send_server_to_server_with_action,            # noqa: F811
                                                   toggle_all_simulator_ports_to_upper_tor,      # noqa: F811
                                                   cable_type,                                   # noqa: F811
-                                                  select_test_mux_ports):                       # noqa: F811
+                                                  select_test_mux_ports,                        # noqa: F811
+                                                  server_subnet):                               # noqa: F811
     """
     Send server to server traffic in active-active setup and confirm no disruption or switchover occurs.
     """
@@ -108,13 +119,15 @@ def test_normal_op_active_server_to_active_server(upper_tor_host, lower_tor_host
     test_mux_ports = select_test_mux_ports(cable_type, 2)
 
     if cable_type == CableType.active_standby:
-        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60,
+                                          server_subnet=server_subnet)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host,
                           skip_tunnel_route=False)
 
     if cable_type == CableType.active_active:
-        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60,
+                                          server_subnet=server_subnet)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type,
@@ -126,7 +139,8 @@ def test_normal_op_active_server_to_standby_server(upper_tor_host, lower_tor_hos
                                                    send_server_to_server_with_action,               # noqa: F811
                                                    toggle_all_simulator_ports_to_upper_tor,         # noqa: F811
                                                    cable_type, force_standby_tor,                   # noqa: F811
-                                                   select_test_mux_ports):                          # noqa: F811
+                                                   select_test_mux_ports,                           # noqa: F811
+                                                   server_subnet):                                  # noqa: F811
     """
     Send server to server traffic in active-standby setup and confirm no disruption or switchover occurs.
     """
@@ -142,10 +156,12 @@ def test_normal_op_active_server_to_standby_server(upper_tor_host, lower_tor_hos
                   "failed to toggle mux port %s to standby on DUT %s" % (tx_mux_port, upper_tor_host.hostname))
 
     if cable_type == CableType.active_standby:
-        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60,
+                                          server_subnet=server_subnet)
 
     if cable_type == CableType.active_active:
-        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60,
+                                          server_subnet=server_subnet)
 
     # TODO: Add per-port db check
 
@@ -155,7 +171,8 @@ def test_upper_tor_config_reload_upstream(upper_tor_host, lower_tor_host,       
                                           send_server_to_t1_with_action,                # noqa: F811
                                           toggle_all_simulator_ports_to_upper_tor,      # noqa: F811
                                           setup_loganalyzer,
-                                          cable_type):                                  # noqa: F811
+                                          cable_type,                                   # noqa: F811
+                                          server_subnet):                               # noqa: F811
     """
     Send upstream traffic and `config reload` the active ToR.
     Confirm switchover occurs and disruption lasted < 1 second for active-standby ports.
@@ -164,13 +181,15 @@ def test_upper_tor_config_reload_upstream(upper_tor_host, lower_tor_host,       
     setup_loganalyzer(upper_tor_host, collect_only=True)
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: config_reload(upper_tor_host, wait=0))
+                                      action=lambda: config_reload(upper_tor_host, wait=0),
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: config_reload(upper_tor_host, wait=0))
+                                      action=lambda: config_reload(upper_tor_host, wait=0),
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type)
@@ -198,7 +217,8 @@ def test_lower_tor_config_reload_downstream_upper_tor(upper_tor_host, lower_tor_
                                                       send_t1_to_server_with_action,            # noqa: F811
                                                       toggle_all_simulator_ports_to_upper_tor,  # noqa: F811
                                                       setup_loganalyzer,
-                                                      cable_type):                              # noqa: F811
+                                                      cable_type,                               # noqa: F811
+                                                      server_subnet):                           # noqa: F811
     """
     Send downstream traffic to the upper ToR and `config reload` the lower ToR.
     Confirm no switchover occurs and no disruption
@@ -206,13 +226,15 @@ def test_lower_tor_config_reload_downstream_upper_tor(upper_tor_host, lower_tor_
     setup_loganalyzer(lower_tor_host, collect_only=True)
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(upper_tor_host, verify=True,
-                                      action=lambda: config_reload(lower_tor_host, wait=0))
+                                      action=lambda: config_reload(lower_tor_host, wait=0),
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host)
 
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(upper_tor_host, verify=True,
-                                      action=lambda: config_reload(lower_tor_host, wait=0))
+                                      action=lambda: config_reload(lower_tor_host, wait=0),
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type)
@@ -241,7 +263,8 @@ def test_tor_switch_upstream(upper_tor_host, lower_tor_host,                # no
                              send_server_to_t1_with_action,                 # noqa: F811
                              toggle_all_simulator_ports_to_upper_tor,       # noqa: F811
                              force_active_tor, force_standby_tor,           # noqa: F811
-                             cable_type):                                   # noqa: F811
+                             cable_type,                                    # noqa: F811
+                             server_subnet):                                # noqa: F811
     """
     Send upstream traffic and perform switchover via CLI.
     Confirm switchover occurs and disruption lasts < 1 second for active-standby ports.
@@ -249,13 +272,15 @@ def test_tor_switch_upstream(upper_tor_host, lower_tor_host,                # no
     """
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_active_tor(lower_tor_host, 'all'))
+                                      action=lambda: force_active_tor(lower_tor_host, 'all'),
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_standby_tor(upper_tor_host, 'all'))
+                                      action=lambda: force_standby_tor(upper_tor_host, 'all'),
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host,
                           expected_standby_health="healthy",
@@ -267,7 +292,8 @@ def test_tor_switch_downstream_active(upper_tor_host, lower_tor_host,           
                                       send_t1_to_server_with_action,                # noqa: F811
                                       toggle_all_simulator_ports_to_upper_tor,      # noqa: F811
                                       force_active_tor, force_standby_tor,          # noqa: F811
-                                      cable_type):                                  # noqa: F811
+                                      cable_type,                                   # noqa: F811
+                                      server_subnet):                               # noqa: F811
     """
     Send downstream traffic to the upper ToR and perform switchover via CLI.
     Confirm switchover occurs and disruption lasts < 1 second for active-standby ports.
@@ -275,13 +301,15 @@ def test_tor_switch_downstream_active(upper_tor_host, lower_tor_host,           
     """
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_active_tor(lower_tor_host, 'all'))
+                                      action=lambda: force_active_tor(lower_tor_host, 'all'),
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_standby_tor(upper_tor_host, 'all'))
+                                      action=lambda: force_standby_tor(upper_tor_host, 'all'),
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host,
                           expected_standby_health="healthy",
@@ -293,7 +321,8 @@ def test_tor_switch_downstream_standby(upper_tor_host, lower_tor_host,          
                                        send_t1_to_server_with_action,               # noqa: F811
                                        toggle_all_simulator_ports_to_upper_tor,     # noqa: F811
                                        force_active_tor, force_standby_tor,         # noqa: F811
-                                       cable_type):                                 # noqa: F811
+                                       cable_type,                                  # noqa: F811
+                                       server_subnet):                              # noqa: F811
     """
     Send downstream traffic to the lower ToR and perform switchover via CLI.
     Confirm switchover occurs and disruption lasts < 1 second for active-standby ports.
@@ -301,13 +330,15 @@ def test_tor_switch_downstream_standby(upper_tor_host, lower_tor_host,          
     """
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_active_tor(lower_tor_host, 'all'))
+                                      action=lambda: force_active_tor(lower_tor_host, 'all'),
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(lower_tor_host, verify=True,
-                                      action=lambda: force_standby_tor(upper_tor_host, 'all'))
+                                      action=lambda: force_standby_tor(upper_tor_host, 'all'),
+                                      server_subnet=server_subnet)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host,
                           expected_standby_health="healthy",
@@ -319,7 +350,8 @@ def test_tor_switch_downstream_standby(upper_tor_host, lower_tor_host,          
 def test_mux_port_switch_active_server_to_active_server(upper_tor_host, lower_tor_host,                 # noqa: F811
                                                         send_server_to_server_with_action,              # noqa: F811
                                                         cable_type, force_standby_tor,                  # noqa: F811
-                                                        select_test_mux_ports):                         # noqa: F811
+                                                        select_test_mux_ports,                          # noqa: F811
+                                                        server_subnet):                                 # noqa: F811
     """
     Send server to server traffic in active-active setup and config the tx mux port to standby.
     Confirm switchover occurs and no disruption.
@@ -335,7 +367,8 @@ def test_mux_port_switch_active_server_to_active_server(upper_tor_host, lower_to
         send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True,
                                           action=lambda: force_standby_tor(upper_tor_host, [tx_mux_port]),
                                           send_interval=0.0035,
-                                          stop_after=60,)
+                                          stop_after=60,
+                                          server_subnet=server_subnet)
 
         pytest_assert(_is_mux_port_standby(upper_tor_host, tx_mux_port),
                       "mux port %s on DUT %s failed to toggle to standby" % (upper_tor_host.hostname, tx_mux_port))
@@ -349,7 +382,8 @@ def test_mux_port_switch_active_server_to_standby_server(upper_tor_host, lower_t
                                                          send_server_to_server_with_action,              # noqa: F811
                                                          cable_type, force_standby_tor,                  # noqa: F811
                                                          force_active_tor,                              # noqa: F811
-                                                         select_test_mux_ports):                         # noqa: F811
+                                                         select_test_mux_ports,                         # noqa: F811
+                                                         server_subnet):                                # noqa: F811
     """
     Send server to server traffic in active-standby setup and config the tx mux port to auto.
     Confirm switchover occurs and no disruption.
@@ -371,7 +405,8 @@ def test_mux_port_switch_active_server_to_standby_server(upper_tor_host, lower_t
         send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True,
                                           action=lambda: force_active_tor(upper_tor_host, [tx_mux_port]),
                                           send_interval=0.0035,
-                                          stop_after=60)
+                                          stop_after=60,
+                                          server_subnet=server_subnet)
 
         pytest_assert(_is_mux_port_active(upper_tor_host, tx_mux_port),
                       "mux port %s on DUT %s failed to toggle back to active" % (upper_tor_host.hostname, tx_mux_port))

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -24,8 +24,7 @@ from tests.common.helpers.assertions import pytest_assert
 
 
 pytestmark = [
-    pytest.mark.topology("dualtor"),
-    pytest.mark.skip_check_dut_health
+    pytest.mark.topology("dualtor")
 ]
 
 

--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -171,7 +171,7 @@ def test_active_tor_kill_bgpd_downstream_standby(
 def test_active_tor_shutdown_bgp_sessions_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa: F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa: F811
-    shutdown_bgp_sessions, cable_type                                   # noqa: F811
+    shutdown_bgp_sessions, cable_type, server_subnet                    # noqa: F811
 ):
     """
     Case: Server -> ToR -> T1 (Active ToR BGP Down)
@@ -185,13 +185,15 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=lambda: shutdown_bgp_sessions(upper_tor_host), random_dst=False
+            action=lambda: shutdown_bgp_sessions(upper_tor_host), random_dst=False,
+            server_subnet=server_subnet
         )
 
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=lambda: shutdown_bgp_sessions(upper_tor_host)
+            action=lambda: shutdown_bgp_sessions(upper_tor_host),
+            server_subnet=server_subnet
         )
 
     if cable_type == CableType.active_active:
@@ -215,7 +217,7 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
 @pytest.mark.skip_active_standby
 def test_active_tor_shutdown_bgp_sessions_downstream(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa: F811
-    cable_type, tunnel_traffic_monitor                                  # noqa: F811
+    cable_type, tunnel_traffic_monitor, server_subnet                   # noqa: F811
 ):
     """
     Case: T1 -> ToR -> Server (Upper ToR shutdown/startup BGP sessions)
@@ -251,4 +253,5 @@ def test_active_tor_shutdown_bgp_sessions_downstream(
 
     # verify the server receives packets with no disrupts, no tunnel traffic
     with tunnel_traffic_monitor(upper_tor_host, existing=False):
-        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60)
+        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60,
+                                      server_subnet=server_subnet)

--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -68,7 +68,7 @@ def test_active_tor_reboot_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa: F811
     toggle_all_simulator_ports_to_upper_tor, toggle_upper_tor_pdu,      # noqa: F811
     wait_for_device_reachable, wait_for_mux_container, cable_type,      # noqa: F811
-    wait_for_pmon_container, setup_loganalyzer                          # noqa: F811
+    wait_for_pmon_container, setup_loganalyzer, server_subnet           # noqa: F811
 ):
     """
     Send upstream traffic and reboot the active ToR. Confirm switchover
@@ -77,7 +77,8 @@ def test_active_tor_reboot_upstream(
     setup_loganalyzer(upper_tor_host, collect_only=True, collect_from_bootup=True)
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=toggle_upper_tor_pdu, stop_after=60
+        action=toggle_upper_tor_pdu, stop_after=60,
+        server_subnet=server_subnet
     )
     wait_for_device_reachable(upper_tor_host)
     wait_for_mux_container(upper_tor_host)
@@ -176,7 +177,7 @@ def test_active_tor_reboot_downstream(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa: F811
     toggle_upper_tor_pdu, wait_for_device_reachable, cable_type,        # noqa: F811
     tunnel_traffic_monitor, mux_status_from_nic_simulator,              # noqa: F811
-    wait_for_mux_container, wait_for_pmon_container                      # noqa: F811
+    wait_for_mux_container, wait_for_pmon_container, server_subnet      # noqa: F811
 ):
     def check_forwarding_state(upper_tor_forwarding_state, lower_tor_forwarding_state):
         mux_status = mux_status_from_nic_simulator()
@@ -226,4 +227,5 @@ def test_active_tor_reboot_downstream(
 
     # verify the server receives packets with no disrupts, no tunnel traffic
     with tunnel_traffic_monitor(upper_tor_host, existing=False):
-        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60)
+        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60,
+                                      server_subnet=server_subnet)

--- a/tests/scripts/garp_service.py
+++ b/tests/scripts/garp_service.py
@@ -17,9 +17,27 @@ class GarpService:
         self.packets = {}
         self.dataplane = ptf.dataplane_instance
 
+    @staticmethod
+    def _as_address_list(value):
+        '''
+        Normalize a config value that may be absent, a single address, or a list of addresses
+        '''
+        if not value:
+            return []
+
+        if not isinstance(value, (list, tuple)):
+            value = [value]
+
+        return [str(ip_interface(addr).ip) for addr in value if addr]
+
     def gen_garp_packets(self):
         '''
-        Read the config file and generate a GARP packet for each configured interface
+        Read the config file and generate GARP/NA packets for each configured interface
+
+        'target_ip', 'target_ipv6' and 'dst_ipv6' each accept either a single address or a
+        list of addresses, so one port can announce an address in several VLAN subnets.
+        A 'dst_ipv6' list is paired with 'target_ipv6' by index; a single 'dst_ipv6' is
+        used for every IPv6 target.
         '''
 
         with open(self.garp_config_file) as f:
@@ -28,33 +46,39 @@ class GarpService:
         for port, config in list(garp_config.items()):
             intf_name = 'eth{}'.format(port)
             source_mac = get_if_hwaddr(intf_name)
-            source_ip_str = config['target_ip']
-            source_ipv6_str = config['target_ipv6']
             dut_mac = config['dut_mac']
-            dst_ipv6 = config['dst_ipv6']
-            source_ip = str(ip_interface(source_ip_str).ip) if source_ip_str else None
-            source_ipv6 = str(ip_interface(source_ipv6_str).ip) if source_ipv6_str else None
+            source_ips = self._as_address_list(config.get('target_ip'))
+            source_ipv6s = self._as_address_list(config.get('target_ipv6'))
+            dst_ipv6s = self._as_address_list(config.get('dst_ipv6'))
+
+            packets = []
 
             # PTF uses Scapy to create packets, so this is ok to create
             # packets through PTF even though we are using Scapy to send the packets
-            garp_pkt = None
-            na_pkt = None
-            if source_ip:
-                garp_pkt = testutils.simple_arp_packet(
+            for source_ip in source_ips:
+                packets.append(testutils.simple_arp_packet(
                     eth_src=source_mac,
                     hw_snd=source_mac,
                     ip_snd=source_ip,
                     # Re-use server IP as target IP, since it is within the subnet of the VLAN IP
                     ip_tgt=source_ip,
-                    arp_op=2)
+                    arp_op=2))
 
-            if source_ipv6:
-                na_pkt = Ether(src=source_mac, dst=dut_mac) \
-                    / IPv6(dst=dst_ipv6, src=source_ipv6) \
-                    / ICMPv6ND_NA(tgt=source_ipv6, S=1, R=0, O=0) \
-                    / ICMPv6NDOptSrcLLAddr(type=2, lladdr=source_mac)
+            for index, source_ipv6 in enumerate(source_ipv6s):
+                if index < len(dst_ipv6s):
+                    dst_ipv6 = dst_ipv6s[index]
+                elif dst_ipv6s:
+                    dst_ipv6 = dst_ipv6s[0]
+                else:
+                    # No gateway configured for this subnet, fall back to all-nodes multicast
+                    dst_ipv6 = 'ff02::1'
 
-            self.packets[intf_name] = [garp_pkt, na_pkt]
+                packets.append(Ether(src=source_mac, dst=dut_mac)
+                               / IPv6(dst=dst_ipv6, src=source_ipv6)
+                               / ICMPv6ND_NA(tgt=source_ipv6, S=1, R=0, O=0)
+                               / ICMPv6NDOptSrcLLAddr(type=2, lladdr=source_mac))
+
+            self.packets[intf_name] = packets
 
     def send_garp_packets(self):
         '''
@@ -65,16 +89,17 @@ class GarpService:
 
         sockets = {}
 
-        for intf, packet in list(self.packets.items()):
+        for intf, packet_list in list(self.packets.items()):
+            if not packet_list:
+                continue
             socket = conf.L2socket(iface=intf)
-            sockets[socket] = packet
+            sockets[socket] = packet_list
 
         try:
             while True:
                 for socket, packet_list in list(sockets.items()):
                     for packet in packet_list:
-                        if packet:
-                            socket.send(packet)
+                        socket.send(packet)
 
                 if self.interval is None:
                     break


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 39469922
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
The requirement is to allow multiple vlan subnets on active-active dualtor and enable the dualtor-io cases to use the secondary vlan subnet to run I/O verification.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

* add secondary vlan subnets to the dualtor-aa topo files.
* allow running dualtor-io cases with specified secondary vlan subnets defined in the topo files.
* fix the ipv6inipv4 packet drop on the uplink.
* adapt garp_service to announce the secondary vlan subnet neighbors.


#### How did you verify/test it?

https://elastictest.org/scheduler/testplan/6a8fdd80a2b56b54e48a09e0

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
