### PR TITLE
Fix drop counters backend ACL DUT selection

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -152,10 +152,11 @@ def parse_combined_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def handle_backend_acl(duthost, tbinfo):
+def handle_backend_acl(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
     """
     Cleanup/Recreate all the existing DATAACL rules
     """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     if "t0-backend" in tbinfo["topo"]["name"]:
         duthost.shell('acl-loader delete DATAACL')
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #27477
The drop counters test selects a frontend DUT using enum_rand_one_per_hwsku_frontend_hostname, but the module autouse handle_backend_acl fixture used the implicit duthost fixture.
In multi-DUT topologies, this can make DATAACL cleanup/recreation run against a different DUT than the DUT selected for the test body.

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202605:
***Before Fix***
Reference dualtor logs showing wrong-DUT selection evidence:
[drop_counters_before_fix_logs.zip](https://github.com/user-attachments/files/31609257/drop_counters_before_fix_logs.zip)

***After Fix***
Tested on Version branch.202605-ars.8512e7eb-buildimage.ad6f5b869a8cacb3cb7eefe7dc226bf6f85480ff-nightly-2026.08.25.14.40
[drop_counters_backend_acl_after_fix_logs.zip](https://github.com/user-attachments/files/31609251/drop_counters_backend_acl_after_fix_logs.zip)

Result: 34 passed, 68 skipped, 0 failures, 0 errors.


### Approach
#### What is the motivation for this PR?
Keep module-level backend ACL setup aligned with the DUT selected for the test in multi-DUT topologies.

#### How did you do it?
Changed handle_backend_acl to take duthosts and enum_rand_one_per_hwsku_frontend_hostname, then resolve:
duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Code inspection:
  - handle_backend_acl previously used implicit duthost.
  - drop counters setup/test paths in the module use duthosts[enum_rand_one_per_hwsku_frontend_hostname].
  - after the change, backend ACL setup uses the same selected DUT as the test.

Runtime:
  - verified reference dualtor before-fix logs.
  - verified after-fix run on tst-esx-63 passed.
  - ran python3 -m py_compile tests/drop_packets/test_drop_counters.py.

#### Any platform specific information?
generic

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
