### PR TITLE
Fix is_bgp_route_synced to check bgpState for all BGP neighbors

### DIFF
--- a/tests/common/helpers/srv6_helper.py
+++ b/tests/common/helpers/srv6_helper.py
@@ -605,6 +605,9 @@ def is_bgp_route_synced(duthost):
     output = duthost.command(cmd)['stdout']
     bgp_info = json.loads(output)
     for neighbor, info in bgp_info.items():
+        if info.get('bgpState') != 'Established':
+            logger.info(f"BGP neighbor {neighbor} is not Established (state={info.get('bgpState')})")
+            return False
         if 'gracefulRestartInfo' in info:
             if "ipv4Unicast" in info['gracefulRestartInfo']:
                 if not info['gracefulRestartInfo']["ipv4Unicast"]['endOfRibStatus']['endOfRibSend']:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
is_bgp_route_synced() could return True while a BGP neighbor was
still in Idle/Active/Connect state, if that neighbor had no
gracefulRestartInfo key yet (e.g. right after BGP daemon restart,
before capability negotiation completes). The EndOfRib checks were
never reached for such neighbors, so the function fell through and
reported the routes as synced.

This caused test_srv6_full_func to proceed with SRv6 dataplane
validation before BGP had actually converged, resulting in an
empty FIB and failed packet forwarding assertions.

Check bgpState == 'Established' for every neighbor unconditionally,
before evaluating any gracefulRestartInfo/EndOfRib details.


<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [X] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

- master: test srv6/test_srv6_dataplane.py passed
- 202605: test srv6/test_srv6_dataplane.py passed

### Approach
#### What is the motivation for this PR?
Test stabilization

#### How did you do it?
A more robust BGP status check
