### PR TITLE
[bmc]: Skip test_metadata_bgp on BMC topology as BGP is not running

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3774,6 +3774,15 @@ memory_checker/test_memory_checker.py:
       - "release in ['202412']"
 
 #######################################
+#####       metadata-scripts      #####
+#######################################
+metadata-scripts/test_metadata_bgp.py:
+  skip:
+    reason: "BGP is not running on BMC topology"
+    conditions:
+      - "'bmc' in topo_type"
+
+#######################################
 #####            mpls             #####
 #######################################
 mpls:


### PR DESCRIPTION
### Description of PR

Skip `metadata-scripts/test_metadata_bgp.py` on BMC topologies. BGP is not running on BMC, so the get loopback interface `get_lo_intf` module fixture fails at setup with `IndexError: list index out of range` (fewer than 2 entries in `minigraph_lo_interfaces`), erroring out the traffic-shift tests.

Summary:

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202608

### Approach
#### What is the motivation for this PR?

On a BMC testbed, the BGP traffic-shift tests error during setup because BGP/loopback interfaces are not configured the way the test expects:

```
tests/metadata-scripts/test_metadata_bgp.py:47: IndexError: list index out of range
  addr = mg_facts["minigraph_lo_interfaces"][i]["addr"]
```

BMC does not run BGP, so these tests are not applicable and should be skipped rather than error.

#### How did you do it?

Added a conditional-mark entry in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` to skip the whole `metadata-scripts/test_metadata_bgp.py` file when `'bmc' in topo_type`. This is the standard code-free way to skip tests by topology, and requires no changes to the test itself.

#### How did you verify/test it?

Validated the YAML parses and the new entry loads correctly via `yaml.safe_load`.

#### Any platform specific information?

Applies to BMC topologies only.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A