### PR TITLE
Use selected DUT in override config check

### DIFF
--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -27,15 +27,17 @@ LOSSY_HWSKU = mellanox_data.LOSSY_ONLY_HWSKUS + broadcom_data.LOSSY_ONLY_HWSKUS
 
 
 @pytest.fixture(scope="module", autouse=True)
-def check_image_version(duthost):
+def check_image_version(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """Skips this test if the SONiC image installed on DUT is older than 202111
 
     Args:
-        duthost: DUT host object.
+        duthosts: DUT host objects.
+        enum_rand_one_per_hwsku_frontend_hostname: Selected frontend DUT hostname.
 
     Returns:
         None.
     """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     skip_release(duthost, ["201811", "201911", "202012", "202106", "202111"])
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #27475

The override config test selects a DUT using `enum_rand_one_per_hwsku_frontend_hostname`, but the module autouse `check_image_version` fixture used the implicit `duthost` fixture.

In multi-DUT topologies, this can make image-version gating run against a different DUT than the DUT selected for the test body.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Fixes #27475

Failure type: day-one issue

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

202605:

***After Fix***

Tested on Version `branch.202605-ars.8512e7eb-buildimage.ad6f5b869a8cacb3cb7eefe7dc226bf6f85480ff-nightly-2026.08.25.14.40`

Evidence files:
- [test_override_config_table.log](https://github.com/user-attachments/files/31608487/test_override_config_table.log)
- [test_override_config_table.xml](https://github.com/user-attachments/files/31608486/test_override_config_table.xml)

XML result:
`topology=dualtor, testbed=dt, testcase=test_load_minigraph_with_golden_config[ldp205], tests=1, failures=0, errors=0, skipped=0`

### Approach

#### What is the motivation for this PR?

Keep module-level setup aligned with the DUT selected for the test in multi-DUT topologies.

#### How did you do it?

Changed `check_image_version` to take `duthosts` and `enum_rand_one_per_hwsku_frontend_hostname`, then resolve:

```python
duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
```

#### How did you verify/test it?

Code inspection:
- `check_image_version` previously used implicit `duthost`.
- Setup/test paths in the module use `duthosts[enum_rand_one_per_hwsku_frontend_hostname]`.
- After the change, the image check uses the same selected DUT as the test.

Runtime:
- Verified the test runs on dualtor reference logs.
- Verified after-fix run on `tst-esx-63` passed.

#### Any platform specific information?

generic

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
