### PR TITLE
[platform_tests/api]: Always remove the port 8000 iptables rules at teardown

### DIFF
--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -8,6 +8,7 @@ SERVER_FILE = 'platform_api_server.py'
 SERVER_PORT = 8000
 
 IPTABLES_DELETE_RULE_CMD = 'iptables -D INPUT -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
+IP6TABLES_DELETE_RULE_CMD = 'ip6tables -D INPUT -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
 
 
 def skip_absent_psu(psu_num, platform_api_conn, psu_skip_list, logger):    # noqa: F811
@@ -45,10 +46,16 @@ def stop_platform_api_service(duthosts):
                 duthost.command('docker exec -i pmon supervisorctl reread')
                 duthost.command('docker exec -i pmon supervisorctl update')
 
-                # We ignore errors here because after a reboot test, the DUT will have power-cycled and will
-                # no longer have the rule we added in the start_platform_api_service fixture, even if the
-                # platform_api_server is running.
-                duthost.command(IPTABLES_DELETE_RULE_CMD, module_ignore_errors=True)
+            # Always remove the rules, regardless of the server state. start_platform_api_service
+            # adds them before the server is started, so a server that is no longer RUNNING at
+            # teardown (pmon restarted, the server crashed, or a reboot test intervened) would
+            # otherwise leave them behind for the rest of the session.
+            #
+            # We ignore errors here because after a reboot test, the DUT will have power-cycled and will
+            # no longer have the rule we added in the start_platform_api_service fixture, even if the
+            # platform_api_server is running.
+            duthost.command(IPTABLES_DELETE_RULE_CMD, module_ignore_errors=True)
+            duthost.command(IP6TABLES_DELETE_RULE_CMD, module_ignore_errors=True)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # 1940 - the tcp/8000 iptables rule added by `start_platform_api_service()` can leak onto the DUT and trip a later `cacl` run.

ADO: 39424741

`start_platform_api_service()` prepends an INPUT ACCEPT rule for tcp/8000 so the test host can reach `platform_api_server.py` inside the pmon container. `stop_platform_api_service()` removes it, but the removal sits **inside** the `if platform_api_service_state == 'RUNNING'` branch:

```python
if platform_api_service_state == 'RUNNING':
    ... stop the server, remove the supervisor config ...
    duthost.command(IPTABLES_DELETE_RULE_CMD, module_ignore_errors=True)
```

If the server is not RUNNING when teardown runs, because pmon restarted, the server crashed, or a reboot test intervened, the delete never executes and the rule stays on the DUT for the rest of the session. A later `cacl` run then fails with:

```
Failed: Unexpected iptables rules:
{'-A INPUT -p tcp -m tcp --dport 8000 -j ACCEPT'}
```

The same fixture asymmetry was reported in #1940 back in 2020. The response at the time was to ignore delete errors, which is the `module_ignore_errors=True` still present today and retained here, but the rule can still leak when the delete is skipped entirely.

This also cleans up the ip6tables rule. `start_platform_api_service()` adds that one on DUTs with an IPv6 management address and nothing removed it before.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/sonic-net/sonic-mgmt/issues/1940 and ADO 39424741
Failure type: day-one issue (the fixture asymmetry has existed since 2020 and was reported in #1940; it surfaces intermittently whenever the server is not RUNNING at teardown)

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: image `20260510.12`, verified on a Nokia 7215 A1 device, topology mx
  - Testplan ID: `6a94e015f286e9ccf7367c04`
  - Result: **SUCCESS**, 35 tests, 0 failures, 0 errors, `retry_times: 0` (no retries used)
  - `platform_tests/api/test_watchdog.py`: 7 tests, 7 passed, 0 skipped, 0 failed

Post-run state on the DUT, which is the direct proof that teardown cleaned up:

```
# iptables -S INPUT | grep 8000   -> no match
# ip6tables -S INPUT | grep 8000  -> no match
# iptables -S INPUT | wc -l       -> 41   (chain otherwise intact)
```

Without this change the rule is still present after teardown whenever the server was not RUNNING.

`tests/platform_tests/api/conftest.py` is byte-identical on `master` and `202605` (blob `dab866af` on both), so this evidence applies to both branches unchanged.

### Approach
#### What is the motivation for this PR?

A leaked tcp/8000 rule causes `cacl/test_cacl_application.py` to fail later in the same session with "Unexpected iptables rules". The failure lands on `cacl`, which is not the test that created the rule, so it is repeatedly misattributed to the image. The platform vendor ran the same `cacl` module and could not reproduce it, and posted their full `iptables -S` output as a negative control showing no `dport 8000` anywhere, which pointed back at our own framework.

#### How did you do it?

Moved the delete out of the `if platform_api_service_state == 'RUNNING'` block so it always runs, keeping `module_ignore_errors=True`. Added `IP6TABLES_DELETE_RULE_CMD` and removed the v6 rule too, mirroring what `start_platform_api_service()` adds.

Note on the fix shape: adding tcp/8000 to `cacl`'s expected rule set would be wrong here, because it would mask a genuine leak. There is precedent for both shapes: #24878 / #24696 added a legitimate rule to the expected list, whereas #18277 fixed the leaking test's teardown when kubesonic left `KUBE-FIREWALL` rules behind and `cacl` failed with this same error shape. tcp/8000 is the second kind.

#### How did you verify/test it?

Two independent ways.

1. **Deterministic proof on hardware** (a Nokia 7215 device). Simulated the fixture to produce exactly the rule `cacl` reports, then confirmed the mechanism:
   - `supervisorctl status platform_api_server` returns `ERROR (no such process)`, so the current teardown takes the `if RUNNING` false path and skips the delete, leaving the rule behind
   - the patched teardown removes both the v4 and the v6 rule in that same state

2. **Functional run** on the 202605 code line, Testplan ID `6a94e015f286e9ccf7367c04`, detailed above. All 7 watchdog cases passed and the DUT was left with no tcp/8000 rule in either table.

Lint: `flake8 --max-line-length=120` is clean on this file (0 findings before and after).

#### Any platform specific information?

None. The fixture is platform independent. The ip6tables half only applies to DUTs with an IPv6 management address, which is why that rule went unnoticed for so long.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change needed.
