### PR TITLE
[gnmi] Migrate revoked certificate test to managed TLS

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -120,6 +120,7 @@ t0:
   - gnmi/test_gnmi_appldb.py
   - gnmi/test_gnmi_configdb.py
   - gnmi/test_gnmi_countersdb.py
+  - gnmi/test_gnmi_crl.py
   - gnmi/test_gnmi_poll.py
   - gnmi/test_gnmi_smartswitch.py
   - gnmi/test_gnoi_killprocess.py
@@ -459,6 +460,7 @@ t1-lag:
   - gnmi/test_gnmi_appldb.py
   - gnmi/test_gnmi_configdb.py
   - gnmi/test_gnmi_countersdb.py
+  - gnmi/test_gnmi_crl.py
   - gnmi/test_gnmi_poll.py
   - gnmi/test_gnmi_smartswitch.py
   - gnmi/test_gnoi_killprocess.py
@@ -797,6 +799,7 @@ t0-vpp:
   - gnmi/test_gnmi.py
   - gnmi/test_gnmi_configdb.py
   - gnmi/test_gnmi_countersdb.py
+  - gnmi/test_gnmi_crl.py
   - gnmi/test_gnoi_os.py
   - gnmi/test_gnoi_system.py
   - hash/test_generic_hash.py
@@ -902,6 +905,7 @@ onboarding_t1_multi_asic:
   - gnmi/test_gnmi_appldb.py
   - gnmi/test_gnmi_configdb.py
   - gnmi/test_gnmi_countersdb.py
+  - gnmi/test_gnmi_crl.py
   - iface_loopback_action/test_iface_loopback_action.py
   - log_fidelity/test_bgp_shutdown.py
   - memory_checker/test_memory_checker.py

--- a/tests/common/cert_utils.py
+++ b/tests/common/cert_utils.py
@@ -285,6 +285,102 @@ class TlsCertificateGenerator:
             self._ca_key, self._ca_cert
         )
 
+    def generate_revoked_cert_with_crl(
+        self,
+        crl_distribution_url: str,
+        output_dir: str,
+        revoked_cn: str = "test.client.revoked.gnmi.sonic",
+    ) -> None:
+        """Write a same-CA revoked client identity and its CRL."""
+        if self._ca_key is None or self._ca_cert is None:
+            self.generate_all()
+
+        key = self._generate_key()
+        not_valid_before, not_valid_after = self._get_validity_period()
+        authority_key_identifier = (
+            x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(
+                self._ca_cert.extensions.get_extension_for_class(
+                    x509.SubjectKeyIdentifier
+                ).value
+            )
+        )
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([
+                x509.NameAttribute(NameOID.COMMON_NAME, revoked_cn),
+            ]))
+            .issuer_name(self._ca_cert.subject)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(not_valid_before)
+            .not_valid_after(not_valid_after)
+            .add_extension(authority_key_identifier, critical=False)
+            .add_extension(
+                x509.CRLDistributionPoints([
+                    x509.DistributionPoint(
+                        full_name=[
+                            x509.UniformResourceIdentifier(crl_distribution_url)
+                        ],
+                        relative_name=None,
+                        reasons=None,
+                        crl_issuer=None,
+                    )
+                ]),
+                critical=False,
+            )
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=True,
+                    key_encipherment=True,
+                    key_cert_sign=False,
+                    crl_sign=False,
+                    content_commitment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(
+                x509.ExtendedKeyUsage([
+                    x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH
+                ]),
+                critical=False,
+            )
+            .sign(self._ca_key, hashes.SHA256())
+        )
+
+        now = datetime.now(timezone.utc)
+        crl_not_before = now - timedelta(days=self.backdate_days)
+        revoked_cert = (
+            x509.RevokedCertificateBuilder()
+            .serial_number(cert.serial_number)
+            .revocation_date(crl_not_before)
+            .build()
+        )
+        crl = (
+            x509.CertificateRevocationListBuilder()
+            .issuer_name(self._ca_cert.subject)
+            .last_update(crl_not_before)
+            .next_update(not_valid_after)
+            .add_extension(authority_key_identifier, critical=False)
+            .add_revoked_certificate(revoked_cert)
+            .sign(self._ca_key, hashes.SHA256())
+        )
+
+        os.makedirs(output_dir, exist_ok=True)
+        with open(os.path.join(output_dir, "gnmiclient.revoked.cer"), "wb") as f:
+            f.write(self._serialize_cert(cert))
+        with open(os.path.join(output_dir, "gnmiclient.revoked.key"), "wb") as f:
+            f.write(self._serialize_key(key))
+        with open(os.path.join(output_dir, "sonic.crl.pem"), "wb") as f:
+            f.write(crl.public_bytes(serialization.Encoding.PEM))
+
     def _serialize_cert(self, cert: x509.Certificate) -> bytes:
         """Serialize certificate to PEM format."""
         return cert.public_bytes(serialization.Encoding.PEM)

--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -13,20 +13,29 @@ Deprecated fixtures (kept for backward compatibility):
     ptf_grpc:              Auto-configured gRPC client via GNMIEnvironment
     ptf_gnoi:              gNOI wrapper around ptf_grpc
 """
+import ipaddress
 import os
+import shlex
 import shutil
 import subprocess
 import tarfile
 import tempfile
+import uuid
 import pytest
 import logging
 from dataclasses import dataclass
 from typing import Optional
 from tests.common.cert_utils import create_gnmi_cert_generator
 from tests.common.grpc_config import grpc_config
-from tests.common.gu_utils import create_checkpoint, rollback
+from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
+from tests.common.helpers.gnmi_log import (
+    MARK_LOG_SCRIPT,
+    READ_LOG_SCRIPT,
+    decode_log_bytes,
+    parse_log_marker,
+)
 from tests.common.ptf_grpc import PtfGrpc
 from tests.common.ptf_gnoi import PtfGnoi
 from tests.common.pygnmi_client import PygnmiClient
@@ -37,6 +46,10 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 GRPCURL_VERSION = "1.9.3"
+REVOKED_CLIENT_CERT = "gnmiclient.revoked.cer"
+REVOKED_CLIENT_KEY = "gnmiclient.revoked.key"
+CRL_FILE = "sonic.crl.pem"
+CRL_PORT = 1234
 
 # Architecture mapping: dpkg --print-architecture → grpcurl release suffix
 _GRPCURL_ARCH_MAP = {
@@ -167,10 +180,11 @@ class GnmiFixture:
     grpc: object        # PtfGrpc (TLS/plaintext) or DutGrpc (UDS)
     gnoi: object        # PtfGnoi or DutGnoi
     pygnmi_client: Optional[PygnmiClient]   # None for UDS transport
-    transport: str = 'tls'      # 'tls', 'plaintext' or 'uds'
+    transport: str = 'tls'      # 'tls', 'tls_crl', 'plaintext' or 'uds'
     _duthost: object = None  # Fixture-selected DUT (post-reboot reconfig, DB cross-checks)
     _ptfhost: object = None  # For post-upgrade cert redistribution
     _cert_dir: Optional[str] = None  # Local cert dir used during setup
+    _crl_enabled: bool = False
 
     @property
     def duthost(self):
@@ -179,6 +193,58 @@ class GnmiFixture:
         if self._duthost is None:
             raise RuntimeError("GnmiFixture was not initialized with duthost reference")
         return self._duthost
+
+    def revoked_client(self):
+        """Construct a lazy PygnmiClient using the CRL-revoked identity."""
+        if not self._crl_enabled or self._cert_dir is None:
+            raise RuntimeError("gnmi_tls was not configured with CRL support")
+        return PygnmiClient(
+            self.host,
+            self.port,
+            plaintext=False,
+            ca_cert=os.path.join(self._cert_dir, grpc_config.CA_CERT),
+            client_cert=os.path.join(self._cert_dir, REVOKED_CLIENT_CERT),
+            client_key=os.path.join(self._cert_dir, REVOKED_CLIENT_KEY),
+            connect=False,
+        )
+
+    def mark_gnmi_log(self):
+        """Record a rotation-aware byte position in /var/log/gnmi.log."""
+        result = self.duthost.shell(
+            "sudo python3 -c {} {}".format(
+                shlex.quote(MARK_LOG_SCRIPT),
+                shlex.quote("/var/log/gnmi.log"),
+            ),
+            module_ignore_errors=True,
+        )
+        if result.get("rc") != 0:
+            raise RuntimeError(
+                "Failed to mark /var/log/gnmi.log: {}".format(result)
+            )
+        return parse_log_marker(result.get("stdout", ""))
+
+    def gnmi_log_since(self, marker):
+        """Read only log bytes after marker, including across rotation/truncation."""
+        result = self.duthost.shell(
+            "sudo python3 -c {} {} {} {} {}".format(
+                shlex.quote(READ_LOG_SCRIPT),
+                shlex.quote("/var/log/gnmi.log"),
+                marker.inode,
+                marker.offset,
+                shlex.quote(marker.anchor),
+            ),
+            module_ignore_errors=True,
+        )
+        if result.get("rc") != 0:
+            raise RuntimeError(
+                "Failed to read new gNMI log bytes: {}".format(result)
+            )
+        try:
+            return decode_log_bytes(result.get("stdout", ""))
+        except (ValueError, TypeError):
+            raise RuntimeError(
+                "Failed to decode new gNMI log bytes: {}".format(result)
+            )
 
     def reconfigure_after_reboot(self):
         """
@@ -195,7 +261,11 @@ class GnmiFixture:
 
         logger.info("Reconfiguring gNMI server after reboot")
         # regen_certs=False: rootfs (and cert files) survived the reboot.
-        _establish_gnoi_tls_handshake(self._duthost, regen_certs=False)
+        _establish_gnoi_tls_handshake(
+            self._duthost,
+            regen_certs=False,
+            enable_crl=self._crl_enabled,
+        )
         logger.info("Post-reboot TLS reconfiguration completed")
 
     def reinstall_certs_after_upgrade(self):
@@ -214,6 +284,8 @@ class GnmiFixture:
         if not self.tls:
             logger.info("Plaintext mode - no TLS cert reinstall needed")
             return
+        if self._crl_enabled:
+            raise RuntimeError("CRL-enabled gnmi_tls does not support image upgrades")
 
         logger.info("Reinstalling gNOI TLS certificates after upgrade")
         # regen_certs=True: upgrade wiped the certs, so recreate them.
@@ -228,8 +300,9 @@ def gnmi_tls(request, duthosts, ptfhost):
     """
     Set up gNMI/gNOI environment and yield a coupled GnmiFixture.
 
-    Supports two transports:
+    Supports three transports:
     - 'tls' (default): TCP+TLS from PTF container (existing behavior)
+    - 'tls_crl': TLS plus a revoked client identity and bounded CRL server
     - 'uds': Unix domain socket from DUT host (no TLS, no server restart)
 
     Opt-in to UDS via indirect parametrize:
@@ -257,6 +330,8 @@ def gnmi_tls(request, duthosts, ptfhost):
     duthost = _get_target_duthost(duthosts, request)
 
     transport = getattr(request, 'param', 'tls')
+    if transport not in ('tls', 'tls_crl', 'uds'):
+        raise ValueError("Unsupported gnmi_tls transport: {}".format(transport))
 
     if transport == 'uds':
         yield from _gnmi_uds_flow(duthost)
@@ -265,6 +340,12 @@ def gnmi_tls(request, duthosts, ptfhost):
     # --- existing TLS flow below (unchanged) ---
     checkpoint_name = "gnoi_tls_setup"
     cert_dir = "/tmp/gnoi_certs"
+    enable_crl = transport == 'tls_crl'
+    crl_server = None
+    teardown_errors = []
+    rollback_succeeded = False
+    restored_service_running = False
+    critical_processes_healthy = False
 
     logger.info("Setting up gNOI TLS server environment")
 
@@ -274,9 +355,26 @@ def gnmi_tls(request, duthosts, ptfhost):
     pygnmi_client = None
     try:
         # 2-5. Generate/distribute certs, configure + restart server, verify handshake
-        _establish_gnoi_tls_handshake(
-            duthost, ptfhost=ptfhost, cert_dir=cert_dir, regen_certs=True, verify=True
-        )
+        if enable_crl:
+            crl_url, crl_bind_address = _get_crl_endpoint(duthost, ptfhost)
+            _create_gnoi_certs(
+                duthost, ptfhost, cert_dir, crl_url=crl_url
+            )
+            crl_server = _start_crl_server(
+                duthost, ptfhost, cert_dir, crl_url, crl_bind_address
+            )
+            _establish_gnoi_tls_handshake(
+                duthost,
+                ptfhost=ptfhost,
+                regen_certs=False,
+                verify=True,
+                enable_crl=True,
+            )
+        else:
+            _establish_gnoi_tls_handshake(
+                duthost, ptfhost=ptfhost, cert_dir=cert_dir,
+                regen_certs=True, verify=True
+            )
 
         # Build coupled client with the exact config we just set up
         host = duthost.mgmt_ip
@@ -315,10 +413,11 @@ def gnmi_tls(request, duthosts, ptfhost):
             grpc=client,
             gnoi=gnoi_client,
             pygnmi_client=pygnmi_client,
-            transport='tls',
+            transport=transport,
             _duthost=duthost,
             _ptfhost=ptfhost,
             _cert_dir=cert_dir,
+            _crl_enabled=enable_crl,
         )
 
         logger.info("Constructed PygnmiClient: %s", pygnmi_client)
@@ -340,23 +439,69 @@ def gnmi_tls(request, duthosts, ptfhost):
             if output.get('rc') or "Config rolled back successfully" not in stdout:
                 error_msg = output.get('stdout', output.get('msg', 'unknown error'))
                 logger.error("Configuration rollback failed: %s", error_msg)
+                teardown_errors.append(
+                    "configuration rollback failed: {}".format(error_msg)
+                )
             else:
                 logger.info("Configuration rollback completed")
+                rollback_succeeded = True
         except Exception as e:
             logger.error("Configuration rollback failed with exception: %s", e)
+            teardown_errors.append(
+                "configuration rollback failed with exception: {}".format(e)
+            )
 
-        try:
-            logger.info("Waiting for critical processes to be healthy after rollback")
-            wait_critical_processes(duthost)
-            logger.info("All critical processes are healthy")
-        except Exception as e:
-            logger.error("Waiting for critical processes failed with exception: %s", e)
+        if enable_crl and rollback_succeeded:
+            try:
+                _restart_gnoi_server(
+                    duthost,
+                    expected_port=_get_configured_gnmi_port(duthost),
+                )
+                restored_service_running = True
+            except Exception as e:
+                logger.error("Failed to restart restored gNMI server: %s", e)
+                teardown_errors.append(
+                    "restart restored gNMI server failed: {}".format(e)
+                )
+
+        if crl_server is not None:
+            try:
+                _stop_crl_server(ptfhost, *crl_server)
+            except Exception as e:
+                logger.error("Failed to stop CRL server: %s", e)
+                teardown_errors.append("stop CRL server failed: {}".format(e))
+
+        if rollback_succeeded:
+            try:
+                logger.info("Waiting for critical processes to be healthy after rollback")
+                wait_critical_processes(duthost)
+                logger.info("All critical processes are healthy")
+                critical_processes_healthy = True
+            except Exception as e:
+                logger.error("Waiting for critical processes failed with exception: %s", e)
+                teardown_errors.append(
+                    "critical process recovery failed: {}".format(e)
+                )
+
+        if (enable_crl and rollback_succeeded and restored_service_running
+                and critical_processes_healthy):
+            try:
+                delete_checkpoint(duthost, checkpoint_name)
+                logger.info("Configuration checkpoint deleted")
+            except Exception as e:
+                logger.error("Failed to delete configuration checkpoint: %s", e)
+                teardown_errors.append(
+                    "delete configuration checkpoint failed: {}".format(e)
+                )
 
         try:
             _delete_gnoi_certs(cert_dir)
             logger.info("Certificate cleanup completed")
         except Exception as e:
             logger.error(f"Failed to cleanup certificates: {e}")
+
+        if enable_crl and teardown_errors:
+            raise RuntimeError("; ".join(teardown_errors))
 
 
 @pytest.fixture(scope="function")
@@ -482,7 +627,8 @@ def ptf_gnoi(ptf_grpc):
 # ---------------------------------------------------------------------------
 
 def _establish_gnoi_tls_handshake(duthost, ptfhost=None, cert_dir=None,
-                                  regen_certs=True, verify=False):
+                                  regen_certs=True, verify=False,
+                                  enable_crl=False):
     """
     Bring the gNOI TLS server into a state where the PTF client can connect.
     Single source of truth called at setup, after reboot, and after upgrade.
@@ -497,7 +643,9 @@ def _establish_gnoi_tls_handshake(duthost, ptfhost=None, cert_dir=None,
         duthost.shell(f"mkdir -p {grpc_config.DUT_CERT_DIR}")  # ensure DUT cert dir exists
         _create_gnoi_certs(duthost, ptfhost, cert_dir)         # gen + copy to DUT/PTF
 
-    _configure_gnoi_tls_server(duthost)  # write TLS settings into CONFIG_DB
+    _configure_gnoi_tls_server(
+        duthost, enable_crl=enable_crl
+    )  # write TLS settings into CONFIG_DB
     _restart_gnoi_server(duthost)        # restart so server picks up new config
 
     if verify:
@@ -507,7 +655,7 @@ def _establish_gnoi_tls_handshake(duthost, ptfhost=None, cert_dir=None,
         _verify_gnoi_tls_connectivity(duthost, ptfhost)
 
 
-def _create_gnoi_certs(duthost, ptfhost, cert_dir):
+def _create_gnoi_certs(duthost, ptfhost, cert_dir, crl_url=None):
     """
     Generate and distribute gNOI TLS certificates.
 
@@ -520,9 +668,14 @@ def _create_gnoi_certs(duthost, ptfhost, cert_dir):
     """
     logger.info("Generating gNOI TLS certificates")
 
-    # Generate certificates with 1-day backdating to handle clock skew
-    generator = create_gnmi_cert_generator(server_ip=duthost.mgmt_ip)
+    # Match the existing gNMI test PKI's tolerance for lab clock skew.
+    generator = create_gnmi_cert_generator(
+        server_ip=duthost.mgmt_ip,
+        backdate_days=7,
+    )
     generator.write_all(cert_dir)
+    if crl_url:
+        generator.generate_revoked_cert_with_crl(crl_url, cert_dir)
 
     logger.info(f"Certificates generated in {cert_dir}")
 
@@ -542,14 +695,19 @@ def _create_gnoi_certs(duthost, ptfhost, cert_dir):
     logger.info("Certificate generation and distribution completed")
 
 
-def _configure_gnoi_tls_server(duthost):
+def _configure_gnoi_tls_server(duthost, enable_crl=False):
     """Configure CONFIG_DB for TLS mode."""
     logger.info("Configuring gNOI server for TLS mode")
 
     # Configure GNMI table for TLS mode
     duthost.shell('sonic-db-cli CONFIG_DB hset "GNMI|gnmi" port 50052')
     duthost.shell('sonic-db-cli CONFIG_DB hset "GNMI|gnmi" client_auth true')
-    duthost.shell('sonic-db-cli CONFIG_DB hset "GNMI|gnmi" log_level 2')
+    log_level = 10 if enable_crl else 2
+    duthost.shell(
+        'sonic-db-cli CONFIG_DB hset "GNMI|gnmi" log_level {}'.format(
+            log_level
+        )
+    )
     duthost.shell('sonic-db-cli CONFIG_DB hset "GNMI|gnmi" user_auth cert')
 
     # Configure certificate paths using centralized config
@@ -565,10 +723,165 @@ def _configure_gnoi_tls_server(duthost):
         '''gnmi_dpu_appl_db_readwrite,gnoi_readwrite"'''
     )
 
+    if enable_crl:
+        duthost.shell('sonic-db-cli CONFIG_DB hset "GNMI|gnmi" enable_crl true')
+        duthost.shell(
+            '''sonic-db-cli CONFIG_DB hset "GNMI_CLIENT_CERT|'''
+            '''test.client.revoked.gnmi.sonic" "role@" '''
+            '''"gnmi_readwrite,gnmi_config_db_readwrite,'''
+            '''gnmi_appl_db_readwrite,gnmi_dpu_appl_db_readwrite,'''
+            '''gnoi_readwrite"'''
+        )
+
     logger.info("TLS configuration completed")
 
 
-def _restart_gnoi_server(duthost):
+def _get_crl_endpoint(duthost, ptfhost):
+    """Return the DUT-reachable CRL URL and optional IPv6 bind address."""
+    facts = duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts']
+    if facts.get('is_mgmt_ipv6_only', False):
+        if not ptfhost.mgmt_ipv6:
+            raise RuntimeError("IPv6-only DUT requires a PTF management IPv6 address")
+        ptf_ipv6 = str(ipaddress.ip_interface(ptfhost.mgmt_ipv6).ip)
+        return (
+            "http://[{}]:{}/crl".format(ptf_ipv6, CRL_PORT),
+            ptf_ipv6,
+        )
+    return "http://{}:{}/crl".format(ptfhost.mgmt_ip, CRL_PORT), None
+
+
+def _start_crl_server(duthost, ptfhost, cert_dir, crl_url,
+                      bind_address=None):
+    """Start an isolated PTF CRL server and return its exact PID and directory."""
+    listener = ptfhost.shell(
+        "ss -ltnH | grep -E '[:.]{}[[:space:]]'".format(CRL_PORT),
+        module_ignore_errors=True,
+    )
+    if listener.get('rc') not in (0, 1):
+        raise RuntimeError("Failed to inspect CRL port on the PTF: {}".format(listener))
+    if listener.get('rc') == 0:
+        raise RuntimeError("CRL port {} is already in use on the PTF".format(CRL_PORT))
+
+    server_dir = "/root/sonic-mgmt-gnmi-crl-{}".format(uuid.uuid4().hex[:8])
+    ptfhost.shell("mkdir -p {}".format(server_dir))
+    server_source = os.path.normpath(os.path.join(
+        os.path.dirname(__file__), "..", "..", "gnmi", "crl", "crl_server.py"
+    ))
+    pid = None
+    try:
+        ptfhost.copy(src=server_source, dest="{}/crl_server.py".format(server_dir))
+        ptfhost.copy(
+            src=os.path.join(cert_dir, CRL_FILE),
+            dest="{}/{}".format(server_dir, CRL_FILE),
+        )
+        bind_arg = ""
+        if bind_address:
+            bind_arg = " --bind {}".format(shlex.quote(bind_address))
+        result = ptfhost.shell(
+            "cd {directory}; /root/env-python3/bin/python crl_server.py "
+            "--port {port}{bind} </dev/null >/dev/null 2>&1 & echo $!".format(
+                directory=shlex.quote(server_dir),
+                port=CRL_PORT,
+                bind=bind_arg,
+            )
+        )
+        pid = int(result.get('stdout', '').strip())
+
+        def _server_ready():
+            process = ptfhost.shell(
+                "kill -0 {} 2>/dev/null".format(pid),
+                module_ignore_errors=True,
+            )
+            ready = ptfhost.shell(
+                "grep -q 'Ready handle request' {}/crl.log".format(
+                    shlex.quote(server_dir)
+                ),
+                module_ignore_errors=True,
+            )
+            return process.get('rc') == 0 and ready.get('rc') == 0
+
+        if not wait_until(30, 1, 0, _server_ready):
+            raise RuntimeError("CRL server failed to become ready")
+
+        def _server_reachable_from_dut():
+            result = duthost.shell(
+                "curl --noproxy '*' -fsS --max-time 5 {} >/dev/null".format(
+                    shlex.quote(crl_url)
+                ),
+                module_ignore_errors=True,
+            )
+            return result.get('rc') == 0
+
+        if not wait_until(30, 2, 0, _server_reachable_from_dut):
+            raise RuntimeError(
+                "CRL endpoint is not reachable from the DUT: {}".format(
+                    crl_url
+                )
+            )
+        logger.info("CRL server started with PID %s in %s", pid, server_dir)
+        return pid, server_dir
+    except Exception:
+        if pid is not None:
+            _stop_crl_server(ptfhost, pid, server_dir)
+        else:
+            ptfhost.shell(
+                "rm -rf {}".format(shlex.quote(server_dir)),
+                module_ignore_errors=True,
+            )
+        raise
+
+
+def _stop_crl_server(ptfhost, pid, server_dir):
+    """Stop only the CRL server started by this fixture and remove its files."""
+    ptfhost.shell("kill {} 2>/dev/null || true".format(pid),
+                  module_ignore_errors=True)
+
+    def _server_stopped():
+        result = ptfhost.shell(
+            "kill -0 {} 2>/dev/null".format(pid),
+            module_ignore_errors=True,
+        )
+        return result.get('rc') != 0
+
+    if not wait_until(10, 1, 0, _server_stopped):
+        ptfhost.shell("kill -9 {} 2>/dev/null || true".format(pid),
+                      module_ignore_errors=True)
+        if not wait_until(5, 1, 0, _server_stopped):
+            raise RuntimeError("CRL server PID {} did not stop".format(pid))
+    remove_result = ptfhost.shell(
+        "rm -rf {}".format(shlex.quote(server_dir)),
+        module_ignore_errors=True,
+    )
+    if remove_result.get('rc') != 0:
+        raise RuntimeError(
+            "Failed to remove CRL server directory: {}".format(
+                remove_result
+            )
+        )
+    verify_result = ptfhost.shell(
+        "test ! -e {}".format(shlex.quote(server_dir)),
+        module_ignore_errors=True,
+    )
+    if verify_result.get('rc') != 0:
+        raise RuntimeError(
+            "CRL server directory still exists: {}".format(server_dir)
+        )
+
+
+def _get_configured_gnmi_port(duthost):
+    """Return the restored configured gNMI port, or the image default."""
+    result = duthost.shell(
+        'sonic-db-cli CONFIG_DB hget "GNMI|gnmi" port',
+        module_ignore_errors=True,
+    )
+    value = (result.get('stdout') or '').strip()
+    if value.isdigit():
+        return int(value)
+    return grpc_config.DEFAULT_PLAINTEXT_PORT
+
+
+def _restart_gnoi_server(duthost,
+                         expected_port=grpc_config.DEFAULT_TLS_PORT):
     """Restart gNOI server to pick up new TLS configuration."""
     logger.info("Restarting gNOI server process")
 
@@ -606,7 +919,7 @@ def _restart_gnoi_server(duthost):
     def _tls_listener_ready():
         status = duthost.shell(
             "sudo ss -ltn | grep -q ':{} '".format(
-                grpc_config.DEFAULT_TLS_PORT
+                expected_port
             ),
             module_ignore_errors=True,
         )
@@ -615,20 +928,20 @@ def _restart_gnoi_server(duthost):
     if not wait_until(60, 2, 0, _tls_listener_ready):
         status = duthost.shell(
             "sudo ss -ltn | grep ':{} '".format(
-                grpc_config.DEFAULT_TLS_PORT
+                expected_port
             ),
             module_ignore_errors=True,
         )
         raise Exception(
             "gNOI server failed to listen on port {} within 60s: {}".format(
-                grpc_config.DEFAULT_TLS_PORT,
+                expected_port,
                 status.get('stdout', ''),
             )
         )
 
     logger.info(
         "gNOI server restart completed (supervisor RUNNING, port %s listening)",
-        grpc_config.DEFAULT_TLS_PORT,
+        expected_port,
     )
 
 

--- a/tests/common/helpers/gnmi_log.py
+++ b/tests/common/helpers/gnmi_log.py
@@ -1,0 +1,177 @@
+"""Rotation-safe byte markers for the managed gNMI service log."""
+
+import base64
+from dataclasses import dataclass
+
+
+MARK_LOG_SCRIPT = r"""
+import base64
+import os
+import sys
+
+path = sys.argv[1]
+with open(path, "rb") as log_file:
+    stat = os.fstat(log_file.fileno())
+    anchor_start = max(0, stat.st_size - 128)
+    log_file.seek(anchor_start)
+    anchor = base64.b64encode(log_file.read()).decode("ascii") or "-"
+print("{} {} {}".format(stat.st_ino, stat.st_size, anchor))
+"""
+
+
+READ_LOG_SCRIPT = r"""
+import base64
+import glob
+import gzip
+import os
+import re
+import sys
+
+current_path = sys.argv[1]
+marker_inode = int(sys.argv[2])
+marker_offset = int(sys.argv[3])
+marker_anchor = b"" if sys.argv[4] == "-" else base64.b64decode(sys.argv[4])
+max_generations = 4
+max_scan_bytes = 16 * 1024 * 1024
+max_output_bytes = 1024 * 1024
+
+def generation(path):
+    if path == current_path:
+        return 0
+    match = re.fullmatch(re.escape(current_path) + r"\.(\d+)(?:\.gz)?", path)
+    return int(match.group(1)) if match else None
+
+def open_log(path):
+    opener = gzip.open if path.endswith(".gz") else open
+    return opener(path, "rb")
+
+def anchor_matches(path, offset):
+    if not marker_anchor:
+        return True
+    anchor_start = max(0, offset - len(marker_anchor))
+    try:
+        with open_log(path) as log_file:
+            log_file.seek(anchor_start)
+            return log_file.read(len(marker_anchor)) == marker_anchor
+    except (FileNotFoundError, OSError):
+        return False
+
+def find_anchor(path):
+    if not marker_anchor:
+        return None
+    overlap = b""
+    scanned = 0
+    try:
+        with open_log(path) as log_file:
+            while scanned < max_scan_bytes:
+                chunk = log_file.read(min(65536, max_scan_bytes - scanned))
+                if not chunk:
+                    break
+                data = overlap + chunk
+                position = data.find(marker_anchor)
+                if position >= 0:
+                    return scanned - len(overlap) + position + len(marker_anchor)
+                overlap = data[-max(0, len(marker_anchor) - 1):]
+                scanned += len(chunk)
+    except (FileNotFoundError, OSError):
+        return None
+    return None
+
+def append_tail(output, path, start, scan_budget):
+    try:
+        with open_log(path) as log_file:
+            log_file.seek(start)
+            while scan_budget[0] > 0:
+                chunk = log_file.read(min(65536, scan_budget[0]))
+                if not chunk:
+                    break
+                output.extend(chunk)
+                scan_budget[0] -= len(chunk)
+                if len(output) > max_output_bytes:
+                    del output[:-max_output_bytes]
+    except (FileNotFoundError, OSError):
+        pass
+
+paths = []
+for path in glob.glob(current_path + "*"):
+    item_generation = generation(path)
+    if item_generation is not None and item_generation <= max_generations:
+        paths.append((item_generation, path))
+paths.sort(reverse=True)
+
+marker_index = None
+marker_start = 0
+truncated_current_index = None
+for index, (_, path) in enumerate(paths):
+    try:
+        same_inode = not path.endswith(".gz") and os.stat(path).st_ino == marker_inode
+    except OSError:
+        same_inode = False
+    if same_inode:
+        size = os.stat(path).st_size
+        if size >= marker_offset and anchor_matches(path, marker_offset):
+            marker_start = marker_offset
+        elif generation(path) == 0:
+            # Search rotated generations before treating this as truncate.
+            truncated_current_index = index
+            continue
+        else:
+            continue
+        marker_index = index
+        break
+
+if marker_index is None and marker_anchor:
+    for index in range(len(paths) - 1, -1, -1):
+        path = paths[index][1]
+        if anchor_matches(path, marker_offset):
+            marker_index = index
+            marker_start = marker_offset
+            break
+        anchor_end = find_anchor(path)
+        if anchor_end is not None:
+            marker_index = index
+            marker_start = anchor_end
+            break
+
+if marker_index is None and truncated_current_index is not None:
+    marker_index = truncated_current_index
+    marker_start = 0
+
+if marker_index is not None:
+    output = bytearray()
+    scan_budget = [max_scan_bytes]
+    append_tail(output, paths[marker_index][1], marker_start, scan_budget)
+    for _, path in paths[marker_index + 1:]:
+        if scan_budget[0] <= 0:
+            break
+        append_tail(output, path, 0, scan_budget)
+else:
+    sys.stderr.write("gNMI log marker no longer identifies retained log bytes")
+    sys.exit(2)
+
+sys.stdout.write(base64.b64encode(bytes(output)).decode("ascii"))
+"""
+
+
+@dataclass(frozen=True)
+class GnmiLogMarker:
+    """Identity and byte offset for a point in the managed gNMI log."""
+
+    inode: int
+    offset: int
+    anchor: str
+
+
+def parse_log_marker(output):
+    """Parse MARK_LOG_SCRIPT output into a GnmiLogMarker."""
+    values = output.strip().split(" ", 2)
+    if len(values) != 3:
+        raise ValueError("Invalid gNMI log marker: {!r}".format(output))
+    return GnmiLogMarker(int(values[0]), int(values[1]), values[2])
+
+
+def decode_log_bytes(output):
+    """Decode READ_LOG_SCRIPT output as UTF-8 while preserving bad bytes."""
+    return base64.b64decode(output.strip(), validate=True).decode(
+        "utf-8", errors="replace"
+    )

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -253,14 +253,6 @@ gnmi/test_gnmi.py::test_gnmi_authorize_failed_with_invalid_cname:
     conditions:
       - "asic_type in ['vpp']"
 
-gnmi/test_gnmi.py::test_gnmi_authorize_failed_with_revoked_cert:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
 gnmi/test_gnmi_appldb.py::test_gnmi_appldb_01:
   skip:
     reason: >
@@ -337,6 +329,14 @@ gnmi/test_gnmi_countersdb.py::test_gnmi_output:
       - "asic_type in ['vpp']"
 
 gnmi/test_gnmi_countersdb.py::test_gnmi_queue_buffer_cnt:
+  skip:
+    reason: >
+            Failed/Errored: To be included
+    conditions_logical_operator: or
+    conditions:
+      - "asic_type in ['vpp']"
+
+gnmi/test_gnmi_crl.py::test_gnmi_authorize_failed_with_revoked_cert:
   skip:
     reason: >
             Failed/Errored: To be included

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
@@ -320,6 +320,11 @@ gnmi/test_gnmi_countersdb.py:
     conditions:
     - asic_type in ['vs'] and 't2' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
+gnmi/test_gnmi_crl.py:
+  skip:
+    conditions:
+    - asic_type in ['vs'] and 't2' in topo_name
+    reason: This test case either cannot pass or should be skipped on virtual chassis
 gnmi/test_gnmi_smartswitch.py:
   skip:
     conditions:

--- a/tests/common/unit_tests/helpers/unit_test_gnmi_log.py
+++ b/tests/common/unit_tests/helpers/unit_test_gnmi_log.py
@@ -1,0 +1,137 @@
+"""Unit tests for rotation-safe gNMI log byte markers."""
+
+import importlib.util
+import gzip
+import subprocess
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "helpers" / "gnmi_log.py"
+
+
+def _load_gnmi_log():
+    spec = importlib.util.spec_from_file_location(
+        "unit_target_gnmi_log", MODULE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_script(script, *args):
+    return subprocess.check_output(
+        [sys.executable, "-c", script, *map(str, args)],
+        text=True,
+    )
+
+
+def _mark(gnmi_log, path):
+    return gnmi_log.parse_log_marker(
+        _run_script(gnmi_log.MARK_LOG_SCRIPT, path)
+    )
+
+
+def _read(gnmi_log, path, marker):
+    encoded = _run_script(
+        gnmi_log.READ_LOG_SCRIPT,
+        path,
+        marker.inode,
+        marker.offset,
+        marker.anchor,
+    )
+    return gnmi_log.decode_log_bytes(encoded)
+
+
+def test_read_log_bytes_appended_after_marker(tmp_path):
+    gnmi_log = _load_gnmi_log()
+    path = tmp_path / "gnmi.log"
+    path.write_text("old bytes\n")
+    marker = _mark(gnmi_log, path)
+
+    with path.open("a") as log_file:
+        log_file.write("new bytes\n")
+
+    assert _read(gnmi_log, path, marker) == "new bytes\n"
+
+
+def test_read_log_bytes_after_truncation(tmp_path):
+    gnmi_log = _load_gnmi_log()
+    path = tmp_path / "gnmi.log"
+    path.write_text("stale revoked diagnostic\n")
+    marker = _mark(gnmi_log, path)
+
+    path.write_text("new generation\n")
+
+    assert _read(gnmi_log, path, marker) == "new generation\n"
+
+
+def test_read_log_bytes_after_truncate_and_regrow(tmp_path):
+    gnmi_log = _load_gnmi_log()
+    path = tmp_path / "gnmi.log"
+    path.write_text("stale marker bytes\n")
+    marker = _mark(gnmi_log, path)
+
+    path.write_text("new generation with unrelated content beyond old size\n")
+
+    assert _read(gnmi_log, path, marker).startswith("new generation")
+
+
+def test_read_log_bytes_across_rotation(tmp_path):
+    gnmi_log = _load_gnmi_log()
+    path = tmp_path / "gnmi.log"
+    path.write_text("old bytes\n")
+    marker = _mark(gnmi_log, path)
+
+    with path.open("a") as log_file:
+        log_file.write("rotated tail\n")
+    path.rename(tmp_path / "gnmi.log.1")
+    path.write_text("new file\n")
+
+    assert _read(gnmi_log, path, marker) == "rotated tail\nnew file\n"
+
+
+def test_read_log_bytes_across_compressed_rotation(tmp_path):
+    gnmi_log = _load_gnmi_log()
+    path = tmp_path / "gnmi.log"
+    path.write_text("old bytes\n")
+    marker = _mark(gnmi_log, path)
+
+    with gzip.open(tmp_path / "gnmi.log.1.gz", "wb") as rotated:
+        rotated.write(path.read_bytes() + b"rotated tail\n")
+    path.write_text("new file\n")
+
+    assert _read(gnmi_log, path, marker) == "rotated tail\nnew file\n"
+
+
+def test_read_log_bytes_across_multiple_rotations(tmp_path):
+    gnmi_log = _load_gnmi_log()
+    path = tmp_path / "gnmi.log"
+    path.write_text("old bytes\n")
+    marker = _mark(gnmi_log, path)
+
+    with path.open("a") as log_file:
+        log_file.write("first tail\n")
+    path.rename(tmp_path / "gnmi.log.2")
+    (tmp_path / "gnmi.log.1").write_text("second generation\n")
+    path.write_text("current generation\n")
+
+    assert _read(gnmi_log, path, marker) == (
+        "first tail\nsecond generation\ncurrent generation\n"
+    )
+
+
+def test_read_log_bytes_are_bounded_to_latest_megabyte_after_marker(tmp_path):
+    gnmi_log = _load_gnmi_log()
+    path = tmp_path / "gnmi.log"
+    path.write_text("old bytes\n")
+    marker = _mark(gnmi_log, path)
+
+    with path.open("ab") as log_file:
+        log_file.write(b"a" * (1024 * 1024))
+        log_file.write(b"latest")
+
+    output = _read(gnmi_log, path, marker)
+    assert len(output.encode()) == 1024 * 1024
+    assert output == "a" * (1024 * 1024 - len("latest")) + "latest"

--- a/tests/common/unit_tests/unit_test_cert_utils.py
+++ b/tests/common/unit_tests/unit_test_cert_utils.py
@@ -1,0 +1,65 @@
+"""Unit tests for shared TLS certificate generation helpers."""
+
+import importlib.util
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "cert_utils.py"
+
+
+def _load_cert_utils():
+    spec = importlib.util.spec_from_file_location(
+        "unit_target_cert_utils", MODULE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_generate_revoked_cert_with_same_ca_and_distribution_point(tmp_path):
+    crl_url = "http://192.0.2.10:1234/crl"
+    cert_utils = _load_cert_utils()
+    generator = cert_utils.create_gnmi_cert_generator(server_ip="192.0.2.1")
+    generator.write_all(str(tmp_path))
+
+    generator.generate_revoked_cert_with_crl(crl_url, str(tmp_path))
+
+    ca_cert = x509.load_pem_x509_certificate(
+        (tmp_path / "gnmiCA.cer").read_bytes()
+    )
+    revoked_cert = x509.load_pem_x509_certificate(
+        (tmp_path / "gnmiclient.revoked.cer").read_bytes()
+    )
+    revoked_key = serialization.load_pem_private_key(
+        (tmp_path / "gnmiclient.revoked.key").read_bytes(),
+        password=None,
+    )
+    crl = x509.load_pem_x509_crl((tmp_path / "sonic.crl.pem").read_bytes())
+
+    ca_cert.public_key().verify(
+        revoked_cert.signature,
+        revoked_cert.tbs_certificate_bytes,
+        padding.PKCS1v15(),
+        revoked_cert.signature_hash_algorithm,
+    )
+    ca_cert.public_key().verify(
+        crl.signature,
+        crl.tbs_certlist_bytes,
+        padding.PKCS1v15(),
+        crl.signature_hash_algorithm,
+    )
+
+    distribution_points = revoked_cert.extensions.get_extension_for_class(
+        x509.CRLDistributionPoints
+    ).value
+    assert distribution_points[0].full_name[0].value == crl_url
+    assert revoked_cert.issuer == ca_cert.subject == crl.issuer
+    assert (
+        revoked_key.public_key().public_numbers()
+        == revoked_cert.public_key().public_numbers()
+    )
+    assert [entry.serial_number for entry in crl] == [revoked_cert.serial_number]

--- a/tests/common/unit_tests/unit_test_gnmi_crl.py
+++ b/tests/common/unit_tests/unit_test_gnmi_crl.py
@@ -1,0 +1,44 @@
+"""Unit tests for revoked-certificate gNMI error handling."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import grpc
+import pytest
+from pygnmi.client import gNMIException
+
+from tests.common.pygnmi_client import PygnmiClientCallError
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "gnmi" / "test_gnmi_crl.py"
+
+
+def _load_test_gnmi_crl():
+    spec = importlib.util.spec_from_file_location(
+        "unit_target_test_gnmi_crl", MODULE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _RpcError(grpc.RpcError):
+    def code(self):
+        return grpc.StatusCode.UNAUTHENTICATED
+
+
+@pytest.mark.parametrize(
+    "cause",
+    [
+        _RpcError(),
+        gNMIException("Peer certificate revoked", _RpcError()),
+    ],
+)
+def test_rpc_status_reads_direct_and_wrapped_grpc_errors(cause):
+    test_gnmi_crl = _load_test_gnmi_crl()
+    error = PygnmiClientCallError("gnmi set failed")
+    error.__cause__ = cause
+
+    assert test_gnmi_crl._rpc_status(error) == grpc.StatusCode.UNAUTHENTICATED

--- a/tests/container_upgrade/testcases.json
+++ b/tests/container_upgrade/testcases.json
@@ -7,6 +7,7 @@
     "gnmi/test_gnmi.py": 0,
     "gnmi/test_gnmi_configdb.py": 0,
     "gnmi/test_gnmi_appldb.py": 0,
+    "gnmi/test_gnmi_crl.py": 0,
     "gnmi/test_gnoi_system.py": 0,
     "gnmi/test_gnoi_file.py": 0,
     "telemetry/test_telemetry.py::test_config_db_parameters": 0,

--- a/tests/gnmi/test_gnmi.py
+++ b/tests/gnmi/test_gnmi.py
@@ -5,7 +5,7 @@ import random
 import threading
 
 from tests.common.helpers.gnmi_utils import gnmi_capabilities, GNMIEnvironment
-from .helper import gnmi_set, dump_gnmi_log, gnmi_subscribe_streaming_sample, gnmi_get, \
+from .helper import gnmi_subscribe_streaming_sample, gnmi_get, \
                     gnmi_subscribe_streaming_onchange
 from tests.common.utilities import wait_until
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
@@ -17,8 +17,11 @@ allure.logger = logger
 pytestmark = [
     pytest.mark.topology('any'),
     pytest.mark.disable_loganalyzer,
-    pytest.mark.usefixtures("setup_gnmi_ntp_client_server", "setup_gnmi_server",
-                            "setup_gnmi_rotated_server", "check_dut_timestamp")
+    pytest.mark.usefixtures(
+        "setup_gnmi_ntp_client_server",
+        "setup_gnmi_server",
+        "check_dut_timestamp",
+    )
 ]
 
 
@@ -42,68 +45,6 @@ def test_gnmi_capabilities(duthosts, rand_one_dut_hostname, localhost):
         "'JSON_IETF' not found in GNMI capabilities response message.\n"
         "- Actual message: {}"
     ).format(msg)
-
-
-def gnmi_create_vnet(duthost, ptfhost, cert=None):
-    file_name = "vnet.txt"
-    text = "{\"Vnet1\": {\"vni\": \"1000\", \"guid\": \"559c6ce8-26ab-4193-b946-ccc6e8f930b2\"}}"
-    with open(file_name, 'w') as file:
-        file.write(text)
-    ptfhost.copy(src=file_name, dest='/root')
-    # Add DASH_VNET_TABLE
-    update_list = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE:@/root/%s" % (file_name)]
-    msg = ""
-    try:
-        gnmi_set(duthost, ptfhost, [], update_list, [], cert)
-    except Exception as e:
-        logger.info("Failed to set: " + str(e))
-        msg = str(e)
-
-    gnmi_log = dump_gnmi_log(duthost)
-
-    return msg, gnmi_log
-
-
-@pytest.fixture(scope="function")
-def setup_crl_server_on_ptf(ptfhost, duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-
-    # Determine which address to bind the CRL server to
-    dut_facts = duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts']
-    is_mgmt_ipv6_only = dut_facts.get('is_mgmt_ipv6_only', False)
-
-    if is_mgmt_ipv6_only and ptfhost.mgmt_ipv6:
-        # Bind to IPv6 address when DUT is IPv6-only
-        bind_addr = ptfhost.mgmt_ipv6
-        logger.info(f"DUT is IPv6-only, binding CRL server to IPv6: {bind_addr}")
-    else:
-        # Bind to all interfaces (default behavior) for IPv4 or mixed environments
-        bind_addr = ''
-        logger.info("Binding CRL server to all interfaces (IPv4 compatible)")
-
-    ptfhost.shell('rm -f /root/crl.log')
-
-    # Start CRL server with appropriate bind address
-    if bind_addr:
-        ptfhost.shell(f'nohup /root/env-python3/bin/python /root/crl_server.py --bind {bind_addr} &')
-    else:
-        ptfhost.shell('nohup /root/env-python3/bin/python /root/crl_server.py &')
-
-    logger.warning("crl server started")
-
-    # Wait untill HTTP server ready
-    def server_ready_log_exist(ptfhost):
-        res = ptfhost.shell("sed -n '/Ready handle request/p'  /root/crl.log", module_ignore_errors=True)
-        logger.debug("crl.log: {}".format(res["stdout_lines"]))
-        return len(res["stdout_lines"]) > 0
-
-    wait_until(60, 1, 0, server_ready_log_exist, ptfhost)
-    logger.warning("crl server ready")
-
-    yield
-
-    # pkill will use the kill signal -9 as exit code, need ignore error
-    ptfhost.shell("pkill -9 -f '/root/env-python3/bin/python /root/crl_server.py'", module_ignore_errors=True)
 
 
 def test_gnmi_subscribe_sample(duthosts, rand_one_dut_hostname, ptfhost):
@@ -152,37 +93,6 @@ def test_gnmi_subscribe_sample(duthosts, rand_one_dut_hostname, ptfhost):
         )
         logger.debug("gNMI subscribe response: %s", stdout_msg)
         validates_subscribe_sample(stdout_msg)
-
-
-def test_gnmi_authorize_failed_with_revoked_cert(duthosts,
-                                                 rand_one_dut_hostname,
-                                                 ptfhost,
-                                                 setup_crl_server_on_ptf):
-    '''
-    Verify GNMI native write, incremental config for configDB
-    GNMI set request with invalid path
-    '''
-    duthost = duthosts[rand_one_dut_hostname]
-
-    retry = 3
-    msg = ""
-    gnmi_log = ""
-    while retry > 0:
-        retry -= 1
-        msg, gnmi_log = gnmi_create_vnet(duthost, ptfhost, "gnmiclient.revoked")
-        # retry when download crl failed, ptf device network not stable
-        if "desc = Peer certificate revoked" in gnmi_log:
-            break
-
-    assert "Unauthenticated" in msg, (
-        "'Unauthenticated' error message not found in GNMI response. "
-        "- Actual message: '{}'"
-    ).format(msg)
-
-    assert "desc = Peer certificate revoked" in gnmi_log, (
-        "'desc = Peer certificate revoked' message not found in GNMI log. "
-        "- Actual GNMI log: '{}'"
-    ).format(gnmi_log)
 
 
 def test_osbuild_version(duthosts, rand_one_dut_hostname, ptfhost):

--- a/tests/gnmi/test_gnmi_crl.py
+++ b/tests/gnmi/test_gnmi_crl.py
@@ -1,0 +1,86 @@
+"""gNMI certificate-revocation tests using the managed TLS fixture."""
+
+import logging
+
+import grpc
+import pytest
+
+from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
+from tests.common.pygnmi_client import PygnmiClientError
+from tests.common.utilities import wait_until
+
+
+logger = logging.getLogger(__name__)
+REVOKED_MESSAGE = "desc = Peer certificate revoked"
+VNET_NAME = "gnmi-crl-revoked"
+VNET_KEY = "DASH_VNET_TABLE:{}".format(VNET_NAME)
+
+pytestmark = [
+    pytest.mark.topology("any"),
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.usefixtures("setup_gnmi_ntp_client_server"),
+]
+
+
+def _rpc_status(error):
+    """Return the gRPC status preserved by pygnmi, when available."""
+    current = error
+    while current is not None:
+        if isinstance(current, grpc.RpcError):
+            return current.code()
+        current = getattr(current, "orig_exc", None) or current.__cause__
+    return None
+
+
+@pytest.mark.parametrize("gnmi_tls", ["tls_crl"], indirect=True)
+def test_gnmi_authorize_failed_with_revoked_cert(
+    gnmi_tls, rand_one_dut_hostname  # noqa: F811
+):
+    """Reject an APPL_DB Set authenticated by a CRL-revoked certificate."""
+    marker = gnmi_tls.mark_gnmi_log()
+    payload = {
+        VNET_NAME: {
+            "vni": "1000",
+            "guid": "559c6ce8-26ab-4193-b946-ccc6e8f930b2",
+        }
+    }
+    client = gnmi_tls.revoked_client()
+    errors = []
+    statuses = []
+    revoked_logged = False
+
+    try:
+        for _ in range(3):
+            try:
+                client.set(update=[(
+                    "sonic-db:APPL_DB/localhost/DASH_VNET_TABLE",
+                    payload,
+                )])
+            except PygnmiClientError as error:
+                errors.append(str(error))
+                statuses.append(_rpc_status(error))
+            else:
+                pytest.fail("Revoked client certificate unexpectedly wrote APPL_DB")
+
+            revoked_logged = wait_until(
+                10,
+                1,
+                0,
+                lambda: REVOKED_MESSAGE in gnmi_tls.gnmi_log_since(marker),
+            )
+            if revoked_logged:
+                break
+    finally:
+        client.close()
+        gnmi_tls.duthost.shell(
+            "sonic-db-cli APPL_DB del '{}'".format(VNET_KEY),
+            module_ignore_errors=True,
+        )
+
+    assert grpc.StatusCode.UNAUTHENTICATED in statuses, (
+        "Expected Unauthenticated status from revoked certificate, got: "
+        "statuses={}, errors={}".format(statuses, errors)
+    )
+    assert revoked_logged, (
+        "Expected revoked-certificate diagnostic in new /var/log/gnmi.log bytes"
+    )


### PR DESCRIPTION
### Description of PR

Summary:
Move the revoked-client-certificate gNMI test from the legacy standalone telemetry process to the function-scoped `gnmi_tls` managed-service fixture.

The new flow generates a revoked client certificate and CRL from the same test CA, serves the CRL from an isolated PTF process, validates the protocol-level `UNAUTHENTICATED` status, and reads only fresh bounded bytes from `/var/log/gnmi.log`. Teardown restores CONFIG_DB and the supervised `gnmi-native` service, removes the checkpoint, CRL server, generated certificates, and test APPL_DB key.


### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `SONiC.master.0-fe40965` on `vms-kvm-t0`
  - `test_gnmi_authorize_failed_with_revoked_cert[vrf_default_1-tls_crl]`: passed in 116.08 seconds on rebased commit `6b9b940c2`
  - Verified `UNAUTHENTICATED` and fresh `desc = Peer certificate revoked` service-log evidence
  - Verified teardown restored supervised `gnmi-native` on `127.0.0.1:8080`, left no CONFIG_DB `GNMI*` keys, checkpoint, APPL_DB test key, PTF CRL process/directory/listener, or local certificate directory
  - Post-test YANG validation, core/config checks, and critical-process checks passed
- Focused unit tests: 10 passed
- `py_compile`, focused `flake8`, conditional-mark sorting, `git diff --check`, and affected-module collection passed

### Approach
#### What is the motivation for this PR?

The legacy revoked-certificate test stopped supervised gNMI, launched a temporary telemetry process, and read a shared `/root/gnmi.log`. That made diagnostics vulnerable to stale or non-UTF-8 bytes and coupled this test to legacy process lifecycle helpers.

#### How did you do it?

- Added same-CA revoked certificate and CRL generation using `cryptography`.
- Added opt-in `tls_crl` support to `gnmi_tls`, including isolated CRL server lifecycle and full rollback verification.
- Added rotation/truncation-safe, base64-encoded bounded reads of fresh `/var/log/gnmi.log` bytes.
- Moved only the revoked-certificate case into `tests/gnmi/test_gnmi_crl.py`; existing capability, SAMPLE, ON_CHANGE, and osbuild tests retain their current setup.

#### How did you verify/test it?

See the Test result section. The exact test was run three times during hardening; the final post-rebase run passed and left the DUT/PTF clean.

#### Any platform specific information?

Validated on VS/KVM. Existing VPP and VS T2 skip behavior is retained under the new module path.

#### Supported testbed topology if it's a new test case?

Existing test case; PR mappings cover `t0`, `t1-lag`, `t0-vpp` with the existing VPP skip, and onboarding multi-ASIC. This is not a new scenario.

### Documentation

No documentation change required; this migrates an existing test to managed infrastructure.
