### PR TITLE
[ansible/vm_set] Add the GoBGP PTF speaker manager

### DIFF
--- a/ansible/library/gobgp.py
+++ b/ansible/library/gobgp.py
@@ -1,0 +1,629 @@
+#!/usr/bin/python
+
+from ansible.module_utils.basic import AnsibleModule
+import jinja2  # nosemgrep: direct-use-of-jinja2
+import glob
+import hashlib
+import json
+import multiprocessing
+import os
+import re
+import sys
+import tempfile
+import traceback
+import time
+
+DOCUMENTATION = '''
+---
+module: gobgp
+version_added: "1.0"
+short_description: manage the gobgp-backed PTF BGP speaker (drop-in for exabgp)
+description:
+    - Start/stop the GoBGP PTF speaker. Each neighbor gets a dedicated gobgpd
+      holding exactly that one BGP session, so a route POSTed to a neighbor's
+      port advertises only over that session, the same semantics exabgp
+      provides. In front of them sits a pool of HTTP shim processes
+      (ansible/roles/vm_set/files/gobgp) that accept the ExaBGP HTTP grammar and
+      translate it into gobgpd gRPC AddPath/DeletePath.
+    - The shim pool is sized min(cores, ports), each member owning a disjoint
+      shard of the neighbor ports per gobgp.shardmap. That module is imported
+      rather than reimplemented, so the manager and the shims cannot disagree
+      about which shim owns which port.
+    - Configuration is two-phase, because the pool spans the whole topology.
+      state=configure runs once per neighbor and only writes files, then
+      state=pool (or started) runs once to merge every neighbor's contribution
+      and render the pool. The pool phase is idempotent and may be re-run after
+      more neighbors are configured.
+    - The deployed package must sit at <GOBGP_PKG_DIR>/gobgp/, which is both
+      this module's import root and the shims' PYTHONPATH.
+options:
+    name:
+        description:
+            - Instance name, per neighbor and family (ARISTA01T1, ARISTA01T1-v6).
+        required: true
+    state:
+        description:
+            - configure, present, absent and status act on one neighbor.
+            - pool, started, restarted and stopped act on the whole speaker.
+        required: true
+        choices: [configure, pool, started, restarted, stopped, present, absent, status]
+    router_id:
+        description:
+            - BGP router id for this neighbor's daemon.
+        required: false
+    local_ip:
+        description:
+            - Local transport address; shared by every PTF speaker.
+        required: false
+    peer_ip:
+        description:
+            - Neighbor address this daemon connects out to.
+        required: false
+    local_asn:
+        description:
+            - Local AS number.
+        required: false
+    peer_asn:
+        description:
+            - Peer AS number.
+        required: false
+    port:
+        description:
+            - HTTP port the shim serves this neighbor on; also derives the
+              gRPC and pprof ports.
+        required: false
+        default: 5000
+    passive:
+        description:
+            - Accepted for exabgp parity and rejected. gobgpd listens only when
+              the global port is positive, and it is fixed at -1 here.
+        required: false
+        default: false
+    debug:
+        description:
+            - Raise gobgpd log level to debug.
+        required: false
+        default: false
+'''
+
+EXAMPLES = '''
+# Phase 1 -- once per neighbor, writes config only
+- name: configure gobgp speaker
+  gobgp:
+    name: ARISTA01T1
+    state: configure
+    router_id: 10.0.0.0
+    local_ip: 10.0.0.0
+    peer_ip: 10.0.0.1
+    local_asn: 65534
+    peer_asn: 65535
+    port: 5000
+
+# Phase 2 -- once, after every neighbor is configured
+- name: start the gobgp speaker
+  gobgp:
+    name: pool
+    state: started
+
+- name: stop the gobgp speaker
+  gobgp:
+    name: pool
+    state: stopped
+'''
+
+DEFAULT_BGP_LISTEN_PORT = 179
+# gRPC port derived deterministically from the HTTP port so it never collides:
+#   v4 http 5000+off -> grpc 50000+off ;  v6 http 6000+off -> grpc 51000+off
+GRPC_PORT_OFFSET = 45000
+# gobgpd's pprof listener defaults to 6060, which is exactly the v6 shim HTTP
+# port for offset 60 (6000+60), and --pprof-disable is ineffective in the
+# binary. Relocating pprof by a further +10000 puts it on 60000+off / 61000+off,
+# clear of both the shim (5000-6999) and gRPC (50000-51999) ranges.
+PPROF_PORT_OFFSET = 10000
+
+GOBGP_BIN = "/usr/local/bin/gobgpd"
+GOBGP_CLI = "/usr/local/bin/gobgp"
+# Directory holding the deployed `gobgp` python package (shim + shardmap).
+GOBGP_PKG_DIR = os.environ.get("GOBGP_PKG_DIR", "/usr/share/gobgp")
+GOBGP_CONF_DIR = "/etc/gobgp"
+# One file per neighbor, merged into the topology-wide portmap by the pool
+# phase. A spool directory rather than an accumulating single file so that a
+# re-run of `configure` for one neighbor cannot corrupt the others' entries.
+PORTMAP_SPOOL_DIR = os.path.join(GOBGP_CONF_DIR, "portmap.d")
+PORTMAP_PATH = os.path.join(GOBGP_CONF_DIR, "portmap.json")
+SUPERVISOR_CONF_DIR = "/etc/supervisor/conf.d"
+
+V4_GROUP = "gobgpv4"
+V6_GROUP = "gobgpv6"
+SHIM_GROUP = "gobgpshim"
+# The shim pool is sharded by port, and shardmap deliberately round-robins over
+# the sorted port list so one shard fronts both families. The pool therefore
+# cannot be split into v4/v6 groups the way the gobgpd programs are.
+ALL_GROUPS = (V4_GROUP, V6_GROUP, SHIM_GROUP)
+
+# supervisord holds a stdout and a stderr pipe per child, so its descriptor use
+# scales with the program count: a 288-process fleet overran the default 1024
+# soft limit and left 87 children FATAL. FD_FLOOR is the value proven on
+# hardware; the per-process term only takes over beyond that scale.
+FD_PER_PROCESS = 16
+FD_FLOOR = 65536
+FD_HARD = 524288
+
+# The shim HTTP ports sit below the ephemeral range, but the ports derived from
+# them do not: grpc lands at 50000-51999 and pprof at 60000-61999, against a
+# default net.ipv4.ip_local_port_range of 32768-60999. An outbound socket can
+# therefore hold a port a restarting daemon must re-bind. The bases cannot move
+# -- clearing 60999 would push pprof past 65535 -- so the ranges are reserved.
+SHIM_PORT_MIN = 5000
+SHIM_PORT_MAX = 6999
+
+# These templates render config files from internal identifiers and paths.
+# autoescape stays on at every render site so they are clear of the XSS sink
+# pattern; the rendered output is unchanged either way.
+#
+# gobgpd TOML config: a single neighbor. gobgpd does not listen (port = -1) and
+# connects out to peer_ip, because all PTF speakers share one local_ip and
+# multiple listening daemons would collide on <local_ip>:179. Passive mode is
+# rejected in setup_gobgp_conf for the same reason.
+gobgpd_config_template = '''\
+[global.config]
+  as = {{ local_asn }}
+  router-id = "{{ router_id }}"
+  port = -1
+  local-address-list = ["{{ local_ip }}"]
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "{{ peer_ip }}"
+    peer-as = {{ peer_asn }}
+  [neighbors.transport.config]
+    local-address = "{{ local_ip }}"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
+'''
+
+gobgpd_supervisord_tmpl = '''\
+[program:gobgpd-{{ name }}]
+command={{ gobgpd }} -f {{ conf_dir }}/{{ name }}.toml -t toml \
+--api-hosts 127.0.0.1:{{ grpc_port }} --pprof-host=127.0.0.1:{{ pprof_port }}\
+{% if debug %} --log-level debug{% endif %}
+stdout_logfile=/tmp/gobgpd-{{ name }}.out.log
+stderr_logfile=/tmp/gobgpd-{{ name }}.err.log
+stdout_logfile_maxbytes=10000000
+stdout_logfile_backups=2
+stderr_logfile_maxbytes=10000000
+stderr_logfile_backups=2
+redirect_stderr=false
+autostart=false
+autorestart=true
+startsecs=1
+numprocs=1
+priority=100
+'''
+
+# One program per shard. `-m gobgp.shim` runs the deployed package; PYTHONPATH
+# points at its parent so the import works without installing it.
+#
+# GOBGP_PORTMAP_DIGEST makes a portmap content change a program *configuration*
+# change. The shim reads portmap.json once at startup, and `supervisorctl update`
+# restarts only programs whose configuration changed -- it does not watch data
+# files. Without the digest, a later pool run that adds ports without changing
+# the shard count renders an identical block, and the added ports never bind.
+gobgp_shim_supervisord_tmpl = '''\
+[program:gobgp-shim-{{ index }}]
+command=/usr/bin/env python3 -m gobgp.shim --portmap {{ portmap }} \
+--shard {{ index }}/{{ shards }}{% if debug %} --debug{% endif %}
+environment=PYTHONPATH="{{ pkg_dir }}",GOBGP_PORTMAP_DIGEST="{{ digest }}"
+stdout_logfile=/tmp/gobgp-shim-{{ index }}.out.log
+stderr_logfile=/tmp/gobgp-shim-{{ index }}.err.log
+stdout_logfile_maxbytes=10000000
+stdout_logfile_backups=2
+stderr_logfile_maxbytes=10000000
+stderr_logfile_backups=2
+redirect_stderr=false
+autostart=false
+autorestart=true
+startsecs=1
+numprocs=1
+priority=200
+'''
+
+group_supervisord_tmpl = '''\
+[group:{{ group }}]
+programs={{ programs }}
+'''
+
+
+def load_shardmap():
+    """Import the deployed ``gobgp.shardmap``.
+
+    Imported, never reimplemented: the shim resolves its own shard with these
+    same helpers, so a second copy of the port-split logic here would be a
+    silent-divergence bug waiting to happen.
+    """
+    if GOBGP_PKG_DIR not in sys.path:
+        sys.path.insert(0, GOBGP_PKG_DIR)
+    try:
+        from gobgp import shardmap
+    except ImportError as exc:
+        # GOBGP_PKG_DIR is both the import root here and the shims' PYTHONPATH,
+        # so it must be the package's parent. The bare ImportError does not say so.
+        raise ImportError(
+            "cannot import gobgp.shardmap from %s (%s). GOBGP_PKG_DIR must be "
+            "the PARENT of the deployed package: the package itself has to be "
+            "%s/gobgp/ containing __init__.py, shardmap.py and shim/. A flat "
+            "layout that copies those files directly into %s will fail here "
+            "and in every shim, which receives the same path as PYTHONPATH."
+            % (GOBGP_PKG_DIR, exc, GOBGP_PKG_DIR, GOBGP_PKG_DIR))
+    return shardmap
+
+
+def grpc_port_for(port):
+    return int(port) + GRPC_PORT_OFFSET
+
+
+def pprof_port_for(port):
+    return grpc_port_for(port) + PPROF_PORT_OFFSET
+
+
+def family_for(port):
+    # v6 speakers use the 6000+ HTTP port range (see filters.py port math)
+    return "v6" if int(port) >= 6000 else "v4"
+
+
+def exec_command(module, cmd, ignore_error=False, msg="executing command"):
+    rc, out, err = module.run_command(cmd)
+    if not ignore_error and rc != 0:
+        module.fail_json(msg="Failed %s: rc=%d, out=%s, err=%s" %
+                         (msg, rc, out, err))
+    return out
+
+
+def _mkdir(path):
+    try:
+        os.makedirs(path, 0o755)
+    except OSError:
+        pass  # already present
+
+
+def _write(path, data):
+    """Write via a temp file and rename.
+
+    The shim reloads its portmap on restart, and supervisord restarts it
+    automatically, so a crash landing in the middle of a pool re-render could
+    otherwise read a half-written file.
+    """
+    directory = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(dir=directory)
+    try:
+        with os.fdopen(fd, 'w') as f:
+            f.write(data)
+        os.chmod(tmp, 0o600)
+        os.rename(tmp, path)
+    except Exception:
+        _remove(tmp)
+        raise
+
+
+def _remove(path):
+    try:
+        os.remove(path)
+    except OSError:
+        pass  # already gone
+
+
+def refresh_supervisord(module):
+    exec_command(module, cmd="supervisorctl reread", ignore_error=True)
+    exec_command(module, cmd="supervisorctl update", ignore_error=True)
+
+
+def _status_lines(output):
+    """``supervisorctl status`` output -> {program: state}."""
+    states = {}
+    for line in output.splitlines():
+        m = re.match(r'^(\S+)\s+(\w+)', line.strip())
+        if m:
+            states[m.group(1)] = m.group(2)
+    return states
+
+
+def get_gobgp_status(module, name):
+    output = exec_command(module, cmd="supervisorctl status gobgpd-%s" % name,
+                          ignore_error=True)
+    return _status_lines(output).get("gobgpd-%s" % name, "UNKNOWN")
+
+
+def wait_groups_running(module, groups, timeout=300):
+    """Poll whole groups until every member is RUNNING.
+
+    Polling the group in one call rather than each program in turn matters at
+    fleet scale: a per-program wait serializes hundreds of timeouts, and a
+    single slow bind under load would blow the play's budget on its own.
+    """
+    deadline = time.time() + timeout
+    pending = {}
+    while time.time() < deadline:
+        pending = {}
+        for group in groups:
+            out = exec_command(module, cmd="supervisorctl status %s:" % group,
+                               ignore_error=True)
+            states = _status_lines(out)
+            if not states:
+                # No output also means an unreachable supervisord or an
+                # unloaded group, so it cannot count as ready.
+                pending["%s:" % group] = "UNKNOWN"
+                continue
+            for program, state in states.items():
+                if state != "RUNNING":
+                    pending[program] = state
+        if not pending:
+            return
+        time.sleep(2)
+    module.fail_json(msg="gobgp speaker not ready after %ds; pending=%s"
+                         % (timeout, pending))
+
+
+def raise_fd_ceiling(module, process_count):
+    """Raise supervisord's descriptor ceiling ahead of a fleet-scale spawn.
+
+    Best-effort: small topologies never reach the default limit, so a hard
+    failure here would regress them for a problem they do not have.
+    """
+    # A soft limit above the hard limit is rejected outright, which -- being
+    # best-effort -- would be swallowed and leave the ceiling unraised.
+    needed = min(max(FD_FLOOR, FD_PER_PROCESS * int(process_count)), FD_HARD)
+    pid = None
+    for candidate in ("/var/run/supervisord.pid", "/run/supervisord.pid"):
+        try:
+            with open(candidate) as f:
+                pid = int(f.read().strip())
+            break
+        except (IOError, OSError, ValueError):
+            continue
+    if pid is None:
+        # supervisord is pid 1 in docker-ptf, so this is normally right. If it is
+        # not, we raise init's limit and achieve nothing; wait_groups_running()
+        # still catches the resulting FATAL children.
+        pid = 1
+        module.log("gobgp: no supervisord pidfile; raising fd ceiling on pid 1")
+    exec_command(module,
+                 cmd="prlimit --pid %d --nofile=%d:%d" % (pid, needed, FD_HARD),
+                 ignore_error=True)
+    return needed
+
+
+def reserve_listener_ports(module):
+    """Keep the derived gRPC/pprof ports out of the ephemeral allocator.
+
+    Best-effort, like ``raise_fd_ceiling``: small topologies never lose the race.
+    The sysctl is network-namespaced, so only the PTF container is affected.
+    Ranges are derived from the port helpers so they cannot drift from the
+    bases; reserving ports outside the ephemeral window is a no-op.
+    """
+    ranges = "%d-%d,%d-%d" % (
+        grpc_port_for(SHIM_PORT_MIN), grpc_port_for(SHIM_PORT_MAX),
+        pprof_port_for(SHIM_PORT_MIN), pprof_port_for(SHIM_PORT_MAX))
+    # Assignment rather than merge: the PTF container reserves nothing else, and
+    # a read-modify-write would add a failure mode to a best-effort call.
+    exec_command(module,
+                 cmd="sysctl -w net.ipv4.ip_local_reserved_ports=%s" % ranges,
+                 ignore_error=True)
+    return ranges
+
+
+def setup_gobgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn,
+                     port, passive=False, debug=False):
+    """Phase 1: everything that concerns exactly one neighbor."""
+    if passive:
+        # port = -1 leaves gobgpd without a listener, and passive suppresses the
+        # outbound connect, so the session has no way to establish.
+        raise ValueError(
+            "passive=True is unsupported by the gobgp speaker: gobgpd listens "
+            "only when the global port is positive, and it is fixed at -1 so "
+            "every neighbor's daemon can share one local_ip. Passive mode "
+            "suppresses the outbound connect, leaving no way to establish.")
+
+    _mkdir(GOBGP_CONF_DIR)
+    _mkdir(PORTMAP_SPOOL_DIR)
+
+    data = jinja2.Template(gobgpd_config_template, autoescape=True).render(  # nosemgrep: direct-use-of-jinja2
+        local_asn=local_asn, router_id=router_id, local_ip=local_ip,
+        peer_ip=peer_ip, peer_asn=peer_asn)
+    _write("%s/%s.toml" % (GOBGP_CONF_DIR, name), data)
+
+    block = jinja2.Template(gobgpd_supervisord_tmpl, autoescape=True).render(  # nosemgrep: direct-use-of-jinja2
+        name=name, gobgpd=GOBGP_BIN, conf_dir=GOBGP_CONF_DIR,
+        grpc_port=grpc_port_for(port), pprof_port=pprof_port_for(port),
+        debug=debug)
+    _write("%s/gobgpd-%s.conf" % (SUPERVISOR_CONF_DIR, name), block)
+
+    # This neighbor's contribution to the topology-wide portmap.
+    entry = {
+        str(port): {
+            "grpc": "127.0.0.1:%d" % grpc_port_for(port),
+            "family": family_for(port),
+            "name": name,
+            "peer": peer_ip,
+            "self_nexthop": local_ip,
+        }
+    }
+    _write("%s/%s.json" % (PORTMAP_SPOOL_DIR, name), json.dumps(entry))
+
+
+def collect_portmap():
+    """Merge every neighbor's spool entry into the topology-wide portmap."""
+    portmap = {}
+    for path in sorted(glob.glob("%s/*.json" % PORTMAP_SPOOL_DIR)):
+        with open(path) as f:
+            portmap.update(json.load(f))
+    return portmap
+
+
+def render_pool(portmap, core_count=None, debug=False):
+    """Phase 2: render the portmap, the shim shard programs and the groups.
+
+    Returns the rendered shard count. Idempotent -- every file it owns is
+    rewritten from the current spool, and all shard programs live in one file so
+    a shrinking pool cannot leave orphaned per-shard files behind.
+
+    Convergence covers the running processes too: the portmap digest is embedded
+    in each shim program, so a changed portmap is a changed configuration and
+    ``supervisorctl update`` restarts the pool onto the new map.
+    """
+    shardmap = load_shardmap()
+    _mkdir(GOBGP_CONF_DIR)
+    serialized = json.dumps(portmap, indent=2, sort_keys=True)
+    _write(PORTMAP_PATH, serialized)
+    digest = hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
+
+    if core_count is None:
+        core_count = multiprocessing.cpu_count()
+    k = shardmap.num_shards(core_count, len(portmap))
+    # num_shards caps at the port count, but partition() additionally clamps to
+    # a non-empty split; render exactly what it yields, or a shim launched with
+    # an out-of-range index would exit on IndexError.
+    shards = shardmap.partition(portmap, k)
+    k = len(shards)
+
+    blocks = [
+        jinja2.Template(gobgp_shim_supervisord_tmpl, autoescape=True).render(  # nosemgrep: direct-use-of-jinja2
+            index=i, shards=k, portmap=PORTMAP_PATH, pkg_dir=GOBGP_PKG_DIR,
+            digest=digest, debug=debug)
+        for i in range(k)
+    ]
+    blocks.append(jinja2.Template(group_supervisord_tmpl, autoescape=True).render(  # nosemgrep: direct-use-of-jinja2
+        group=SHIM_GROUP,
+        programs=",".join("gobgp-shim-%d" % i for i in range(k))))
+    _write("%s/%s.conf" % (SUPERVISOR_CONF_DIR, SHIM_GROUP), "\n".join(blocks))
+
+    for group, family in ((V4_GROUP, "v4"), (V6_GROUP, "v6")):
+        names = [spec["name"] for _, spec in sorted(portmap.items(), key=lambda kv: int(kv[0]))
+                 if spec.get("family") == family]
+        path = "%s/%s.conf" % (SUPERVISOR_CONF_DIR, group)
+        if not names:
+            # An empty `programs=` is a supervisord config error, so a topology
+            # with only one family must not leave a stale group file behind.
+            _remove(path)
+            continue
+        _write(path, jinja2.Template(group_supervisord_tmpl, autoescape=True).render(  # nosemgrep: direct-use-of-jinja2
+            group=group, programs=",".join("gobgpd-%s" % n for n in names)))
+
+    return k
+
+
+def existing_groups():
+    return [g for g in ALL_GROUPS
+            if os.path.exists("%s/%s.conf" % (SUPERVISOR_CONF_DIR, g))]
+
+
+def start_gobgp(module, groups):
+    """Start gobgpd first, then the shims.
+
+    Ordering is deliberate: the shims dial the gRPC endpoints, and starting them
+    second means a shard's first request does not race a daemon that has not yet
+    opened its API socket.
+    """
+    for group in groups:
+        exec_command(module, cmd="supervisorctl start %s:" % group,
+                     ignore_error=True)
+    wait_groups_running(module, groups)
+
+
+def stop_gobgp(module, groups):
+    # Reverse of start: drop the front end before the daemons behind it.
+    for group in reversed(groups):
+        exec_command(module, cmd="supervisorctl stop %s:" % group,
+                     ignore_error=True)
+
+
+def remove_gobgp_conf(name):
+    for path in ("%s/%s.toml" % (GOBGP_CONF_DIR, name),
+                 "%s/%s.json" % (PORTMAP_SPOOL_DIR, name),
+                 "%s/gobgpd-%s.conf" % (SUPERVISOR_CONF_DIR, name)):
+        _remove(path)
+
+
+def remove_neighbor(module, name, debug=False):
+    """Drop one neighbor and reconverge the pool around it.
+
+    Only this neighbor's daemon is stopped; the rest of the fleet keeps serving.
+    """
+    exec_command(module, cmd="supervisorctl stop gobgpd-%s" % name,
+                 ignore_error=True)
+    remove_gobgp_conf(name)
+    # The group files still name this neighbor's program, and supervisord fails
+    # to load a group whose `programs=` references a missing section, wedging
+    # the family rather than the one neighbor.
+    render_pool(collect_portmap(), debug=debug)
+    refresh_supervisord(module)
+
+
+def fail_with_traceback(module, exc):
+    """Fail with the exception message and a real traceback.
+
+    Failures here name a missing package or an unwritable path, so the frame is
+    the diagnostic.
+    """
+    module.fail_json(msg="Error: %s" % exc, traceback=traceback.format_exc())
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(required=True, type='str'),
+            state=dict(required=True, choices=[
+                'configure', 'pool', 'started', 'restarted', 'stopped',
+                'present', 'absent', 'status'], type='str'),
+            router_id=dict(required=False, type='str'),
+            local_ip=dict(required=False, type='str'),
+            peer_ip=dict(required=False, type='str'),
+            local_asn=dict(required=False, type='int'),
+            peer_asn=dict(required=False, type='int'),
+            port=dict(required=False, type='int', default=5000),
+            passive=dict(required=False, type='bool', default=False),
+            debug=dict(required=False, type='bool', default=False),
+        ),
+        supports_check_mode=False)
+
+    p = module.params
+    name = p['name']
+    state = p['state']
+
+    result = {}
+    try:
+        if state in ('configure', 'present'):
+            setup_gobgp_conf(name, p['router_id'], p['local_ip'], p['peer_ip'],
+                             p['local_asn'], p['peer_asn'], p['port'],
+                             passive=p['passive'], debug=p['debug'])
+            if state == 'present':
+                refresh_supervisord(module)
+        elif state in ('pool', 'started', 'restarted'):
+            portmap = collect_portmap()
+            shards = render_pool(portmap, debug=p['debug'])
+            result = {'shards': shards, 'ports': len(portmap)}
+            result['nofile'] = raise_fd_ceiling(module, len(portmap) + shards)
+            result['reserved_ports'] = reserve_listener_ports(module)
+            refresh_supervisord(module)
+            groups = existing_groups()
+            if state == 'restarted':
+                stop_gobgp(module, groups)
+            if state in ('started', 'restarted'):
+                start_gobgp(module, groups)
+        elif state == 'stopped':
+            stop_gobgp(module, existing_groups())
+        elif state == 'absent':
+            remove_neighbor(module, name, debug=p['debug'])
+        elif state == 'status':
+            result = {'status': get_gobgp_status(module, name)}
+    except Exception as exc:
+        fail_with_traceback(module, exc)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/library/gobgp.py
+++ b/ansible/library/gobgp.py
@@ -293,7 +293,7 @@ def _remove(path):
     try:
         os.remove(path)
     except FileNotFoundError:
-        pass
+        pass  # teardown is idempotent, so an already-deleted path is expected
 
 
 def refresh_supervisord(module):

--- a/ansible/library/gobgp.py
+++ b/ansible/library/gobgp.py
@@ -70,7 +70,7 @@ options:
     port:
         description:
             - HTTP port the shim serves this neighbor on; also derives the
-              gRPC and pprof ports.
+              gRPC port.
         required: false
         default: 5000
     passive:
@@ -113,13 +113,12 @@ EXAMPLES = '''
 
 DEFAULT_BGP_LISTEN_PORT = 179
 # gRPC port derived deterministically from the HTTP port so it never collides:
-#   v4 http 5000+off -> grpc 50000+off ;  v6 http 6000+off -> grpc 51000+off
-GRPC_PORT_OFFSET = 45000
-# gobgpd's pprof listener defaults to 6060, which is exactly the v6 shim HTTP
-# port for offset 60 (6000+60), and --pprof-disable is ineffective in the
-# binary. Relocating pprof by a further +10000 puts it on 60000+off / 61000+off,
-# clear of both the shim (5000-6999) and gRPC (50000-51999) ranges.
-PPROF_PORT_OFFSET = 10000
+#   v4 http 5000+off -> grpc 61000+off ;  v6 http 6000+off -> grpc 62000+off
+# The offset also places the band above net.ipv4.ip_local_port_range, whose
+# per-netns kernel default is 32768-60999, and inside the 16-bit port space. The
+# shims hold one loopback gRPC channel per neighbor, so an ephemeral source port
+# could otherwise take the API port a restarting gobgpd must re-bind.
+GRPC_PORT_OFFSET = 56000
 
 GOBGP_BIN = "/usr/local/bin/gobgpd"
 GOBGP_CLI = "/usr/local/bin/gobgp"
@@ -141,19 +140,8 @@ SHIM_GROUP = "gobgpshim"
 # cannot be split into v4/v6 groups the way the gobgpd programs are.
 ALL_GROUPS = (V4_GROUP, V6_GROUP, SHIM_GROUP)
 
-# supervisord holds a stdout and a stderr pipe per child, so its descriptor use
-# scales with the program count: a 288-process fleet overran the default 1024
-# soft limit and left 87 children FATAL. FD_FLOOR is the value proven on
-# hardware; the per-process term only takes over beyond that scale.
-FD_PER_PROCESS = 16
-FD_FLOOR = 65536
-FD_HARD = 524288
-
-# The shim HTTP ports sit below the ephemeral range, but the ports derived from
-# them do not: grpc lands at 50000-51999 and pprof at 60000-61999, against a
-# default net.ipv4.ip_local_port_range of 32768-60999. An outbound socket can
-# therefore hold a port a restarting daemon must re-bind. The bases cannot move
-# -- clearing 60999 would push pprof past 65535 -- so the ranges are reserved.
+# Bounds of the shim HTTP band the manager is given ports from (filters.py port
+# math), and the basis of the derived gRPC band.
 SHIM_PORT_MIN = 5000
 SHIM_PORT_MAX = 6999
 
@@ -186,10 +174,13 @@ gobgpd_config_template = '''\
       afi-safi-name = "ipv6-unicast"
 '''
 
+# supervisord program for one gobgpd. Both HTTP flags are required: pprof and
+# prometheus metrics share a single listener that starts unless both are off,
+# and its 127.0.0.1:6060 default is the v6 shim port at offset 60.
 gobgpd_supervisord_tmpl = '''\
 [program:gobgpd-{{ name }}]
 command={{ gobgpd }} -f {{ conf_dir }}/{{ name }}.toml -t toml \
---api-hosts 127.0.0.1:{{ grpc_port }} --pprof-host=127.0.0.1:{{ pprof_port }}\
+--api-hosts 127.0.0.1:{{ grpc_port }} --pprof-disable --metrics-path ""\
 {% if debug %} --log-level debug{% endif %}
 stdout_logfile=/tmp/gobgpd-{{ name }}.out.log
 stderr_logfile=/tmp/gobgpd-{{ name }}.err.log
@@ -266,10 +257,6 @@ def grpc_port_for(port):
     return int(port) + GRPC_PORT_OFFSET
 
 
-def pprof_port_for(port):
-    return grpc_port_for(port) + PPROF_PORT_OFFSET
-
-
 def family_for(port):
     # v6 speakers use the 6000+ HTTP port range (see filters.py port math)
     return "v6" if int(port) >= 6000 else "v4"
@@ -281,13 +268,6 @@ def exec_command(module, cmd, ignore_error=False, msg="executing command"):
         module.fail_json(msg="Failed %s: rc=%d, out=%s, err=%s" %
                          (msg, rc, out, err))
     return out
-
-
-def _mkdir(path):
-    try:
-        os.makedirs(path, 0o755)
-    except OSError:
-        pass  # already present
 
 
 def _write(path, data):
@@ -312,8 +292,8 @@ def _write(path, data):
 def _remove(path):
     try:
         os.remove(path)
-    except OSError:
-        pass  # already gone
+    except FileNotFoundError:
+        pass
 
 
 def refresh_supervisord(module):
@@ -344,9 +324,9 @@ def wait_groups_running(module, groups, timeout=300):
     fleet scale: a per-program wait serializes hundreds of timeouts, and a
     single slow bind under load would blow the play's budget on its own.
     """
-    deadline = time.time() + timeout
+    deadline = time.monotonic() + timeout
     pending = {}
-    while time.time() < deadline:
+    while time.monotonic() < deadline:
         pending = {}
         for group in groups:
             out = exec_command(module, cmd="supervisorctl status %s:" % group,
@@ -367,54 +347,6 @@ def wait_groups_running(module, groups, timeout=300):
                          % (timeout, pending))
 
 
-def raise_fd_ceiling(module, process_count):
-    """Raise supervisord's descriptor ceiling ahead of a fleet-scale spawn.
-
-    Best-effort: small topologies never reach the default limit, so a hard
-    failure here would regress them for a problem they do not have.
-    """
-    # A soft limit above the hard limit is rejected outright, which -- being
-    # best-effort -- would be swallowed and leave the ceiling unraised.
-    needed = min(max(FD_FLOOR, FD_PER_PROCESS * int(process_count)), FD_HARD)
-    pid = None
-    for candidate in ("/var/run/supervisord.pid", "/run/supervisord.pid"):
-        try:
-            with open(candidate) as f:
-                pid = int(f.read().strip())
-            break
-        except (IOError, OSError, ValueError):
-            continue
-    if pid is None:
-        # supervisord is pid 1 in docker-ptf, so this is normally right. If it is
-        # not, we raise init's limit and achieve nothing; wait_groups_running()
-        # still catches the resulting FATAL children.
-        pid = 1
-        module.log("gobgp: no supervisord pidfile; raising fd ceiling on pid 1")
-    exec_command(module,
-                 cmd="prlimit --pid %d --nofile=%d:%d" % (pid, needed, FD_HARD),
-                 ignore_error=True)
-    return needed
-
-
-def reserve_listener_ports(module):
-    """Keep the derived gRPC/pprof ports out of the ephemeral allocator.
-
-    Best-effort, like ``raise_fd_ceiling``: small topologies never lose the race.
-    The sysctl is network-namespaced, so only the PTF container is affected.
-    Ranges are derived from the port helpers so they cannot drift from the
-    bases; reserving ports outside the ephemeral window is a no-op.
-    """
-    ranges = "%d-%d,%d-%d" % (
-        grpc_port_for(SHIM_PORT_MIN), grpc_port_for(SHIM_PORT_MAX),
-        pprof_port_for(SHIM_PORT_MIN), pprof_port_for(SHIM_PORT_MAX))
-    # Assignment rather than merge: the PTF container reserves nothing else, and
-    # a read-modify-write would add a failure mode to a best-effort call.
-    exec_command(module,
-                 cmd="sysctl -w net.ipv4.ip_local_reserved_ports=%s" % ranges,
-                 ignore_error=True)
-    return ranges
-
-
 def setup_gobgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn,
                      port, passive=False, debug=False):
     """Phase 1: everything that concerns exactly one neighbor."""
@@ -427,8 +359,8 @@ def setup_gobgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn,
             "every neighbor's daemon can share one local_ip. Passive mode "
             "suppresses the outbound connect, leaving no way to establish.")
 
-    _mkdir(GOBGP_CONF_DIR)
-    _mkdir(PORTMAP_SPOOL_DIR)
+    os.makedirs(GOBGP_CONF_DIR, 0o755, exist_ok=True)
+    os.makedirs(PORTMAP_SPOOL_DIR, 0o755, exist_ok=True)
 
     data = jinja2.Template(gobgpd_config_template, autoescape=True).render(  # nosemgrep: direct-use-of-jinja2
         local_asn=local_asn, router_id=router_id, local_ip=local_ip,
@@ -437,8 +369,7 @@ def setup_gobgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn,
 
     block = jinja2.Template(gobgpd_supervisord_tmpl, autoescape=True).render(  # nosemgrep: direct-use-of-jinja2
         name=name, gobgpd=GOBGP_BIN, conf_dir=GOBGP_CONF_DIR,
-        grpc_port=grpc_port_for(port), pprof_port=pprof_port_for(port),
-        debug=debug)
+        grpc_port=grpc_port_for(port), debug=debug)
     _write("%s/gobgpd-%s.conf" % (SUPERVISOR_CONF_DIR, name), block)
 
     # This neighbor's contribution to the topology-wide portmap.
@@ -475,7 +406,7 @@ def render_pool(portmap, core_count=None, debug=False):
     ``supervisorctl update`` restarts the pool onto the new map.
     """
     shardmap = load_shardmap()
-    _mkdir(GOBGP_CONF_DIR)
+    os.makedirs(GOBGP_CONF_DIR, 0o755, exist_ok=True)
     serialized = json.dumps(portmap, indent=2, sort_keys=True)
     _write(PORTMAP_PATH, serialized)
     digest = hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
@@ -605,8 +536,6 @@ def main():
             portmap = collect_portmap()
             shards = render_pool(portmap, debug=p['debug'])
             result = {'shards': shards, 'ports': len(portmap)}
-            result['nofile'] = raise_fd_ceiling(module, len(portmap) + shards)
-            result['reserved_ports'] = reserve_listener_ports(module)
             refresh_supervisord(module)
             groups = existing_groups()
             if state == 'restarted':

--- a/ansible/roles/vm_set/files/gobgp/tests/test_manager.py
+++ b/ansible/roles/vm_set/files/gobgp/tests/test_manager.py
@@ -1,0 +1,783 @@
+"""Unit tests for the ``gobgp`` ansible module (the speaker manager).
+
+The manager renders config; it never talks to a DUT, so everything here runs
+against a temporary directory tree with ``supervisorctl`` faked out.
+
+The invariant worth most of these tests is that the manager and the shim agree
+about the port split. The manager is required to *import* ``gobgp.shardmap``
+rather than reimplement it, so the tests assert the rendered artifacts against
+``shardmap.partition`` directly -- if the manager ever grows its own copy of the
+math, these fail.
+"""
+import ast
+import hashlib
+import json
+import os
+import sys
+import types
+
+import pytest
+import yaml
+
+from gobgp import shardmap
+
+
+def _load_manager():
+    """Import ``ansible/library/gobgp.py`` without a real ansible install.
+
+    Ansible is absent here, and the module is a stand-alone library file rather
+    than an importable package, so stub the one ansible symbol it needs and load
+    it by path.
+    """
+    if 'ansible' not in sys.modules:
+        ansible = types.ModuleType('ansible')
+        module_utils = types.ModuleType('ansible.module_utils')
+        basic = types.ModuleType('ansible.module_utils.basic')
+        basic.AnsibleModule = object
+        ansible.module_utils = module_utils
+        module_utils.basic = basic
+        sys.modules['ansible'] = ansible
+        sys.modules['ansible.module_utils'] = module_utils
+        sys.modules['ansible.module_utils.basic'] = basic
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    library = os.path.abspath(
+        os.path.join(here, os.pardir, os.pardir, os.pardir, os.pardir,
+                     os.pardir, 'library'))
+    path = os.path.join(library, 'gobgp.py')
+    if not os.path.exists(path):
+        pytest.skip("ansible/library/gobgp.py not found at %s" % path)
+
+    if sys.version_info[0] >= 3:
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("gobgp_manager", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    else:  # pragma: no cover - repo is py3, kept so the import cannot silently pass
+        import imp
+        mod = imp.load_source("gobgp_manager", path)
+    return mod
+
+
+mgr = _load_manager()
+
+
+class FakeModule(object):
+    """Records ``supervisorctl`` invocations and replays canned status output."""
+
+    def __init__(self, statuses=None):
+        self.commands = []
+        # {group: [output, output, ...]} consumed in order, last one repeats.
+        self.statuses = statuses or {}
+        self.failed = None
+        self.fail_kwargs = {}
+        self.logs = []
+
+    def log(self, msg):
+        self.logs.append(msg)
+
+    def run_command(self, cmd):
+        self.commands.append(cmd)
+        if cmd.startswith("supervisorctl status "):
+            target = cmd.split()[-1].rstrip(':')
+            outputs = self.statuses.get(target)
+            if outputs:
+                out = outputs[0] if len(outputs) == 1 else outputs.pop(0)
+                return 0, out, ""
+            return 0, "", ""
+        return 0, "", ""
+
+    def fail_json(self, msg=None, **kw):
+        self.failed = msg
+        self.fail_kwargs = kw
+        raise AssertionError(msg)
+
+    @property
+    def supervisor_actions(self):
+        return [c for c in self.commands
+                if c.startswith("supervisorctl start")
+                or c.startswith("supervisorctl stop")]
+
+
+@pytest.fixture
+def tree(tmp_path, monkeypatch):
+    """Point every path the manager writes to at a temp tree."""
+    conf = tmp_path / "gobgp"
+    spool = conf / "portmap.d"
+    supervisor = tmp_path / "conf.d"
+    pkg = tmp_path / "pkg"
+    for d in (conf, spool, supervisor, pkg):
+        d.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(mgr, "GOBGP_CONF_DIR", str(conf))
+    monkeypatch.setattr(mgr, "PORTMAP_SPOOL_DIR", str(spool))
+    monkeypatch.setattr(mgr, "PORTMAP_PATH", str(conf / "portmap.json"))
+    monkeypatch.setattr(mgr, "SUPERVISOR_CONF_DIR", str(supervisor))
+    monkeypatch.setattr(mgr, "GOBGP_PKG_DIR", str(pkg))
+    return types.SimpleNamespace(conf=conf, spool=spool, supervisor=supervisor,
+                                 pkg=pkg)
+
+
+def configure(n, family="v4", base_port=5000):
+    """Configure ``n`` neighbors of one family, returning their names."""
+    names = []
+    for off in range(n):
+        name = "ARISTA%02dT1" % (off + 1)
+        if family == "v6":
+            name += "-v6"
+        mgr.setup_gobgp_conf(
+            name=name, router_id="10.10.246.254", local_ip="10.10.246.254",
+            peer_ip="10.0.0.%d" % (off + 1), local_asn=65534, peer_asn=65535,
+            port=base_port + off)
+        names.append(name)
+    return names
+
+
+def read(path):
+    with open(str(path)) as f:
+        return f.read()
+
+
+# --- phase 1: per-neighbor configure -----------------------------------------
+
+def test_configure_writes_toml_program_and_spool_entry(tree):
+    configure(1)
+
+    toml = read(tree.conf / "ARISTA01T1.toml")
+    # gobgpd must not listen: every PTF speaker shares one local_ip, so a
+    # listening daemon would collide on <local_ip>:179 with its siblings.
+    assert "port = -1" in toml
+    assert 'neighbor-address = "10.0.0.1"' in toml
+    assert 'local-address = "10.10.246.254"' in toml
+    assert "passive-mode" not in toml
+
+    program = read(tree.supervisor / "gobgpd-ARISTA01T1.conf")
+    assert "[program:gobgpd-ARISTA01T1]" in program
+    # The pool phase owns startup ordering, so programs must not self-start.
+    assert "autostart=false" in program
+
+    entry = json.loads(read(tree.spool / "ARISTA01T1.json"))
+    assert entry == {
+        "5000": {
+            "grpc": "127.0.0.1:50000",
+            "family": "v4",
+            "name": "ARISTA01T1",
+            "peer": "10.0.0.1",
+            "self_nexthop": "10.10.246.254",
+        }
+    }
+
+
+def test_configure_rejects_passive(tree):
+    """port = -1 leaves gobgpd without a listener and passive suppresses the
+    outbound connect, so the pair renders a config that starts and never
+    establishes.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        mgr.setup_gobgp_conf("N", "10.0.0.0", "10.0.0.0", "10.0.0.1", 1, 2,
+                             5000, passive=True)
+    assert "passive" in str(excinfo.value).lower()
+    assert not (tree.conf / "N.toml").exists()
+
+
+def test_pprof_relocated_clear_of_shim_and_grpc_ranges(tree):
+    """gobgpd's default pprof port (6060) is a v6 shim HTTP port.
+
+    ``--pprof-disable`` is ineffective in the binary, so the manager relocates
+    the listener instead. The collision is invisible until a route POST lands on
+    the squatted port, which makes it worth pinning down here.
+    """
+    grpc_lo = mgr.SHIM_PORT_MIN + mgr.GRPC_PORT_OFFSET
+    grpc_hi = mgr.SHIM_PORT_MAX + mgr.GRPC_PORT_OFFSET
+    for port in (5000, 5060, 6000, 6060, 6071):
+        pprof = mgr.pprof_port_for(port)
+        grpc = mgr.grpc_port_for(port)
+        assert not mgr.SHIM_PORT_MIN <= pprof <= mgr.SHIM_PORT_MAX
+        assert not grpc_lo <= pprof <= grpc_hi
+        assert pprof != grpc
+
+    configure(1)
+    program = read(tree.supervisor / "gobgpd-ARISTA01T1.conf")
+    assert "--pprof-host=127.0.0.1:60000" in program
+    assert ":6060" not in program
+
+
+def test_family_derives_from_the_port_range():
+    assert mgr.family_for(5000) == "v4"
+    assert mgr.family_for(5071) == "v4"
+    assert mgr.family_for(6000) == "v6"
+    assert mgr.family_for(6071) == "v6"
+
+
+# --- phase 2: pool render -----------------------------------------------------
+
+def test_collect_portmap_merges_every_neighbor(tree):
+    configure(4)
+    configure(4, family="v6", base_port=6000)
+    portmap = mgr.collect_portmap()
+    assert len(portmap) == 8
+    assert set(portmap) == {"5000", "5001", "5002", "5003",
+                            "6000", "6001", "6002", "6003"}
+
+
+def test_pool_render_matches_shardmap_exactly(tree):
+    """The rendered pool must be the one shardmap describes.
+
+    Covering + disjoint + the right cardinality: this is the contract the shims
+    rely on to serve their slice without coordinating with each other.
+    """
+    configure(4)
+    configure(4, family="v6", base_port=6000)
+    portmap = mgr.collect_portmap()
+
+    k = mgr.render_pool(portmap, core_count=4)
+    expected = shardmap.partition(portmap, shardmap.num_shards(4, len(portmap)))
+    assert k == len(expected)
+
+    written = json.loads(read(tree.conf / "portmap.json"))
+    assert written == portmap
+
+    union = {}
+    for shard in expected:
+        assert not set(union) & set(shard)   # disjoint
+        union.update(shard)
+    assert union == portmap                  # covering
+
+    conf = read(tree.supervisor / "gobgpshim.conf")
+    for i in range(k):
+        assert "[program:gobgp-shim-%d]" % i in conf
+    assert "[program:gobgp-shim-%d]" % k not in conf
+
+
+def test_shim_command_uses_the_slash_shard_form(tree):
+    """``--shard`` is one ``i/k`` argument, not two positional values."""
+    configure(4)
+    k = mgr.render_pool(mgr.collect_portmap(), core_count=2)
+    conf = read(tree.supervisor / "gobgpshim.conf")
+    for i in range(k):
+        assert "--shard %d/%d" % (i, k) in conf
+    assert "-m gobgp.shim" in conf
+    assert 'PYTHONPATH="%s"' % tree.pkg in conf
+    assert str(tree.conf / "portmap.json") in conf
+
+
+def test_fleet_pool_is_sized_by_cores_not_sessions(tree):
+    """The whole point of the pool: process count tracks cores, not neighbors.
+
+    A shim-per-session deploy at this scale costs ~11.5 GB of interpreter
+    overhead; a core-sized pool costs ~640 MB at measured performance parity.
+    """
+    portmap = {}
+    for off in range(144):
+        for base, family in ((5000, "v4"), (6000, "v6")):
+            portmap[str(base + off)] = {
+                "grpc": "127.0.0.1:%d" % (base + off + 45000),
+                "family": family, "name": "ARISTA%03dT1" % (off + 1),
+            }
+    assert len(portmap) == 288
+
+    k = mgr.render_pool(portmap, core_count=16)
+    assert k == 16
+
+    conf = read(tree.supervisor / "gobgpshim.conf")
+    assert conf.count("[program:gobgp-shim-") == 16
+
+    # Every port still served, exactly once, by some shard.
+    served = {}
+    for i in range(k):
+        shard = shardmap.shard_for(portmap, k, i)
+        assert not set(served) & set(shard)
+        served.update(shard)
+    assert served == portmap
+
+    # A shard fronts both families, which is why the pool cannot be split into
+    # v4/v6 groups the way the gobgpd programs are.
+    families = {spec["family"] for spec in shardmap.shard_for(portmap, k, 0).values()}
+    assert families == {"v4", "v6"}
+
+
+def test_shard_count_never_exceeds_the_port_count(tree):
+    """More cores than ports must not spawn shims that own nothing.
+
+    ``partition`` clamps the split, so a manager that rendered the raw
+    ``min(cores, ports)`` would launch a shim whose index is out of range and it
+    would exit on IndexError.
+    """
+    configure(2)
+    portmap = mgr.collect_portmap()
+    k = mgr.render_pool(portmap, core_count=64)
+    assert k == 2
+    conf = read(tree.supervisor / "gobgpshim.conf")
+    assert "[program:gobgp-shim-2]" not in conf
+    for i in range(k):
+        assert shardmap.shard_for(portmap, k, i)   # no empty shard
+
+
+def test_shim_group_lists_every_shard(tree):
+    configure(4)
+    k = mgr.render_pool(mgr.collect_portmap(), core_count=4)
+    conf = read(tree.supervisor / "gobgpshim.conf")
+    assert "[group:gobgpshim]" in conf
+    programs = conf.split("programs=")[-1].strip()
+    assert programs.split(",") == ["gobgp-shim-%d" % i for i in range(k)]
+
+
+def test_gobgpd_groups_split_by_family(tree):
+    configure(3)
+    configure(3, family="v6", base_port=6000)
+    mgr.render_pool(mgr.collect_portmap(), core_count=4)
+
+    v4 = read(tree.supervisor / "gobgpv4.conf")
+    v6 = read(tree.supervisor / "gobgpv6.conf")
+    assert "[group:gobgpv4]" in v4
+    assert "programs=gobgpd-ARISTA01T1,gobgpd-ARISTA02T1,gobgpd-ARISTA03T1" in v4
+    assert "programs=gobgpd-ARISTA01T1-v6,gobgpd-ARISTA02T1-v6,gobgpd-ARISTA03T1-v6" in v6
+
+
+def test_single_family_topology_leaves_no_stale_group_file(tree):
+    """An empty ``programs=`` is a supervisord config error.
+
+    A v4-only topology (v6 route generation disabled) must not inherit a v6
+    group file from an earlier run.
+    """
+    stale = tree.supervisor / "gobgpv6.conf"
+    stale.write_text("[group:gobgpv6]\nprograms=gobgpd-GONE-v6\n")
+
+    configure(2)
+    mgr.render_pool(mgr.collect_portmap(), core_count=2)
+
+    assert (tree.supervisor / "gobgpv4.conf").exists()
+    assert not stale.exists()
+
+
+def test_pool_render_is_idempotent_and_prunes_a_shrinking_pool(tree):
+    """Re-running the pool phase converges instead of accumulating.
+
+    announce_routes configures v4 for every neighbor and then v6 for every
+    neighbor, so the pool phase can legitimately run more than once with a
+    growing portmap; a torn-down topology shrinks it again.
+    """
+    configure(8)
+    first = mgr.render_pool(mgr.collect_portmap(), core_count=8)
+    assert first == 8
+
+    again = mgr.render_pool(mgr.collect_portmap(), core_count=8)
+    assert again == first
+
+    for name in configure(8)[2:]:
+        mgr.remove_gobgp_conf(name)
+    shrunk = mgr.render_pool(mgr.collect_portmap(), core_count=8)
+    assert shrunk == 2
+
+    # All shard programs share one file precisely so a shrink cannot orphan one.
+    conf = read(tree.supervisor / "gobgpshim.conf")
+    assert "[program:gobgp-shim-2]" not in conf
+    assert len(list(tree.supervisor.glob("gobgp-shim-*.conf"))) == 0
+
+
+# --- lifecycle ----------------------------------------------------------------
+
+RUNNING = "gobgpd-ARISTA01T1   RUNNING   pid 100, uptime 0:00:05"
+
+
+def test_start_brings_up_daemons_before_shims(tree):
+    """A shim must not dial a gRPC socket its daemon has not opened yet."""
+    configure(2)
+    mgr.render_pool(mgr.collect_portmap(), core_count=2)
+    module = FakeModule(statuses={g: [RUNNING] for g in ("gobgpv4", "gobgpshim")})
+
+    mgr.start_gobgp(module, mgr.existing_groups())
+
+    starts = [c for c in module.supervisor_actions if c.startswith("supervisorctl start")]
+    assert starts == ["supervisorctl start gobgpv4:",
+                      "supervisorctl start gobgpshim:"]
+
+
+def test_stop_tears_down_in_reverse(tree):
+    configure(2)
+    configure(2, family="v6", base_port=6000)
+    mgr.render_pool(mgr.collect_portmap(), core_count=2)
+    module = FakeModule()
+
+    mgr.stop_gobgp(module, mgr.existing_groups())
+
+    assert module.supervisor_actions == ["supervisorctl stop gobgpshim:",
+                                         "supervisorctl stop gobgpv6:",
+                                         "supervisorctl stop gobgpv4:"]
+
+
+def test_existing_groups_skips_groups_that_were_never_rendered(tree):
+    configure(2)
+    mgr.render_pool(mgr.collect_portmap(), core_count=2)
+    # v6 was never configured, so starting `gobgpv6:` would just error.
+    assert mgr.existing_groups() == ["gobgpv4", "gobgpshim"]
+
+
+def test_wait_returns_once_the_whole_group_is_running(tree, monkeypatch):
+    monkeypatch.setattr(mgr.time, "sleep", lambda _s: None)
+    module = FakeModule(statuses={"gobgpv4": [
+        "gobgpd-ARISTA01T1   STARTING",
+        "gobgpd-ARISTA01T1   RUNNING   pid 1, uptime 0:00:02",
+    ]})
+    mgr.wait_groups_running(module, ["gobgpv4"], timeout=30)
+
+
+def test_wait_reports_the_programs_still_pending(tree, monkeypatch):
+    """A fleet-scale failure must name what is stuck, not just time out."""
+    monkeypatch.setattr(mgr.time, "sleep", lambda _s: None)
+    module = FakeModule(statuses={"gobgpshim": ["gobgp-shim-3   FATAL"]})
+
+    with pytest.raises(AssertionError):
+        mgr.wait_groups_running(module, ["gobgpshim"], timeout=1)
+    assert "gobgp-shim-3" in module.failed
+    assert "FATAL" in module.failed
+
+
+def test_wait_treats_a_silent_group_as_pending(tree, monkeypatch):
+    """An unreachable supervisord or an unloaded group yields no status lines,
+    which must not read as ready.
+    """
+    monkeypatch.setattr(mgr.time, "sleep", lambda _s: None)
+    module = FakeModule()
+
+    with pytest.raises(AssertionError):
+        mgr.wait_groups_running(module, ["gobgpv4"], timeout=1)
+    assert "UNKNOWN" in module.failed
+
+
+def test_wait_polls_the_group_not_each_program(tree, monkeypatch):
+    """Per-program waits serialize hundreds of timeouts at fleet scale."""
+    monkeypatch.setattr(mgr.time, "sleep", lambda _s: None)
+    module = FakeModule(statuses={"gobgpv4": [RUNNING]})
+    mgr.wait_groups_running(module, ["gobgpv4"], timeout=30)
+
+    status_cmds = [c for c in module.commands if c.startswith("supervisorctl status")]
+    assert status_cmds == ["supervisorctl status gobgpv4:"]
+
+
+# --- fd ceiling ---------------------------------------------------------------
+
+def test_fd_ceiling_clears_the_scale_that_failed_on_hardware(tree):
+    """288 processes overran the default 1024 limit and left 87 children FATAL.
+
+    Sizing purely off the process count would land at ~1.1k here -- just above
+    the limit that already failed -- so the floor carries the fleet case.
+    """
+    module = FakeModule()
+    needed = mgr.raise_fd_ceiling(module, 288)
+
+    assert needed >= 65536
+    assert any("prlimit" in c and "--nofile=%d:" % needed in c
+               for c in module.commands)
+
+
+@pytest.mark.parametrize("count,expected", [
+    (2, "floor"),                    # a 2-neighbor topology still gets the floor
+    (8192, "linear"),                # mid-range scales with the process count
+    (10 ** 6, "cap"),                # beyond the hard limit, prlimit would reject
+])
+def test_fd_ceiling_sizing_is_floor_then_linear_then_capped(tree, count, expected):
+    """The ceiling is piecewise: max(FD_FLOOR, per_process * n), capped at FD_HARD.
+
+    All three segments matter. Without the floor a fleet-sized run lands just
+    above the limit that already failed on hardware; without the cap the request
+    exceeds the hard limit and prlimit rejects it, which a best-effort call
+    swallows -- leaving the ceiling unraised.
+    """
+    module = FakeModule()
+    needed = mgr.raise_fd_ceiling(module, count)
+
+    if expected == "floor":
+        assert needed == mgr.FD_FLOOR
+    elif expected == "linear":
+        assert needed == mgr.FD_PER_PROCESS * count
+        assert needed <= mgr.FD_HARD
+    else:
+        assert needed == mgr.FD_HARD
+
+
+def test_fd_ceiling_is_best_effort(tree, monkeypatch):
+    """Small topologies never hit the limit; failing to raise it must not
+    regress them for a problem they do not have."""
+    class Failing(FakeModule):
+        def run_command(self, cmd):
+            self.commands.append(cmd)
+            return 1, "", "prlimit: not permitted"
+
+    module = Failing()
+    mgr.raise_fd_ceiling(module, 16)     # must not raise
+    assert module.failed is None
+
+
+# --- regression: portmap digest and group integrity ---------------------------
+
+def test_growing_the_portmap_restarts_the_pool_even_when_k_is_saturated(tree):
+    """A changed portmap must be a changed shim *configuration*.
+
+    The shim reads portmap.json once at startup, and ``supervisorctl update``
+    restarts only programs whose config changed. announce_routes runs the pool
+    phase twice -- v4 then v6 -- so once k saturates at the core count the
+    second render would otherwise be byte-identical, leaving every v6 port
+    unbound while every process reports RUNNING.
+    """
+    def portmap_for(families):
+        out = {}
+        for off in range(72):
+            for base, family in families:
+                out[str(base + off)] = {
+                    "grpc": "127.0.0.1:%d" % (base + off + 45000),
+                    "family": family, "name": "ARISTA%02dT1" % off,
+                }
+        return out
+
+    conf = tree.supervisor / "gobgpshim.conf"
+
+    v4_only = portmap_for([(5000, "v4")])
+    assert mgr.render_pool(v4_only, core_count=16) == 16
+    first = read(conf)
+
+    both = portmap_for([(5000, "v4"), (6000, "v6")])
+    assert mgr.render_pool(both, core_count=16) == 16      # k is saturated
+    second = read(conf)
+
+    assert first != second, \
+        "shim config unchanged after the portmap grew: supervisorctl update " \
+        "would not restart the pool and the added ports would never bind"
+
+    # Re-rendering the same map must still be a no-op, or every pool run would
+    # bounce the speaker.
+    mgr.render_pool(both, core_count=16)
+    assert read(conf) == second
+
+
+def test_shim_program_carries_the_portmap_digest(tree):
+    configure(4)
+    mgr.render_pool(mgr.collect_portmap(), core_count=2)
+    expected = hashlib.sha256(
+        read(tree.conf / "portmap.json").encode("utf-8")).hexdigest()[:16]
+    assert ('GOBGP_PORTMAP_DIGEST="%s"' % expected
+            in read(tree.supervisor / "gobgpshim.conf"))
+
+
+def test_absent_leaves_no_group_pointing_at_a_deleted_program(tree):
+    """supervisord fails to load a group naming a section that is gone.
+
+    That wedges the whole family group, not just the removed neighbor, so the
+    group files have to be re-rendered when a neighbor is dropped.
+    """
+    names = configure(3)
+    mgr.render_pool(mgr.collect_portmap(), core_count=2)
+    assert "gobgpd-%s" % names[1] in read(tree.supervisor / "gobgpv4.conf")
+
+    mgr.remove_gobgp_conf(names[1])
+    mgr.render_pool(mgr.collect_portmap(), core_count=2)
+
+    group = read(tree.supervisor / "gobgpv4.conf")
+    assert "gobgpd-%s" % names[1] not in group
+    programs = group.split("programs=")[-1].strip().splitlines()[0].split(",")
+    for program in programs:
+        assert (tree.supervisor / ("%s.conf" % program.strip())).exists(), \
+            "group references %s but its program file is gone" % program
+
+
+# --- ephemeral-port reservation ------------------------------------------------
+
+def test_reserved_ports_cover_every_derived_listener(tree):
+    """The gRPC and pprof bands are derived, so the reservation must be too.
+
+    Writing the ranges out by hand would let a change to either offset leave the
+    reservation pointing at the window the daemons no longer use.
+    """
+    module = FakeModule()
+    ranges = mgr.reserve_listener_ports(module)
+
+    reserved = set()
+    for span in ranges.split(","):
+        lo, hi = (int(x) for x in span.split("-"))
+        reserved.update(range(lo, hi + 1))
+
+    for port in (mgr.SHIM_PORT_MIN, 5500, 6000, mgr.SHIM_PORT_MAX):
+        assert mgr.grpc_port_for(port) in reserved
+        assert mgr.pprof_port_for(port) in reserved
+
+    assert any("ip_local_reserved_ports=%s" % ranges in c
+               for c in module.commands)
+
+
+def test_reserved_ports_cover_the_ephemeral_overlap(tree):
+    """Everything the daemons bind inside 32768-60999 must be reserved.
+
+    That window is the container default for net.ipv4.ip_local_port_range; a
+    fixed port inside it can be held by an outbound socket when a daemon
+    restarts, which is the failure this reservation exists to prevent.
+    """
+    EPHEMERAL_LO, EPHEMERAL_HI = 32768, 60999
+
+    reserved = set()
+    for span in mgr.reserve_listener_ports(FakeModule()).split(","):
+        lo, hi = (int(x) for x in span.split("-"))
+        reserved.update(range(lo, hi + 1))
+
+    exposed = set()
+    for port in range(mgr.SHIM_PORT_MIN, mgr.SHIM_PORT_MAX + 1):
+        for listener in (mgr.grpc_port_for(port), mgr.pprof_port_for(port)):
+            if EPHEMERAL_LO <= listener <= EPHEMERAL_HI:
+                exposed.add(listener)
+
+    assert exposed                      # the overlap is real, not hypothetical
+    assert exposed <= reserved
+
+
+def test_every_derived_listener_is_a_legal_port(tree):
+    """Guards the rejected fix for the overlap.
+
+    Shifting the gRPC base above the ephemeral window would need an offset of
+    56000, which puts pprof (grpc + 10000) at 71000 -- past the 16-bit ceiling.
+    The reservation is used precisely because the bases cannot move.
+    """
+    for port in (mgr.SHIM_PORT_MIN, mgr.SHIM_PORT_MAX):
+        assert mgr.grpc_port_for(port) <= 65535
+        assert mgr.pprof_port_for(port) <= 65535
+
+
+def test_reserving_ports_is_best_effort(tree):
+    """A container without permission to set the sysctl must still deploy."""
+    class Failing(FakeModule):
+        def run_command(self, cmd):
+            self.commands.append(cmd)
+            return 1, "", "sysctl: permission denied"
+
+    module = Failing()
+    mgr.reserve_listener_ports(module)   # must not raise
+    assert module.failed is None
+
+
+def test_pool_reserves_the_listener_ports_before_the_fleet_spawns(tree):
+    """The reservation is useless once the daemons are already binding."""
+    configure(2)
+    module = FakeModule(statuses={g: [RUNNING] for g in ("gobgpv4", "gobgpshim")})
+    portmap = mgr.collect_portmap()
+    shards = mgr.render_pool(portmap, core_count=2)
+    mgr.raise_fd_ceiling(module, len(portmap) + shards)
+    mgr.reserve_listener_ports(module)
+    mgr.start_gobgp(module, mgr.existing_groups())
+
+    reserved_at = next(i for i, c in enumerate(module.commands)
+                       if "ip_local_reserved_ports" in c)
+    started_at = next(i for i, c in enumerate(module.commands)
+                      if c.startswith("supervisorctl start"))
+    assert reserved_at < started_at
+
+
+# --- deployed-package layout ---------------------------------------------------
+
+def test_missing_package_names_the_expected_layout(tree, tmp_path, monkeypatch):
+    """GOBGP_PKG_DIR is the shims' PYTHONPATH as well as the manager's import
+    root, so it must be the package's parent. A flat deploy is the predecessor
+    layout and the likeliest mistake; the bare ImportError does not say so.
+    """
+    # Block at the import system so the result holds for any checkout path.
+    class _BlockGobgp(object):
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname == "gobgp" or fullname.startswith("gobgp."):
+                raise ImportError("blocked by test")
+            return None
+
+    monkeypatch.setattr(mgr, "GOBGP_PKG_DIR", str(tmp_path / "nothing-here"))
+    monkeypatch.delitem(sys.modules, "gobgp", raising=False)
+    monkeypatch.delitem(sys.modules, "gobgp.shardmap", raising=False)
+    monkeypatch.setattr(sys, "meta_path", [_BlockGobgp()] + list(sys.meta_path))
+
+    with pytest.raises(ImportError) as excinfo:
+        mgr.load_shardmap()
+
+    message = str(excinfo.value)
+    assert "PARENT" in message
+    assert "/gobgp/" in message
+
+
+def test_failure_reports_the_frame_not_the_traceback_repr():
+    """`str(sys.exc_info())` -- the inherited idiom -- renders the traceback
+    object's repr, so the operator gets `<traceback object at 0x...>` instead of
+    the frames. The layout ImportError above is raised inside main()'s try, so
+    that idiom would deliver this module's clearest error wrapped in noise.
+    """
+    module = FakeModule()
+
+    def raise_layout_error():
+        raise ImportError("cannot import shardmap; expected the PARENT of /gobgp/")
+
+    try:
+        raise_layout_error()
+    except Exception as exc:
+        with pytest.raises(AssertionError):
+            mgr.fail_with_traceback(module, exc)
+
+    assert module.failed == "Error: cannot import shardmap; expected the PARENT of /gobgp/"
+    assert "<traceback object at" not in module.failed
+    assert "raise_layout_error" in module.fail_kwargs["traceback"]
+    assert "ImportError" in module.fail_kwargs["traceback"]
+
+
+# --- teardown -----------------------------------------------------------------
+
+def test_absent_stops_only_the_removed_neighbor(tree):
+    """`absent` is a per-neighbor state, so the surviving daemons and the shim
+    pool keep serving while the removed one is dropped.
+    """
+    names = configure(3)
+    mgr.render_pool(mgr.collect_portmap(), core_count=2)
+    module = FakeModule()
+
+    mgr.remove_neighbor(module, names[1])
+
+    stops = [c for c in module.supervisor_actions
+             if c.startswith("supervisorctl stop")]
+    assert stops == ["supervisorctl stop gobgpd-ARISTA02T1"]
+    assert set(mgr.collect_portmap()) == {"5000", "5002"}
+    groups = read(tree.supervisor / "gobgpv4.conf")
+    assert "gobgpd-ARISTA02T1" not in groups
+    assert "gobgpd-ARISTA01T1" in groups
+
+
+def test_absent_removes_the_neighbor_from_the_next_portmap(tree):
+    names = configure(3)
+    mgr.remove_gobgp_conf(names[1])
+
+    assert not (tree.conf / "ARISTA02T1.toml").exists()
+    assert not (tree.supervisor / "gobgpd-ARISTA02T1.conf").exists()
+    assert set(mgr.collect_portmap()) == {"5000", "5002"}
+
+
+# --- module documentation -----------------------------------------------------
+
+def _argument_spec_keys():
+    """Parameter names from the module's AnsibleModule argument_spec."""
+    with open(mgr.__file__) as f:
+        tree = ast.parse(f.read())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "argument_spec" and isinstance(kw.value, ast.Call):
+                return {k.arg for k in kw.value.keywords}
+    raise AssertionError("argument_spec not found")
+
+
+def test_documentation_is_valid_ansible_yaml():
+    """ansible-doc parses DOCUMENTATION as YAML and reads `options` as a
+    mapping of parameter names, so a plain-scalar description or a capitalised
+    key leaves the module undocumented.
+    """
+    doc = yaml.safe_load(mgr.DOCUMENTATION)
+
+    assert doc["module"] == "gobgp"
+    assert isinstance(doc["options"], dict)
+    assert set(doc["options"]) == _argument_spec_keys()
+    for name, spec in doc["options"].items():
+        assert spec.get("description"), "%s has no description" % name
+
+
+def test_examples_are_valid_yaml():
+    tasks = yaml.safe_load(mgr.EXAMPLES)
+    assert isinstance(tasks, list) and tasks

--- a/ansible/roles/vm_set/files/gobgp/tests/test_manager.py
+++ b/ansible/roles/vm_set/files/gobgp/tests/test_manager.py
@@ -11,6 +11,7 @@ math, these fail.
 """
 import ast
 import hashlib
+import itertools
 import json
 import os
 import sys
@@ -159,7 +160,7 @@ def test_configure_writes_toml_program_and_spool_entry(tree):
     entry = json.loads(read(tree.spool / "ARISTA01T1.json"))
     assert entry == {
         "5000": {
-            "grpc": "127.0.0.1:50000",
+            "grpc": "127.0.0.1:61000",
             "family": "v4",
             "name": "ARISTA01T1",
             "peer": "10.0.0.1",
@@ -180,25 +181,17 @@ def test_configure_rejects_passive(tree):
     assert not (tree.conf / "N.toml").exists()
 
 
-def test_pprof_relocated_clear_of_shim_and_grpc_ranges(tree):
-    """gobgpd's default pprof port (6060) is a v6 shim HTTP port.
+def test_gobgpd_http_listener_is_disabled(tree):
+    """gobgpd serves pprof and prometheus metrics from one HTTP listener.
 
-    ``--pprof-disable`` is ineffective in the binary, so the manager relocates
-    the listener instead. The collision is invisible until a route POST lands on
-    the squatted port, which makes it worth pinning down here.
+    Disabling either alone leaves it bound, and its default port 6060 is the v6
+    shim HTTP port at offset 60. Both flags are required to remove it.
     """
-    grpc_lo = mgr.SHIM_PORT_MIN + mgr.GRPC_PORT_OFFSET
-    grpc_hi = mgr.SHIM_PORT_MAX + mgr.GRPC_PORT_OFFSET
-    for port in (5000, 5060, 6000, 6060, 6071):
-        pprof = mgr.pprof_port_for(port)
-        grpc = mgr.grpc_port_for(port)
-        assert not mgr.SHIM_PORT_MIN <= pprof <= mgr.SHIM_PORT_MAX
-        assert not grpc_lo <= pprof <= grpc_hi
-        assert pprof != grpc
-
     configure(1)
     program = read(tree.supervisor / "gobgpd-ARISTA01T1.conf")
-    assert "--pprof-host=127.0.0.1:60000" in program
+    assert "--pprof-disable" in program
+    assert '--metrics-path ""' in program
+    assert "--pprof-host" not in program
     assert ":6060" not in program
 
 
@@ -271,7 +264,7 @@ def test_fleet_pool_is_sized_by_cores_not_sessions(tree):
     for off in range(144):
         for base, family in ((5000, "v4"), (6000, "v6")):
             portmap[str(base + off)] = {
-                "grpc": "127.0.0.1:%d" % (base + off + 45000),
+                "grpc": "127.0.0.1:%d" % mgr.grpc_port_for(base + off),
                 "family": family, "name": "ARISTA%03dT1" % (off + 1),
             }
     assert len(portmap) == 288
@@ -445,6 +438,15 @@ def test_wait_treats_a_silent_group_as_pending(tree, monkeypatch):
     assert "UNKNOWN" in module.failed
 
 
+def test_wait_deadline_survives_a_wall_clock_jump(tree, monkeypatch):
+    """Bring-up takes minutes, and an NTP step must not end the wait early."""
+    monkeypatch.setattr(mgr.time, "sleep", lambda _s: None)
+    jumped = itertools.count(0, 3600)
+    monkeypatch.setattr(mgr.time, "time", lambda: 1e9 + next(jumped))
+    module = FakeModule(statuses={"gobgpv4": ["gobgpd-ARISTA01T1   STARTING", RUNNING]})
+    mgr.wait_groups_running(module, ["gobgpv4"], timeout=30)
+
+
 def test_wait_polls_the_group_not_each_program(tree, monkeypatch):
     """Per-program waits serialize hundreds of timeouts at fleet scale."""
     monkeypatch.setattr(mgr.time, "sleep", lambda _s: None)
@@ -453,60 +455,6 @@ def test_wait_polls_the_group_not_each_program(tree, monkeypatch):
 
     status_cmds = [c for c in module.commands if c.startswith("supervisorctl status")]
     assert status_cmds == ["supervisorctl status gobgpv4:"]
-
-
-# --- fd ceiling ---------------------------------------------------------------
-
-def test_fd_ceiling_clears_the_scale_that_failed_on_hardware(tree):
-    """288 processes overran the default 1024 limit and left 87 children FATAL.
-
-    Sizing purely off the process count would land at ~1.1k here -- just above
-    the limit that already failed -- so the floor carries the fleet case.
-    """
-    module = FakeModule()
-    needed = mgr.raise_fd_ceiling(module, 288)
-
-    assert needed >= 65536
-    assert any("prlimit" in c and "--nofile=%d:" % needed in c
-               for c in module.commands)
-
-
-@pytest.mark.parametrize("count,expected", [
-    (2, "floor"),                    # a 2-neighbor topology still gets the floor
-    (8192, "linear"),                # mid-range scales with the process count
-    (10 ** 6, "cap"),                # beyond the hard limit, prlimit would reject
-])
-def test_fd_ceiling_sizing_is_floor_then_linear_then_capped(tree, count, expected):
-    """The ceiling is piecewise: max(FD_FLOOR, per_process * n), capped at FD_HARD.
-
-    All three segments matter. Without the floor a fleet-sized run lands just
-    above the limit that already failed on hardware; without the cap the request
-    exceeds the hard limit and prlimit rejects it, which a best-effort call
-    swallows -- leaving the ceiling unraised.
-    """
-    module = FakeModule()
-    needed = mgr.raise_fd_ceiling(module, count)
-
-    if expected == "floor":
-        assert needed == mgr.FD_FLOOR
-    elif expected == "linear":
-        assert needed == mgr.FD_PER_PROCESS * count
-        assert needed <= mgr.FD_HARD
-    else:
-        assert needed == mgr.FD_HARD
-
-
-def test_fd_ceiling_is_best_effort(tree, monkeypatch):
-    """Small topologies never hit the limit; failing to raise it must not
-    regress them for a problem they do not have."""
-    class Failing(FakeModule):
-        def run_command(self, cmd):
-            self.commands.append(cmd)
-            return 1, "", "prlimit: not permitted"
-
-    module = Failing()
-    mgr.raise_fd_ceiling(module, 16)     # must not raise
-    assert module.failed is None
 
 
 # --- regression: portmap digest and group integrity ---------------------------
@@ -525,7 +473,7 @@ def test_growing_the_portmap_restarts_the_pool_even_when_k_is_saturated(tree):
         for off in range(72):
             for base, family in families:
                 out[str(base + off)] = {
-                    "grpc": "127.0.0.1:%d" % (base + off + 45000),
+                    "grpc": "127.0.0.1:%d" % mgr.grpc_port_for(base + off),
                     "family": family, "name": "ARISTA%02dT1" % off,
                 }
         return out
@@ -580,93 +528,43 @@ def test_absent_leaves_no_group_pointing_at_a_deleted_program(tree):
             "group references %s but its program file is gone" % program
 
 
-# --- ephemeral-port reservation ------------------------------------------------
+# --- derived listener ports ---------------------------------------------------
 
-def test_reserved_ports_cover_every_derived_listener(tree):
-    """The gRPC and pprof bands are derived, so the reservation must be too.
+def test_derived_grpc_ports_avoid_the_ephemeral_range(tree):
+    """The gRPC band must sit outside net.ipv4.ip_local_port_range.
 
-    Writing the ranges out by hand would let a change to either offset leave the
-    reservation pointing at the window the daemons no longer use.
-    """
-    module = FakeModule()
-    ranges = mgr.reserve_listener_ports(module)
-
-    reserved = set()
-    for span in ranges.split(","):
-        lo, hi = (int(x) for x in span.split("-"))
-        reserved.update(range(lo, hi + 1))
-
-    for port in (mgr.SHIM_PORT_MIN, 5500, 6000, mgr.SHIM_PORT_MAX):
-        assert mgr.grpc_port_for(port) in reserved
-        assert mgr.pprof_port_for(port) in reserved
-
-    assert any("ip_local_reserved_ports=%s" % ranges in c
-               for c in module.commands)
-
-
-def test_reserved_ports_cover_the_ephemeral_overlap(tree):
-    """Everything the daemons bind inside 32768-60999 must be reserved.
-
-    That window is the container default for net.ipv4.ip_local_port_range; a
-    fixed port inside it can be held by an outbound socket when a daemon
-    restarts, which is the failure this reservation exists to prevent.
+    Its per-netns kernel default is 32768-60999. A fixed port inside that window
+    can be held by a loopback ephemeral socket when a daemon restarts, so the
+    band is placed above it.
     """
     EPHEMERAL_LO, EPHEMERAL_HI = 32768, 60999
 
-    reserved = set()
-    for span in mgr.reserve_listener_ports(FakeModule()).split(","):
-        lo, hi = (int(x) for x in span.split("-"))
-        reserved.update(range(lo, hi + 1))
-
-    exposed = set()
     for port in range(mgr.SHIM_PORT_MIN, mgr.SHIM_PORT_MAX + 1):
-        for listener in (mgr.grpc_port_for(port), mgr.pprof_port_for(port)):
-            if EPHEMERAL_LO <= listener <= EPHEMERAL_HI:
-                exposed.add(listener)
-
-    assert exposed                      # the overlap is real, not hypothetical
-    assert exposed <= reserved
+        listener = mgr.grpc_port_for(port)
+        assert not EPHEMERAL_LO <= listener <= EPHEMERAL_HI
+        assert listener <= 65535
 
 
-def test_every_derived_listener_is_a_legal_port(tree):
-    """Guards the rejected fix for the overlap.
+def test_shim_and_grpc_bands_are_disjoint(tree):
+    """A derived gRPC port must never land on another neighbor's shim port."""
+    shim = set(range(mgr.SHIM_PORT_MIN, mgr.SHIM_PORT_MAX + 1))
+    grpc = {mgr.grpc_port_for(port) for port in shim}
+    assert not shim & grpc
 
-    Shifting the gRPC base above the ephemeral window would need an offset of
-    56000, which puts pprof (grpc + 10000) at 71000 -- past the 16-bit ceiling.
-    The reservation is used precisely because the bases cannot move.
+
+# --- filesystem helpers -------------------------------------------------------
+
+def test_remove_is_silent_only_for_a_missing_file(tmp_path):
+    """Callers delete paths that may be absent, so only that case is absorbed.
+
+    Anything else -- an unwritable directory, a path component that is a file --
+    would otherwise leave a supervisord program file behind while teardown
+    reported success.
     """
-    for port in (mgr.SHIM_PORT_MIN, mgr.SHIM_PORT_MAX):
-        assert mgr.grpc_port_for(port) <= 65535
-        assert mgr.pprof_port_for(port) <= 65535
+    mgr._remove(str(tmp_path / "never-written.conf"))
 
-
-def test_reserving_ports_is_best_effort(tree):
-    """A container without permission to set the sysctl must still deploy."""
-    class Failing(FakeModule):
-        def run_command(self, cmd):
-            self.commands.append(cmd)
-            return 1, "", "sysctl: permission denied"
-
-    module = Failing()
-    mgr.reserve_listener_ports(module)   # must not raise
-    assert module.failed is None
-
-
-def test_pool_reserves_the_listener_ports_before_the_fleet_spawns(tree):
-    """The reservation is useless once the daemons are already binding."""
-    configure(2)
-    module = FakeModule(statuses={g: [RUNNING] for g in ("gobgpv4", "gobgpshim")})
-    portmap = mgr.collect_portmap()
-    shards = mgr.render_pool(portmap, core_count=2)
-    mgr.raise_fd_ceiling(module, len(portmap) + shards)
-    mgr.reserve_listener_ports(module)
-    mgr.start_gobgp(module, mgr.existing_groups())
-
-    reserved_at = next(i for i, c in enumerate(module.commands)
-                       if "ip_local_reserved_ports" in c)
-    started_at = next(i for i, c in enumerate(module.commands)
-                      if c.startswith("supervisorctl start"))
-    assert reserved_at < started_at
+    with pytest.raises(IsADirectoryError):
+        mgr._remove(str(tmp_path))
 
 
 # --- deployed-package layout ---------------------------------------------------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,7 @@ stages:
 
         TARGET_BRANCH="${SYSTEM_PULLREQUEST_TARGETBRANCH:-refs/heads/master}"
         TARGET_BRANCH="${TARGET_BRANCH#refs/heads/}"
-        SHIM_PATH="ansible/roles/vm_set/files/gobgp"
+        SHIM_PATHS=("ansible/roles/vm_set/files/gobgp" "ansible/library/gobgp.py")
 
         # Default to running the tests. A gate that cannot work out its own
         # base must not drop coverage, and must not fail the pipeline either.
@@ -103,12 +103,12 @@ stages:
 
         if git fetch origin "${TARGET_BRANCH}" --depth=1 &&
            BASE_COMMIT=$(git merge-base "origin/${TARGET_BRANCH}" HEAD 2>/dev/null) &&
-           CHANGED_FILES=$(git diff --name-only "${BASE_COMMIT}" HEAD -- "${SHIM_PATH}" | tr '\n' ' '); then
+           CHANGED_FILES=$(git diff --name-only "${BASE_COMMIT}" HEAD -- "${SHIM_PATHS[@]}" | tr '\n' ' '); then
           if [[ -n "${CHANGED_FILES}" ]]; then
-            echo "Detected changes under ${SHIM_PATH}: ${CHANGED_FILES}"
+            echo "Detected changes under ${SHIM_PATHS[*]}: ${CHANGED_FILES}"
           else
             CHANGED="false"
-            echo "No changes detected under ${SHIM_PATH}"
+            echo "No changes detected under ${SHIM_PATHS[*]}"
           fi
         else
           echo "Cannot diff against origin/${TARGET_BRANCH}; running the tests"
@@ -116,7 +116,7 @@ stages:
 
         echo "##vso[task.setvariable variable=GOBGP_SHIM_CHANGED;isOutput=true]${CHANGED}"
       name: DetectChanges
-      displayName: "Check changed files under ansible/roles/vm_set/files/gobgp"
+      displayName: "Check changed files under the GoBGP shim and speaker manager"
 
   - job: static_analysis
     displayName: "Static Analysis"
@@ -204,7 +204,7 @@ stages:
     )
   jobs:
   - job: run_gobgp_shim_unit_tests
-    displayName: "Run GoBGP shim unit tests"
+    displayName: "Run GoBGP shim and speaker manager unit tests"
     timeoutInMinutes: 15
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -214,13 +214,15 @@ stages:
 
     - script: |
         set -euo pipefail
-        sudo uv pip install --system pytest
+        # jinja2 backs the speaker manager's config rendering; pyyaml backs the
+        # DOCUMENTATION schema test.
+        sudo uv pip install --system pytest jinja2 pyyaml
       displayName: "Install unit test dependencies"
 
     - script: |
         set -euo pipefail
         python -m pytest ansible/roles/vm_set/files/gobgp/tests -q -rs
-      displayName: "Run GoBGP shim unit tests"
+      displayName: "Run GoBGP shim and speaker manager unit tests"
 
 
 - stage: Test


### PR DESCRIPTION
### Description of PR

Adds `ansible/library/gobgp.py`, the ansible module that configures and launches the GoBGP PTF
speaker — the shim engine merged in
[sonic-mgmt PR 26701](https://github.com/sonic-net/sonic-mgmt/pull/26701).

Design: HLD [sonic-mgmt PR 26382](https://github.com/sonic-net/sonic-mgmt/pull/26382), change
set CS1.

**This module ships dormant.** ExaBGP remains the sole speaker every topology uses; the module
becomes reachable when the follow-up PR adds the `bgp_speaker` flag. Merge impact stays confined
to a widened CI gate.

Summary:
Fixes # (issue) — testbed framework work, tracked by the HLD above.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

**Targets `master` only.** New testbed framework code; release branches are unaffected.

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: N/A

### Tested branch

- [x] master

### Test result

- master: 39 unit-test cases pass (`ansible/roles/vm_set/files/gobgp/tests`), flake8 clean.

### Approach

#### What is the motivation for this PR?

ExaBGP advertises serially from Python — one text line per prefix, re-parsed and sent one UPDATE
at a time, rig-measured at ~1.45k prefixes/sec. That ceiling is what the HLD removes: per-session
delivery is 3.7×–9.7× faster with GoBGP, the ratio grows with route count, and the same serial path
is what makes announce/withdraw flaky at scale.

GoBGP moves encoding to Go and **decouples the API from the BGP process**. ExaBGP's config declares
its own API child, binding one API endpoint to one BGP process; GoBGP takes updates over gRPC, so
the injection front end becomes a *shared pool* sized to the machine rather than one process per
session.

That decoupling is what this module exploits, and it is what keeps the speedup deployable at fleet
scale: at 288 sessions a front end per neighbor costs ~11.5 GB, against ~640 MB for a pool of ~16 —
memory `O(cores)` not `O(sessions)`, inside the PTF container budget, with per-session delivery
unchanged by the pooling.

#### How did you do it?

**One `gobgpd` per neighbor, a shared shim pool in front.** Each neighbor gets a `gobgpd` holding
exactly that one session, so a route POSTed to a neighbor's port advertises over that neighbor's
session alone — matching ExaBGP's semantics. The pool is sized `min(cores, ports)`, and the port
split comes from `gobgp.shardmap`, **imported rather than reimplemented**, so the manager and the
shims agree on which shim owns which port.

**Two phases, because the pool spans the topology while ansible configures one neighbor at a time:**

| State | Scope | Writes |
|---|---|---|
| `configure` | per neighbor | the neighbor's TOML, its `gobgpd` supervisord program, its portmap spool entry |
| `pool` | topology-wide | merges the spool, sizes the pool, renders the shim programs and all group files |

`pool` is idempotent: it converges as more neighbors are configured, and prunes a shrinking pool.

##### Configuration files — ExaBGP vs GoBGP

| Purpose | ExaBGP | GoBGP |
|---|---|---|
| BGP session config | `/etc/exabgp/<name>.conf` — bespoke brace/semicolon DSL | `/etc/gobgp/<name>.toml` — TOML, gobgpd's native format |
| Injection API | **declared in the same file** (`process http-api { run … }`), forked by exabgp | **separate supervisord program** — injection rides gRPC |
| API helper source | `/usr/share/exabgp/http_api.py`, written at run time | ships in the PTF image |
| Runtime env | `/etc/exabgp/exabgp.env` | command-line flags |
| Port → session map | implicit; baked into each neighbor's config | `/etc/gobgp/portmap.json`, merged from `/etc/gobgp/portmap.d/` |
| Per-neighbor supervisord program | `/etc/supervisor/conf.d/exabgp-<name>.conf` | `/etc/supervisor/conf.d/gobgpd-<name>.conf` |
| Front-end supervisord programs | implicit (exabgp's own child) | `/etc/supervisor/conf.d/gobgpshim.conf` — **k** shim programs plus their group |
| Group files | templated by the playbook from `exabgp.conf.j2` | rendered **by the module**: `gobgpv4.conf`, `gobgpv6.conf`, `gobgpshim.conf` |

At 288 sessions that is 304 supervised programs (288 `gobgpd` + k shims) against ExaBGP's 288; a
one-shim-per-neighbor design would reach 576. The module owns the group files because `k` is known
only after the pool phase.

##### Four choices that carry evidence

| Choice | Why |
|---|---|
| `GOBGP_PORTMAP_DIGEST` in each shim's `environment=` | `supervisorctl update` restarts programs whose *config* changed, and the shim reads `portmap.json` once at startup. `announce_routes` runs the pool phase twice (v4, v6), so once `k` saturates the second render is byte-identical. At 72 neighbors on 16 cores, **all 72 v6 ports stayed unbound while every process reported RUNNING**. The digest changes only when the map changes, preserving idempotence |
| `reserve_listener_ports()` rather than higher port bases | gRPC (50000–51999) and v4 pprof (60000–60999) sit inside the default `ip_local_port_range`. Clearing 60999 by moving the bases puts pprof (`grpc + 10000`) at **71000, above the 16-bit ceiling**; reserving the bands stays inside it, best-effort and namespaced to the PTF container |
| `prlimit` rather than `[supervisord] minfds` | The 1024 default left **87 of 288 children FATAL** on a physical chassis. Per supervisor 4.3.0, `minfds` runs `close_fd()` per descriptor **in every forked child** and exits supervisord when the container hard limit sits below it; `prlimit` lifts the `EMFILE` constraint alone |
| `fail_with_traceback()` rather than `str(sys.exc_info())` | The inherited idiom renders the 3-tuple, yielding `<traceback object at 0x…>`. Failures here name a missing package or an unwritable path, where the frame is the diagnostic |

Also from that hardware run: `gobgpd` runs non-listening (`port = -1`, active outbound connect,
since PTF speakers share one `local_ip`), and pprof is relocated off its `127.0.0.1:6060` default,
which collides with the v6 shim port at offset 60.

#### How did you verify/test it?

39 unit-test cases cover both phases, shard math asserted against `shardmap.partition`, ordered
bring-up and reverse teardown, group integrity, the fd ceiling, the port reservation, the
deployed-package layout, and the DOCUMENTATION schema. A 19-mutation matrix — dropping the digest,
the fd floor/cap, the port reservation, the group family filter, the passive guard, among others —
was **caught in full** by the tests claiming those behaviors. The deploy path and caller sequence
become reachable with the wiring PR.

**CI gate:** the GoBGP change detector covered `ansible/roles/vm_set/files/gobgp` alone, so a
speaker manager in `ansible/library` would have merged with the unit tests skipped. This PR widens
it to both paths, and adds `jinja2` (config rendering) and `pyyaml` (the DOCUMENTATION schema
test).

#### Any platform specific information?

Runs in the PTF container, opens no DB connection, and stays platform-agnostic. The
`gobgpd`/`gobgp` binaries and gRPC stubs ship in `docker-ptf` (merged in sonic-buildimage).

#### Supported testbed topology if it's a new test case?

N/A. Once wired in, the speaker is topology-agnostic and selected by `bgp_speaker`, defaulting to
`exabgp`.

### Pending / out of scope

Planned for subsequent PRs:

| # | Item |
|---|---|
| 1 | `bgp_speaker` variable and the `announce_routes.yml` branch — the flip that makes the speaker reachable |
| 2 | `ptf_control.py` reaper coverage for `gobgpd` and the shims |
| 3 | Batched route driver |
| 4 | End-to-end testbed evidence (KVM t0/t1/dualtor/m0 equivalence: `bgp_speaker=gobgp` == `exabgp`) |
| 5 | Receive path / `test_bgpmon` migration |
| 6 | ExaBGP retirement — out of series; `bgp_speaker` is reversible and ExaBGP stays the default |

**Two contracts the wiring PR honours**, as invariants of this module:

1. **Package layout.** `GOBGP_PKG_DIR` (`/usr/share/gobgp`) serves as this module's import root and
   the shims' `PYTHONPATH`, so the package lands at `/usr/share/gobgp/gobgp/`. `load_shardmap()`
   raises an error naming that layout.
2. **Caller sequence.** `state=configure` per neighbor → **exactly one `state=pool` per family
   pass** → `supervisorctl start <group>:`. The module renders the group files, so the playbook
   leaves them alone; `EXAMPLES` demonstrates the sequence.

### Documentation

The module self-documents via `ansible-doc` — `DOCUMENTATION` and `EXAMPLES` cover every state,
the two-phase contract, and the package layout. Design lives in the HLD linked above; the runbook
lands with the wiring PR.
