### PR TITLE
Use selected DUT in BGP dual ASN image check

### DIFF
--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -29,15 +29,17 @@ pytestmark = [pytest.mark.topology("t0")]
 
 
 @pytest.fixture(autouse=True, scope="module")
-def check_image_version(duthost):
+def check_image_version(duthosts, rand_one_dut_hostname):
     """Skips this test if the SONiC image installed on DUT is older than 202205
 
     Args:
-        duthost: Hostname of DUT.
+        duthosts: DUT host objects.
+        rand_one_dut_hostname: Hostname selected for this test module.
 
     Returns:
         None.
     """
+    duthost = duthosts[rand_one_dut_hostname]
     skip_release(duthost, ["201811", "201911", "202012", "202106", "202111"])
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #27473
The BGP dual ASN test selects a DUT using rand_one_dut_hostname, but the module autouse check_image_version fixture used the implicit duthost fixture.
In multi-DUT topologies, this can make image-version gating run against a different DUT than the DUT selected for the test body.

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202605: 
***After Fix***
Tested  on  Version branch.202605-ars.8512e7eb-buildimage.ad6f5b869a8cacb3cb7eefe7dc226bf6f85480ff-nightly-2026.08.25.14.40
[test_bgp_dual_asn.log](https://github.com/user-attachments/files/31607553/test_bgp_dual_asn.log)
[test_bgp_dual_asn.xml](https://github.com/user-attachments/files/31607554/test_bgp_dual_asn.xml)


### Approach
#### What is the motivation for this PR?
 Keep module-level setup aligned with the DUT selected for the test in multi-DUT topologies.

#### How did you do it?
Changed check_image_version to take duthosts and rand_one_dut_hostname, then resolve:
duthost = duthosts[rand_one_dut_hostname]

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Code inspection:
  - check_image_version previously used implicit duthost.
  - setup/test paths in the module use duthosts[rand_one_dut_hostname].
  - after the change, the image check uses the same selected DUT as the test.

  Runtime:
  - verified the test runs on dualtor reference logs.
  - verified after-fix run on tst-esx-63 passed.
  
#### Any platform specific information?
generic

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
