### PR TITLE
[dhcp_relay] Centralize server reply giaddr selection for OFFER/ACK/NAK packet builders

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -585,13 +585,16 @@ class DHCPTest(DataplaneBaseTest):
             pkt /= scapy.PADDING("\x00" * padding_bytes)
         return pkt
 
+    # Choose the IP a DHCP server should reply to. Source-interface and server-VRF
+    # paths use Loopback as giaddr; server-id-override/vrf-selection use relay iface IP.
+    def get_server_reply_giaddr(self):
+        if (self.link_selection and self.source_interface) or self.server_vrf:
+            return self.switch_loopback_ip
+        return self.relay_iface_ip
+
     def create_dhcp_offer_packet(self):
-        if (self.link_selection and self.source_interface) or self.dual_tor:
-            ip_dst = self.switch_loopback_ip
-            ip_gateway = self.switch_loopback_ip
-        elif self.server_id_override or not self.dual_tor:
-            ip_dst = self.relay_iface_ip
-            ip_gateway = self.relay_iface_ip
+        ip_dst = self.get_server_reply_giaddr()
+        ip_gateway = ip_dst
 
         return self.dhcp_offer_packet(
             eth_server=self.server_iface_mac,
@@ -624,13 +627,8 @@ class DHCPTest(DataplaneBaseTest):
         udp = scapy.UDP(sport=self.DHCP_SERVER_PORT,
                         dport=self.DHCP_CLIENT_PORT)
 
-        giaddr = self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip
+        giaddr = self.get_server_reply_giaddr()
         siaddr = self.server_ip[0]
-        if self.relay_agent == "sonic-relay-agent":
-            if self.server_id_override:
-                giaddr = self.relay_iface_ip
-            elif (self.link_selection and self.source_interface):
-                giaddr = self.switch_loopback_ip
 
         bootp = scapy.BOOTP(op=2,
                             htype=1,
@@ -817,15 +815,8 @@ class DHCPTest(DataplaneBaseTest):
         return self.merge_layers_to_packet(ether, ip, udp, bootp)
 
     def create_dhcp_ack_packet(self):
-        if self.server_id_override:
-            ip_dst = self.relay_iface_ip
-            ip_gateway = self.relay_iface_ip
-        elif (self.link_selection and self.source_interface):
-            ip_dst = self.switch_loopback_ip
-            ip_gateway = self.switch_loopback_ip
-        else:
-            ip_dst = self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip
-            ip_gateway = ip_dst
+        ip_dst = self.get_server_reply_giaddr()
+        ip_gateway = ip_dst
 
         dhcp_ack_packet = testutils.dhcp_ack_packet(
                           eth_server=self.server_iface_mac,
@@ -860,10 +851,7 @@ class DHCPTest(DataplaneBaseTest):
         udp = scapy.UDP(sport=self.DHCP_SERVER_PORT,
                         dport=self.DHCP_CLIENT_PORT, len=262)
         # Choose giaddr based on test mode
-        if (self.link_selection and self.source_interface) or self.dual_tor:
-            giaddr = self.switch_loopback_ip
-        elif self.server_id_override or not self.dual_tor:
-            giaddr = self.relay_iface_ip
+        giaddr = self.get_server_reply_giaddr()
 
         bootp = scapy.BOOTP(op=2,
                             htype=1,

--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -17,8 +17,57 @@ from tests.common.dhcp_relay_utils import (
         sonic_dhcp_relay_config,
         sonic_dhcp_relay_unconfig
 )
+from tests.common.dhcp_relay_utils import wait_dhcp_relay_ready
 from tests.common.dhcp_relay_utils import enable_sonic_dhcpv4_relay_agent  # noqa: F401
 import json
+
+
+# both the VRF master and the expected IP before sending PTF traffic.
+def _interface_ready_in_vrf(duthost, iface, vrf_name, ip_addr):
+    vrf_ok = duthost.shell(
+        f"ip -d link show dev {iface} | grep -w 'master {vrf_name}'",
+        module_ignore_errors=True
+    )["rc"] == 0
+    ip_ok = duthost.shell(
+        f"ip -4 addr show dev {iface} | grep -w '{ip_addr}'",
+        module_ignore_errors=True
+    )["rc"] == 0
+    return vrf_ok and ip_ok
+
+
+def _all_portchannels_up(duthost, portchannels):
+    int_status = duthost.show_interface(command="status")["ansible_facts"]["int_status"]
+    for pc in portchannels:
+        if pc not in int_status:
+            return False
+        if int_status[pc].get("admin_state") != "up":
+            return False
+        if int_status[pc].get("oper_state") != "up":
+            return False
+    return True
+
+
+def _remove_saved_interface_ips(duthost, saved_entries, interface):
+    for key in list(saved_entries.keys()):
+        parts = key.split("|", 2)
+        if len(parts) == 3 and parts[1] == interface:
+            duthost.shell(
+                f"sudo config interface ip remove {interface} {parts[2]}",
+                module_ignore_errors=True)
+
+
+def _swss_process_running(duthost, process):
+    output = duthost.shell(
+        f"docker exec swss supervisorctl status {process}",
+        module_ignore_errors=True)["stdout"]
+    return "RUNNING" in output
+
+
+def _restart_tunnel_packet_handler(duthost):
+    duthost.shell(
+        "docker exec swss supervisorctl restart tunnel_packet_handler",
+        module_ignore_errors=True)
+    return wait_until(60, 5, 0, _swss_process_running, duthost, "tunnel_packet_handler")
 
 
 def _save_interface_ip_entries(duthost, table, interface):
@@ -552,9 +601,17 @@ def test_dhcp_relay_with_non_default_vrf(
                     duthost.shell(
                         f"sudo config interface ip remove {loopback_for_src} {ip_with_mask}",
                         module_ignore_errors=True)
+            # source_intf makes dhcp4relay use Loopback as giaddr. Move Loopback into the
+            # client VRF so the server reply to Loopback is trapped in the correct VRF.
             duthost.shell(
                 f"sudo config interface vrf bind {loopback_for_src} {CLIENT_VRF_NAME}")
             _restore_interface_ip_entries(duthost, saved_loopback_ips)
+            pytest_assert(
+                wait_until(60, 5, 0, _interface_ready_in_vrf,
+                           duthost, loopback_for_src, CLIENT_VRF_NAME,
+                           dut_dhcp_relay_data[0]["switch_loopback_ip"]),
+                f"{loopback_for_src} is not ready in {CLIENT_VRF_NAME}"
+            )
 
         for dhcp_relay in dut_dhcp_relay_data:
             dhcp_servers = ",".join(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
@@ -575,6 +632,7 @@ def test_dhcp_relay_with_non_default_vrf(
                 duthost.shell(f'config dhcpv4_relay add --dhcpv4-servers {dhcp_servers}'
                               f' --vrf-selection enable --server-id-override enable {vlan_iface}')
                 server_id_override = True
+            wait_dhcp_relay_ready(duthost, ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc'])
 
             # Run the DHCP relay test on the PTF host
             ptf_runner(ptfhost,
@@ -621,21 +679,28 @@ def test_dhcp_relay_with_non_default_vrf(
         # deleting the VRF so it has no remaining member interfaces.
         # Only needed when we rebound it (source_intf testcase).
         if saved_loopback_ips:
-            loopback_ip_key_prefix = "LOOPBACK_INTERFACE|{}|".format(loopback_for_src)
-            for key in list(saved_loopback_ips.keys()):
-                if key.startswith(loopback_ip_key_prefix):
-                    ip_with_mask = key.split("|", 2)[2]
-                    duthost.shell(
-                        f"sudo config interface ip remove {loopback_for_src} {ip_with_mask}",
-                        module_ignore_errors=True)
+            _remove_saved_interface_ips(duthost, saved_loopback_ips, loopback_for_src)
             duthost.shell(
                 f"sudo config interface vrf unbind {loopback_for_src}",
                 module_ignore_errors=True)
 
-        # VRF config cleanup
+        # VRF config cleanup. Unbind interfaces explicitly before deleting the
+        # VRF to avoid transient kernel/FRR/tunnel handler races.
         duthost.shell(f"sudo config route del prefix vrf {CLIENT_VRF_NAME} 0.0.0.0/0 nexthop"
-                      f" vrf {CLIENT_VRF_NAME} {first_params['nexthop']}")
-        duthost.shell(f"sudo config vrf del {CLIENT_VRF_NAME}")
+                      f" vrf {CLIENT_VRF_NAME} {first_params['nexthop']}",
+                      module_ignore_errors=True)
+        _remove_saved_interface_ips(duthost, saved_vlan_ips, vlan_iface)
+        duthost.shell(
+            f"sudo config interface vrf unbind {vlan_iface}",
+            module_ignore_errors=True)
+
+        for pc in portchannels:
+            _remove_saved_interface_ips(duthost, saved_pc_ips, pc)
+            duthost.shell(
+                f"sudo config interface vrf unbind {pc}",
+                module_ignore_errors=True)
+
+        duthost.shell(f"sudo config vrf del {CLIENT_VRF_NAME}", module_ignore_errors=True)
 
         # Restore all interface CONFIG_DB entries (base entry, IPs, and attributes).
         # "config interface vrf bind" strips ALL IPs (secondary IPv4, IPv6, etc.),
@@ -647,6 +712,17 @@ def test_dhcp_relay_with_non_default_vrf(
         _restore_interface_ip_entries(duthost, saved_loopback_ips)
         _restore_interface_ip_entries(duthost, saved_vlan_ips)
         _restore_interface_ip_entries(duthost, saved_pc_ips)
+        duthost.shell("sudo config save -y")
+        # PortChannels can flap during VRF cleanup. Wait for them to recover before
+        # restarting tunnel_packet_handler so later tests do not inherit stale state.
+        pytest_assert(
+            wait_until(150, 5, 0, _all_portchannels_up, duthost, list(portchannels.keys())),
+            "PortChannels did not recover to admin/oper up after VRF cleanup"
+        )
+        pytest_assert(
+            _restart_tunnel_packet_handler(duthost),
+            "tunnel_packet_handler did not recover after PortChannels came up"
+        )
         duthost.shell("sudo config save -y")
 
 
@@ -760,9 +836,17 @@ def test_dhcp_relay_with_different_non_default_vrf(
                 duthost.shell(
                     f"sudo config interface ip remove {loopback_for_src} {ip_with_mask}",
                     module_ignore_errors=True)
+        # Server replies enter through SERVER_VRF_NAME and target Loopback giaddr.
+        # Bind Loopback to the server VRF so IP2ME/trap handling exists in that VRF.
         duthost.shell(
             f"sudo config interface vrf bind {loopback_for_src} {SERVER_VRF_NAME}")
         _restore_interface_ip_entries(duthost, saved_loopback_ips)
+        pytest_assert(
+            wait_until(60, 5, 0, _interface_ready_in_vrf,
+                       duthost, loopback_for_src, SERVER_VRF_NAME,
+                       dut_dhcp_relay_data[0]["switch_loopback_ip"]),
+            f"{loopback_for_src} is not ready in {SERVER_VRF_NAME}"
+        )
 
         for dhcp_relay in dut_dhcp_relay_data:
             dhcp_servers = ",".join(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
@@ -821,27 +905,33 @@ def test_dhcp_relay_with_different_non_default_vrf(
         duthost.shell(f"config dhcpv4_relay del {vlan_iface}", module_ignore_errors=True)
 
         # Unbind the source-interface Loopback from SERVER_VRF_NAME before
-        # deleting the VRF so it has no remaining member interfaces. Restore
-        # the saved CONFIG_DB entries so all original Loopback IP attributes
-        # (IPv4, IPv6, secondary flag, etc.) come back.
+        # deleting the VRF so it has no remaining member interfaces.
         if saved_loopback_ips:
-            for key in list(saved_loopback_ips.keys()):
-                if key.startswith(loopback_ip_key_prefix):
-                    ip_with_mask = key.split("|", 2)[2]
-                    duthost.shell(
-                        f"sudo config interface ip remove {loopback_for_src} {ip_with_mask}",
-                        module_ignore_errors=True)
+            _remove_saved_interface_ips(duthost, saved_loopback_ips, loopback_for_src)
             duthost.shell(
                 f"sudo config interface vrf unbind {loopback_for_src}",
                 module_ignore_errors=True)
             _restore_interface_ip_entries(duthost, saved_loopback_ips)
 
-        # VRF config cleanup
+        # VRF config cleanup. Unbind interfaces explicitly before deleting the
+        # VRFs to avoid transient kernel/FRR/tunnel handler races.
         duthost.shell(f"sudo config route del prefix vrf {SERVER_VRF_NAME} 0.0.0.0/0 nexthop"
-                      f" vrf {SERVER_VRF_NAME} {first_params['nexthop']}")
+                      f" vrf {SERVER_VRF_NAME} {first_params['nexthop']}",
+                      module_ignore_errors=True)
 
-        duthost.shell(f"sudo config vrf del {CLIENT_VRF_NAME}")
-        duthost.shell(f"sudo config vrf del {SERVER_VRF_NAME}")
+        _remove_saved_interface_ips(duthost, saved_vlan_ips, vlan_iface)
+        duthost.shell(
+            f"sudo config interface vrf unbind {vlan_iface}",
+            module_ignore_errors=True)
+
+        for pc in portchannels:
+            _remove_saved_interface_ips(duthost, saved_pc_ips, pc)
+            duthost.shell(
+                f"sudo config interface vrf unbind {pc}",
+                module_ignore_errors=True)
+
+        duthost.shell(f"sudo config vrf del {CLIENT_VRF_NAME}", module_ignore_errors=True)
+        duthost.shell(f"sudo config vrf del {SERVER_VRF_NAME}", module_ignore_errors=True)
 
         # Restore all interface CONFIG_DB entries (base entry, IPs, and attributes).
         # "config interface vrf bind" strips ALL IPs (secondary IPv4, IPv6, etc.),
@@ -850,9 +940,20 @@ def test_dhcp_relay_with_different_non_default_vrf(
         # Instead, we save and restore the exact CONFIG_DB entries via redis-cli,
         # preserving all attributes (e.g. the secondary flag). intfmgrd then
         # automatically applies the restored entries to the kernel.
+        _restore_interface_ip_entries(duthost, saved_loopback_ips)
         _restore_interface_ip_entries(duthost, saved_vlan_ips)
         _restore_interface_ip_entries(duthost, saved_pc_ips)
         duthost.shell("sudo config save -y")
+        # PortChannels can flap during VRF cleanup. Wait for them to recover before
+        # restarting tunnel_packet_handler so later tests do not inherit stale state.
+        pytest_assert(
+            wait_until(150, 5, 0, _all_portchannels_up, duthost, list(portchannels.keys())),
+            "PortChannels did not recover to admin/oper up after VRF cleanup"
+        )
+        pytest_assert(
+            _restart_tunnel_packet_handler(duthost),
+            "tunnel_packet_handler did not recover after PortChannels came up"
+        )
 
 
 @pytest.mark.parametrize("max_hop_count", [CONFIG_HOP_COUNT, MAX_HOP_COUNT])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Centralize server reply giaddr selection for OFFER/ACK/NAK packet builders

Summary:
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/1358
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
Verified test_dhcp_relay_option82_suboptions[source_intf-sonic-relay-agent], test_dhcp_relay_option82_suboptions[server_id_override-sonic-relay-agent] and test_dhcp_relay_default in branch.202605-ars.81ed8a32-buildimage.94f39efbfba9878881126e45c3b926decb74dd48-nightly-2026.09.16.15.47

### Approach
#### What is the motivation for this PR?
Centralize server reply giaddr selection for OFFER/ACK/NAK packet builders

#### How did you do it?
Added these fixes

- A central method to get the server reply giaddr selection for OFFER/ACK/NAK packet builders
- call these methods in discover , request and ack packet constructions

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Verified test_dhcp_relay_option82_suboptions[source_intf-sonic-relay-agent], test_dhcp_relay_option82_suboptions[server_id_override-sonic-relay-agent] and test_dhcp_relay_default in branch.202605-ars.81ed8a32-buildimage.94f39efbfba9878881126e45c3b926decb74dd48-nightly-2026.09.16.15.47

| Topology | Relayed DISCOVER `giaddr` | OFFER/ACK destination | OFFER/ACK `giaddr` | Relayed BOOTP `giaddr` |
|---|---|---|---|---|
| Single-ToR T0 | `192.168.0.1` | `192.168.0.1` | `192.168.0.1` | `192.168.0.1` |
| Dual-ToR | `10.1.0.32` | `10.1.0.32` | `10.1.0.32` | `192.168.0.1` |

[t0_logs.tgz](https://github.com/user-attachments/files/32509138/t0_logs.tgz)
[dualtor_logs.tgz](https://github.com/user-attachments/files/32509149/dualtor_logs.tgz)

validated in t0 topology and dualtor AA topology

### Test results

| Test | Status |
| --- | --- |
| `tests/dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default` | PASS |
| `tests/dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_option82_suboptions[source_intf-sonic-relay-agent]` | PASS |
| `tests/dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_option82_suboptions[server_id_override-sonic-relay-agent]` | SKIPPED |

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
