### PR TITLE
[202605][eos]: Reclaim stale configure sessions on eos_config failure

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -83,11 +83,54 @@ class EosHost(AnsibleHostBase):
     def __repr__(self):
         return self.__str__()
 
+    def _abort_pending_config_sessions(self):
+        """Best-effort abort of stale pending EOS ``configure session``s.
+
+        EOS permits only a handful of pending config sessions. When an
+        ``eos_config`` commit times out it strands its ``ansible_*`` session;
+        enough stranded sessions exhaust the pool and every later
+        ``eos_config`` fails with "Maximum number of pending sessions has been
+        reached". Aborting them frees the pool so a retry can succeed.
+        """
+        try:
+            out = self.eos_command(
+                commands=['show configuration sessions detail | json']
+            )
+            sessions = out['stdout'][0].get('sessions', {})
+        except Exception as e:
+            logging.warning('Could not list EOS config sessions on %s: %s',
+                            self.hostname, e)
+            return
+        for sess_name, sess_info in sessions.items():
+            # Only reclaim sessions this framework created; never touch a
+            # session that has already been committed ('completed').
+            if not sess_name.startswith('ansible_'):
+                continue
+            if sess_info.get('state') == 'completed':
+                continue
+            try:
+                self.eos_command(
+                    commands=['configure session {} abort'.format(sess_name)]
+                )
+                logging.info('Aborted stale EOS config session [%s] on %s',
+                             sess_name, self.hostname)
+            except Exception as e:
+                logging.warning('Failed to abort EOS config session [%s] on %s: %s',
+                                sess_name, self.hostname, e)
+
     @retry(RunAnsibleModuleFail, tries=3, delay=5)
     def shutdown(self, interface_name):
-        out = self.eos_config(
-            lines=['shutdown'],
-            parents=['interface {}'.format(interface_name)])
+        try:
+            out = self.eos_config(
+                lines=['shutdown'],
+                parents=['interface {}'.format(interface_name)],
+                diff_against='running')
+        except RunAnsibleModuleFail:
+            # A timed-out commit strands a pending 'configure session'; free
+            # stale sessions so the @retry attempt is not blocked by
+            # 'Maximum number of pending sessions has been reached'.
+            self._abort_pending_config_sessions()
+            raise
         logging.info('Shut interface [%s]' % interface_name)
         return out
 
@@ -97,9 +140,15 @@ class EosHost(AnsibleHostBase):
 
     @retry(RunAnsibleModuleFail, tries=3, delay=5)
     def no_shutdown(self, interface_name):
-        out = self.eos_config(
-            lines=['no shutdown'],
-            parents=['interface {}'.format(interface_name)])
+        try:
+            out = self.eos_config(
+                lines=['no shutdown'],
+                parents=['interface {}'.format(interface_name)],
+                diff_against='running')
+        except RunAnsibleModuleFail:
+            # See shutdown(): reclaim stranded sessions before @retry re-runs.
+            self._abort_pending_config_sessions()
+            raise
         logging.info('No shut interface [%s]' % interface_name)
         return out
 
@@ -392,7 +441,7 @@ class EosHost(AnsibleHostBase):
         err_out = False
         if 'stdout' in cmd_output_obj:
             stdout = cmd_output_obj['stdout']
-            msg = stdout[-1] if type(stdout) == list else stdout
+            msg = stdout[-1] if isinstance(stdout, list) else stdout
             err_out = 'Cannot advertise' in msg
 
         return ('failed' in cmd_output_obj and cmd_output_obj['failed']) or err_out


### PR DESCRIPTION
### Description of PR

Manual cherry-pick / backport of #26993 to the **202605** branch.

The automatic cherry-pick hit a conflict (label `Cherry Pick Conflict_202605`) because the master version of `tests/common/devices/eos.py` carries the converged-topology `eos_config`/`eos_command` VRF-aware wrapper methods that do **not** exist on 202605; git pulled those in as surrounding context. The conflict was resolved by keeping **only** the actual change from #26993 (the `_abort_pending_config_sessions()` helper and the `shutdown()`/`no_shutdown()` try/except edits) and dropping the master-only VRF wrappers. On 202605 `shutdown()`/`no_shutdown()` already call `self.eos_config(...)` (resolved via `__getattr__` to the Ansible module), so the added `diff_against='running'` kwarg passes through unchanged. The resulting diff is semantically identical to the original PR (+55/−6, single file).

Original PR: #26993 (merge commit `0b417d3c63e79e315aac0ef6698a63d14a3f4d7a`)

### Type of change

- [x] Bug fix

### Back port request

- [x] 202605

Tracking issue/work item: ADO 39219113

### Tested branch

- [x] 202605

### Test result

- 202605: 20260510.10 (from the original PR run)

```
dualtor_mgmt/test_server_failure.py::test_server_reboot[active-active] PASSED   [100%]

===== 1 passed, 1 deselected, 138 warnings in 311.25s (0:05:11) =====
```

### Approach

#### What is the motivation for this PR?

Fix the following failure on 202605:

```
tests.common.errors.RunAnsibleModuleFail: run module eos_config failed ...
configure session ansible_<id> % Maximum number of pending sessions has been reached.
Please commit or abort previous sessions before creating a new one.
```

#### How did you do it?

`EosHost` config writes go through the `eos_config` Ansible module, which applies config inside a `configure session ansible_<id>` and commits it with `end`. If that commit times out (e.g. when a degraded fanout makes each privileged command slow), the session is left pending. EOS allows only a handful of pending sessions, so stranded sessions accumulate across the `shutdown()` `@retry` and the dualtor fanout-shutdown retry loop until every later `eos_config` fails with "Maximum number of pending sessions has been reached".

Add `EosHost._abort_pending_config_sessions()`, which lists `show configuration sessions detail | json` and aborts each pending `ansible_*` session (never touching non-ansible or already-committed sessions). `shutdown()`/`no_shutdown()` call it on `RunAnsibleModuleFail` and re-raise, so the existing `@retry` runs against a freed pool. Also set `diff_against='running'` so an idempotent retry opens no session at all.

#### How did you verify/test it?

See the 202605 test result above (from the original PR validation).