### PR TITLE
[platform_tests][test_sfp] Skip power override test for CMIS QSFP+C optics

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -390,8 +390,10 @@ class TestSfpApi(PlatformApiTestBase):
 
     def is_xcvr_support_power_override(self, xcvr_info_dict):
         """Returns True if transceiver supports power override, False if not supported"""
+        # Power override is an SFF-8636-only feature; CMIS-managed optics (QSFP-DD, QSFP+C)
+        # do not implement it and return None for get_power_override().
         xcvr_type = xcvr_info_dict["type_abbrv_name"]
-        is_valid_xcvr_type = "QSFP" in xcvr_type and xcvr_type != "QSFP-DD"
+        is_valid_xcvr_type = "QSFP" in xcvr_type and xcvr_type not in ("QSFP-DD", "QSFP+C")
         return self.is_xcvr_optical(xcvr_info_dict) and is_valid_xcvr_type
 
     def get_interfaces_to_flap_after_sfp_reset(self, port_index_to_info_dict, duthost):


### PR DESCRIPTION
### Description of PR

`test_power_override` in `platform_tests/api/test_sfp.py` fails on CMIS-managed QSFP+ optics.

#### Type of change
- [x] Bug fix

### Approach

**What is the motivation for this PR?**

`TestSfpApi::test_power_override` calls the SFF-8636-only `get_power_override()` API on transceivers that `is_xcvr_support_power_override()` reports as supporting power override. That helper only excluded `"QSFP-DD"`:

```python
is_valid_xcvr_type = "QSFP" in xcvr_type and xcvr_type != "QSFP-DD"
```

CMIS-managed QSFP+ optics (SFF-8024 identifier `0x1E`, `type_abbrv_name = "QSFP+C"`, full type `"QSFP+ or later with CMIS"`) contain `"QSFP"` and are not literally `"QSFP-DD"`, so they slip through. Power override is an SFF-8636-only feature and is not implemented in CMIS, so `get_power_override()` returns `None`, and the test fails with `Unable to retrieve transceiver <N> power override data`.

`is_xcvr_optical()` in the same class already recognizes `QSFP+C` as a CMIS type alongside `QSFP-DD`/`OSFP-8X`/`BP`, so this helper was simply inconsistent with the rest of the file.

**How did you do it?**

Exclude `"QSFP+C"` in addition to `"QSFP-DD"` so CMIS optics are skipped (not failed), consistent with `is_xcvr_optical()`:

```python
is_valid_xcvr_type = "QSFP" in xcvr_type and xcvr_type not in ("QSFP-DD", "QSFP+C")
```

No change for SFF-8636 `QSFP+`/`QSFP28` optics (still tested) or `QSFP-DD` (still skipped); only `QSFP+C` moves from "fail" to "skip".

**How did you verify/test it?**

Verified via cross-run log evidence: on a run where these optics report `type_abbrv_name = "QSFP-DD"`, all such ports are already skipped and the test passes; on a run where the same optic family reports `"QSFP+C"`, the ports fall through and fail on `get_power_override()` returning `None`. The fix makes both cases skip consistently. flake8 clean, `py_compile` clean.
