### PR TITLE
[snappi] Add bcmcmd fallback so VOQ credit-watchdog disable/enable takes effect on images without swss #4658

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -899,6 +899,20 @@ def _set_credit_watchdog(duthost, enable, asic_value=None):
         logger.info("%s VOQ credit watchdog via APPL_DB SWITCH_TABLE credit_watchdog=%s (namespace: %s)",
                     'Enabled' if enable else 'Disabled', value, ns or 'default')
 
+    # Fallback for images without sonic-swss #4658 (where SwitchOrch reports
+    # 'Unsupported switch attribute credit_watchdog' and the APPL_DB write above
+    # is a no-op): program the Broadcom-DNX IPS credit-watchdog scan register
+    # directly. CRDT_WD_MIN_SCAN_CYCLE_PERIOD=0 disables the watchdog scan; 0x124
+    # is the hardware default, restored when re-enabling. Harmless to run
+    # alongside the SAI/APPL_DB path once the image carries #4658.
+    scan_period = "0x124" if enable else "0"
+    for unit in duthost.facts.get('asics_present', [0]):
+        duthost.shell("bcmcmd -n {} 'm IPS_CREDIT_WATCHDOG_CONFIGURATION "
+                      "CRDT_WD_MIN_SCAN_CYCLE_PERIOD={}'".format(unit, scan_period))
+        logger.info("%s VOQ credit watchdog via bcmcmd IPS_CREDIT_WATCHDOG_"
+                    "CONFIGURATION CRDT_WD_MIN_SCAN_CYCLE_PERIOD=%s (unit: %s)",
+                    'Enabled' if enable else 'Disabled', scan_period, unit)
+
 
 def disable_packet_aging(duthost, asic_value=None):
     """


### PR DESCRIPTION
## Description

`_set_credit_watchdog()` (used by `disable_packet_aging()` / `enable_packet_aging()`) writes the APPL_DB `SWITCH_TABLE:switch` `credit_watchdog` field, which `SwitchOrch` maps to `SAI_SWITCH_ATTR_CREDIT_WD` **only on images that carry sonic-swss #4658**.

On images without #4658 (e.g. current 202511 broadcom-dnx builds), `SwitchOrch` logs `Unsupported switch attribute credit_watchdog` and the APPL_DB write is a **silent no-op** — so `disable_packet_aging()` / `enable_packet_aging()` never actually change the VOQ credit watchdog. The still-active watchdog then **drains PFC-paused lossless VOQs**, which breaks the snappi tests that depend on the paused queue staying put.

## Fix

Add a fallback that also programs the Broadcom-DNX **IPS credit-watchdog scan register** directly:
- `CRDT_WD_MIN_SCAN_CYCLE_PERIOD=0` to disable the watchdog scan
- `0x124` (hardware default) to re-enable

It complements the SAI/APPL_DB path (harmless to run alongside it once the image carries #4658) and is gated to broadcom-dnx by the function's existing early return. One file, ~14 lines.

## Why this is one change (not per-test)

Both the pfcwd and ECN suites reach this through the same `disable_packet_aging()` / `enable_packet_aging()` helpers, so a single fix in `_set_credit_watchdog()` covers all of them.

## Verification (hardware)

On a broadcom-dnx testbed (NH-5010, 202511 image), with this fallback:
- `pfcwd_actions::test_pfcwd_drop_over_subs_40_09` — **passed** (egress lossless queue correctly frozen during the pause)
- `pfcwd_actions::test_pfcwd_frwd_over_subs_40_09` — **passed**
- `ecn::test_multidut_dequeue_ecn_brcm_dnx::test_dequeue_ecn` — capture restored (no more near-zero "Only capture X/Y"); marking probability within Pmax:
  - `[1800 pkts, pmax 50]` → 21.08% ≤ 50 — **passed**
  - `[2400 pkts, pmax 25]` → 24.41% ≤ 25 — **passed**

Without the fallback (stock 202511), the watchdog stays active: the over_subs egress queue advances (assertion trips) and the ECN capture is near-zero.

## Related
- sonic-swss #4658 (the SwitchOrch `credit_watchdog` knob this falls back for)
