### PR TITLE
[202605] Count multi-member PortChannels once in the all-port-storm ratio (#27382)

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -560,7 +560,7 @@ def _prepare_background_traffic_params(duthost, queues, selected_test_ports, tes
     dst_ips = []
     for selected_test_port in selected_test_ports:
         selected_test_port_info = test_ports_info[selected_test_port]
-        if type(selected_test_port_info["rx_port_id"]) == list:
+        if isinstance(selected_test_port_info["rx_port_id"], list):
             src_ports.append(selected_test_port_info["rx_port_id"][0])
         else:
             src_ports.append(selected_test_port_info["rx_port_id"])

--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -760,19 +760,24 @@ def verify_all_ports_pfc_storm_in_expected_state(dut, storm_hndle, expected_stat
         logger.warning("No ports found to verify")
         return False
 
-    # On non-dualtor t0 topologies, setup_pfc_test assigns a single VLAN neighbor IP
-    # (self.vlan_nw) to every VLAN port, so at most one of those ports can actually
-    # receive PTF background traffic -- the DUT does one ND/ARP lookup and routes all
-    # traffic out a single port. Counting every such VLAN port individually against the
-    # storm threshold inflates the denominator and causes false failures.
+    # Some port types are assigned a single shared neighbor IP by design, so only one
+    # of the ports sharing that IP can actually receive the routed PTF background
+    # traffic and build the egress queue occupancy that PFCWD needs to declare a storm:
+    #   * VLAN ports - on non-dualtor t0, setup_pfc_test assigns self.vlan_nw to every
+    #     VLAN port and the DUT does a single ND/ARP lookup for it.
+    #   * PortChannel members - parse_pc_list assigns the PortChannel's single BGP peer
+    #     address to every member, so the DUT LAG-hashes the flow onto one member.
+    # Counting each of those ports individually inflates the denominator and causes
+    # false failures even though the fanout is pausing every physical link.
     #
-    # To keep the numerator and denominator consistent, group VLAN ports that share a
-    # test_neighbor_addr and treat each group as one "effective" port (success = any
-    # member reached the expected state). Non-VLAN ports (routed interfaces and
-    # PortChannel members, which also share a neighbor IP by design in parse_pc_list)
-    # are always counted individually. This adjustment only applies to the storm phase.
+    # To keep the numerator and denominator consistent, group ports of those types that
+    # share a test_neighbor_addr and treat each group as one "effective" port (success =
+    # any member reached the expected state). Routed interfaces get a unique neighbor
+    # address each, so they always form single-port groups and are counted individually.
+    # This adjustment only applies to the storm phase.
     if expected_state == "storm" and test_ports_info:
-        vlan_ip_groups = {}
+        shared_ip_types = ('vlan', 'portchannel')
+        shared_ip_groups = {}
         standalone_ports = []
         seen_ports = set()
         for port, _queue_idx in ports_to_check:
@@ -781,23 +786,24 @@ def verify_all_ports_pfc_storm_in_expected_state(dut, storm_hndle, expected_stat
             seen_ports.add(port)
             info = test_ports_info.get(port, {}) or {}
             ip = info.get('test_neighbor_addr')
-            if info.get('test_port_type') == 'vlan' and ip:
-                vlan_ip_groups.setdefault(ip, []).append(port)
+            port_type = info.get('test_port_type')
+            if port_type in shared_ip_types and ip:
+                shared_ip_groups.setdefault((port_type, ip), []).append(port)
             else:
                 standalone_ports.append(port)
 
-        # Only adjust when VLAN ports actually share an IP (the non-dualtor case).
-        if any(len(ports) > 1 for ports in vlan_ip_groups.values()):
-            effective_total = len(vlan_ip_groups) + len(standalone_ports)
+        # Only adjust when ports actually share a neighbor IP.
+        if any(len(ports) > 1 for ports in shared_ip_groups.values()):
+            effective_total = len(shared_ip_groups) + len(standalone_ports)
             effective_success = 0
-            for ip, ports in vlan_ip_groups.items():
+            for _group_key, ports in shared_ip_groups.items():
                 if any(port_results.get(p, False) for p in ports):
                     effective_success += 1
             for port in standalone_ports:
                 if port_results.get(port, False):
                     effective_success += 1
             logger.info(
-                "Adjusting for duplicate VLAN neighbor IPs: ports_in_expected_state %d->%d, "
+                "Adjusting for duplicate neighbor IPs: ports_in_expected_state %d->%d, "
                 "total_ports %d->%d",
                 ports_in_expected_state, effective_success, total_ports, effective_total)
             ports_in_expected_state = effective_success


### PR DESCRIPTION
### Description of PR

Summary:
Manual backport of #27382 to the `202605` branch. The automated cherry-pick failed
(label `Cherry Pick Conflict_202605`), so this PR carries the change with the conflict
resolved by hand.

Related issue: https://github.com/sonic-net/sonic-mgmt/issues/27425
Original PR: #27382 (commit f9a9eeb681b1c99c07331db6931d974a7423ad6f)

Fixes `pfcwd/test_pfcwd_all_port_storm.py::TestPfcwdAllPortStorm::test_all_port_storm_restore`
failing on platforms with multi-member PortChannels (observed on Mellanox SN4600C / SPC3,
`str2-msn4600c-acs-04`), where only 40 of 44 ports reach PFC storm state and the ratio
falls below the 75% threshold.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request

- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

(This PR *is* the 202605 backport.)

### Approach

#### What is the motivation for this PR?

`PfcCmd.parse_pc_list()` assigns the PortChannel's single BGP peer address as
`test_neighbor_addr` to **every** member port. PTF background traffic to that address is
therefore one flow, which the DUT LAG-hashes onto exactly one member. The other members
never build egress queue occupancy, so PFCWD can never declare a storm on them - even
though the fanout is pausing every physical link.

On a 2-member-PortChannel SN4600C that costs 4 ports out of 44, taking the ratio to
40/44 = 90.9%... but the restore phase then only sees the 40 that stormed, and the
denominator mismatch pushes it under the 75% threshold.

#### How did you do it?

Extends the duplicate-neighbor grouping already present in
`verify_all_ports_pfc_storm_in_expected_state` (added by #25147 for VLAN ports) to cover
PortChannel members as well:

- `vlan_ip_groups` -> `shared_ip_groups`, keyed by `(port_type, test_neighbor_addr)`
  instead of just the address, so a VLAN port and a PortChannel member that happen to
  share an address are never merged into the same group.
- `shared_ip_types = ('vlan', 'portchannel')`.
- A group counts as one "effective" port, and succeeds if **any** member reached the
  expected state.

Routed interfaces get a unique neighbor address each, so they always form single-port
groups and continue to be counted individually. The adjustment still applies to the storm
phase only.

### Cherry-pick conflict and how it was resolved

`git cherry-pick -x f9a9eeb681` onto `202605` conflicts in exactly one file:

```
M  tests/common/helpers/pfcwd_helper.py          <- applied cleanly (the actual fix)
UU tests/pfcwd/test_pfcwd_all_port_storm.py      <- conflict
```

**The conflict is contextual, not semantic, and the correct resolution is to make no
change to that file at all.**

#27382 touched `test_pfcwd_all_port_storm.py` for one reason only: to *restore*
`test_ports_info=setup_pfc_test['test_ports']` on the storm-phase `run_test()` call.
That argument had been dropped **on master** by #24563, which re-indented the block into
a `try/finally` to add `cleanup_ptf_ips()`.

#24563 was never backported here:

```
upstream/master : cleanup_ptf_ips occurrences = 2
upstream/202605 : cleanup_ptf_ips occurrences = 0
```

So on `202605` the regression never happened - the branch still carries #25147's original
wiring, and `test_ports_info` is already passed (line 298). Git only reports a conflict
because master's copy of the same code sits one indentation level deeper inside `try:`
and wraps its arguments differently. Confirmation: in the conflict output,
`test_ports_info=setup_pfc_test['test_ports']` appears in the **common** region below the
markers, i.e. git matched it on both sides.

The branch side was therefore kept for `test_pfcwd_all_port_storm.py`, leaving it
byte-identical to `202605`. Net change in this PR is `pfcwd_helper.py` only.

Verification performed on the resolved tree:

- No conflict markers remain.
- `test_ports_info=setup_pfc_test['test_ports']` is present on the storm-phase call.
- `verify_all_ports_pfc_storm_in_expected_state` matches the post-merge master version,
  apart from two pre-existing `202605` logging differences (`.format()` vs f-string) that
  this change does not touch.
- `git diff upstream/202605 HEAD` = `pfcwd_helper.py` only, 25 insertions / 19 deletions
  (24/18 for the cherry-pick, plus the 1-line lint fix described below).
- `flake8 --max-line-length=120` clean; `py_compile` OK.

### Second commit: pre-existing E721 lint failure on `202605`

The `Pre_test Static Analysis` check failed on the first push with a finding that this
PR did not introduce:

```
tests/common/helpers/pfcwd_helper.py:563:12: E721 do not compare types,
for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```

Line 563 is byte-identical on `upstream/202605`, so it is pre-existing lint debt. It
surfaces here only because the pre-commit `flake8` hook lints the **whole changed file**,
not just the changed lines - so any PR that touches `pfcwd_helper.py` on this branch hits
the same wall.

Cause: #26072, which bumps the `flake8` pre-commit hook from `6.0.0` to `7.1.1`, was
backported to `202605` as `a59771db7b`. Its follow-up #26073, which fixes the
`E721`/`E502` findings that stricter linter surfaces, was **not** backported. The branch
therefore runs the newer linter without the corresponding fixes.

The second commit applies the exact one-line change master already carries in
`cafdb1588c` (#26073) for this line:

```diff
-        if type(selected_test_port_info["rx_port_id"]) == list:
+        if isinstance(selected_test_port_info["rx_port_id"], list):
```

This is behaviourally equivalent - `rx_port_id` is always either a plain `list` or a
scalar, never a `list` subclass - and it converges `202605` toward master.

> Note for maintainers: `202605` is missing the rest of #26073 as well (21 files in
> total). Only the hunk needed to unblock this PR is included here; a separate backport
> of the full commit would be the cleaner way to clear the remaining debt.

#### How did you verify/test it?

The change was verified on hardware against a `202605` image before the original PR was
merged. All seven pfcwd modules (`test_pfc_config.py`, `test_pfcwd_all_port_storm.py`,
`test_pfcwd_cli.py`, `test_pfcwd_function.py`, `test_pfcwd_timer_accuracy.py`,
`test_pfcwd_warm_reboot.py`, `test_xon_not_counted.py`) across every available platform
family - **651 passed, 0 failed** on 15 testbeds:

| Platform | Testbed | Passed | Skipped | Failed | Job |
|---|---|---:|---:|---:|---|
| Broadcom TD3 (7050CX3) | testbed-bjw2-can-t0-7050-1 | 48 | 11 | **0** | [6a907f5ef57cc4ef7fcd83bc](https://elastictest.org/scheduler/testplan/6a907f5ef57cc4ef7fcd83bc) |
|  | testbed-bjw2-can-t0-7050-2 | 48 | 11 | **0** | [6a907f65c02c8a580dfec577](https://elastictest.org/scheduler/testplan/6a907f65c02c8a580dfec577) |
|  | vms20-t0-7050cx3-2 | 48 | 11 | **0** | [6a90faadf57cc4ef7fcd84e3](https://elastictest.org/scheduler/testplan/6a90faadf57cc4ef7fcd84e3) |
| Broadcom TH (7060CX) | testbed-bjw2-can-t0-7060-9 | 48 | 11 | **0** | [6a907f74a2b56b54e48a0bac](https://elastictest.org/scheduler/testplan/6a907f74a2b56b54e48a0bac) |
|  | testbed-bjw2-can-t0-7060-10 | 48 | 11 | **0** | [6a907f6cf57cc4ef7fcd83be](https://elastictest.org/scheduler/testplan/6a907f6cf57cc4ef7fcd83be) |
|  | testbed-bjw3-can-t1-7060-1 | 48 | 11 | **0** | [6a9132aba2b56b54e48a0d8d](https://elastictest.org/scheduler/testplan/6a9132aba2b56b54e48a0d8d) |
|  | testbed-bjw3-can-t1-7060-2 | 48 | 11 | **0** | [6a9140bb69f529d156ccc685](https://elastictest.org/scheduler/testplan/6a9140bb69f529d156ccc685) |
| Cisco Q200 (8101/8102) | testbed-bjw2-can-t1-8101-1 | 40 | 11 | **0** | [6a9082f2f57cc4ef7fcd83c4](https://elastictest.org/scheduler/testplan/6a9082f2f57cc4ef7fcd83c4) |
|  | testbed-bjw2-can-t1-8102-1 | 40 | 11 | **0** | [6a9082fdae6f9bbcd6a88eb3](https://elastictest.org/scheduler/testplan/6a9082fdae6f9bbcd6a88eb3) |
|  | testbed-bjw2-can-t1-8102-2 | 40 | 11 | **0** | [6a9083087e50e72ef81bd646](https://elastictest.org/scheduler/testplan/6a9083087e50e72ef81bd646) |
| Mellanox SPC (SN2700) | testbed-bjw-can-2700-3 | 39 | 12 | **0** | [6a90fab5d025e08c23cc57b5](https://elastictest.org/scheduler/testplan/6a90fab5d025e08c23cc57b5) |
|  | testbed-bjw-can-2700-4 | 39 | 12 | **0** | [6a908668f57cc4ef7fcd83d3](https://elastictest.org/scheduler/testplan/6a908668f57cc4ef7fcd83d3) |
| Mellanox SPC3 (SN4600C) | testbed-bjw2-can-t0-4600c-5 | 39 | 12 | **0** | [6a908671f57cc4ef7fcd83d5](https://elastictest.org/scheduler/testplan/6a908671f57cc4ef7fcd83d5) |
|  | testbed-bjw2-can-t1-4600c-3 | 39 | 14 | **0** | [6a908682c0a5d5aae841168c](https://elastictest.org/scheduler/testplan/6a908682c0a5d5aae841168c) |
|  | testbed-bjw2-can-t1-4600c-6 | 39 | 14 | **0** | [6a908679d025e08c23cc56bc](https://elastictest.org/scheduler/testplan/6a908679d025e08c23cc56bc) |

Two further testbeds (`vms20-t0-7050cx3-1`, `testbed-bjw2-can-t0-4600c-1`) could not be
scheduled inside the verification window - they stayed queued behind nightly-test locks
and were cancelled on lock timeout without executing a single case, so they carry no
result.

Because the resolution leaves `test_pfcwd_all_port_storm.py` untouched on this branch,
the code under test here is identical to what was verified above.

#### Any platform specific information?

The failure is only observable on platforms whose topology gives PortChannels more than
one member; it was found on Mellanox SN4600C (SPC3). The fix itself is platform-agnostic
and only changes threshold arithmetic - no traffic, ARP, or port selection behaviour
changes.

#### Supported testbed topology if it's a new test case?

N/A - not a new test case.

### Documentation

No user-facing documentation change. The rationale is captured in code comments above the
grouping block in `verify_all_ports_pfc_storm_in_expected_state`.

