### PR TITLE
test(vpp): xfail flaky BGP session setup

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -53,6 +53,12 @@ bgp/test_bgp_bbr.py::test_bbr_status_consistent_after_reload[:
     conditions:
       - "asic_type in ['vpp']"
 
+bgp/test_bgp_session.py::test_bgp_session_interface_down:
+  xfail:
+    reason: "VPP BGP sessions intermittently fail to establish during module setup"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/27487 and asic_type in ['vpp']"
+
 bgp/test_bgp_suppress_fib.py:
   skip:
     reason: >


### PR DESCRIPTION
### Description of PR

Summary:
Conditionally xfail `test_bgp_session_interface_down` on SONiC-VPP while the module-scoped BGP convergence issue remains open.

Tracks #27487

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: intermittent VPP setup flake

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- Fleet evidence: 33 setup errors across 33 PR plans in the last 30 days, all on `t1-lag-vpp`.
- Representative failures:
  - https://elastictest.org/scheduler/testplan/6a9316a3b7a4f26c75c0594e
  - https://elastictest.org/scheduler/testplan/6a9110a7d025e08c23cc57ea
  - https://elastictest.org/scheduler/testplan/6a89d0db5585d0b8ab0a829a
- Parsed `tests_mark_conditions_sonic_vpp.yaml` and verified the condition matches the target node prefix.

### Approach
#### What is the motivation for this PR?

The VPP-only test parameter intermittently fails before reaching its existing unsupported-platform skip because the module-scoped setup fixture times out waiting for all BGP sessions. This creates unrelated PR failures even though retries complete.

#### How did you do it?

Added an issue-gated VPP xfail for the complete parameterized function. The function-level scope is required because the failure occurs in its shared module fixture before the test body runs.

#### How did you verify/test it?

Confirmed the same assertion in the three newest affected logs, verified each plan recovered on module retry, and parsed the updated conditional mark file.

#### Any platform specific information?

This applies only when `asic_type` is `vpp`. The 30-day fleet data contains only `t1-lag-vpp` occurrences.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
