### PR TITLE
snappi/pfcwd: use get_pfcwd_timers in burst-storm and multi-node helpers

### DIFF
--- a/tests/snappi_tests/pfcwd/files/pfcwd_burst_storm_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_burst_storm_helper.py
@@ -5,8 +5,7 @@ import random
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id              # noqa: F401
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
-    get_pfcwd_poll_interval, get_pfcwd_detect_time, get_pfcwd_restore_time, \
-    enable_packet_aging, start_pfcwd, sec_to_nanosec                             # noqa: F401
+    get_pfcwd_timers, enable_packet_aging, start_pfcwd, sec_to_nanosec           # noqa: F401
 from tests.common.snappi_tests.port import select_ports, select_tx_port           # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
@@ -73,9 +72,10 @@ def run_pfcwd_burst_storm_test(api,
     start_pfcwd(ingress_duthost, tx_port['asic_value'])
     enable_packet_aging(ingress_duthost)
 
-    poll_interval_sec = get_pfcwd_poll_interval(egress_duthost, rx_port['asic_value']) / 1000.0
-    detect_time_sec = get_pfcwd_detect_time(host_ans=egress_duthost, intf=rx_port['peer_port'], asic_value=rx_port['asic_value']) / 1000.0        # noqa: E501
-    restore_time_sec = get_pfcwd_restore_time(host_ans=egress_duthost, intf=rx_port['peer_port'], asic_value=rx_port['asic_value']) / 1000.0      # noqa: E501
+    timers = get_pfcwd_timers(egress_duthost, rx_port['peer_port'], rx_port['asic_value'])
+    poll_interval_sec = timers['poll_interval']
+    detect_time_sec = timers['detection_time']
+    restore_time_sec = timers['restoration_time']
     burst_cycle_sec = poll_interval_sec + detect_time_sec + restore_time_sec + 0.1
     data_flow_dur_sec = ceil(burst_cycle_sec * BURST_EVENTS)
     pause_flow_dur_sec = poll_interval_sec * 0.5

--- a/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
@@ -6,7 +6,7 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                              # noqa: F401
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
-    start_pfcwd, enable_packet_aging, get_pfcwd_poll_interval, get_pfcwd_detect_time, \
+    start_pfcwd, enable_packet_aging, get_pfcwd_timers, \
     sec_to_nanosec                                                                                # noqa: F401
 from tests.common.snappi_tests.port import select_ports                                           # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp                                 # noqa: F401
@@ -103,9 +103,9 @@ def run_pfcwd_multi_node_test(api,
         start_pfcwd(duthost, asic)
         enable_packet_aging(duthost)
 
-    poll_interval_sec = get_pfcwd_poll_interval(egress_duthost, rx_port['asic_value']) / 1000.0
-    detect_time_sec = get_pfcwd_detect_time(host_ans=egress_duthost, intf=rx_port['peer_port'],
-                                            asic_value=rx_port['asic_value']) / 1000.0
+    timers = get_pfcwd_timers(egress_duthost, rx_port['peer_port'], rx_port['asic_value'])
+    poll_interval_sec = timers['poll_interval']
+    detect_time_sec = timers['detection_time']
 
     if trigger_pfcwd:
         pfc_storm_dur_sec = poll_interval_sec + detect_time_sec


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #27454

`run_pfcwd_burst_storm_test` (`tests/snappi_tests/pfcwd/files/pfcwd_burst_storm_helper.py`) and `run_pfcwd_multi_node_test` (`tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py`) read the pfcwd timers with the raw getters (`get_pfcwd_poll_interval` / `get_pfcwd_detect_time` / `get_pfcwd_restore_time`) and divide by 1000.0 immediately. On a platform whose image ships without a default pfcwd profile, `pfcwd start_default` is effectively a no-op, the CONFIG_DB `PFC_WD` table stays unpopulated, the getters return `None`, and the tests error out during setup:

```
TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'
```

`get_pfcwd_timers()` in `tests/common/snappi_tests/common_helpers.py` (added in #25950) already solves this for `pfcwd_basic_helper.py`: it reads all three timers, skips the test via `pytest_require` with a clear message when any is missing, and converts ms to seconds. This PR switches the two remaining helpers to it, matching the basic helper's idiom.

The multi-node helper only consumes `poll_interval` and `detection_time`; `get_pfcwd_timers` still validates all three fields, which is correct since they are populated together by `pfcwd start_default`.

The pattern dates back to the original snappi migration in #3906. No behavioral change when PFC_WD config is present — the same three CONFIG_DB reads and the same ms-to-sec conversion happen inside `get_pfcwd_timers()`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202512
- [x] 202605
- [ ] N/A

### Tested branch

- [x] master

### Test result

Static verification: flake8 and `py_compile` pass on both files; no remaining references to the removed imports.

Behavior with PFC_WD configured is unchanged by construction — `get_pfcwd_timers()` performs the identical getter calls and `/ 1000.0` conversion the helpers did inline. The skip path (PFC_WD absent) is the same code already exercised daily by `test_pfcwd_basic_with_snappi.py` since #25950.