### PR TITLE
[H6-128] [BMC] Fixes for test_reload_config w.r.t BMC topo

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -70,27 +70,30 @@ def test_reload_configuration(duthosts, enum_rand_one_per_hwsku_hostname,
     logging.info("Wait until all critical services are fully started")
     wait_critical_processes(duthost)
 
-    logging.info("Wait some time for all the transceivers to be detected")
-    max_wait_time_for_transceivers = 300
-    if duthost.facts["platform"] in ["x86_64-cel_e1031-r0", "x86_64-88_lc0_36fh_m-r0"]:
-        max_wait_time_for_transceivers = 900
-    assert wait_until(max_wait_time_for_transceivers, 20, 0, check_all_interface_information,
-                      duthost, interfaces, xcvr_skip_list), (
-        "Not all transceivers detected in {timeout} seconds. "
-        "- Interfaces checked: {interfaces}\n"
-        "- Max wait time (seconds): {timeout}"
-    ).format(
-        timeout=max_wait_time_for_transceivers,
-        interfaces=list(interfaces.keys())
-    )
+    if duthost.is_bmc():
+        logging.info("Skipping interface and transceiver checks for BMC")
+    else:
+        logging.info("Wait some time for all the transceivers to be detected")
+        max_wait_time_for_transceivers = 300
+        if duthost.facts["platform"] in ["x86_64-cel_e1031-r0", "x86_64-88_lc0_36fh_m-r0"]:
+            max_wait_time_for_transceivers = 900
+        assert wait_until(max_wait_time_for_transceivers, 20, 0, check_all_interface_information,
+                          duthost, interfaces, xcvr_skip_list), (
+            "Not all transceivers detected in {timeout} seconds. "
+            "- Interfaces checked: {interfaces}\n"
+            "- Max wait time (seconds): {timeout}"
+        ).format(
+            timeout=max_wait_time_for_transceivers,
+            interfaces=list(interfaces.keys())
+        )
 
-    logging.info("Check transceiver status")
-    for asic_index in duthost.get_frontend_asic_ids():
-        # Get the interfaces pertaining to that asic
-        interface_list = get_port_map(duthost, asic_index)
-        interfaces_per_asic = {k: v for k, v in list(interface_list.items()) if k in interfaces}
-        check_transceiver_basic(duthost, asic_index,
-                                interfaces_per_asic, xcvr_skip_list)
+        logging.info("Check transceiver status")
+        for asic_index in duthost.get_frontend_asic_ids():
+            # Get the interfaces pertaining to that asic
+            interface_list = get_port_map(duthost, asic_index)
+            interfaces_per_asic = {k: v for k, v in list(interface_list.items()) if k in interfaces}
+            check_transceiver_basic(duthost, asic_index,
+                                    interfaces_per_asic, xcvr_skip_list)
 
     if asic_type in ["mellanox"]:
 
@@ -226,6 +229,17 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
         "The config reload command returned an unexpected 'Retry later' message or failed to execute successfully. "
         "Output: '{}'\n"
     ).format(stdout)
+
+    if duthost.is_bmc():
+        # BMC devices have no SWSS service. The checks below rely on SWSS being
+        # temporarily unready after reload, and later stop SWSS explicitly.
+        logging.info("Skipping SWSS-dependent config reload checks for BMC")
+        assert wait_until(360, 20, 0, config_system_checks_passed, duthost, delayed_services), (
+            "System checks did not pass within the allotted time after config reload on "
+            "Delayed services: {}"
+        ).format(delayed_services)
+        wait_critical_processes(duthost)
+        return
 
     # Immediately after one config reload command, another shouldn't execute and wait for system checks
     logging.info("Checking config reload after system is up")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

- This PR fixes tests/platform_tests/test_reload_config.py failures on BMC topology, where the tests assume a host-CPU switching platform with front-panel ports and SWSS.

- _test_reload_configuration_: Skips transceiver and interface checks on BMC. BMC has no dataplane ports or transceivers, so check_all_interface_information() and check_transceiver_basic() are not applicable after config reload.

- _test_reload_configuration_checks_: Skips SWSS-dependent reload scenarios on BMC. The latter half of the test stops SWSS and verifies config reload is blocked until system checks pass; BMC does not run SWSS, so those steps cannot execute.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
<img width="1708" height="593" alt="image" src="https://github.com/user-attachments/assets/99d16539-d73a-49dd-9ee6-73c223a32a6c" />

### Approach
#### What is the motivation for this PR?

-  _tests/platform_tests/test_reload_config.py_ fails on BMC topology, where the tests assume a host-CPU switching platform with front-panel ports and SWSS.

#### How did you do it?

- Skips transceiver, interface checks and SWSS-dependent reload scenarios if the topo is BMC.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

- Ran _test_reload_config.py_ tests on BMC topo and made sure all tests are passing without any issues.

- No change to host-CPU or other platform behavior.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
