### PR TITLE
Display bgp counters along with PTF capture for better debugging in case of failure

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -412,6 +412,31 @@ def match_bgp_update(packet, src_ip, dst_ip, action, route, is_v6_topo):
         return False
 
 
+def _clear_bgp_neighbor_counters(asichost, neighbor_ips):
+    """Reset BGP message-stats counters (session untouched)."""
+    for ip in neighbor_ips:
+        try:
+            asichost.run_vtysh(" -c 'clear bgp {} message-stats'".format(ip))
+        except Exception as e:
+            logging.warning("Failed to clear BGP message-stats for %s: %s", ip, e)
+
+
+def _dump_bgp_neighbor_counters(asichost, neighbor_ips, is_v6_topo):
+    """Return per-neighbor BGP message statistics as text."""
+    neighbor_cmd = (
+        "show bgp ipv6 neighbors {}" if is_v6_topo else "show ip bgp neighbors {}"
+    )
+    sections = []
+    for ip in neighbor_ips:
+        try:
+            res = asichost.run_vtysh(" -c '{}'".format(neighbor_cmd.format(ip)))
+            stdout = res["stdout"]
+        except Exception as e:
+            stdout = "failed to collect counters: {}".format(e)
+        sections.append("===== BGP neighbor {} =====\n{}".format(ip, stdout))
+    return "\n".join(sections)
+
+
 def test_bgp_update_timer_single_route(
     common_setup_teardown,
     constants,
@@ -457,6 +482,8 @@ def test_bgp_update_timer_single_route(
             bgp_pcap = BGP_LOG_TMPL % i
             with capture_bgp_packages_to_file(duthost, "any", bgp_pcap, n0.namespace):
                 asichost = duthost.asic_instance_from_namespace(n0.namespace)
+                # Clear counters so Sent/Rcvd reflect only this route's exchange.
+                _clear_bgp_neighbor_counters(asichost, [n0.ip, n1.ip])
                 n0.announce_route(route)
                 time.sleep(constants.sleep_interval)
                 res = asichost.run_vtysh(
@@ -509,7 +536,10 @@ def test_bgp_update_timer_single_route(
                 err_msg %= ("withdraw", route, n1.peer_ip, n1.ip)
                 no_update = True
             if no_update:
-                pytest.fail(err_msg)
+                # Dump counters to distinguish control-plane vs capture issue.
+                counters = _dump_bgp_neighbor_counters(asichost, [n0.ip, n1.ip], is_v6_topo)
+                logging.error("pcap validation failed: %s\ncounters:\n%s", err_msg, counters)
+                pytest.fail("{}\nBGP neighbor counters:\n{}".format(err_msg, counters))
 
             announce_intervals.append(
                 announce_from_dut_to_n1[0].time - announce_from_n0_to_dut[0].time


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Execute "show bgp neighbors <nbr_ip>" command to display the BGP neighbor's packet statistics to prove that the DUT did not receive any route update/withdraw packet from PTF.

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
The testcase does the following

1. Create BGP neighbors 192.168.0.2(N-0) and 192.168.0.3(N-1)(on PTF)
2. 5 routes are announced one by one from N0 to the DUT.
3. A tcpdump is started to capture the packets.
4. After every route is announced, the show command is executed to display the routes advertised to the DUT by N-0 and N-   Routes advertised by N-0 should be seen as expected
5. The route is withdrawn by N-0. Again show command is executed to display the routes advertised to the DUT by N-0 and N-1. No routes should be present as it is withdrawn
6. Packet capture is validated to check if below packets are there accordingly

**In the failure case, the routes are still present after N-0 withdraws the route i.e after step 5.**
Tcpdump validation of all packet types shows that the DUT never received any withdraw packets from N0. Hence the routes are still present. This looks like a problem from the PTF end and there is no issue with the DUT’s behavior as it never received the withdraw packets. Hence adding the bgp neighbor's statistics will further prove the same.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
