### PR TITLE
Fix drop counters ASIC type lookup

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -330,7 +330,9 @@ def check_if_skip():
 
 
 @pytest.fixture(scope='module')
-def do_test(duthosts, weak_server):
+def do_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, weak_server):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+
     def do_counters_test(discard_group, pkt, ptfadapter, ports_info, sniff_ports, tx_dut_ports=None,    # noqa: F811
                          comparable_pkt=None, skip_counter_check=False, drop_information=None, ip_ver='ipv4'):
         """
@@ -344,7 +346,7 @@ def do_test(duthosts, weak_server):
         @param ip_ver: A string, ipv4 or ipv6
         """
         check_if_skip()
-        asic_type = duthosts[0].facts["asic_type"]
+        asic_type = duthost.facts["asic_type"]
         if asic_type == "vs":
             skip_counter_check = True
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #27481

The drop counters test selects a frontend DUT through `enum_rand_one_per_hwsku_frontend_hostname`, but `do_test` read ASIC type from `duthosts[0]`.
In multi-DUT topologies, `duthosts[0]` can be different from the selected frontend DUT, so skip logic can use the wrong DUT's ASIC type.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Fixes #27481

Failure type: day-one issue

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

202605:

***After Fix***

Tested on Version branch.202605-ars.8512e7eb-buildimage.ad6f5b869a8cacb3cb7eefe7dc226bf6f85480ff-nightly-2026.08.25.14.40

- `drop_packets/test_drop_counters.py`: 34 passed, 68 skipped
- Revised implementation targeted validation: `test_acl_drop` result was 1 passed, 2 skipped, 99 deselected
- [drop_counters_asic_type_after_fix_logs.zip](https://github.com/user-attachments/files/31611649/drop_counters_asic_type_after_fix_logs.zip)

### Approach
#### What is the motivation for this PR?

Keep drop counter skip logic aligned with the selected frontend DUT in multi-DUT topologies.

#### How did you do it?

Changed `do_test` to take `enum_rand_one_per_hwsku_frontend_hostname`, resolve the selected DUT with `duthosts[enum_rand_one_per_hwsku_frontend_hostname]`, and read ASIC type from that selected DUT.

#### How did you verify/test it?

Code inspection:

- `do_test` previously read ASIC type from `duthosts[0]`.
- The module-scope consumers and supporting fixtures use `enum_rand_one_per_hwsku_frontend_hostname` for the selected DUT path.
- After the change, ASIC-type skip logic uses the same selected DUT as the packet test path.

Runtime:

- Verified `drop_packets/test_drop_counters.py` passed on 202605 dualtor.
- Verified targeted `test_acl_drop` validation passed after revising the implementation.

#### Any platform specific information?

generic

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
