### PR TITLE
tests/voq: Fix failures for multi-ASIC DUT connected to a cEOS neighbor

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -811,9 +811,10 @@ class EosHost(AnsibleHostBase):
             return re.match(r'\d+', v.strip()).group() + '000'
         return list(map(extract_speed_only, speed_list))
 
-    def get_dut_iface_mac(self, interface_name):
+    def get_dut_iface_mac(self, interface_name, use_bridge_mac=False):
         """
         Gets the MAC address of specified interface.
+        If use_bridge_mac is true, get the bridge MAC instead of the routed MAC
 
         Returns:
             str: The MAC address of the specified interface, or None if it is not found.
@@ -822,7 +823,7 @@ class EosHost(AnsibleHostBase):
             command = 'show interfaces {} | json'.format(interface_name)
             output = self.eos_command(commands=[command])['stdout'][0]
             forwardingModel = output["interfaces"][interface_name]["forwardingModel"]
-            if forwardingModel == "routed":
+            if use_bridge_mac and forwardingModel == "routed":
                 self.eos_config(
                     lines=['switchport'],
                     parents=['interface {}'.format(interface_name)])

--- a/tests/common/macsec/macsec_helper.py
+++ b/tests/common/macsec/macsec_helper.py
@@ -139,7 +139,7 @@ def get_appl_db(host, host_port_name, peer, peer_port_name):
     if isinstance(peer, EosHost):
         re_match = re.search(r'\d+', peer_port_name)
         peer_port_identifer = int(re_match.group())
-        peer_sci = get_sci(peer.get_dut_iface_mac(peer_port_name), peer_port_identifer)
+        peer_sci = get_sci(peer.get_dut_iface_mac(peer_port_name, use_bridge_mac=True), peer_port_identifer)
     else:
         peer_sci = get_sci(peer.get_dut_iface_mac(peer_port_name))
     egress_sc_table = sonic_db_cli(


### PR DESCRIPTION
### Description of PR
Summary:

The VOQ tests described in the linked issue fail when run on a multi-ASIC with a cEOS neighbour.

The solution is to use the routed MAC address for all tests but the MACsec tests in which the bridge MAC address is used instead.

Fixes #27395

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #27395 
Failure type: regression

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

VOQ tests run on 202605: 79/93 tests pass
VOQ tests run on 202605 with this change: 89/93 tests pass (remaining failures to be investigated)

### Approach
#### What is the motivation for this PR?
Fix the failing VOQ tests for multi-ASIC DUTs with cEOS neighbour

#### How did you do it?
Change the way we retrieve the MAC address for a cEOS neighbour: use the routed MAC address for all tests but the MACsec tests in which the bridge MAC address is used.
Solution from @peterbailey-arista.

#### How did you verify/test it?
Ran the VOQ tests on a multi-ASIC DUT with a cEOS neighbour.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A