### PR TITLE
[devices]: Detect Broadcom TD3_X2 ASICs

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1821,7 +1821,7 @@ Totals               6450                 6449
     def _try_get_brcm_asic_name(self, output):
         search_sets = {
             "td2": {"b85", "BCM5685"},
-            "td3": {"b87", "BCM5687"},
+            "td3": {"b87", "BCM5687", "b274", "BCM56274"},
             "td4": {"b78", "BCM5678"},
             "th":  {"b96", "BCM5696"},
             "th2": {"b97", "BCM5697"},


### PR DESCRIPTION
### Description of PR

Summary:
Fix the shared Broadcom ASIC detector so TD3_X2 devices using PCI ID `b274` / device name `BCM56274` are reported as `td3` instead of `unknown`.

This resolves the consistent failure in:
`everflow.test_everflow_testbed.TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer`

Failure history: 492 failures and zero passes across 41 Arista-720DT-G48S4 M0 plans and eleven images. Each bed fails these four IPv4 combinations after the functional policer validation succeeds:
- downstream with `m0_l3_scenario`
- upstream with `m0_l3_scenario`
- downstream with `m0_vlan_scenario`
- upstream with `m0_vlan_scenario`

Existing fixes https://github.com/sonic-net/sonic-mgmt/pull/27257 and https://github.com/sonic-net/sonic-mgmt/pull/27412 already skip only the unreliable mirror-port TX/queue counter assertions for `td3`. They did not apply to 720DT because the shared detector returned `unknown`. This PR leaves the Everflow test unchanged and makes the existing guard work from the correct ASIC identity.

Microsoft ADO (number only): 39471819
ADO: https://msazure.visualstudio.com/One/_workitems/edit/39471819

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39471819
Failure type: day-one issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master, head `535a72eb8d7b615e75f5ce05de707d16a3a41ff5`: `python3 -m py_compile tests/common/devices/sonic.py`, `python3 -m flake8 tests/common/devices/sonic.py --max-line-length=120`, and `git diff --check` passed. Exact-head Azure CI build 1207233 passed all required checks: https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1207233
- 202605 hardware, validation head `5c249011`: internal-202605 on `testbed-bjw2-can-720dt-5` / `bjw2-can-720dt-5`, M0, Arista-720DT-G48S4, `SONiC.20260510.12`, build commit `644c1a022f`.
- Pretest: 11 passed, 3 expected skips, exit 0.
- Live detector probe: the DUT `lspci` output contains `Device b274`; patched `SonicHost.get_asic_name()` returned `td3`; 1 passed, exit 0.
- Target invocation: `./run_tests.sh -n testbed-bjw2-can-720dt-5 -c everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer -i ../ansible/veos,../ansible/bjw2 -u -x -a False -t m0`.
- Initial target run plus five consecutive valid runs: every run passed all four affected IPv4 combinations and skipped the same four unsupported IPv6 combinations; 24/24 affected cases passed, zero failures/errors, every run exit 0.

Per valid run, the passing cases were:
- `erspan_ipv4-cli-downstream-m0_vlan_scenario`
- `erspan_ipv4-cli-downstream-m0_l3_scenario`
- `erspan_ipv4-cli-upstream-m0_vlan_scenario`
- `erspan_ipv4-cli-upstream-m0_l3_scenario`

### Approach
#### What is the motivation for this PR?

The 720DT `lspci` output contains `Broadcom Inc. and subsidiaries Device b274`. The current static mapping only recognizes `b87` / `BCM5687` as TD3, so `get_asic_name()` returns `unknown` for the TD3_X2 ASIC.

The device identity is corroborated by sonic-buildimage at commit `04d4692fba8c443b5c5683f96a3fc0d90473094a`:
- 720DT PCI inventory records `id: b274`: https://github.com/sonic-net/sonic-buildimage/blob/04d4692fba8c443b5c5683f96a3fc0d90473094a/device/arista/x86_64-arista_720dt_48s/pcie.yaml#L93-L97
- Broadcom headers define `BCM56274_DEVICE_ID 0xb274`: https://github.com/sonic-net/sonic-buildimage/blob/04d4692fba8c443b5c5683f96a3fc0d90473094a/platform/broadcom/saibcm-modules-legacy-th/include/soc/devids.h#L1341-L1346
- Platform code identifies `TD3_X2 = 0xb274`: https://github.com/sonic-net/sonic-buildimage/blob/04d4692fba8c443b5c5683f96a3fc0d90473094a/platform/broadcom/sonic-platform-modules-micas/common/modules/wb_mac_bsc.c#L53-L58

#### How did you do it?

Added `b274` and `BCM56274` to the existing `td3` search set in `_try_get_brcm_asic_name`. The detector already performs case-sensitive substring searches. The added terms follow the existing convention: a lowercase short PCI ID matching `lspci` (`b274`) and the uppercase Broadcom device name (`BCM56274`). Both identify device ID `0xb274`; existing `b87` / `BCM5687` behavior is unchanged.

The previous exact-HWSKU change in `tests/everflow/test_everflow_testbed.py` was removed completely. That file is identical to current upstream master.

#### Caller audit

Audited all 37 direct `SonicHost.get_asic_name()` calls across 20 files. Three calls to the separate GCU HWSKU mapper are unaffected. No audited caller becomes unsafe when 720DT is correctly identified as TD3. The only additional active paths outside Everflow are the already-intended TD3 behavior in dualtor mock setup and tunnel QoS remap.

#### How did you verify/test it?

Ran targeted syntax, flake8, whitespace, exact-head CI, a live detector probe, pretest, and six valid hardware target runs on internal-202605.

#### Any platform specific information?

Arista-720DT-G48S4 uses Broadcom TD3_X2, PCI device ID `b274` / `BCM56274`.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A