### PR TITLE
Enhance dwrr test

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4770,6 +4770,8 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         pkts_num_egr_mem = int(self.test_params.get('pkts_num_egr_mem', 0))
         topo = self.test_params['topo']
         platform_asic = self.test_params['platform_asic']
+        hwsku = self.test_params.get('hwsku', '')
+        use_set_scheduler = asic_type == 'cisco-8000' and 'Cisco-8223' not in hwsku
         prio_list = self.test_params.get('dscp_list', [])
         q_pkt_cnt = self.test_params.get('q_pkt_cnt', [])
         q_list = self.test_params.get('q_list', [])
@@ -4910,7 +4912,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                         break
                     recv_pkt = scapy.Ether(received.packet)
 
-            if asic_type == 'cisco-8000':
+            if use_set_scheduler:
                 out, err, ret = self.exec_cmd_on_dut(
                     self.dst_server_ip,
                     self.test_params['dut_username'],
@@ -4960,7 +4962,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                     # Ignore captured non-IP packet
                     continue
 
-            if asic_type == 'cisco-8000':
+            if use_set_scheduler:
                 # Release port
                 self.sai_thrift_port_tx_enable(
                     self.dst_client,
@@ -4973,9 +4975,12 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
             for prio, q_cnt in zip(prio_list, q_pkt_cnt):
                 queue_num_of_pkts[prio] = q_cnt
 
+            dscp_to_queue = dict(zip(prio_list, q_list))
+
             total_pkts = 0
 
             diff_list = []
+            dscp_order = []
 
             for pkt_to_inspect in pkts:
                 if 'backend' in topo:
@@ -4983,14 +4988,26 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                 else:
                     dscp_of_pkt = pkt_to_inspect.payload.tos >> 2
                 total_pkts += 1
+                dscp_order.append(dscp_of_pkt)
 
                 # Count packet ordering
-
                 queue_pkt_counters[dscp_of_pkt] += 1
                 if queue_pkt_counters[dscp_of_pkt] == queue_num_of_pkts[dscp_of_pkt]:
                     diff_list.append((dscp_of_pkt, q_cnt_sum - total_pkts))
 
-                print(queue_pkt_counters, file=sys.stderr)
+            # Print the received ordering as a compact table: 40 two-char columns per
+            # row, single-space separated (~119 chars wide), so the scheduling pattern
+            # is visible at a glance even for thousands of packets.
+            def format_packet_table(values, per_row=40):
+                lines = []
+                for i in range(0, len(values), per_row):
+                    row = values[i:i + per_row]
+                    lines.append(" ".join("{:2d}".format(v) for v in row))
+                return "\n".join(lines)
+
+            queue_order = [dscp_to_queue.get(d, d) for d in dscp_order]
+            print("Packet ordering (DSCP):\n{}".format(format_packet_table(dscp_order)), file=sys.stderr)
+            print("Packet ordering (Queue):\n{}".format(format_packet_table(queue_order)), file=sys.stderr)
 
             print("Difference for each dscp: ", file=sys.stderr)
             print(diff_list, file=sys.stderr)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4995,13 +4995,23 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
             print("Difference for each dscp: ", file=sys.stderr)
             print(diff_list, file=sys.stderr)
 
+            failures = []
+
+            # All packets sent should be received intact
+            print([q_cnt_sum, total_pkts], file=sys.stderr)
+            if q_cnt_sum != total_pkts:
+                failures.append("Not all packets received: sent %d but received %d" % (
+                    q_cnt_sum, total_pkts))
+
+            # Difference for each dscp should be within the scheduling limit
             for dscp, diff in diff_list:
                 if platform_asic and platform_asic == "broadcom-dnx":
                     logging.info(
                         "On J2C+ can't control how packets are dequeued (CS00012272267) - so ignoring diff check now")
                 elif not dry_run:
-                    assert diff < limit, "Difference for %d is %d which exceeds limit %d" % (
-                        dscp, diff, limit)
+                    if diff >= limit:
+                        failures.append("Difference for %d is %d which exceeds limit %d" % (
+                            dscp, diff, limit))
 
             # Read counters
             print("DST port counters: ")
@@ -5010,9 +5020,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
             print(list(map(operator.sub, queue_counters,
                            queue_counters_base)), file=sys.stderr)
 
-            print([q_cnt_sum, total_pkts], file=sys.stderr)
-            # All packets sent should be received intact
-            assert (q_cnt_sum == total_pkts)
+            assert len(failures) == 0, "WRRtest failures:\n" + "\n".join(failures)
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id],
                                            enable_port_by_unblock_queue=False)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4981,6 +4981,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
 
             diff_list = []
             dscp_order = []
+            terminating_indices = set()
 
             for pkt_to_inspect in pkts:
                 if 'backend' in topo:
@@ -4994,20 +4995,36 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                 queue_pkt_counters[dscp_of_pkt] += 1
                 if queue_pkt_counters[dscp_of_pkt] == queue_num_of_pkts[dscp_of_pkt]:
                     diff_list.append((dscp_of_pkt, q_cnt_sum - total_pkts))
+                    terminating_indices.add(total_pkts - 1)
 
             # Print the received ordering as a compact table: 40 two-char columns per
-            # row, single-space separated (~119 chars wide), so the scheduling pattern
-            # is visible at a glance even for thousands of packets.
-            def format_packet_table(values, per_row=40):
+            # row (~119 chars wide), so the scheduling pattern is visible at a glance
+            # even for thousands of packets. The separator after a packet is "E" when it
+            # is the last packet of its DSCP/queue, otherwise a space.
+            def format_packet_table(values, terminators, per_row=40):
                 lines = []
-                for i in range(0, len(values), per_row):
-                    row = values[i:i + per_row]
-                    lines.append(" ".join("{:2d}".format(v) for v in row))
+                for start in range(0, len(values), per_row):
+                    row_end = min(start + per_row, len(values))
+                    parts = []
+                    for idx in range(start, row_end):
+                        parts.append("{:2d}".format(values[idx]))
+                        if idx in terminators:
+                            parts.append("E")
+                        elif idx < row_end - 1:
+                            parts.append(" ")
+                    lines.append("".join(parts))
                 return "\n".join(lines)
 
             queue_order = [dscp_to_queue.get(d, d) for d in dscp_order]
-            print("Packet ordering (DSCP):\n{}".format(format_packet_table(dscp_order)), file=sys.stderr)
-            print("Packet ordering (Queue):\n{}".format(format_packet_table(queue_order)), file=sys.stderr)
+            print("Packet ordering (DSCP):\n{}".format(
+                format_packet_table(dscp_order, terminating_indices)), file=sys.stderr)
+            print("Packet ordering (Queue):\n{}".format(
+                format_packet_table(queue_order, terminating_indices)), file=sys.stderr)
+
+            queue_pkt_count = {q: queue_pkt_counters[d] for d, q in zip(prio_list, q_list)}
+            queue_sent_count = {q: cnt for q, cnt in zip(q_list, q_pkt_cnt)}
+            print("Sent packet count per queue: {}".format(queue_sent_count), file=sys.stderr)
+            print("Received packet count per queue: {}".format(queue_pkt_count), file=sys.stderr)
 
             print("Difference for each dscp: ", file=sys.stderr)
             print(diff_list, file=sys.stderr)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4900,18 +4900,30 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
             for p in list(self.dataplane.ports.values()):
                 p.socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 41943040)
 
-            # recv packets for leakout
-            if 'cisco-8000' in asic_type:
-                recv_pkt = scapy.Ether()
-
-                while recv_pkt:
+            def poll_test_pkts():
+                """Drain the dst port, returning the packets that belong to this test flow."""
+                received_pkts = []
+                while True:
                     received = self.dataplane.poll(
                         device_number=0, port_number=dst_port_id, timeout=2)
                     if isinstance(received, self.dataplane.PollFailure):
-                        recv_pkt = None
                         break
                     recv_pkt = scapy.Ether(received.packet)
+                    try:
+                        if recv_pkt[scapy.IP].src == src_port_ip and recv_pkt[scapy.IP].dst == dst_port_ip and \
+                                recv_pkt[scapy.IP].id == exp_ip_id:
+                            received_pkts.append(recv_pkt)
+                    except AttributeError:
+                        continue
+                    except IndexError:
+                        # Ignore captured non-IP packet
+                        continue
+                return received_pkts
 
+            # recv packets for leakout
+            if 'cisco-8000' in asic_type:
+                leakout_pkts_received = len(poll_test_pkts())
+                print("Leakout pkts received:", leakout_pkts_received, file=sys.stderr)
             if use_set_scheduler:
                 out, err, ret = self.exec_cmd_on_dut(
                     self.dst_server_ip,
@@ -4939,28 +4951,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                     [dst_port_id],
                     enable_port_by_unblock_queue=False)
 
-            cnt = 0
-            pkts = []
-            recv_pkt = scapy.Ether()
-
-            while recv_pkt:
-                received = self.dataplane.poll(
-                    device_number=0, port_number=dst_port_id, timeout=2)
-                if isinstance(received, self.dataplane.PollFailure):
-                    recv_pkt = None
-                    break
-                recv_pkt = scapy.Ether(received.packet)
-
-                try:
-                    if recv_pkt[scapy.IP].src == src_port_ip and recv_pkt[scapy.IP].dst == dst_port_ip and \
-                            recv_pkt[scapy.IP].id == exp_ip_id:
-                        cnt += 1
-                        pkts.append(recv_pkt)
-                except AttributeError:
-                    continue
-                except IndexError:
-                    # Ignore captured non-IP packet
-                    continue
+            pkts = poll_test_pkts()
 
             if use_set_scheduler:
                 # Release port


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The pre-existing DWRR test suffers from several issues that greatly impact debuggability:

Problems
1) Excessive and unhelpful logging of lists with no descriptive text. In particular, the looped print logging the DSCP arrival count list for every packet (64 * n_packets scale of output). 
2) The packet arrival count and ordering checks appear to be ordered backwards. Failures in ordering obfuscate a failure to capture all packets, which makes root-cause much more challenging. 

Solutions:
1) Create a precise matrix showing the exact queue ordering received in a compact and scaleable format. 
2) Merge the assertions into well-documented failure message lists. Thus if some packets fail to capture and some packets are out of order, 2 failure messages will be printed indicating as such. 

Small change: Encountered this during testing for Cisco-8223, currently need to skip the "set_scheduler" extra logic for this device as this is not supported. 

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

master: cf80329e1c5bd7fc7009f3e25ea8a1d1846cc884 - Cisco-8223 and Cisco-8102 pass DWRR test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Sample output on Cisco8102:
```
Leakout pkts received: 14
Success in setting scheduler in DUT.
Packet ordering (DSCP):
8  0  8  8  5  3  3 46  4 46 48  8  0  0  5  3  5  4  4 46 48 48  8  0  8  5  3  4  3 46 48  8  0  3  5 46  4 46 48  8
0  0  5  5  3  4  4 46  8 48 48  8  5  0  3  3  4 46 48  8  0  3  5  4 46 48 46  8  0  5  0  5  3  4 46  4 48  8 48  8
0  5  3  3  4 46 48  8  0  5  3  4 46 46 48  8  0  0  3  5  5 46  4  4 48 48  8  0  8  5  4  3  3 46  8 48  0  5  0  3
4 46 46 48  0  8  3  5  5  4  4 46 48 48  8  8  5  0  3  3 46  4 46  8 48  0  0  5  3  5  4 46 48  8  0  5  3  4  4 46
48  8  8 48  0  5  3  3  4 46 46 48  0  8  0  5  5  3  4 46 48  8  0  5  3  4 46  4 48 48  0  8  8  5  3  3  4 46 48 46
8  0  5  0  5  3 46  4 48  8 48  0  3  5  4  4 46 48  8  8  5  0  4  3  3 46 46  8 48  0  0  5  3  5 46  4 48 48  0  8
5  3  4  4 46 48  8  8  5  0  3  3  4 46 46 48  8  0  0  3  5  5  4 48 46 48  8  8  0  5  3  4 46  4  8 48  0  5  3  3
4 46 48 46  8  0  5  0  5  3  4  4 46  8 48 48  8  0  3  5  4 46 48  8  0  5  3  4  3 46 46  8 48  0  5  0  5  3 46  4
4 48 48  0  8  8  3  5  3  4 46 48  8  5  0  3 46  4 46  8 48  0  0  5  3  5  4  4 46 48 48  8  8  0  5  4  3  3 46 48
8  0  5  3  4 46 46 48  0  8  0  5  5  3  4  4 46  8 48 48  8  0  5  3  3  4 46 48  8  0  5  4  3 46 48 46  8  5  0  0
5  3  4 46  4  8 48  8 48  0  5  3  3  4 46 48  8  0  5  0  3  4 46 46  8 48  0  5  3  5 46  4  4 48 48  8  0  8  5  3
4  3 46 46 48  8  0  5  5  0  3  4 46 48  8  0  5  4  3  4 46 48 48  8  8  5  0  3  3  4 46 46 48  8E 0  0  3  5  5  4
48 46  5E 0E 4  3  4 46E48 48E 3  3  4  3  4  3  4  4  3E 4E
Packet ordering (Queue):
0  1  0  0  2  3  3  5  4  5  6  0  1  1  2  3  2  4  4  5  6  6  0  1  0  2  3  4  3  5  6  0  1  3  2  5  4  5  6  0
1  1  2  2  3  4  4  5  0  6  6  0  2  1  3  3  4  5  6  0  1  3  2  4  5  6  5  0  1  2  1  2  3  4  5  4  6  0  6  0
1  2  3  3  4  5  6  0  1  2  3  4  5  5  6  0  1  1  3  2  2  5  4  4  6  6  0  1  0  2  4  3  3  5  0  6  1  2  1  3
4  5  5  6  1  0  3  2  2  4  4  5  6  6  0  0  2  1  3  3  5  4  5  0  6  1  1  2  3  2  4  5  6  0  1  2  3  4  4  5
6  0  0  6  1  2  3  3  4  5  5  6  1  0  1  2  2  3  4  5  6  0  1  2  3  4  5  4  6  6  1  0  0  2  3  3  4  5  6  5
0  1  2  1  2  3  5  4  6  0  6  1  3  2  4  4  5  6  0  0  2  1  4  3  3  5  5  0  6  1  1  2  3  2  5  4  6  6  1  0
2  3  4  4  5  6  0  0  2  1  3  3  4  5  5  6  0  1  1  3  2  2  4  6  5  6  0  0  1  2  3  4  5  4  0  6  1  2  3  3
4  5  6  5  0  1  2  1  2  3  4  4  5  0  6  6  0  1  3  2  4  5  6  0  1  2  3  4  3  5  5  0  6  1  2  1  2  3  5  4
4  6  6  1  0  0  3  2  3  4  5  6  0  2  1  3  5  4  5  0  6  1  1  2  3  2  4  4  5  6  6  0  0  1  2  4  3  3  5  6
0  1  2  3  4  5  5  6  1  0  1  2  2  3  4  4  5  0  6  6  0  1  2  3  3  4  5  6  0  1  2  4  3  5  6  5  0  2  1  1
2  3  4  5  4  0  6  0  6  1  2  3  3  4  5  6  0  1  2  1  3  4  5  5  0  6  1  2  3  2  5  4  4  6  6  0  1  0  2  3
4  3  5  5  6  0  1  2  2  1  3  4  5  6  0  1  2  4  3  4  5  6  6  0  0  2  1  3  3  4  5  5  6  0E 1  1  3  2  2  4
6  5  2E 1E 4  3  4  5E 6  6E 3  3  4  3  4  3  4  4  3E 4E
Sent packet count per queue: {3: 75, 4: 75, 0: 70, 1: 70, 2: 70, 5: 70, 6: 70}
Received packet count per queue: {3: 75, 4: 75, 0: 70, 1: 70, 2: 70, 5: 70, 6: 70}
Difference for each dscp:
[(8, 26), (5, 17), (0, 16), (46, 12), (48, 10), (3, 1), (4, 0)]
[500, 500]
[72, 73, 72, 77, 77, 72, 72, 0]
ok

----------------------------------------------------------------------
Ran 1 test in 21.044s

OK
```

Example on Cisco-8223 where the packet count is increased by an order of magnitude to cause drops, and the count per queue is skewed to cause simultaneous misordering detection:
```
 0  0  0  0  0  0  3  4  1  3  4  1  3  4  1  3  4  1  3  4  1  3  4  1  3  4  1  3  4  1  3  4  5  3  4  5  3  2  5  3 
 2  5  3  2  5  3  2  5  2  0  6  2  0  6  2  0  6  2  0  6  2  0  1  2  0  1  3  2  0  1  3  2  0  1E 3  2  0  5  3  2 
 0  5  3  4  0  5  3  4  0  5  3  4  0  5  3  4  5  3  4  5  3  4  5  3  4  5  3  4  5  3  4  5  3  4  0  5  3  4  0  5 
 3  4  0  6  4  0  6  4  0  6  2  0  6  2  0  5  2  0  5  2  0  5  3  2  0  5  3  2  0  5  3  2  0  5  3E 2  0  5  2  5 
 2  5  2  5  2  0  5  2  0  5  4  0  5  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  5  4  0  5  4  0  5  4  0  5 
 4  0  5  4  0  5  4  5  2  5  2  5  2  5  2  5  2  5  2  5  2  5  2  6  2  0  6  2  0  6  2  0  6  4  0  5  4  0  5  4 
 0  5  4  0  5  4  0  5  4  0  5  4  0  5  2  0  5  2  0  6  2  0  6  2  6  2  6  2  5  2  5  2  0  5  2  0  5  2  0  5 
 2  0  5  2  0  5  4  0  5  4  0  5  4  0  5  4  0  5  4  0  5  4  0  5  4  0  6  2  0  6  2  0  6  2  6  2  6  2  6  2 
 0  6  2  0  5  2  0  5  2  0  5  2  0  5  2  0  5  2  0  5  4  0  5  4  0  5  4  0  5  2  0  5  2  0  5  2  0  5  2  0 
 5  2  0  6  2  0  6  2  0  5  2  0  5  2  0  5  2  0  5  2  0  5  2  0  5  0  5  0  0  0  0  5  2  5  2  5  4  5  4  5 
 4  5  4  6  4  6  4  6  2  6  2  6  2  0  6  2  0  6  2  0  6  2  0  6  2  0  5  2  0  5  2  0  5  2  0  5  2  0  5  2 
 0  5  2  0  5  4  0  5  4  0  5  4  5  4  6  4  0  5  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4 
 0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  6  4  6  4  6  4  6  2  6  2  0  6  2  0  6  2  0  6  2  0  6  4  0  6  4 
 0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  2  0  6  2  0 
 6  4  0  6  4  0  4  0  0  0  0  0  0  6  4  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6 
 2  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  4  0  6  2  0  6  2  0  6  2  0  6  2  0  6  2 
 0  6  2  0  6  2  0  6  2  0  6  2  0  6  4  0  6  4  0  6  4  0  6  6  4  0  6  4  0  6  4  0  6  4  0  6  4  6  4    
Sent packet count per queue: {0: 800, 1: 500, 2: 700, 3: 600, 4: 800, 5: 600, 6: 700}                                   
Received packet count per queue: {0: 722, 1: 500, 2: 609, 3: 600, 4: 653, 5: 559, 6: 556}                               
Difference for each dscp:                                                                                               
[(0, 1106), (3, 1025)]                                                                                                  
[4700, 4199]                                                                                                            
DST port counters:                                                                                                      
[812, 506, 706, 609, 810, 607, 706, 0]                                                                                  
FAIL                                                                                                                    
                                                                                                                        
======================================================================                                                  
FAIL: sai_qos_tests.WRRtest                                                                                             
----------------------------------------------------------------------                                                  
Traceback (most recent call last):                                                                                      
  File "/root/saitests/py3/sai_qos_tests.py", line 5048, in runTest                                                     
    assert len(failures) == 0, "WRRtest failures:\n" + "\n".join(failures)                                              
           ^^^^^^^^^^^^^^^^^^                                                                                           
AssertionError: WRRtest failures:                                                                                       
Not all packets received: sent 4700 but received 4199                                                                   
Difference for 0 is 1106 which exceeds limit 20                                                                         
Difference for 3 is 1025 which exceeds limit 20                                                                         
                                                                                                                        
----------------------------------------------------------------------                                                  
Ran 1 test in 17.943s                                                                                                   
                                                                                                                        
FAILED (failures=1)                                                                                                     
```
Note that the "E" in the output denotes the queue arrival for 0 and 3 that occurred far before the end of the packet stream, explaining the test's complaint. 