### PR TITLE
Fix TACACS selected DUT image checks

### DIFF
--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -166,13 +166,14 @@ def rw_user_client(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def check_image_version(duthost):
+def check_image_version(duthosts, enum_rand_one_per_hwsku_hostname):
     """Skips this test if the SONiC image installed on DUT is older than 202112
     Args:
-        duthost: Hostname of DUT.
+        duthosts: DUT hosts.
     Returns:
         None.
     """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     skip_release(duthost, per_command_accounting_skip_versions)
 
 

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -85,13 +85,14 @@ def local_user_client():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def check_image_version(duthost):
+def check_image_version(duthosts, enum_rand_one_per_hwsku_hostname):
     """Skips this test if the SONiC image installed on DUT is older than 202112
     Args:
-        duthost: Hostname of DUT.
+        duthosts: DUT hosts.
     Returns:
         None.
     """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     skip_release(duthost, per_command_authorization_skip_versions)
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #27479

The TACACS accounting and authorization tests select a DUT using `enum_rand_one_per_hwsku_hostname`, but the module autouse `check_image_version` fixtures used the implicit `duthost` fixture.
In multi-DUT topologies, this can make image-version gating run against a different DUT than the DUT selected for the test body.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Fixes #27479

Failure type: day-one issue

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

202605:

***After Fix***

Tested on Version branch.202605-ars.8512e7eb-buildimage.ad6f5b869a8cacb3cb7eefe7dc226bf6f85480ff-nightly-2026.08.25.14.40

- `tacacs/test_accounting.py`: 7 passed
- `tacacs/test_authorization.py`: 13 passed
- [tacacs_after_fix_logs.zip](https://github.com/user-attachments/files/31610171/tacacs_after_fix_logs.zip)

### Approach
#### What is the motivation for this PR?

Keep module-level image-version setup aligned with the DUT selected for the test in multi-DUT topologies.

#### How did you do it?

Changed the TACACS `check_image_version` fixtures to take `duthosts` and `enum_rand_one_per_hwsku_hostname`, then resolve:

```python
duthost = duthosts[enum_rand_one_per_hwsku_hostname]
```

#### How did you verify/test it?

Code inspection:

- `check_image_version` previously used implicit `duthost`.
- Setup and test paths in the modules use `duthosts[enum_rand_one_per_hwsku_hostname]`.
- After the change, the image check uses the same selected DUT as the test.

Runtime:

- Verified `tacacs/test_accounting.py` passed on 202605 dualtor.
- Verified `tacacs/test_authorization.py` passed on 202605 dualtor.

#### Any platform specific information?

generic

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
