### PR TITLE
[cacl]: Clamp SSH ACCEPT rule insert position to INPUT chain length

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -284,7 +284,7 @@ def dummy_acl_rules(duthosts, enum_rand_one_per_hwsku_hostname):
     # It has to wait cacl rules to be effective.
     wait_until(200, 10, 2, check_iptable_rules, duthost)
     # add ACCEPT rule for SSH to make sure testbed access
-    duthost.command("iptables -I INPUT 3 -p tcp -m tcp --dport 22 -j ACCEPT")
+    insert_ssh_accept_rule(duthost)
 
     yield file_path
 
@@ -330,6 +330,31 @@ def check_iptable_rules(duthost):
     duthost.command("ip6tables -S")
 
     return False
+
+
+def insert_ssh_accept_rule(duthost):
+    """
+    Insert the SSH ACCEPT rule into the INPUT chain after acl-loader has reprogrammed it.
+
+    "iptables -I INPUT 3" assumes the chain already holds at least two rules. That is not
+    always true right after "acl-loader update full". An IPv6-only scale config, for
+    example, programs every rule into ip6tables and leaves the IPv4 INPUT chain nearly
+    empty, so the fixed position is out of range and iptables fails the whole test with
+    "Index of insertion too big".
+
+    Clamp the position to the current chain length so the rule always lands at a valid
+    index. Ordering does not matter here because the tests compare rule sets rather than
+    sequence.
+
+    Args:
+        duthost: DUT to insert the rule on.
+
+    Returns:
+        None.
+    """
+    rules = duthost.command("iptables -S INPUT")["stdout_lines"]
+    position = min(3, len([rule for rule in rules if rule.startswith("-A ")]) + 1)
+    duthost.command("iptables -I INPUT {} -p tcp -m tcp --dport 22 -j ACCEPT".format(position))
 
 
 # To specify a port range instead of a single port, use iptables format:
@@ -1015,7 +1040,7 @@ def generate_scale_rules(duthost, ip_type):
     # It has to wait cacl rules to be effective.
     wait_until(200, 10, 2, check_iptable_rules, duthost)
     # add ACCEPT rule for SSH to make sure testbed access
-    duthost.command("iptables -I INPUT 3 -p tcp -m tcp --dport 22 -j ACCEPT")
+    insert_ssh_accept_rule(duthost)
 
 
 def verify_cacl_show_acl_rule(duthost, acl_file):


### PR DESCRIPTION
### Description of PR

Summary:
Fixes intermittent `test_cacl_scale_rules_ipv6` failures caused by a hard-coded iptables insert position.

ADO: 39424741

`generate_scale_rules()` and `dummy_acl_rules()` both insert the SSH ACCEPT rule at a fixed position 3:

```
iptables -I INPUT 3 -p tcp -m tcp --dport 22 -j ACCEPT
```

That assumes the IPv4 INPUT chain already holds at least two rules. It does not hold right after `acl-loader update full`. The ipv6 scale config programs all 150 rules into ip6tables, so the IPv4 chain is left nearly empty and position 3 is out of range. iptables then fails the whole test with:

```
iptables: Index of insertion too big.
cmd = ['iptables', '-I', 'INPUT', '3', '-p', 'tcp', '-m', 'tcp', '--dport', '22', '-j', 'ACCEPT']
```

Measured on a Nokia 7215 device the chain went from 41 rules down to fewer than 2. This is exactly why `test_cacl_scale_rules_ipv4` passes while `test_cacl_scale_rules_ipv6` fails on the same DUT minutes apart.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): ADO 39424741
Failure type: day-one issue (the hard-coded position 3 has been there since the scale tests were added; it only became visible once the ipv6 scale case ran on a DUT whose IPv4 chain is emptied by the repave)

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: image `20260510.12`, verified on a Nokia 7215 A1 device, topology mx
  - Testplan ID: `6a94e015f286e9ccf7367c04`
  - Result: **SUCCESS**, 35 tests, 0 failures, 0 errors, `retry_times: 0` (no retries used)
  - `cacl/test_cacl_application.py`: 9 tests, 5 passed, 4 skipped, 0 failed

| Case | Result |
| --- | --- |
| `test_cacl_scale_rules_ipv6` | success |
| `test_cacl_scale_rules_ipv4` | success |
| `test_cacl_acl_loader` | success |
| `test_cacl_application_nondualtor` | success |
| `test_caclmgrd_syslog` | success |

The 4 skips are topology gates unrelated to this change (`dualtor` x2, `multi-ASIC`, `t0/t1-only`).

`generate_scale_rules()` is byte-identical on `master` and `202605`, so this evidence applies to both branches unchanged.

### Approach
#### What is the motivation for this PR?

`test_cacl_scale_rules_ipv6` fails roughly 22-29% of runs on our Nokia 7215 nightly lanes with `Index of insertion too big`. The failure is in test setup, not in the code under test, so it produces a false signal against the image.

#### How did you do it?

Added `insert_ssh_accept_rule()`, which reads the current INPUT chain and clamps the insert position to the chain length:

```python
rules = duthost.command("iptables -S INPUT")["stdout_lines"]
position = min(3, len([rule for rule in rules if rule.startswith("-A ")]) + 1)
```

Both call sites now use it. Ordering is not significant here because the tests compare rule sets, and the ordering assertion in `verify_cacl` is commented out.

As a side effect, a genuinely unreachable DUT now fails on `iptables -S INPUT` with a plain connection error instead of the misleading insertion-index error.

#### How did you verify/test it?

Two independent ways.

1. **Deterministic proof on hardware** (a Nokia 7215 device). Emptied the IPv4 INPUT chain to reproduce the exact precondition, then:
   - `iptables -I INPUT 3 ...` -> `iptables: Index of insertion too big.` (reproduces the reported failure)
   - clamped position 1 -> rule inserted successfully

   This matters because the case only fails 22-29% of the time, so a single green run is not sufficient evidence on its own.

2. **Functional run** on the 202605 code line, Testplan ID `6a94e015f286e9ccf7367c04`, detailed above. `test_cacl_scale_rules_ipv6` passed with no retries.

Lint: `flake8 --max-line-length=120` reports 5 findings on this file both before and after the change (same pre-existing E231/E221, shifted by the added lines). No new findings introduced.

#### Any platform specific information?

None. The bug is in test setup and is platform independent. It surfaces on any DUT where the ipv6 scale repave leaves the IPv4 INPUT chain shorter than 2 rules; it was observed on Nokia 7215 (marvell-prestera).

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change needed.
