### PR TITLE
generic_config_updater: Add add-cluster GCU test for cable-length update

### DIFF
--- a/tests/common/buffer_utils.py
+++ b/tests/common/buffer_utils.py
@@ -1,0 +1,47 @@
+import os
+
+
+def load_lossless_info_from_pg_profile_lookup(duthost, dut_asic):
+    """
+    Load pg_profile_lookup.ini into a dictionary of default lossless profiles.
+
+    Args:
+        duthost: the DUT host object
+        dut_asic: the ASIC instance
+
+    Returns:
+        dict: mapping (speed, cable_length) -> profile_info
+    """
+    threshold_mode = dut_asic.run_redis_cmd(
+        argv=['redis-cli', '-n', 4, 'hget', 'BUFFER_POOL|ingress_lossless_pool', 'mode']
+    )[0]
+    threshold_field_name = 'dynamic_th' if threshold_mode == 'dynamic' else 'static_th'
+
+    dut_hwsku = duthost.facts["hwsku"]
+    dut_platform = duthost.facts["platform"]
+    skudir = "/usr/share/sonic/device/{}/{}/".format(dut_platform, dut_hwsku)
+    if dut_asic.namespace is not None:
+        skudir = skudir + dut_asic.namespace.split('asic')[-1] + '/'
+
+    pg_profile_lookup_file = os.path.join(skudir, 'pg_profile_lookup.ini')
+    duthost.file(path=pg_profile_lookup_file, state="file")
+    lines = duthost.shell('cat {}'.format(pg_profile_lookup_file))["stdout_lines"]
+
+    profiles = {}
+    for line in lines:
+        if not line or line.startswith('#'):
+            continue
+        tokens = line.split()
+        speed, cable_length, size, xon, xoff, threshold = tokens[:6]
+        profile_info = {
+            'pool': '[BUFFER_POOL|ingress_lossless_pool]',
+            'size': size,
+            'xon': xon,
+            'xoff': xoff,
+            threshold_field_name: threshold
+        }
+        if len(tokens) > 6:
+            profile_info['xon_offset'] = tokens[6]
+        profiles[(speed, cable_length)] = profile_info
+
+    return profiles

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2560,12 +2560,6 @@ generic_config_updater/add_cluster/test_add_cluster.py:
     conditions:
       - asic_type in ['vs']
 
-generic_config_updater/add_cluster/test_update_cable_length.py:
-  skip:
-    reason: This test case either cannot pass or should be skipped on virtual chassis
-    conditions:
-      - asic_type in ['vs']
-
 generic_config_updater/add_cluster/test_port_speed_change.py:
   skip:
     reason: "This test case right now only supported for Nokia Chassis"
@@ -2582,6 +2576,12 @@ generic_config_updater/add_cluster/test_port_speed_upgrade.py:
       - "topo_type != 't2'"
       - "switch_type != 'chassis-packet'"
       - "hwsku not in ['x86_64-88_lc0_36fh-r0']"
+
+generic_config_updater/add_cluster/test_update_cable_length.py:
+  skip:
+    reason: This test case either cannot pass or should be skipped on virtual chassis
+    conditions:
+      - asic_type in ['vs']
 
 generic_config_updater/test_apply_patch_perf.py:
   xfail:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2560,6 +2560,12 @@ generic_config_updater/add_cluster/test_add_cluster.py:
     conditions:
       - asic_type in ['vs']
 
+generic_config_updater/add_cluster/test_update_cable_length.py:
+  skip:
+    reason: This test case either cannot pass or should be skipped on virtual chassis
+    conditions:
+      - asic_type in ['vs']
+
 generic_config_updater/add_cluster/test_port_speed_change.py:
   skip:
     reason: "This test case right now only supported for Nokia Chassis"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
@@ -240,6 +240,11 @@ generic_config_updater/add_cluster/test_add_cluster.py:
     conditions:
     - asic_type in ['vs'] and 't2' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
+generic_config_updater/add_cluster/test_update_cable_length.py:
+  skip:
+    conditions:
+      - asic_type in ['vs'] and 't2' in topo_name
+    reason: This test case either cannot pass or should be skipped on virtual chassis
 generic_config_updater/test_bgp_prefix.py:
   skip:
     conditions:

--- a/tests/generic_config_updater/add_cluster/test_update_cable_length.py
+++ b/tests/generic_config_updater/add_cluster/test_update_cable_length.py
@@ -1,0 +1,242 @@
+import copy
+import logging
+
+import pytest
+
+from tests.common.buffer_utils import load_lossless_info_from_pg_profile_lookup
+from tests.common.gu_utils import apply_patch, delete_tmpfile, expect_op_success, generate_tmpfile
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.interface_utils import check_interface_status_of_up_ports
+from tests.common.utilities import wait_until
+from tests.generic_config_updater.add_cluster.helpers import change_interface_admin_state_for_namespace, \
+    get_active_interfaces, get_cfg_info_from_dut, select_random_active_interface
+
+pytestmark = [
+    pytest.mark.topology("t2")
+]
+
+logger = logging.getLogger(__name__)
+
+
+def _namespace_cli_prefix(namespace):
+    return '' if namespace is None else '-n ' + namespace
+
+
+def _namespace_json_prefix(namespace):
+    return '' if namespace is None else '/' + namespace
+
+
+def _profile_name(profile_ref):
+    """Normalize CONFIG_DB profile refs such as '[BUFFER_PROFILE|name]' to 'name'."""
+    if not profile_ref:
+        return profile_ref
+    return profile_ref.strip('[]').split('|')[-1]
+
+
+def _rewrite_profile_ref(current_ref, new_profile_name):
+    if current_ref and current_ref.startswith('['):
+        return '[BUFFER_PROFILE|{}]'.format(new_profile_name)
+    return new_profile_name
+
+
+def find_nearest_cable_length(pg_profile_info_dict, speed, cable_length):
+    """
+    Finds a different supported cable length for the required port speed.
+
+    Prefers the next-shorter supported length; if the current length is already
+    the shortest, uses the next-longer length.
+    """
+    filtered_dict = {key: value for key, value in pg_profile_info_dict.items() if key[0] == speed}
+    if not filtered_dict:
+        pytest.skip("Speed {} is not present in pg_profile_lookup.ini".format(speed))
+
+    sorted_cable_lengths_for_speed = sorted([int(key[1][:-1]) for key in filtered_dict.keys()])
+    try:
+        current_length = int(cable_length[:-1])
+        index = sorted_cable_lengths_for_speed.index(current_length)
+    except (TypeError, ValueError):
+        pytest.skip("Current cable length {} is not in pg_profile_lookup.ini for speed {}".format(
+            cable_length, speed))
+
+    if index > 0:
+        return sorted_cable_lengths_for_speed[index - 1]
+    if index < len(sorted_cable_lengths_for_speed) - 1:
+        return sorted_cable_lengths_for_speed[index + 1]
+
+    pytest.skip("Cannot change cable length; only one supported length for speed {}".format(speed))
+
+
+def _apply_cable_length_patch(duthost, json_namespace, cable_length_config):
+    json_patch = [
+        {
+            "op": "add",
+            "path": "{}/CABLE_LENGTH/AZURE".format(json_namespace),
+            "value": cable_length_config
+        }
+    ]
+    tmpfile = generate_tmpfile(duthost)
+    try:
+        output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+        expect_op_success(duthost, output)
+    finally:
+        delete_tmpfile(duthost, tmpfile)
+
+
+@pytest.mark.disable_loganalyzer
+def test_update_cable_length(duthosts,
+                             rand_one_dut_front_end_hostname,
+                             enum_rand_one_frontend_asic_index,
+                             enum_rand_one_asic_namespace):
+    """
+    Verifies GCU cable-length update for interfaces in one random ASIC namespace.
+
+    Interfaces are shut down, CABLE_LENGTH is patched, then interfaces are brought
+    up so buffermgrd remaps lossless BUFFER_PROFILE / BUFFER_PG. CONFIG_DB and
+    APPL_DB are checked. CABLE_LENGTH and interface admin state are restored.
+    """
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    ns_cli = _namespace_cli_prefix(enum_rand_one_asic_namespace)
+    json_namespace = _namespace_json_prefix(enum_rand_one_asic_namespace)
+
+    config_facts = duthost.config_facts(
+        host=duthost.hostname, source="running", namespace=enum_rand_one_asic_namespace
+    )['ansible_facts']
+    active_interfaces = get_active_interfaces(config_facts, duthost=duthost)
+
+    try:
+        selected_intf = select_random_active_interface(duthost, enum_rand_one_asic_namespace)
+    except IndexError:
+        pytest.skip("No active Ethernet interfaces available for cable length update")
+
+    supported_pg_profile_info_dict = load_lossless_info_from_pg_profile_lookup(
+        duthost, duthost.asic_instance(enum_rand_one_frontend_asic_index))
+
+    initial_cable_length = duthost.shell(
+        'sonic-db-cli {} CONFIG_DB hget "CABLE_LENGTH|AZURE" {}'.format(ns_cli, selected_intf)
+    )['stdout']
+    initial_port_speed = duthost.shell(
+        'sonic-db-cli {} CONFIG_DB hget "PORT|{}" speed'.format(ns_cli, selected_intf)
+    )['stdout']
+    pytest_assert(initial_cable_length and initial_port_speed,
+                  "Failed to read cable length or speed for {}".format(selected_intf))
+
+    initial_pg_lossless_profile_name = 'pg_lossless_{}_{}_profile'.format(
+        initial_port_speed, initial_cable_length)
+    initial_buffer_profile_info = get_cfg_info_from_dut(
+        duthost, 'BUFFER_PROFILE', enum_rand_one_asic_namespace) or {}
+    initial_buffer_pg_info = get_cfg_info_from_dut(
+        duthost, 'BUFFER_PG', enum_rand_one_asic_namespace) or {}
+    initial_pg_lossless_profile_info = initial_buffer_profile_info.get(initial_pg_lossless_profile_name)
+    if not initial_pg_lossless_profile_info:
+        pytest.skip("Initial lossless profile {} not found in BUFFER_PROFILE".format(
+            initial_pg_lossless_profile_name))
+
+    target_cable_length_val = find_nearest_cable_length(
+        supported_pg_profile_info_dict, initial_port_speed, initial_cable_length)
+    target_cable_length = "{}m".format(target_cable_length_val)
+    logger.info("Changing cable length from {} to {}.".format(initial_cable_length, target_cable_length))
+
+    initial_cable_length_config = get_cfg_info_from_dut(
+        duthost, 'CABLE_LENGTH', enum_rand_one_asic_namespace
+    )
+    pytest_assert(initial_cable_length_config and initial_cable_length_config.get('AZURE'),
+                  "Failed to read CABLE_LENGTH|AZURE from CONFIG_DB")
+    initial_cable_length_config = initial_cable_length_config.get('AZURE')
+
+    target_cable_length_config = {}
+    for interface, length in list(initial_cable_length_config.items()):
+        if interface in active_interfaces:
+            target_cable_length_config[interface] = target_cable_length
+        else:
+            target_cable_length_config[interface] = length
+
+    expected_pg_lossless_profile_name = 'pg_lossless_{}_{}_profile'.format(
+        initial_port_speed, target_cable_length)
+    supported_pg_profile_info_for_speed = supported_pg_profile_info_dict.get(
+        (initial_port_speed, target_cable_length))
+    pytest_assert(supported_pg_profile_info_for_speed,
+                  "No pg_profile_lookup.ini entry for speed {} cable {}".format(
+                      initial_port_speed, target_cable_length))
+
+    expected_pg_lossless_profile_info = copy.deepcopy(initial_pg_lossless_profile_info)
+    expected_pg_lossless_profile_info['xon'] = supported_pg_profile_info_for_speed.get('xon')
+    expected_pg_lossless_profile_info['xoff'] = supported_pg_profile_info_for_speed.get('xoff')
+    if 'xon_offset' in supported_pg_profile_info_for_speed:
+        expected_pg_lossless_profile_info['xon_offset'] = supported_pg_profile_info_for_speed.get('xon_offset')
+
+    expected_buffer_pg_info = copy.deepcopy(initial_buffer_pg_info)
+    for key, value in list(expected_buffer_pg_info.items()):
+        if _profile_name(value.get('profile')) == initial_pg_lossless_profile_name:
+            value['profile'] = _rewrite_profile_ref(value.get('profile'), expected_pg_lossless_profile_name)
+
+    cable_length_changed = False
+    interfaces_shutdown = False
+    try:
+        change_interface_admin_state_for_namespace(config_facts,
+                                                   duthost,
+                                                   enum_rand_one_asic_namespace,
+                                                   status='down',
+                                                   apply=True,
+                                                   verify=True)
+        interfaces_shutdown = True
+
+        _apply_cable_length_patch(duthost, json_namespace, target_cable_length_config)
+        cable_length_changed = True
+        pytest_assert(get_cfg_info_from_dut(duthost, 'CABLE_LENGTH', enum_rand_one_asic_namespace).get(
+            'AZURE') == target_cable_length_config, "Cable length value was not updated in CONFIG_DB.")
+
+        change_interface_admin_state_for_namespace(config_facts,
+                                                   duthost,
+                                                   enum_rand_one_asic_namespace,
+                                                   status='up',
+                                                   apply=True,
+                                                   verify=True)
+        interfaces_shutdown = False
+        pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
+                      "Not all ports that are admin up are operationally up")
+
+        updated_buffer_profile_info = get_cfg_info_from_dut(
+            duthost, 'BUFFER_PROFILE', enum_rand_one_asic_namespace) or {}
+        updated_buffer_pg_info = get_cfg_info_from_dut(
+            duthost, 'BUFFER_PG', enum_rand_one_asic_namespace) or {}
+        pytest_assert(expected_pg_lossless_profile_name in updated_buffer_profile_info,
+                      "Expected buffer profile {} was not created in CONFIG_DB.".format(
+                          expected_pg_lossless_profile_name))
+
+        updated_profile = updated_buffer_profile_info[expected_pg_lossless_profile_name]
+        for field in ('xon', 'xoff', 'xon_offset'):
+            if field not in expected_pg_lossless_profile_info:
+                continue
+            pytest_assert(str(updated_profile.get(field)) == str(expected_pg_lossless_profile_info[field]),
+                          "BUFFER_PROFILE {} field {} expected {} found {}".format(
+                              expected_pg_lossless_profile_name, field,
+                              expected_pg_lossless_profile_info[field], updated_profile.get(field)))
+
+        pytest_assert(updated_buffer_pg_info == expected_buffer_pg_info,
+                      "Didn't find expected BUFFER_PG info in CONFIG_DB.")
+
+        cmd = "sonic-db-cli {} APPL_DB keys BUFFER_PROFILE_TABLE:*".format(ns_cli)
+        updated_buffer_profile_info_appl_db = duthost.shell(cmd)["stdout"]
+        pytest_assert(expected_pg_lossless_profile_name in updated_buffer_profile_info_appl_db,
+                      "Expected buffer profile {} was not created in APPL_DB.".format(
+                          expected_pg_lossless_profile_name))
+    finally:
+        try:
+            if cable_length_changed or interfaces_shutdown:
+                change_interface_admin_state_for_namespace(config_facts,
+                                                           duthost,
+                                                           enum_rand_one_asic_namespace,
+                                                           status='down',
+                                                           apply=True,
+                                                           verify=True)
+            if cable_length_changed:
+                logger.info("Restoring CABLE_LENGTH to initial values via reverse patch.")
+                _apply_cable_length_patch(duthost, json_namespace, initial_cable_length_config)
+            change_interface_admin_state_for_namespace(config_facts,
+                                                       duthost,
+                                                       enum_rand_one_asic_namespace,
+                                                       status='up',
+                                                       apply=True,
+                                                       verify=True)
+        except Exception as restore_err:
+            logger.warning("Failed to restore cable length or interface state: {}".format(restore_err))

--- a/tests/generic_config_updater/add_cluster/test_update_cable_length.py
+++ b/tests/generic_config_updater/add_cluster/test_update_cable_length.py
@@ -49,14 +49,17 @@ def find_nearest_cable_length(pg_profile_info_dict, speed, cable_length):
     filtered_dict = {key: value for key, value in pg_profile_info_dict.items() if key[0] == speed}
     if not filtered_dict:
         pytest.skip("Speed {} is not present in pg_profile_lookup.ini".format(speed))
+        return None
 
     sorted_cable_lengths_for_speed = sorted([int(key[1][:-1]) for key in filtered_dict.keys()])
+    index = None
     try:
         current_length = int(cable_length[:-1])
         index = sorted_cable_lengths_for_speed.index(current_length)
     except (TypeError, ValueError):
         pytest.skip("Current cable length {} is not in pg_profile_lookup.ini for speed {}".format(
             cable_length, speed))
+        return None
 
     if index > 0:
         return sorted_cable_lengths_for_speed[index - 1]
@@ -64,6 +67,7 @@ def find_nearest_cable_length(pg_profile_info_dict, speed, cable_length):
         return sorted_cable_lengths_for_speed[index + 1]
 
     pytest.skip("Cannot change cable length; only one supported length for speed {}".format(speed))
+    return None
 
 
 def _apply_cable_length_patch(duthost, json_namespace, cable_length_config):
@@ -107,6 +111,7 @@ def test_update_cable_length(duthosts,
         selected_intf = select_random_active_interface(duthost, enum_rand_one_asic_namespace)
     except IndexError:
         pytest.skip("No active Ethernet interfaces available for cable length update")
+        return
 
     supported_pg_profile_info_dict = load_lossless_info_from_pg_profile_lookup(
         duthost, duthost.asic_instance(enum_rand_one_frontend_asic_index))

--- a/tests/qos/test_buffer_traditional.py
+++ b/tests/qos/test_buffer_traditional.py
@@ -1,9 +1,9 @@
 import logging
-import os
 import pytest
 
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.buffer_utils import load_lossless_info_from_pg_profile_lookup
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -119,7 +119,7 @@ def setup_module(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_front
         enum_rand_one_per_hwsku_frontend_hostname: Random DUT hostname per HWSKU
         enum_frontend_asic_index: Frontend ASIC index
     """
-    global RECLAIM_BUFFER_ON_ADMIN_DOWN
+    global DEFAULT_LOSSLESS_PROFILES, RECLAIM_BUFFER_ON_ADMIN_DOWN
 
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     dut_asic = duthost.asic_instance(enum_frontend_asic_index)
@@ -130,54 +130,7 @@ def setup_module(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_front
     else:
         RECLAIM_BUFFER_ON_ADMIN_DOWN = False
 
-    load_lossless_info_from_pg_profile_lookup(duthost, dut_asic)
-
-
-def load_lossless_info_from_pg_profile_lookup(duthost, dut_asic):
-    """Load pg_profile_lookup.ini to a dictionary. Called only once when the module is initialized
-
-    Args:
-        duthost: The DUT host object
-        dut_asic: The DUT ASIC instance
-
-    Returns:
-        None: Updates the global DEFAULT_LOSSLESS_PROFILES dictionary
-    """
-    global DEFAULT_LOSSLESS_PROFILES
-
-    # Check the threshold mode
-    threshold_mode = dut_asic.run_redis_cmd(argv=['redis-cli', '-n', 4, 'hget', 'BUFFER_POOL|ingress_lossless_pool',
-                                                  'mode'])[0]
-    threshold_field_name = 'dynamic_th' if threshold_mode == 'dynamic' else 'static_th'
-    dut_hwsku = duthost.facts["hwsku"]
-    dut_platform = duthost.facts["platform"]
-    skudir = "/usr/share/sonic/device/{}/{}/".format(dut_platform, dut_hwsku)
-    if dut_asic.namespace is not None:
-        skudir = skudir + dut_asic.namespace.split('asic')[-1] + '/'
-    pg_profile_lookup_file = os.path.join(skudir, 'pg_profile_lookup.ini')
-    duthost.file(path=pg_profile_lookup_file, state="file")
-    lines = duthost.shell('cat {}'.format(
-        pg_profile_lookup_file))["stdout_lines"]
-    DEFAULT_LOSSLESS_PROFILES = {}
-    for line in lines:
-        if line[0] == '#':
-            continue
-        tokens = line.split()
-        speed = tokens[0]
-        cable_length = tokens[1]
-        size = tokens[2]
-        xon = tokens[3]
-        xoff = tokens[4]
-        threshold = tokens[5]
-        profile_info = {
-            'pool': '[BUFFER_POOL|ingress_lossless_pool]',
-            'size': size,
-            'xon': xon,
-            'xoff': xoff,
-            threshold_field_name: threshold}
-        if len(tokens) > 6:
-            profile_info['xon_offset'] = tokens[6]
-        DEFAULT_LOSSLESS_PROFILES[(speed, cable_length)] = profile_info
+    DEFAULT_LOSSLESS_PROFILES = load_lossless_info_from_pg_profile_lookup(duthost, dut_asic)
 
 
 def make_dict_from_output_lines(lines):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR adds a T2 add-cluster Generic Config Updater test that changes CABLE_LENGTH via apply-patch and checks that lossless BUFFER_PROFILE/BUFFER_PG remapping follows the new length.

It replaces closed PR #20654. The add-cluster helpers from #14887 are already on master, so this change only adds the missing test and a shared pg_profile_lookup.ini loader. 

Review comments from #20654  are addressed:
- Verification always runs, 
- Unsupported cable-length cases skip instead of writing "Nonem", 
- Expected buffer data is deep-copied and asserted, and 
- CABLE_LENGTH plus interface admin state are restored with a reverse patch so checkpoint rollback does not have to modify BUFFER_PROFILE.

The test is topology t2 only. It is not added to kvmtest.sh. VS chassis is skipped via conditional marks, matching test_add_cluster.py.

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
- Add tests/generic_config_updater/add_cluster/test_update_cable_length.py to patch CABLE_LENGTH on a frontend ASIC namespace, bring ports back up, and assert CONFIG_DB / APPL_DB lossless profile remapping.
- Extract load_lossless_info_from_pg_profile_lookup() into tests/common/buffer_utils.py and use it from test_buffer_traditional.py.
- Restore CABLE_LENGTH with a reverse patch and always bring interfaces back up, including on failure.
- Skip the new test on VS, same as other add-cluster tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] New Test case
    - [X] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
Add-cluster GCU coverage for cable-length change was split out of #14887 and posted as #20654, which was closed with the plan to open a new PR.

Without this test, a CABLE_LENGTH apply-patch that fails to remap pg_lossless_* BUFFER_PROFILE / BUFFER_PG would not be caught. 
#20654  also could not be merged as written: 
- buffer checks were behind verify=False and never ran; 
- a single supported cable length produced "Nonem"; 
- expected profile dicts aliased live CONFIG_DB data; and 
- module checkpoint rollback failed on Cisco T2 because it tried to patch BUFFER_PROFILE
(rdma_config_update_validator).

This PR lands that scenario on current master with above issues fixed.
#### How did you do it?
1. Shared helper
   Moved pg_profile_lookup.ini parsing out of test_buffer_traditional.py
   into tests/common/buffer_utils.py. The helper returns a
   (speed, cable_length) -> profile map. test_buffer_traditional.py now
   assigns DEFAULT_LOSSLESS_PROFILES from that return value and keeps its
   newer helpers (parse_pg_range, get_lossless_priorities,
   get_lossless_buffer_pgs).

2. Cable-length test
   On one random frontend ASIC namespace:
   - Pick an active interface and a different supported cable length from
     pg_profile_lookup.ini (prefer shorter, else longer; skip if there is
     only one length or the current length is not in the lookup).
   - Shut interfaces down with the existing add-cluster helper.
   - apply-patch CABLE_LENGTH|AZURE for active interfaces.
   - Bring interfaces up, wait until admin-up ports are operational, then
     assert:
       - CABLE_LENGTH in CONFIG_DB
       - new pg_lossless_<speed>_<length>_profile in CONFIG_DB, including
         xon / xoff / xon_offset
       - BUFFER_PG mapping
       - profile present in APPL_DB BUFFER_PROFILE_TABLE

3. Restoration
   In a finally block, reverse-patch CABLE_LENGTH to the original AZURE
   table and bring interfaces back up.
   That avoids relying on checkpoint rollback to remove or replace BUFFER_PROFILE.

4. Gate / skip
   Marked topology t2. Added VS skip entries next to test_add_cluster.py
   in tests_mark_conditions.yaml and tests_mark_conditions_vs_t2.yaml.
   kvmtest.sh is unchanged; that runner does not execute add-cluster T2
   tests.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
We will add the verification logs soon.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
