### PR TITLE
Xfail test_pfcwd_timer_accuracy for #27459

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4120,6 +4120,10 @@ pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy
     reason: "ipv6 mgmt ip is not supported, see check_timer_accuracy_test.yml#43"
     conditions:
     - "is_mgmt_ipv6_only==True"
+  xfail:
+    reason: "pfcwd timer accuracy test fails intermittently"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/27459"
 
 pfcwd/test_pfcwd_warm_reboot.py:
    skip:


### PR DESCRIPTION

### Description of PR
test_pfcwd_timer_accuracy consistently fails on Mellanox-SN4280-O4X96 HWSKU — PFCWD is configured but never detects any PFC storm across all 20 iterations. The same test passes on the same physical device when running with Mellanox-SN4280-O28 HWSKU.

We observed that BUFFER_PG in CONFIG_DB only contains priority group 0 (lossy) for all ports. Priority groups 3-4 (lossless) are missing entirely.

Summary:
Fixes # (issue)
xfail

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: NA

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
Xfailed and nonblocking tests

### Approach
#### What is the motivation for this PR?
#27459 needs to xfail related test.
#### How did you do it?
Add xfail
#### How did you verify/test it?
Run

#### Any platform specific information?
Any
#### Supported testbed topology if it's a new test case?
Any
### Documentation
NA
