### PR TITLE
[snmp] Skip recirculation RIF in error/discard interface selection

### DIFF
--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -63,6 +63,11 @@ def get_interfaces(duthost, tbinfo):
     """
     rif_counters = parse_rif_counters(duthost.command("show interfaces counters rif")["stdout_lines"])
     for interface in rif_counters:
+        # Recirculation/internal RIFs (e.g. Ethernet-Rec0) match the 'Eth' name check but do not
+        # expose the ifInDiscards/ifInErrors MIBs this test validates; skip them so a front-panel
+        # RIF or PortChannel is selected instead.
+        if interface.startswith('Ethernet-Rec') or 'Recirc' in interface:
+            continue
         if 'Eth' in interface:
             return [interface], interface
         else:


### PR DESCRIPTION
#### Why I did it
`snmp/test_snmp_interfaces.py::test_snmp_interfaces_error_discard` selects the RIF under test with `get_interfaces()`, which returns the first RIF whose name contains the substring `Eth`. On topologies where every front-panel routed link is a PortChannel, the only `Eth`-named RIF is the internal recirculation port (e.g. `Ethernet-Rec0` on Broadcom DNX/VOQ platforms). That port does not expose the `ifInDiscards`/`ifInErrors` MIBs the test reads, so the test fails with:

```
port_interface = 'Ethernet-Rec0'
KeyError: 'ifInDiscards'
```

The test passed on topologies that still had front-panel physical `Ethernet` RIFs, because it happened to land on a real routed interface. It is a latent selection bug exposed when only PortChannels + the recirc port remain.

#### How I did it
Skip `Ethernet-Rec*` / `Recirc*` interfaces in `get_interfaces()` so a front-panel RIF or PortChannel that exposes the required MIBs is selected instead. No behavior change on topologies that already had a valid front-panel RIF.

#### How to verify it
Run `test_snmp_interfaces_error_discard` on a topology whose front-panel routed links are all PortChannels (e.g. a single-node T2 max topology). Before: `KeyError: 'ifInDiscards'`. After: a front-panel RIF/PortChannel is selected and the discard/error validation runs.
