### PR TITLE
[snappi][pfcwd]: Avoid false failures from interface counter noise

### DIFF
--- a/tests/snappi_tests/pfcwd/files/pfcwd_actions_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_actions_helper.py
@@ -309,7 +309,14 @@ def run_pfc_test(api,
         # Check for loss packets on IXIA and DUT.
         if (test_def['enable_pfcwd_drop'] or test_def['enable_credit_wd']):
             pytest_assert(test_stats['tgen_loss_pkts'] == 0, 'Loss seen on TGEN')
-        pytest_assert(test_stats['dut_loss_pkts'] == 0, 'Loss seen on DUT')
+        # dut_loss_pkts is a sum of generic interface RX/TX error+drop counters
+        # across all monitored ports, not scoped to the Snappi test flows, so it
+        # is diagnostic only (see #27403). Actual test-flow loss is verified by
+        # the TGEN and DUT queue-counter checks below.
+        if test_stats['dut_loss_pkts'] > 0:
+            logger.warning("Non-zero DUT interface error/drop counters seen ({} pkts). These are "
+                           "generic interface counters, not scoped to the Snappi test flows, and "
+                           "do not by themselves indicate test-flow loss.".format(test_stats['dut_loss_pkts']))
 
         # Check for Tx and Rx packets on IXIA for lossless and lossy streams.
         if (test_def['enable_pfcwd_drop'] or test_def['enable_credit_wd']):


### PR DESCRIPTION
### Description of PR

Summary:

Fixes #27403

The PFCWD action test currently treats `dut_loss_pkts` as a hard test-flow loss signal. However, this value is an aggregate of generic interface RX/TX error and drop counters across the monitored DUT ports. Small incidental counter increments can therefore fail the test even when the traffic generator reports zero end-to-end packet loss.

This change makes the generic DUT interface counter result diagnostic-only while preserving the existing flow-scoped TGEN and DUT queue-counter loss validations.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: false-positive test failure

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `python3 -m py_compile tests/snappi_tests/pfcwd/files/pfcwd_actions_helper.py` passed.
- `git diff --check` passed.
- Functional execution of the PFCWD Snappi test requires an IXIA/Snappi testbed and was not available locally.

### Approach

#### What is the motivation for this PR?

`test_stats['dut_loss_pkts']` is calculated from generic interface RX/TX error and drop counters. Those counters are not scoped to the Snappi test flows and can include small incidental link-level drops after the counters are cleared.

This can cause a false failure even when the TGEN reports zero packet loss and the existing per-flow and DUT queue-counter validations pass.

#### How did you do it?

Changed the strict `dut_loss_pkts == 0` assertion to a warning when generic DUT interface error/drop counters are non-zero.

The existing flow-scoped validations remain unchanged, including:

- TGEN end-to-end loss validation
- lossless and lossy TGEN RX/TX comparisons
- TGEN RX versus DUT queue-counter packet checks

#### How did you verify/test it?

Verified the modified Python module compiles successfully and the diff has no whitespace errors.

The functional PFCWD test requires a Snappi/IXIA testbed, so end-to-end hardware validation is left to the SONiC test environment.

#### Any platform specific information?

No. The change only affects validation logic in the Snappi PFCWD action test.

#### Supported testbed topology if it's a new test case?

N/A — no new test case.

### Documentation

N/A
