### PR TITLE
[bgp][test_bgp_update_replication] Increase RIB convergence wait timeout

### DIFF
--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -284,7 +284,9 @@ def test_bgp_update_replication(
     setup_duthost_intervals,
 ):
     NUM_ROUTES = 10_000
-    ROUTE_WAIT_TIMEOUT = 60
+    # Large-scale single-node topologies with a high base route count need a
+    # longer RIB convergence window than the default to avoid false failures.
+    ROUTE_WAIT_TIMEOUT = 120
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     bgp_peers: list[BGPNeighbor] = setup_bgp_peers
     duthost_intervals: list[float] = setup_duthost_intervals


### PR DESCRIPTION
### Description of PR

Increase `ROUTE_WAIT_TIMEOUT` in `test_bgp_update_replication` from 60 to 120 seconds.

#### Type of change
- [x] Bug fix

### Approach

**What is the motivation for this PR?**

`test_bgp_update_replication` injects and withdraws 10,000 routes across 60 iterations, allowing a fixed 60-second window for the RIB to converge after each announce/withdraw. On large-scale single-node topologies with a high base route count, route installation/withdrawal can take longer than 60 seconds, so the exact RIB-count assertion can fail while the device is still converging (the RIB reaches ~99.5% of the expected count within the window). This is a test-timing limitation, not a functional BGP defect.

**How did you do it?**

Increase `ROUTE_WAIT_TIMEOUT` from 60 to 120 seconds so the convergence window matches the scale of these topologies. No other behavior is changed.

**How did you verify/test it?**

Validated on a large-scale single-node testbed: with the increased timeout the test passes with no change in functional behavior. Without the change, the same test fails the RIB-count assertion by ~0.5% while the device is still converging.
