### PR TITLE
[bmc][bmp]: Skip test_restart_bmp_docker on bmc topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -782,6 +782,12 @@ bmp/:
     conditions:
       - "release in ['master']"
 
+bmp/test_docker_restart.py::test_restart_bmp_docker:
+  skip:
+    reason: "BMP service is not present on bmc topology"
+    conditions:
+      - "topo_type in ['bmc']"
+
 #######################################
 #####            cacl             #####
 #######################################


### PR DESCRIPTION
### Description of PR
Summary:
Fixes #27441

`bmp/test_docker_restart.py::test_restart_bmp_docker` calls `asichost.restart_service("bmp")`, which runs `sudo systemctl start bmp`. On `bmc` topology the BMP service is not present, so this fails with `Failed to start bmp.service: Unit bmp.service not found.` (rc=5) instead of being skipped.

This PR skips the test on `bmc` topology using the `conditional_mark` plugin (no in-code changes to the test).

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202608

### Approach
#### What is the motivation for this PR?
The test hard-fails on `bmc` topology testbeds (e.g. `str4-Nokia-7220-Th6p-1-bmc` on `vms77-bmc-7220-1`), producing false negatives because the BMP service is not present there.

#### How did you do it?
Added a `conditional_mark` entry in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` that skips `bmp/test_docker_restart.py::test_restart_bmp_docker` when `topo_type in ['bmc']`. This keeps the skip policy in the central conditions file and leaves the test body unchanged.

#### How did you verify/test it?
- Verified the YAML parses and the new key resolves to the expected skip condition.
- On a `bmc` topology, the test is marked skipped; on other topologies it runs as before.

#### Any platform specific information?
Skips on `bmc` topology.

#### Supported testbed topology if it's a new test case?
N/A — existing test.

### Documentation
N/A