### PR TITLE
Dom basic registry refactor

### DIFF
--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -32,32 +32,41 @@ LANE_NUM_PLACEHOLDER = "LANE_NUM"
 MEDIA_LANE_MASK_KEY = "media_lane_mask"
 DomMappedField = namedtuple("DomMappedField", ("source_attr", "attr_value"))
 DomThresholdMappedField = namedtuple("DomThresholdMappedField", ("source_attr", "attr_value", "threshold_key"))
+DomQuantitySpec = namedtuple(
+    "DomQuantitySpec",
+    ("threshold_db_prefix", "sensor_field_template", "operational_attr", "consistency_unit"),
+)
 
 THRESHOLD_FIELD_SUFFIXES = ("lowalarm", "lowwarning", "highwarning", "highalarm")
+DOM_QUANTITY_REGISTRY = {
+    "temperature": DomQuantitySpec("temp", "temperature", "temperature_operational_range", "C"),
+    "voltage": DomQuantitySpec("vcc", "voltage", "voltage_operational_range", "V"),
+    "laser_temperature": DomQuantitySpec(
+        "lasertemp",
+        "laser_temperature",
+        "laser_temperature_operational_range",
+        "C",
+    ),
+    "tx_power": DomQuantitySpec("txpower", "tx{}power", "txLANE_NUMpower_operational_range", "dB"),
+    "rx_power": DomQuantitySpec("rxpower", "rx{}power", "rxLANE_NUMpower_operational_range", "dB"),
+    "tx_bias": DomQuantitySpec("txbias", "tx{}bias", "txLANE_NUMbias_operational_range", "percent"),
+}
 THRESHOLD_FIELD_PREFIXES = {
-    "temperature": "temp",
-    "voltage": "vcc",
-    "laser_temperature": "lasertemp",
-    "tx_bias": "txbias",
-    "tx_power": "txpower",
-    "rx_power": "rxpower",
+    base_name: spec.threshold_db_prefix
+    for base_name, spec in DOM_QUANTITY_REGISTRY.items()
 }
 THRESHOLD_TO_OPERATIONAL_ATTR = {
-    "temperature": "temperature_operational_range",
-    "voltage": "voltage_operational_range",
-    "laser_temperature": "laser_temperature_operational_range",
-    "tx_bias": "txLANE_NUMbias_operational_range",
-    "tx_power": "txLANE_NUMpower_operational_range",
-    "rx_power": "rxLANE_NUMpower_operational_range",
+    base_name: spec.operational_attr
+    for base_name, spec in DOM_QUANTITY_REGISTRY.items()
 }
 THRESHOLD_VALUE_TOLERANCE = 0.01
 CONSISTENCY_FIELD_TEMPLATES_BY_BASE = {
-    "temperature": "temperature",
-    "voltage": "voltage",
-    "laser_temperature": "laser_temperature",
-    "tx_power": "tx{}power",
-    "rx_power": "rx{}power",
-    "tx_bias": "tx{}bias",
+    base_name: spec.sensor_field_template
+    for base_name, spec in DOM_QUANTITY_REGISTRY.items()
+}
+CONSISTENCY_UNITS_BY_BASE = {
+    base_name: spec.consistency_unit
+    for base_name, spec in DOM_QUANTITY_REGISTRY.items()
 }
 
 DOM_POLLING_ENABLED_VALUES = ("", "enabled")
@@ -190,6 +199,22 @@ def consistency_field_template_for_attr(attr_name):
         return None
     base_name = attr_name[:-len(CONSISTENCY_SUFFIX)]
     return CONSISTENCY_FIELD_TEMPLATES_BY_BASE.get(base_name)
+
+
+def consistency_unit_for_attr(attr_name):
+    """Return the output unit for a configured consistency attribute."""
+    if not attr_name.endswith(CONSISTENCY_SUFFIX):
+        return None
+    base_name = attr_name[:-len(CONSISTENCY_SUFFIX)]
+    return CONSISTENCY_UNITS_BY_BASE.get(base_name)
+
+
+def dom_consistency_attributes():
+    """Return DOM consistency attribute names derived from the quantity registry."""
+    return tuple(
+        "{}{}".format(base_name, CONSISTENCY_SUFFIX)
+        for base_name in DOM_QUANTITY_REGISTRY
+    )
 
 
 def field_template_is_lane_expanded(field_template):

--- a/tests/transceiver/dom/dom_helpers.py
+++ b/tests/transceiver/dom/dom_helpers.py
@@ -28,28 +28,55 @@ STATE_DB_THRESHOLD_TABLE = "TRANSCEIVER_DOM_THRESHOLD"
 OPERATIONAL_SUFFIX = "_operational_range"
 THRESHOLD_SUFFIX = "_threshold_range"
 CONSISTENCY_SUFFIX = "_consistency_variation_threshold"
+CONSISTENCY_MODE_ABSOLUTE = "absolute"
+CONSISTENCY_MODE_PERCENT = "percent"
 LANE_NUM_PLACEHOLDER = "LANE_NUM"
 MEDIA_LANE_MASK_KEY = "media_lane_mask"
 DomMappedField = namedtuple("DomMappedField", ("source_attr", "attr_value"))
 DomThresholdMappedField = namedtuple("DomThresholdMappedField", ("source_attr", "attr_value", "threshold_key"))
 DomQuantitySpec = namedtuple(
     "DomQuantitySpec",
-    ("threshold_db_prefix", "sensor_field_template", "operational_attr", "consistency_unit"),
+    ("threshold_db_prefix", "sensor_field_template", "operational_attr", "consistency_unit", "consistency_mode"),
 )
 
 THRESHOLD_FIELD_SUFFIXES = ("lowalarm", "lowwarning", "highwarning", "highalarm")
 DOM_QUANTITY_REGISTRY = {
-    "temperature": DomQuantitySpec("temp", "temperature", "temperature_operational_range", "C"),
-    "voltage": DomQuantitySpec("vcc", "voltage", "voltage_operational_range", "V"),
+    "temperature": DomQuantitySpec(
+        "temp",
+        "temperature",
+        "temperature_operational_range",
+        "C",
+        CONSISTENCY_MODE_ABSOLUTE,
+    ),
+    "voltage": DomQuantitySpec("vcc", "voltage", "voltage_operational_range", "V", CONSISTENCY_MODE_ABSOLUTE),
     "laser_temperature": DomQuantitySpec(
         "lasertemp",
         "laser_temperature",
         "laser_temperature_operational_range",
         "C",
+        CONSISTENCY_MODE_ABSOLUTE,
     ),
-    "tx_power": DomQuantitySpec("txpower", "tx{}power", "txLANE_NUMpower_operational_range", "dB"),
-    "rx_power": DomQuantitySpec("rxpower", "rx{}power", "rxLANE_NUMpower_operational_range", "dB"),
-    "tx_bias": DomQuantitySpec("txbias", "tx{}bias", "txLANE_NUMbias_operational_range", "percent"),
+    "tx_power": DomQuantitySpec(
+        "txpower",
+        "tx{}power",
+        "txLANE_NUMpower_operational_range",
+        "dB",
+        CONSISTENCY_MODE_ABSOLUTE,
+    ),
+    "rx_power": DomQuantitySpec(
+        "rxpower",
+        "rx{}power",
+        "rxLANE_NUMpower_operational_range",
+        "dB",
+        CONSISTENCY_MODE_ABSOLUTE,
+    ),
+    "tx_bias": DomQuantitySpec(
+        "txbias",
+        "tx{}bias",
+        "txLANE_NUMbias_operational_range",
+        "%",
+        CONSISTENCY_MODE_PERCENT,
+    ),
 }
 THRESHOLD_FIELD_PREFIXES = {
     base_name: spec.threshold_db_prefix
@@ -66,6 +93,10 @@ CONSISTENCY_FIELD_TEMPLATES_BY_BASE = {
 }
 CONSISTENCY_UNITS_BY_BASE = {
     base_name: spec.consistency_unit
+    for base_name, spec in DOM_QUANTITY_REGISTRY.items()
+}
+CONSISTENCY_MODES_BY_BASE = {
+    base_name: spec.consistency_mode
     for base_name, spec in DOM_QUANTITY_REGISTRY.items()
 }
 
@@ -207,6 +238,14 @@ def consistency_unit_for_attr(attr_name):
         return None
     base_name = attr_name[:-len(CONSISTENCY_SUFFIX)]
     return CONSISTENCY_UNITS_BY_BASE.get(base_name)
+
+
+def consistency_mode_for_attr(attr_name):
+    """Return the validation mode for a configured consistency attribute."""
+    if not attr_name.endswith(CONSISTENCY_SUFFIX):
+        return None
+    base_name = attr_name[:-len(CONSISTENCY_SUFFIX)]
+    return CONSISTENCY_MODES_BY_BASE.get(base_name)
 
 
 def dom_consistency_attributes():

--- a/tests/transceiver/dom/test_dom_consistency.py
+++ b/tests/transceiver/dom/test_dom_consistency.py
@@ -15,6 +15,8 @@ from tests.transceiver.dom.dom_helpers import (
     STATE_DB_SENSOR_TABLE,
     build_dom_sensor_plan,
     consistency_field_template_for_attr,
+    consistency_unit_for_attr,
+    dom_consistency_attributes,
     field_template_is_lane_expanded,
     format_dom_port_failure,
     format_optional_float,
@@ -29,14 +31,21 @@ TX_BIAS_CONSISTENCY_ATTR = "tx_bias_consistency_variation_threshold"
 MODE_ABSOLUTE = "absolute"
 MODE_PERCENT = "percent"
 
-CONSISTENCY_CHECK_DEFINITIONS = (
-    ("temperature_consistency_variation_threshold", "C", MODE_ABSOLUTE),
-    ("voltage_consistency_variation_threshold", "V", MODE_ABSOLUTE),
-    ("laser_temperature_consistency_variation_threshold", "C", MODE_ABSOLUTE),
-    ("tx_power_consistency_variation_threshold", "dB", MODE_ABSOLUTE),
-    ("rx_power_consistency_variation_threshold", "dB", MODE_ABSOLUTE),
-    (TX_BIAS_CONSISTENCY_ATTR, "percent", MODE_PERCENT),
-)
+CONSISTENCY_CHECK_MODES_BY_ATTR = {
+    TX_BIAS_CONSISTENCY_ATTR: MODE_PERCENT,
+}
+
+
+def _consistency_check_definitions():
+    """Return ``(attr_name, unit, mode)`` definitions from the DOM quantity registry."""
+    return tuple(
+        (
+            attr_name,
+            consistency_unit_for_attr(attr_name),
+            CONSISTENCY_CHECK_MODES_BY_ATTR.get(attr_name, MODE_ABSOLUTE),
+        )
+        for attr_name in dom_consistency_attributes()
+    )
 
 
 def _parse_positive_int(attr_name, raw_value, minimum):
@@ -88,6 +97,7 @@ def _parse_tx_bias_warning_range(dom_attrs):
 def _build_dom_consistency_plan(port_attributes_dict, dom_primary_ports, sensor_plan_by_port):
     """Build per-port update-count and variation checks from DOM attributes."""
     plan_by_port = {}
+    consistency_checks = _consistency_check_definitions()
     for port in dom_primary_ports:
         dom_attrs = port_attributes_dict.get(port, {}).get(DOM_ATTRIBUTES_KEY, {})
         sensor_plan = sensor_plan_by_port.get(port, {})
@@ -107,18 +117,21 @@ def _build_dom_consistency_plan(port_attributes_dict, dom_primary_ports, sensor_
             attr_name in dom_attrs
             and consistency_field_template_for_attr(attr_name)
             and field_template_is_lane_expanded(consistency_field_template_for_attr(attr_name))
-            for attr_name, _unit, _mode in CONSISTENCY_CHECK_DEFINITIONS
+            for attr_name, _unit, _mode in consistency_checks
         )
         if has_lane_check and sensor_plan.get("errors"):
             errors.extend(sensor_plan["errors"])
 
-        for attr_name, unit, mode in CONSISTENCY_CHECK_DEFINITIONS:
+        for attr_name, unit, mode in consistency_checks:
             if attr_name not in dom_attrs:
                 continue
 
             field_template = consistency_field_template_for_attr(attr_name)
             if field_template is None:
                 errors.append("{} has no DOM consistency field mapping".format(attr_name))
+                continue
+            if unit is None:
+                errors.append("{} has no DOM consistency unit mapping".format(attr_name))
                 continue
             lane_expanded = field_template_is_lane_expanded(field_template)
 

--- a/tests/transceiver/dom/test_dom_consistency.py
+++ b/tests/transceiver/dom/test_dom_consistency.py
@@ -12,9 +12,12 @@ from tests.transceiver.common.db_helpers import (
     parse_update_time,
 )
 from tests.transceiver.dom.dom_helpers import (
+    CONSISTENCY_MODE_ABSOLUTE,
+    CONSISTENCY_MODE_PERCENT,
     STATE_DB_SENSOR_TABLE,
     build_dom_sensor_plan,
     consistency_field_template_for_attr,
+    consistency_mode_for_attr,
     consistency_unit_for_attr,
     dom_consistency_attributes,
     field_template_is_lane_expanded,
@@ -28,12 +31,6 @@ logger = logging.getLogger(__name__)
 UPDATE_ADVANCE_MARGIN_SEC = 5
 TX_BIAS_THRESHOLD_ATTR = "tx_bias_threshold_range"
 TX_BIAS_CONSISTENCY_ATTR = "tx_bias_consistency_variation_threshold"
-MODE_ABSOLUTE = "absolute"
-MODE_PERCENT = "percent"
-
-CONSISTENCY_CHECK_MODES_BY_ATTR = {
-    TX_BIAS_CONSISTENCY_ATTR: MODE_PERCENT,
-}
 
 
 def _consistency_check_definitions():
@@ -42,7 +39,7 @@ def _consistency_check_definitions():
         (
             attr_name,
             consistency_unit_for_attr(attr_name),
-            CONSISTENCY_CHECK_MODES_BY_ATTR.get(attr_name, MODE_ABSOLUTE),
+            consistency_mode_for_attr(attr_name),
         )
         for attr_name in dom_consistency_attributes()
     )
@@ -127,12 +124,6 @@ def _build_dom_consistency_plan(port_attributes_dict, dom_primary_ports, sensor_
                 continue
 
             field_template = consistency_field_template_for_attr(attr_name)
-            if field_template is None:
-                errors.append("{} has no DOM consistency field mapping".format(attr_name))
-                continue
-            if unit is None:
-                errors.append("{} has no DOM consistency unit mapping".format(attr_name))
-                continue
             lane_expanded = field_template_is_lane_expanded(field_template)
 
             threshold, threshold_error = _parse_non_negative_threshold(attr_name, dom_attrs[attr_name])
@@ -277,11 +268,11 @@ def _validate_tx_bias_percent_pair(port, field, check, previous_sample, current_
     delta_percent = abs(current_value - previous_value) / abs(previous_value) * 100
     if delta_percent > check["threshold"]:
         return _format_delta_failure(
-            field, sample_index, delta_percent, check["threshold"], "%", previous_value, current_value
+            field, sample_index, delta_percent, check["threshold"], check["unit"], previous_value, current_value
         ), True, None
-    logger.debug("DOM consistency PASS %s %s sample %d->%d: delta=%.2f%% limit=%s%%",
+    logger.debug("DOM consistency PASS %s %s sample %d->%d: delta=%.2f%s limit=%s%s",
                  port, field, sample_index, sample_index + 1, delta_percent,
-                 format_optional_float(check["threshold"]))
+                 check["unit"], format_optional_float(check["threshold"]), check["unit"])
     return None, True, None
 
 
@@ -296,7 +287,7 @@ def _validate_pair(port, field, check, previous_sample, current_sample, sample_i
 
     previous_value = _numeric_sensor_value(previous_sensor, field)
     current_value = _numeric_sensor_value(current_sensor, field)
-    if check["mode"] == MODE_ABSOLUTE:
+    if check["mode"] == CONSISTENCY_MODE_ABSOLUTE:
         return _validate_absolute_pair(
             port, field, check, previous_sensor, current_sensor, previous_value, current_value, sample_index
         )
@@ -363,7 +354,7 @@ def _validate_port_samples(port, port_samples, plan):
                 failures.append(error)
 
     percent_attrs = {
-        check["source_attr"] for check in plan["field_checks"].values() if check["mode"] == MODE_PERCENT
+        check["source_attr"] for check in plan["field_checks"].values() if check["mode"] == CONSISTENCY_MODE_PERCENT
     }
     for attr_name in sorted(percent_attrs):
         if checked_by_attr[attr_name]:


### PR DESCRIPTION
### Description of PR

  Summary:
  Refactor the DOM quantity mapping logic into a single shared registry and derive the existing DOM lookup tables from it.

  Fixes # N/A

  This is a non-functional refactor. It consolidates the DOM quantity metadata used by TC3 threshold validation and TC4 consistency
  validation into one source of truth in `tests/transceiver/dom/dom_helpers.py`. The existing per-test behavior remains unchanged, but the
  mapping tables are now derived from a single registry instead of being maintained independently.

  ### Type of change

  - [ ] Bug fix
  - [x] Testbed and Framework(new/improvement)
  - [ ] New Test case
    - [ ] Skipped for non-supported platforms
  - [ ] Test case improvement

  ### Back port request

  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511
  - [ ] 202512
  - [ ] 202605

  Tracking issue/work item for backport/cherry-pick request:
  N/A

  Failure type:
  N/A

  ### Tested branch

  - [x] master
  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511
  - [ ] 202512
  - [ ] 202605
  - [ ] N/A

  ### Test result

  Validated on `single-dut-mgmt62` with DUT `str-nexthop_4010-01`.

  - TC1:
    - `./tests/run_tests.sh -c "tests/transceiver/dom/test_dom_availability.py" ...`
    - Result: `1 passed`

  - TC2:
    - `./tests/run_tests.sh -c "tests/transceiver/dom/test_dom_operational_range.py" ...`
    - Result: `1 passed`

  - TC3:
    - `./tests/run_tests.sh -c "tests/transceiver/dom/test_dom_threshold.py" ...`
    - Result: `1 passed`

  - TC4:
    - `./tests/run_tests.sh -c "tests/transceiver/dom/test_dom_consistency.py" ...`
    - Result: `1 passed`

  ### Approach

  #### What is the motivation for this PR?

  The DOM test suite currently uses several separate lookup tables for the same set of DOM quantities. That makes the mapping logic harder
  to maintain and increases the chance of drift when a quantity name, field prefix, or paired operational attribute changes.

  #### How did you do it?

  Added a single `DOM_QUANTITY_REGISTRY` in `tests/transceiver/dom/dom_helpers.py` that stores the shared metadata for each DOM quantity:
  - STATE_DB threshold prefix
  - sensor field template
  - paired operational-range attribute
  - consistency unit

  The existing lookup tables are now derived from this registry. TC4 consistency validation now also derives its attribute list and units
  from the shared helper instead of maintaining a separate hard-coded definition list.

  #### How did you verify/test it?

  Ran the full DOM basic test set on `single-dut-mgmt62` against `str-nexthop_4010-01`:
  - TC1 availability validation: passed
  - TC2 operational range validation: passed
  - TC3 threshold validation: passed
  - TC4 consistency validation: passed

  #### Any platform specific information?

  Validated on `str-nexthop_4010-01` with Accelight AGP80SC0CW41002 transceivers.

  #### Supported testbed topology if it's a new test case?

  PTP topology / real transceiver hardware testbed.
  Validated on `single-dut-mgmt62`.

  ### Documentation

  No documentation update required. This is an internal refactor with no behavioral change.
