### PR TITLE
[H6-128][BMC] Skip disabled container during post-check of container autorestart

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -531,7 +531,10 @@ def postcheck_critical_processes_status(duthost, feature_autorestart_states, up_
         check_all_critical_processes_status, duthost
     )
 
+    disabled_containers = get_disabled_container_list(duthost)
     for feature_name in list(feature_autorestart_states.keys()):
+        if feature_name in disabled_containers:
+            continue
         if feature_name in duthost.DEFAULT_ASIC_SERVICES:
             for asic in duthost.asics:
                 service_name = asic.get_service_name(feature_name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

- Fixes _tests/autorestart/test_container_autorestart.py_ failures on BMC topology, where every parametrized case failed during _postcheck_critical_processes_status_.

- On BMC, features such as bgp, swss, syncd, and teamd are disabled and have no systemctl unit, but still appear in show feature autorestart with autorestart state disabled.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
<img width="1725" height="931" alt="image" src="https://github.com/user-attachments/assets/56652948-fddd-4569-aee4-48fc73d1e8f1" />

### Approach
#### What is the motivation for this PR?

- _tests/autorestart/test_container_autorestart.py_ failures on BMC topology, where every parametrized case failed during _postcheck_critical_processes_status_.

#### How did you do it?

- Aligns post-check with the rest of the test file: skip features returned by get_disabled_container_list() (same helper used in run_test_on_single_container() 

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

- Ran tests/autorestart/test_container_autorestart.py on BMC topo and made sure all tests are passing without any issues.

- No change to DEFAULT_ASIC_SERVICES in sonic.py; BMC already correctly removes non-applicable ASIC services there. The gap was that post-check did not filter by feature status.

#### Any platform specific information?

- 'bmc-shared-mgmt' topo with H6-128-BMC HWsKU

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
