### PR TITLE
[dut_console]: Extend SSH timeout for stress input

### DIFF
--- a/tests/dut_console/test_console_stress.py
+++ b/tests/dut_console/test_console_stress.py
@@ -1,6 +1,7 @@
 import hashlib
 
 import pytest
+from tests.common.connections.ssh_console_conn import SSHConsoleConn
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
@@ -76,7 +77,7 @@ def test_console_stress_input(duthost_console):
 
     The test verifies:
     - Console can accept large command inputs without hanging
-    - All input characters are successfully transmitted and echoed back
+    - All input characters are successfully received, verified with a DUT-side hash
     - Console remains responsive after large input
     """
     # Generate a large string to send as input
@@ -84,14 +85,27 @@ def test_console_stress_input(duthost_console):
     large_string = '0123456789' * 10000  # 100,000 chars
 
     expected_hash = hashlib.md5(large_string.encode()).hexdigest()
-    output = duthost_console.send_command_timing(
-        f"echo -n '{large_string}' | md5sum",
-        read_timeout=300,
-        last_read=2.0
-    )
+    stress_timeout = 300
+
+    # Netmiko's read_timeout does not apply while Paramiko is writing. A serial
+    # console can drain 100 KB more slowly than Paramiko's default 20-second
+    # channel timeout, so extend the write timeout for this operation.
+    is_ssh_console = isinstance(duthost_console, SSHConsoleConn)
+    if is_ssh_console:
+        original_write_timeout = duthost_console.remote_conn.gettimeout()
+        duthost_console.remote_conn.settimeout(stress_timeout)
+    try:
+        output = duthost_console.send_command_timing(
+            f"echo -n '{large_string}' | md5sum",
+            read_timeout=stress_timeout,
+            last_read=2.0
+        )
+    finally:
+        if is_ssh_console:
+            duthost_console.remote_conn.settimeout(original_write_timeout)
 
     pytest_assert(expected_hash in output,
-                  f"Input integrity check failed: md5sum of echoed 100K chars "
+                  f"Input integrity check failed: md5sum of received 100K chars "
                   f"expected {expected_hash}, console returned: {output!r}")
 
     # Verify console is still responsive


### PR DESCRIPTION
Temporarily extend the Paramiko channel write timeout while sending the 100 KB console payload. Slow serial consumption can exhaust the remote SSH window longer than the default 20-second timeout, while Netmiko's read_timeout does not apply during command transmission.

Restore the original timeout afterward, leave non-SSH console backends unchanged, and clarify that integrity is verified using the DUT-side MD5 hash.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the SSH-backed console stress input test timing out while Paramiko sends the 100 KB input payload through a slow serial console.

Netmiko's `read_timeout=300` applies only after command transmission. It does not cover the preceding Paramiko channel write, which can exceed the default 20-second timeout when the terminal server drains data slowly onto the serial line.

Fixes: N/A — no dedicated issue has been filed for the SSH/Paramiko failure.

Related to #27398. That issue and PR #27400 cover the equivalent large-write timeout for the conserver/pexpect backend, while this PR covers the `SSHConsoleConn`/Paramiko backend.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
https://elastictest.org/scheduler/testplan/6a9246501f93430ec24b1469?leftSideViewMode=detail
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
`test_console_stress_input` sends a 100 KB command through the DUT console and verifies that the DUT received the complete input using an MD5 hash.

On an SSH-backed terminal server, Paramiko exhausted the remote SSH channel send window while the terminal server was draining data at the slower serial-console rate. The remote window remained at zero long enough for Paramiko's default approximately 20-second channel timeout to expire. Around 50 KB of the command remained unsent when the failure occurred.

The existing `read_timeout=300` did not prevent this failure because Netmiko writes the entire command before starting its read loop. Therefore, the timeout occurred inside Paramiko's `sendall()` operation before Netmiko began applying its read timeout.

#### How did you do it?
For the `SSHConsoleConn` backend:

1. Read and save the existing Paramiko channel timeout.
2. Temporarily set the channel timeout to 300 seconds before sending the 100 KB command.
3. Execute the existing `send_command_timing()` operation.
4. Restore the exact original timeout in a `finally` block, including when the original timeout is `None` or the command fails.

Non-SSH console backends are unchanged.

The test description and failure message were also clarified to state that input integrity is verified using the DUT-side MD5 hash, rather than terminal echo.

#### How did you verify/test it?
Ran the complete `dut_console/test_console_stress.py` module on a physical Mellanox SN4700 using an SSH-backed Cisco terminal server.

Both tests passed:

- `test_console_stress_output`
- `test_console_stress_input`

The input test successfully transmitted the complete 100 KB payload, passed the DUT-side MD5 integrity validation, and confirmed that the console remained responsive after the transfer.

Test evidence:

https://elastictest.org/scheduler/testplan/6a91e9e9df972746564342f3

<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
The issue was reproduced and the fix was validated with:

- Platform: `x86_64-mlnx_msn4700-r0`
- HwSKU: `Mellanox-SN4700-O32`
- Image: `SONiC.20260510.11`
- Console backend: `SSHConsoleConn` using Paramiko through a Cisco terminal server

The fix is not expected to be DUT-platform-specific. It is scoped to SSH console connections where terminal-server or serial-line consumption can take longer than Paramiko's default channel timeout.

#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
