### PR TITLE
[202511] Count multi-member PortChannels once in the all-port-storm ratio (#27382)

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -723,19 +723,24 @@ def verify_all_ports_pfc_storm_in_expected_state(dut, storm_hndle, expected_stat
         logger.warning("No ports found to verify")
         return False
 
-    # On non-dualtor t0 topologies, setup_pfc_test assigns a single VLAN neighbor IP
-    # (self.vlan_nw) to every VLAN port, so at most one of those ports can actually
-    # receive PTF background traffic -- the DUT does one ND/ARP lookup and routes all
-    # traffic out a single port. Counting every such VLAN port individually against the
-    # storm threshold inflates the denominator and causes false failures.
+    # Some port types are assigned a single shared neighbor IP by design, so only one
+    # of the ports sharing that IP can actually receive the routed PTF background
+    # traffic and build the egress queue occupancy that PFCWD needs to declare a storm:
+    #   * VLAN ports - on non-dualtor t0, setup_pfc_test assigns self.vlan_nw to every
+    #     VLAN port and the DUT does a single ND/ARP lookup for it.
+    #   * PortChannel members - parse_pc_list assigns the PortChannel's single BGP peer
+    #     address to every member, so the DUT LAG-hashes the flow onto one member.
+    # Counting each of those ports individually inflates the denominator and causes
+    # false failures even though the fanout is pausing every physical link.
     #
-    # To keep the numerator and denominator consistent, group VLAN ports that share a
-    # test_neighbor_addr and treat each group as one "effective" port (success = any
-    # member reached the expected state). Non-VLAN ports (routed interfaces and
-    # PortChannel members, which also share a neighbor IP by design in parse_pc_list)
-    # are always counted individually. This adjustment only applies to the storm phase.
+    # To keep the numerator and denominator consistent, group ports of those types that
+    # share a test_neighbor_addr and treat each group as one "effective" port (success =
+    # any member reached the expected state). Routed interfaces get a unique neighbor
+    # address each, so they always form single-port groups and are counted individually.
+    # This adjustment only applies to the storm phase.
     if expected_state == "storm" and test_ports_info:
-        vlan_ip_groups = {}
+        shared_ip_types = ('vlan', 'portchannel')
+        shared_ip_groups = {}
         standalone_ports = []
         seen_ports = set()
         for port, _queue_idx in ports_to_check:
@@ -744,23 +749,24 @@ def verify_all_ports_pfc_storm_in_expected_state(dut, storm_hndle, expected_stat
             seen_ports.add(port)
             info = test_ports_info.get(port, {}) or {}
             ip = info.get('test_neighbor_addr')
-            if info.get('test_port_type') == 'vlan' and ip:
-                vlan_ip_groups.setdefault(ip, []).append(port)
+            port_type = info.get('test_port_type')
+            if port_type in shared_ip_types and ip:
+                shared_ip_groups.setdefault((port_type, ip), []).append(port)
             else:
                 standalone_ports.append(port)
 
-        # Only adjust when VLAN ports actually share an IP (the non-dualtor case).
-        if any(len(ports) > 1 for ports in vlan_ip_groups.values()):
-            effective_total = len(vlan_ip_groups) + len(standalone_ports)
+        # Only adjust when ports actually share a neighbor IP.
+        if any(len(ports) > 1 for ports in shared_ip_groups.values()):
+            effective_total = len(shared_ip_groups) + len(standalone_ports)
             effective_success = 0
-            for ip, ports in vlan_ip_groups.items():
+            for _group_key, ports in shared_ip_groups.items():
                 if any(port_results.get(p, False) for p in ports):
                     effective_success += 1
             for port in standalone_ports:
                 if port_results.get(port, False):
                     effective_success += 1
             logger.info(
-                "Adjusting for duplicate VLAN neighbor IPs: ports_in_expected_state %d->%d, "
+                "Adjusting for duplicate neighbor IPs: ports_in_expected_state %d->%d, "
                 "total_ports %d->%d",
                 ports_in_expected_state, effective_success, total_ports, effective_total)
             ports_in_expected_state = effective_success


### PR DESCRIPTION
### Description of PR

Backport of #27382 to `202511`.

Fixes `pfcwd/test_pfcwd_all_port_storm.py::TestPfcwdAllPortStorm::test_all_port_storm_restore`
failing on platforms with multi-member PortChannels (observed on Mellanox SN4600C / SPC3,
`str2-msn4600c-acs-04`), where only 40 of 44 ports reach PFC storm state and the ratio falls
below the 75 % threshold.

Related issue: https://github.com/sonic-net/sonic-mgmt/issues/27425

The SONiC bot raised a `Cherry Pick Conflict_202511` label on #27382, so this PR was created
manually with the conflict resolved by hand. See the section below for exactly what conflicted
and why the resolution is a no-op on this branch.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Back port request

- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202511

### Approach

#### What is the motivation for this PR?

`verify_all_ports_pfc_storm_in_expected_state` already grouped ports that share a neighbor IP,
but only for VLAN ports. PortChannel members share a neighbor address by design for exactly the
same reason, so on a topology with multi-member PortChannels the denominator counted each member
separately while the numerator could only ever contribute once. The ratio was therefore
structurally unable to reach 100 %, and dropped below the 75 % threshold on SN4600C.

#### How did you do it?

Extend the existing duplicate-neighbor grouping from VLAN ports to PortChannel members, so a
multi-member PortChannel is counted once in the all-port-storm ratio.

This is a deliberately **verification-only** change: it makes the pass/fail accounting consistent
with how the test topology assigns neighbor addresses. It does not change traffic distribution on
the DUT, and no DUT or neighbor configuration is touched.

### Cherry-pick conflict and how it was resolved

`git cherry-pick -x f9a9eeb681` applies `tests/common/helpers/pfcwd_helper.py` cleanly and
conflicts only in `tests/pfcwd/test_pfcwd_all_port_storm.py`.

**The conflict is contextual, not semantic, and the correct resolution is to make no change to
that file on this branch.**

#27382 touched `test_pfcwd_all_port_storm.py` for one reason only: to *restore* a single argument
on the storm-phase call. Its entire diff for that file is one added line, with no deletions:

```diff
@@ class TestPfcwdAllPortStorm(object):
+                              test_ports_info=setup_pfc_test['test_ports'],
```

That line is **already present on `202511`**, in the same position and with the same value:

```
                          stormed_ports_list=stormed_ports_list,
                          selected_test_ports=selected_test_ports,
                          test_ports_info=setup_pfc_test['test_ports'],   <-- already here
                          tbinfo=tbinfo)
```

The argument was dropped on `master` by #24563, which also wrapped the body in a `try:` block and
added a `cleanup_ptf_ips()` helper. **#24563 was never backported to `202511`**, so the regression
it introduced never reached this branch and there is nothing to restore here. What git reports as
a conflict is purely the surrounding `try:` indentation and line wrapping that #24563 introduced
on master.

Taking the incoming (master) side of the conflict hunk would import that `try:` from an
un-backported commit and produce code that does not even parse:

```
SyntaxError: expected 'except' or 'finally' block
```

because the matching `finally:` lives outside the conflict region and does not exist on this
branch. So the branch side was kept for `test_pfcwd_all_port_storm.py`, leaving it byte-identical
to `202511`. Net change in this PR is `pfcwd_helper.py` only.

Verification performed on the resolved tree:

- No conflict markers remain.
- `test_ports_info=setup_pfc_test['test_ports']` is present on the storm-phase call.
- `test_pfcwd_all_port_storm.py` is byte-identical to `upstream/202511`.
- `verify_all_ports_pfc_storm_in_expected_state` is **byte-identical to the post-merge master
  version**.
- `git diff upstream/202511 HEAD` = `pfcwd_helper.py` only, 24 insertions / 18 deletions.
- `flake8 7.1.1 --max-line-length=120` clean (the version pinned in `.pre-commit-config.yaml`);
  `py_compile` OK.
- The patch is byte-identical to the private branch that was validated on hardware, and the final
  contents of both files match that branch exactly.

#### How did you verify/test it?

The change was validated on hardware against a `202511` image before the original PR was merged,
running the whole `pfcwd` suite (not just the affected module) with `repeat_times=5` on each
testbed.

**13 testbeds passed, 580 test cases passed, 0 failures.**

| Testbed | Verdict | Pass | Fail | Skip | Plan | Note |
|---|---|---|---|---|---|---|
| `testbed-bjw-can-2700-3` | ✅ PASS | 40 | 0 | 12 | [plan](https://elastictest.org/scheduler/testplan/6a9140d669f529d156ccc687) |  |
| `testbed-bjw-can-2700-4` | ✅ PASS | 40 | 0 | 12 | [plan](https://elastictest.org/scheduler/testplan/6a90c6357e50e72ef81bd6e8) |  |
| `testbed-bjw2-can-t0-4600c-2` | ✅ PASS | 22 | 0 | 3 | [plan](https://elastictest.org/scheduler/testplan/6a90433ec02c8a580dfec50b) |  |
| `testbed-bjw2-can-t0-4600c-5` | ✅ PASS | 40 | 0 | 12 | [plan](https://elastictest.org/scheduler/testplan/6a9090f2d025e08c23cc56d6) |  |
| `testbed-bjw2-can-t0-7050-1` | ✅ PASS | 49 | 0 | 11 | [plan](https://elastictest.org/scheduler/testplan/6a90bee7c0a5d5aae84116fe) |  |
| `testbed-bjw2-can-t0-7050-2` | ✅ PASS | 49 | 0 | 11 | [plan](https://elastictest.org/scheduler/testplan/6a90c5ead025e08c23cc5738) |  |
| `testbed-bjw2-can-t0-7060-10` | ✅ PASS | 49 | 0 | 11 | [plan](https://elastictest.org/scheduler/testplan/6a90c5f1ae6f9bbcd6a88f6e) |  |
| `testbed-bjw2-can-t0-7060-9` | ✅ PASS | 49 | 0 | 11 | [plan](https://elastictest.org/scheduler/testplan/6a90c5f9a2b56b54e48a0c47) |  |
| `testbed-bjw2-can-t1-4600c-3` | ✅ PASS | 40 | 0 | 14 | [plan](https://elastictest.org/scheduler/testplan/6a909104a2b56b54e48a0bd2) |  |
| `testbed-bjw2-can-t1-4600c-6` | ✅ PASS | 40 | 0 | 14 | [plan](https://elastictest.org/scheduler/testplan/6a9090fbc02c8a580dfec5b3) |  |
| `testbed-bjw2-can-t1-8101-1` | ✅ PASS | 41 | 0 | 11 | [plan](https://elastictest.org/scheduler/testplan/6a90c61ca2b56b54e48a0c4b) |  |
| `testbed-bjw2-can-t1-8102-1` | ✅ PASS | 41 | 0 | 11 | [plan](https://elastictest.org/scheduler/testplan/6a90c622ae6f9bbcd6a88f72) |  |
| `testbed-bjw2-can-t1-8102-2` | ✅ PASS | 41 | 0 | 11 | [plan](https://elastictest.org/scheduler/testplan/6a90c627c02c8a580dfec620) |  |
| `testbed-bjw2-can-t0-4600c-1` | ⚠️ TESTFAIL | 39 | 0 | 14 | [plan](https://elastictest.org/scheduler/testplan/6a9140f37e50e72ef81bd81b) | `test_pfcwd_timer_accuracy` — unrelated module, does not use the changed function |
| `testbed-bjw3-can-t1-7060-1` | ⬜ lock timeout | 0 | 0 | 0 | [plan](https://elastictest.org/scheduler/testplan/6a91d0dedf972746564342ce) | testbed never acquired (4 h lock wait), no test executed |
| `testbed-bjw3-can-t1-7060-2` | ⬜ lock timeout | 0 | 0 | 0 | [plan](https://elastictest.org/scheduler/testplan/6a917c80cdb6fbe04615b79b) | testbed never acquired (4 h lock wait), no test executed |
| `vms20-t0-7050cx3-1` | ⬜ lock timeout | 0 | 0 | 0 | [plan](https://elastictest.org/scheduler/testplan/6a917c87f286e9ccf736782b) | testbed never acquired (4 h lock wait), no test executed |
| `vms20-t0-7050cx3-2` | ⬜ lock timeout | 0 | 0 | 0 | [plan](https://elastictest.org/scheduler/testplan/6a91056b56636b4b06de9513) | testbed never acquired (4 h lock wait), no test executed |

The one `TESTFAIL` is in `test_pfcwd_timer_accuracy.py`, a module that does not import or call
`verify_all_ports_pfc_storm_in_expected_state` — the only function this PR changes — so it cannot
be caused by this change. The 4 `lock timeout` rows never acquired their testbed within the 4 h
wait window and executed no tests at all.

#### Any platform specific information?

The bug is visible on any topology with multi-member PortChannels; it was originally reproduced on
Mellanox SN4600C / SPC3 (`str2-msn4600c-acs-04`). The fix is platform independent.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No user-facing documentation change. The rationale is captured in code comments and in #27382.
