### PR TITLE
[platform_tests/api]: Always remove the port 8000 iptables rules at teardown

### DIFF
--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -8,6 +8,7 @@ SERVER_FILE = 'platform_api_server.py'
 SERVER_PORT = 8000
 
 IPTABLES_DELETE_RULE_CMD = 'iptables -D INPUT -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
+IP6TABLES_DELETE_RULE_CMD = 'ip6tables -D INPUT -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
 
 
 def skip_absent_psu(psu_num, platform_api_conn, psu_skip_list, logger):    # noqa: F811
@@ -45,10 +46,16 @@ def stop_platform_api_service(duthosts):
                 duthost.command('docker exec -i pmon supervisorctl reread')
                 duthost.command('docker exec -i pmon supervisorctl update')
 
-                # We ignore errors here because after a reboot test, the DUT will have power-cycled and will
-                # no longer have the rule we added in the start_platform_api_service fixture, even if the
-                # platform_api_server is running.
-                duthost.command(IPTABLES_DELETE_RULE_CMD, module_ignore_errors=True)
+            # Always remove the rules, regardless of the server state. start_platform_api_service
+            # adds them before the server is started, so a server that is no longer RUNNING at
+            # teardown (pmon restarted, the server crashed, or a reboot test intervened) would
+            # otherwise leave them behind for the rest of the session.
+            #
+            # We ignore errors here because after a reboot test, the DUT will have power-cycled and will
+            # no longer have the rule we added in the start_platform_api_service fixture, even if the
+            # platform_api_server is running.
+            duthost.command(IPTABLES_DELETE_RULE_CMD, module_ignore_errors=True)
+            duthost.command(IP6TABLES_DELETE_RULE_CMD, module_ignore_errors=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -10,6 +10,32 @@ SERVER_PORT = 8000
 IPTABLES_DELETE_RULE_CMD = 'iptables -D INPUT -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
 IP6TABLES_DELETE_RULE_CMD = 'ip6tables -D INPUT -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
 
+# Upper bound on how many copies of the rule we try to remove. start_platform_api_service
+# is function scoped and re-adds the rule every time the server is unreachable, so a server
+# that dies part way through a module can leave more than one copy behind.
+MAX_RULE_DELETE_ATTEMPTS = 10
+
+
+def _remove_server_port_rules(duthost):
+    """
+    Remove every copy of the port 8000 ACCEPT rule this test run may have added.
+
+    start_platform_api_service adds either the IPv4 or the IPv6 rule depending on the
+    management address family, never both, so one of these deletes is expected to be a
+    no-op. "iptables -D" removes a single matching rule, so keep deleting until there is
+    nothing left to remove.
+
+    Errors are ignored throughout: after a reboot test the DUT has power cycled and the
+    rule is already gone, which is not a failure.
+    """
+    for delete_cmd in (IPTABLES_DELETE_RULE_CMD, IP6TABLES_DELETE_RULE_CMD):
+        for _ in range(MAX_RULE_DELETE_ATTEMPTS):
+            result = duthost.command(delete_cmd, module_ignore_errors=True)
+            # Default to non-zero so anything that does not report an rc, such as an
+            # unreachable host, stops the loop instead of raising KeyError.
+            if result.get('rc', 1) != 0:
+                break
+
 
 def skip_absent_psu(psu_num, platform_api_conn, psu_skip_list, logger):    # noqa: F811
     name = psu.get_name(platform_api_conn, psu_num)
@@ -25,6 +51,13 @@ def stop_platform_api_service(duthosts):
         yield
     finally:
         for duthost in duthosts:
+            # Remove the port 8000 rules first. The checks below can raise, for example when
+            # pmon is not running and the supervisorctl status output is empty, and the rules
+            # have to come off regardless or they leak into the rest of the session and trip a
+            # later cacl run. Nothing after this point needs the port: the remaining commands
+            # all go over SSH via "docker exec".
+            _remove_server_port_rules(duthost)
+
             # Stop the server and remove our supervisor config changes
             pmon_path_supervisor = os.path.join(os.sep, 'etc', 'supervisor', 'conf.d', 'platform_api_server.conf')
             pmon_path_script = os.path.join(os.sep, 'opt', SERVER_FILE)
@@ -45,17 +78,6 @@ def stop_platform_api_service(duthosts):
                 duthost.command('docker exec -i pmon rm -f {}'.format(pmon_path_script))
                 duthost.command('docker exec -i pmon supervisorctl reread')
                 duthost.command('docker exec -i pmon supervisorctl update')
-
-            # Always remove the rules, regardless of the server state. start_platform_api_service
-            # adds them before the server is started, so a server that is no longer RUNNING at
-            # teardown (pmon restarted, the server crashed, or a reboot test intervened) would
-            # otherwise leave them behind for the rest of the session.
-            #
-            # We ignore errors here because after a reboot test, the DUT will have power-cycled and will
-            # no longer have the rule we added in the start_platform_api_service fixture, even if the
-            # platform_api_server is running.
-            duthost.command(IPTABLES_DELETE_RULE_CMD, module_ignore_errors=True)
-            duthost.command(IP6TABLES_DELETE_RULE_CMD, module_ignore_errors=True)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Description of PR

Summary:
`start_platform_api_service` adds an iptables ACCEPT rule for tcp/8000 so the test host can reach `platform_api_server` inside pmon. The matching delete in `stop_platform_api_service` sat inside the `if platform_api_service_state == 'RUNNING'` branch, so whenever the server was not running at teardown the rule was left on the DUT.

Once leaked, it stays for the rest of the session and trips any later `cacl` run:

```
Failed: Unexpected iptables rules: {'-A INPUT -p tcp -m tcp --dport 8000 -j ACCEPT'}
```

The rule is added by the fixture, not by `caclmgrd`, so `cacl` is right to flag it. The bug is that the fixture does not always clean up after itself.

This PR moves the removal out of that branch so it always runs, and addresses three further problems found while testing the first version:

**1. Duplicate rules were not fully cleaned.** `start_platform_api_service` is `scope='function'` and re-adds the rule whenever port 8000 is unreachable, while `stop_platform_api_service` is `scope='module'` and runs once. A server that dies part way through a module gets the rule added again by the next test, and a single `iptables -D` removes only one copy. Now deletes in a bounded loop until there is nothing left to remove.

**2. The cleanup ran too late.** It sat below

```python
platform_api_service_state = [line.strip().split()[1] for line in out['stdout_lines']][0]
```

which raises `IndexError` when the status output is empty, for example when the pmon container is not running. That is one of the very situations this fix is meant to cover, and the delete never executed there. Moved to the top of the loop body, above the status probe. Nothing below needs the port; the remaining commands all go over SSH via `docker exec`.

**3. IPv4/IPv6 asymmetry.** `start_platform_api_service` adds either the IPv4 or the IPv6 rule depending on the management address family, never both. The old code only ever deleted the IPv4 rule, so on a v6-managed DUT the rule leaked **even when the server was running**. Both are now removed, and the no-op case is documented.

The delete result is read with `.get('rc', 1)` so a result carrying no `rc`, such as an unreachable host, ends the loop rather than raising `KeyError`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 39424741
Failure type: test infrastructure

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

Verified on a Nokia 7215 device, topology mx, with `retry_times: 0` so no result is masked by a retry.

**Testplan ID: `6a96ce60df97274656434a3d`**

This run carried the current head of this PR, including the three hardening changes above.

| Module | Result |
| --- | --- |
| `platform_tests/api/test_watchdog.py` | 7 passed, 0 failed |
| `cacl/test_cacl_application.py` | 5 passed, 4 topology skips, 0 failed |
| Whole plan | 48 tests, 41 passed, 7 skipped, 0 failed, 0 errors |

After the run the DUT showed **no tcp/8000 rule in either `iptables -S INPUT` or `ip6tables -S INPUT`**, and the INPUT chain was intact.

An earlier testplan, `6a94e015f286e9ccf7367c04`, covered the first revision of this fix before the hardening was added. It is superseded by the run above.

**Offline coverage.** The teardown was also replayed against 9 scenarios with the DUT interactions stubbed, since several are hard to produce on demand:

| Scenario | Result |
| --- | --- |
| Server not running, rule must still be removed | pass |
| Server running, rule removed and server stopped | pass |
| Three duplicate rules from a mid-module server death | pass, all removed |
| pmon container gone, status output empty | pass, rule still removed |
| v6-managed DUT, v6 removed and v4 delete a harmless no-op | pass |
| Nothing to remove after a reboot | pass, one attempt per family |
| Pathological case, loop stays bounded | pass, capped at the limit |
| Unreachable host returning no `rc` | pass, no `KeyError` |
| Normal case command count | 3 delete commands |

### Approach
#### What is the motivation for this PR?

A test fixture should not leave state on the DUT that makes unrelated later tests fail. This one did, and the failure surfaced far from its cause, in `cacl`, which made it look like a `caclmgrd` problem.

#### How did you do it?

Moved the rule removal above the supervisorctl status probe so it always runs, put it in a bounded loop so every copy is removed, and covered both address families.

#### How did you verify/test it?

Hardware run on a Nokia 7215, plus the offline scenario replay. Details in the Test result section.

#### Any platform specific information?

None. The fixture and the leak are platform independent; it was found on Nokia 7215 because that is where the affected lanes run.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change needed.
