### PR TITLE
[pfcwd] Enable chip-side PFC storm on Z9332f (Tomahawk3) SONiC fanout

### DIFF
--- a/tests/common/helpers/pfc_gen_brcm_xgs.py
+++ b/tests/common/helpers/pfc_gen_brcm_xgs.py
@@ -141,11 +141,14 @@ class FanoutPfcStorm():
         The users of this class are only expected to call
         startPfcStorm and endAllPfcStorm
         '''
-        mmuPort = self.intfToMmuPort[intf]
+        mmuPort = self.intfToMmuPort.get(intf)
         port = self.intfToPort[intf]
         if self.switchChip.startswith(("Tomahawk6", "Tomahawk5", "Tomahawk4")):
             self._bcmltshellCmd(f"pt MMU_INTFO_XPORT_BKP_HW_UPDATE_DISr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP=0")
             self._bcmltshellCmd(f"pt MMU_INTFO_TO_XPORT_BKPr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP=0")
+        elif self.os == 'sonic' and self.switchChip.startswith("Tomahawk3"):
+            self._cliCmd(f"setreg MMU_INTFO_TO_XPORT_BKP.{port} PAUSE_PFC_BKP=0")
+            self._cliCmd(f"setreg MMU_INTFO_XPORT_BKP_HW_UPDATE_DIS.{port} PAUSE_PFC_BKP=0")
         else:
             self._bcmshellCmd(f"setreg CHFC2PFC_STATE.{port} PRI_BKP=0")
         if self.os == 'sonic':
@@ -162,7 +165,7 @@ class FanoutPfcStorm():
             return
         self.intfsEnabled.append(intf)
 
-        mmuPort = self.intfToMmuPort[intf]
+        mmuPort = self.intfToMmuPort.get(intf)
         port = self.intfToPort[intf]
         if self.os == 'sonic':
             self._shellCmd(f"redis-cli -n 4 HSET \"PORT_QOS_MAP|{intf}\" \"pfc_enable\" \"\"")
@@ -178,6 +181,9 @@ class FanoutPfcStorm():
         if self.switchChip.startswith(("Tomahawk6", "Tomahawk5", "Tomahawk4")):
             self._bcmltshellCmd(f"pt MMU_INTFO_XPORT_BKP_HW_UPDATE_DISr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP=1")
             self._bcmltshellCmd(f"pt MMU_INTFO_TO_XPORT_BKPr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP={self.priority}")
+        elif self.os == 'sonic' and self.switchChip.startswith("Tomahawk3"):
+            self._cliCmd(f"setreg MMU_INTFO_XPORT_BKP_HW_UPDATE_DIS.{port} PAUSE_PFC_BKP=1")
+            self._cliCmd(f"setreg MMU_INTFO_TO_XPORT_BKP.{port} PAUSE_PFC_BKP={self.priority}")
         else:
             self._bcmshellCmd(f"setreg CHFC2PFC_STATE.{port} PRI_BKP={self.priority}")
 

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -37,6 +37,7 @@ def get_chip_name_if_asic_pfc_storm_supported(fanout):
         "M2-W6940-64X1-FR4": "Tomahawk5",
         "Nokia-IXR7220": "Tomahawk6",
         "NH-4210-F-O256": "Tomahawk6",
+        "DellEMC-Z9332f": "Tomahawk3",
         }
 
     for sku, chip in hwSkuInfo.items():
@@ -275,7 +276,11 @@ class PFCStorm(object):
         if self.asic_type == 'vs':
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_eos.j2")
-        elif self.dut.topo_type == 't2' and self.peer_device.os == 'sonic':
+        elif (self.dut.topo_type == 't2' and self.peer_device.os == 'sonic'
+              and not get_chip_name_if_asic_pfc_storm_supported(self._get_sonic_fanout_hwsku())):
+            # Chip-capable SONiC fanouts fall through to the chip-side (bcmcmd) path below,
+            # which delivers gapless hardware pause. The raw-socket software t2 path produces
+            # choppy pause that the strict Broadcom pfcwd detector catches only intermittently.
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_{}_t2.j2".format(self.peer_device.os))
         elif self.fanout_asic_type == 'mellanox' and self.peer_device.os == 'sonic':
@@ -300,7 +305,9 @@ class PFCStorm(object):
         if self.asic_type == 'vs':
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_eos.j2")
-        elif self.dut.topo_type == 't2' and self.peer_device.os == 'sonic':
+        elif (self.dut.topo_type == 't2' and self.peer_device.os == 'sonic'
+              and not get_chip_name_if_asic_pfc_storm_supported(self._get_sonic_fanout_hwsku())):
+            # Mirror _prepare_start_template: chip-capable SONiC fanouts use the bcmcmd path.
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_{}_t2.j2".format(self.peer_device.os))
         elif self.fanout_asic_type == 'mellanox' and self.peer_device.os == 'sonic':


### PR DESCRIPTION
### Description
On t2 single-node VoQ testbeds behind a **DellEMC-Z9332f SONiC fanout**, `pfcwd/test_pfcwd_all_port_storm.py` is flaky and then fails: only one of the two paired routed ports reaches storm state.

**Root cause:** the software `pfc_gen` produces *choppy* pause — the DUT's `SAI_PORT_STAT_PFC_3_ON2OFF_RX_PKTS` keeps incrementing, i.e. the pause repeatedly lapses. The strict Broadcom pfcwd detector requires **zero on→off transitions across consecutive polls** (gapless pause), so whether a given port is detected as stormed is stochastic → one paired port intermittently misses → the test caps at 1/2 → fail.

The chip-side (`bcmcmd`) storm path exists to provide *gapless hardware pause*, but it did not support Tomahawk3:
- `DellEMC-Z9332f`/`Tomahawk3` was not mapped in `get_chip_name_if_asic_pfc_storm_supported`, and the `t2`/SONiC template branch unconditionally selected the software path.
- `pfc_gen_brcm_xgs.py` only had a Tomahawk4/5/6 register path (SDKLT `pt MMU_INTFO_*`) and an EOS-only `CHFC2PFC_STATE` else-branch; neither works on BCM56980 (Tomahawk3) under SONiC.
- `startPfcStorm`/`_endPfcStorm` read `intfToMmuPort[intf]` unconditionally, which `KeyError`s on the SONiC Tomahawk3 fanout (its `show portmap` parse does not populate the MMU-port map), crashing the generator before any register write.

### Fix
- Map `DellEMC-Z9332f` → `Tomahawk3`.
- Let chip-capable SONiC fanouts fall through the `t2` template branch to the chip-side (arista) template.
- Add a Tomahawk3 SONiC branch that drives gapless hardware pause via classic `bcmcmd setreg MMU_INTFO_TO_XPORT_BKP` / `MMU_INTFO_XPORT_BKP_HW_UPDATE_DIS` (these registers exist and are writable on BCM56980).
- Make the `mmuPort` lookup non-fatal (the Tomahawk3 path indexes by logical port, not MMU port).

### How verified
On a NH-5010 + Z9332f testbed, with the chip-side path the DUT shows continuous `PFC_3` RX with **`ON2OFF` flat at zero** (gapless pause) on **both** paired ports simultaneously — which software generation cannot achieve. `test_all_port_storm_restore` (IPv4 + IPv6) passes **2/2 on repeated runs**, versus 2 failed before.

> Draft: opened for review; will un-draft after CI.
