### PR TITLE
[voq][macsec]: Separate routed and bridge MAC lookup

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -815,8 +815,34 @@ class EosHost(AnsibleHostBase):
         """
         Gets the MAC address of specified interface.
 
+        For a routed interface this is the interface's own routed MAC, not
+        the bridge/system MAC (see get_bridge_mac() for that).
+
         Returns:
             str: The MAC address of the specified interface, or None if it is not found.
+        """
+        try:
+            command = 'show interfaces {} | json'.format(interface_name)
+            output = self.eos_command(commands=[command])['stdout'][0]
+            mac = output["interfaces"][interface_name]["physicalAddress"]
+            return mac
+        except Exception as e:
+            logger.error('Failed to get MAC address for interface "{}", exception: {}'.format(interface_name, repr(e)))
+            return None
+
+    def get_bridge_mac(self, interface_name):
+        """
+        Gets the bridge/system MAC address EOS uses for the interface in L2/switchport mode.
+
+        For an already-switchport interface this is just its physicalAddress.
+        For a routed interface, EOS only reports the bridge MAC while the
+        interface is temporarily in switchport mode, so this briefly toggles
+        the interface to switchport, re-reads it, then restores routed mode.
+        The 'no switchport' restoration is always attempted once 'switchport'
+        has been applied, even if the intervening read fails.
+
+        Returns:
+            str: The bridge MAC address of the specified interface, or None if it is not found.
         """
         try:
             command = 'show interfaces {} | json'.format(interface_name)
@@ -826,14 +852,17 @@ class EosHost(AnsibleHostBase):
                 self.eos_config(
                     lines=['switchport'],
                     parents=['interface {}'.format(interface_name)])
-                output = self.eos_command(commands=[command])['stdout'][0]
-                self.eos_config(
-                    lines=['no switchport'],
-                    parents=['interface {}'.format(interface_name)])
+                try:
+                    output = self.eos_command(commands=[command])['stdout'][0]
+                finally:
+                    self.eos_config(
+                        lines=['no switchport'],
+                        parents=['interface {}'.format(interface_name)])
             mac = output["interfaces"][interface_name]["physicalAddress"]
             return mac
         except Exception as e:
-            logger.error('Failed to get MAC address for interface "{}", exception: {}'.format(interface_name, repr(e)))
+            logger.error('Failed to get bridge MAC address for interface "{}", exception: {}'.format(
+                interface_name, repr(e)))
             return None
 
     def iface_macsec_ok(self, interface_name):

--- a/tests/common/macsec/macsec_helper.py
+++ b/tests/common/macsec/macsec_helper.py
@@ -139,7 +139,7 @@ def get_appl_db(host, host_port_name, peer, peer_port_name):
     if isinstance(peer, EosHost):
         re_match = re.search(r'\d+', peer_port_name)
         peer_port_identifer = int(re_match.group())
-        peer_sci = get_sci(peer.get_dut_iface_mac(peer_port_name), peer_port_identifer)
+        peer_sci = get_sci(peer.get_bridge_mac(peer_port_name), peer_port_identifer)
     else:
         peer_sci = get_sci(peer.get_dut_iface_mac(peer_port_name))
     egress_sc_table = sonic_db_cli(

--- a/tests/common/macsec/recovery_helpers.py
+++ b/tests/common/macsec/recovery_helpers.py
@@ -8,6 +8,7 @@ from tests.common.helpers.dut_utils import (
     is_container_running,
     is_hitting_start_limit,
 )
+from tests.common.devices.eos import EosHost
 from tests.common.macsec.macsec_helper import (
     check_appl_db,
     get_sci,
@@ -165,7 +166,10 @@ def snapshot_appl_db_saks(duthost, ctrl_links):
     saks = {}
     for port_name, nbr in ctrl_links.items():
         host_sci = get_sci(duthost.get_dut_iface_mac(port_name))
-        peer_sci = get_sci(nbr["host"].get_dut_iface_mac(nbr["port"]))
+        if isinstance(nbr["host"], EosHost):
+            peer_sci = get_sci(nbr["host"].get_bridge_mac(nbr["port"]))
+        else:
+            peer_sci = get_sci(nbr["host"].get_dut_iface_mac(nbr["port"]))
         for an in range(4):
             v = _get_appl_db_sa_sak(duthost, port_name, host_sci, an, egress=True)
             if v:

--- a/tests/common/unit_tests/devices/unit_test_eos_host.py
+++ b/tests/common/unit_tests/devices/unit_test_eos_host.py
@@ -1,0 +1,181 @@
+"""
+Unit tests for tests/common/devices/eos.py (EosHost) get_dut_iface_mac /
+get_bridge_mac.
+
+EosHost extends AnsibleHostBase, whose __init__ needs a live ansible_adhoc
+fixture. To unit test the pure MAC-retrieval logic without a real cEOS
+device (or Ansible), instantiate via EosHost.__new__(EosHost) -- bypassing
+__init__ -- and shadow the eos_command/eos_config bound methods with
+MagicMocks as instance attributes. get_dut_iface_mac/get_bridge_mac only
+ever touch those two methods, so this fully exercises the logic added by
+(and, for get_dut_iface_mac, reverted from) PR #21312:
+
+  * get_dut_iface_mac() must be back to its pre-#21312 behavior: read
+    'show interfaces <if> | json' once and return physicalAddress, with no
+    switchport/routed config changes -- see issue #27395.
+  * get_bridge_mac() carries the #21312 switchport-toggle behavior MACsec
+    needs, and must always attempt to restore 'no switchport' once
+    'switchport' has been applied, even if the intervening read raises.
+
+Follows the repo unit-test convention (unit_test_*.py, unittest.mock).
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, call
+
+import pytest
+
+# Make the repo root importable so ``tests.common.devices.eos`` resolves
+# regardless of the pytest invocation directory.
+_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(_TEST_DIR)))
+)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from tests.common.devices.eos import EosHost  # noqa: E402
+
+INTERFACE = "Ethernet1"
+
+
+def make_host():
+    """Instantiate an EosHost without running its Ansible-dependent __init__."""
+    host = EosHost.__new__(EosHost)
+    host.hostname = "eos_test"
+    return host
+
+
+def show_interfaces_output(forwarding_model, physical_address):
+    """Shape a 'show interfaces <if> | json' eos_command() return value."""
+    return {
+        "stdout": [{
+            "interfaces": {
+                INTERFACE: {
+                    "forwardingModel": forwarding_model,
+                    "physicalAddress": physical_address,
+                }
+            }
+        }]
+    }
+
+
+SWITCHPORT_PARENTS = ["interface {}".format(INTERFACE)]
+
+
+class TestGetDutIfaceMac:
+    """get_dut_iface_mac() must be back to pre-#21312 semantics: a single
+    read, no config changes, regardless of forwardingModel."""
+
+    def test_routed_interface_returns_first_read_no_config_calls(self):
+        host = make_host()
+        host.eos_command = MagicMock(
+            return_value=show_interfaces_output("routed", "AA:AA:AA:AA:AA:01"))
+        host.eos_config = MagicMock()
+
+        mac = host.get_dut_iface_mac(INTERFACE)
+
+        assert mac == "AA:AA:AA:AA:AA:01"
+        assert host.eos_command.call_count == 1
+        host.eos_config.assert_not_called()
+
+    def test_switched_interface_returns_physical_address_no_config_calls(self):
+        host = make_host()
+        host.eos_command = MagicMock(
+            return_value=show_interfaces_output("bridged", "BB:BB:BB:BB:BB:02"))
+        host.eos_config = MagicMock()
+
+        mac = host.get_dut_iface_mac(INTERFACE)
+
+        assert mac == "BB:BB:BB:BB:BB:02"
+        assert host.eos_command.call_count == 1
+        host.eos_config.assert_not_called()
+
+    def test_malformed_output_returns_none(self):
+        host = make_host()
+        host.eos_command = MagicMock(return_value={"stdout": [{}]})
+        host.eos_config = MagicMock()
+
+        assert host.get_dut_iface_mac(INTERFACE) is None
+        host.eos_config.assert_not_called()
+
+
+class TestGetBridgeMac:
+    """get_bridge_mac() carries the #21312 switchport-toggle behavior that
+    MACsec relies on to observe the bridge/system MAC of a routed port."""
+
+    def test_already_switched_interface_no_toggle(self):
+        host = make_host()
+        host.eos_command = MagicMock(
+            return_value=show_interfaces_output("bridged", "CC:CC:CC:CC:CC:03"))
+        host.eos_config = MagicMock()
+
+        mac = host.get_bridge_mac(INTERFACE)
+
+        assert mac == "CC:CC:CC:CC:CC:03"
+        assert host.eos_command.call_count == 1
+        host.eos_config.assert_not_called()
+
+    def test_routed_interface_toggles_switchport_and_restores(self):
+        host = make_host()
+        host.eos_command = MagicMock(side_effect=[
+            show_interfaces_output("routed", "AA:AA:AA:AA:AA:01"),
+            show_interfaces_output("routed", "DD:DD:DD:DD:DD:04"),
+        ])
+        host.eos_config = MagicMock()
+
+        mac = host.get_bridge_mac(INTERFACE)
+
+        # The bridge MAC is the second (switchport-mode) read, not the
+        # first (routed-mode) read.
+        assert mac == "DD:DD:DD:DD:DD:04"
+        assert host.eos_command.call_count == 2
+        assert host.eos_config.call_args_list == [
+            call(lines=["switchport"], parents=SWITCHPORT_PARENTS),
+            call(lines=["no switchport"], parents=SWITCHPORT_PARENTS),
+        ]
+
+    def test_restoration_attempted_even_if_second_read_raises(self):
+        host = make_host()
+        host.eos_command = MagicMock(side_effect=[
+            show_interfaces_output("routed", "AA:AA:AA:AA:AA:01"),
+            Exception("simulated eos_command failure"),
+        ])
+        host.eos_config = MagicMock()
+
+        # The method's broad except swallows the failure and returns None,
+        # matching get_dut_iface_mac's existing error-handling contract.
+        assert host.get_bridge_mac(INTERFACE) is None
+
+        # 'no switchport' must still have been attempted: the interface
+        # must never be left stranded in switchport mode.
+        assert host.eos_config.call_args_list == [
+            call(lines=["switchport"], parents=SWITCHPORT_PARENTS),
+            call(lines=["no switchport"], parents=SWITCHPORT_PARENTS),
+        ]
+
+    def test_restoration_failure_is_reported_not_hidden(self):
+        host = make_host()
+        host.eos_command = MagicMock(
+            return_value=show_interfaces_output("routed", "AA:AA:AA:AA:AA:01"))
+        # 'switchport' succeeds; 'no switchport' itself fails.
+        host.eos_config = MagicMock(side_effect=[None, Exception("restore failed")])
+
+        # The failure must not be silently swallowed: get_bridge_mac still
+        # reports failure the same way every other error path does (log +
+        # None), rather than returning a MAC as if nothing went wrong.
+        assert host.get_bridge_mac(INTERFACE) is None
+        assert host.eos_config.call_count == 2
+
+    def test_malformed_output_returns_none(self):
+        host = make_host()
+        host.eos_command = MagicMock(return_value={"stdout": [{}]})
+        host.eos_config = MagicMock()
+
+        assert host.get_bridge_mac(INTERFACE) is None
+        host.eos_config.assert_not_called()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([os.path.abspath(__file__), "-v"]))


### PR DESCRIPTION
### Description of PR

Summary:

Fixes #27395

PR #21312 changed `EosHost.get_dut_iface_mac()` so routed cEOS interfaces are temporarily switched to L2 mode before reading `physicalAddress`. That behavior was needed by MACsec to obtain the bridge/system MAC used for SCI construction, but it also changed the return value for non-MACsec callers.

VOQ tests expect the routed interface MAC, so returning the bridge MAC causes ARP/ASIC DB MAC mismatches and related failures.

This change restores `get_dut_iface_mac()` to return the interface MAC as-is and adds an explicit `get_bridge_mac()` helper for MACsec callers that require the bridge/system MAC.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: regression

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: new `unit_test_eos_host.py` coverage passed: 8 tests.
- master: `tests/common/unit_tests/devices/` passed: 22 tests total.
- `python3 -m py_compile` passed for all changed Python files.
- `git diff --check` passed.
- End-to-end VOQ/MACsec validation against a cEOS testbed was not available locally.

### Approach

#### What is the motivation for this PR?

`EosHost.get_dut_iface_mac()` is shared by both VOQ and MACsec, but the two use cases need different EOS MAC addresses:

- VOQ needs the routed interface MAC used by ARP/ND and neighbor programming.
- MACsec needs the bridge/system MAC when constructing the peer SCI for a routed cEOS interface.

PR #21312 made bridge-MAC retrieval the default for every EosHost caller, which fixed MACsec but regressed VOQ.

#### How did you do it?

- Restored `EosHost.get_dut_iface_mac()` to its original read-only behavior.
- Added `EosHost.get_bridge_mac()` for callers that explicitly need the bridge/system MAC.
- Updated the two MACsec EOS call paths to use `get_bridge_mac()`.
- Kept non-EOS MACsec behavior unchanged.
- Made the temporary switchport transition exception-safe by always attempting `no switchport` restoration after a successful `switchport` change.
- Added focused unit tests for routed/switchport behavior, bridge-MAC retrieval, restoration on failure, and malformed command output.

No VOQ test changes are required because restoring `get_dut_iface_mac()` restores the routed-MAC semantics VOQ already expects.

#### How did you verify/test it?

Added unit coverage using mocked `eos_command`/`eos_config` calls so the MAC lookup logic can be validated without a physical cEOS testbed.

Validation performed:

- 8 new EosHost unit tests passed.
- 22 total device unit tests passed.
- Changed Python files compile successfully.
- `git diff --check` reports no whitespace errors.

#### Any platform specific information?

The regression affects tests using an EOS/cEOS neighbor. The shared helper change preserves existing SONiC-host MAC lookup behavior.

#### Supported testbed topology if it's a new test case?

N/A — no new functional test case.

### Documentation

N/A
