### PR TITLE
Skip warm reboot sn6600 ld 202605

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -335,11 +335,16 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
     elif test_type == "reboot":
         # Use warm reboot for t0, cold reboot for others
         topo_name = tbinfo["topo"]["name"]
-        logger.info("Rebooting DUT {} with type {}".format(duthost.hostname, topo_name))
         if topo_name.startswith("t0"):
             reboot_type = "warm"
         else:
             reboot_type = "cold"
+        # Remove this override once warm reboot is supported on SN6600 LD.
+        if reboot_type == "warm" and "sn6600_ld" in duthost.facts.get("platform", ""):
+            logger.info("Overriding warm reboot with cold reboot on SN6600 LD because "
+                        "warm reboot is unsupported on this platform")
+            reboot_type = "cold"
+        logger.info("Rebooting DUT {} with type {}".format(duthost.hostname, reboot_type))
         reboot(duthost, localhost, reboot_type=reboot_type, wait_warmboot_finalizer=True,
                warmboot_finalizer_timeout=360)
 

--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -817,9 +817,17 @@ def param_reboot(request, duthost, localhost, loganalyzer):
     """
     reboot_type = request.config.getoption("--bgp_suppress_fib_reboot_type")
     reboot_type_list = ["reload", "cold", "warm", "fast"]
+    # Remove this override once warm/fast reboot is supported on SN6600 LD.
+    sn6600_ld_warm_unsupported = "sn6600_ld" in duthost.facts.get("platform", "")
+    if sn6600_ld_warm_unsupported:
+        reboot_type_list = [rt for rt in reboot_type_list if rt not in ("warm", "fast")]
     if reboot_type == "random":
         reboot_type = random.choice(reboot_type_list)
-        logger.info("Randomly choose {} from reload, cold, warm, fast".format(reboot_type))
+        logger.info("Randomly choose {} from {}".format(reboot_type, reboot_type_list))
+    elif reboot_type in ("warm", "fast") and sn6600_ld_warm_unsupported:
+        logger.info("Overriding {} reboot with cold reboot on SN6600 LD because "
+                    "warm/fast reboot is unsupported on this platform".format(reboot_type))
+        reboot_type = "cold"
 
     if reboot_type == "reload":
         config_reload(duthost, safe_reload=True, ignore_loganalyzer=loganalyzer)

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -256,7 +256,7 @@ arp/test_unknown_mac.py::TestUnknownMac::test_unknown_mac:
 
 arp/test_wr_arp.py:
   skip:
-    reason: "Warm reboot is broken on dualtor topology. Device fails to recover by sanity check. Skipping for now. Not supported in standalone topos / Warm reboot is not required for 202412 and this test is not run on this asic type or version or topology currently"
+    reason: "Warm reboot is broken on dualtor topology. Device fails to recover by sanity check. Skipping for now. Not supported in standalone topos / Warm reboot is not required for 202412 and this test is not run on this asic type or version or topology currently. Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
     conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/16502 and 'dualtor' in topo_name"
@@ -266,6 +266,7 @@ arp/test_wr_arp.py:
       - *lossyTopos
       - "topo_type not in ['t0']"
       - "'f2' in topo_name"
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 ########################################
 ######        autorestart          #####
@@ -391,6 +392,12 @@ bgp/test_bgp_aggregate_address_resilience.py:
     reason: "Skip for multi-ASIC testbed"
     conditions:
       - "is_multi_asic==True"
+
+bgp/test_bgp_aggregate_address_resilience.py::test_aggregate_persists_warm_reboot:
+  skip:
+    reason: "Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions:
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 bgp/test_bgp_aggregate_address_route_withdrawal.py:
   skip:
@@ -2989,7 +2996,7 @@ gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_halt:
 
 gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm:
   skip:
-    reason: "Warm reboot should only run on t0 topology but not on dualtor"
+    reason: "Warm reboot should only run on t0 topology but not on dualtor. Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
     conditions_logical_operator: or
     conditions:
       - "topo_type not in ['t0']"
@@ -2997,6 +3004,7 @@ gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm:
       - "'isolated' in topo_name"
       - "release in ['202412']"
       - "'f2' in topo_name"
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 ###############################################
 #####       golden_config_infra           #####
@@ -4077,7 +4085,7 @@ pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy
 
 pfcwd/test_pfcwd_warm_reboot.py:
    skip:
-     reason: "Warm Reboot is not supported in T2 or in standalone topos. / Pfcwd tests skipped on M* testbed. / Warm reboot is not required for isolated topo / Pfcwd warm reboot is not supported on cisco-8000 platform. Warm reboot is not supported on smartswitch. /  It is skipped  for '202412' for now"
+     reason: "Warm Reboot is not supported in T2 or in standalone topos. / Pfcwd tests skipped on M* testbed. / Warm reboot is not required for isolated topo / Pfcwd warm reboot is not supported on cisco-8000 platform. Warm reboot is not supported on smartswitch. /  It is skipped  for '202412' for now. Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
      conditions_logical_operator: or
      conditions:
         - "'t2' in topo_name or topo_type in ['lrh', 'urh']"
@@ -4092,6 +4100,7 @@ pfcwd/test_pfcwd_warm_reboot.py:
         - "is_smartswitch==True"
         - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/20675"
         - "release in ['202412']"
+        - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
    xfail:
      reason: "This case has a known issue. Skipping until the issue is addressed."
      conditions_logical_operator: or
@@ -4136,10 +4145,32 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info:
 
 platform_tests/test_advanced_reboot.py:
   skip:
-    reason: "Advanced reboot tests are not supported on lossy topologies. Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
-    conditions_logical_operator: or
+    reason: "Advanced reboot tests are not supported on lossy topologies."
     conditions:
       - *lossyTopos
+
+platform_tests/test_advanced_reboot.py::test_cancelled_warm_reboot:
+  skip:
+    reason: "Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions:
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
+
+platform_tests/test_advanced_reboot.py::test_warm_reboot:
+  skip:
+    reason: "Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions:
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
+
+platform_tests/test_advanced_reboot.py::test_warm_reboot_mac_jump:
+  skip:
+    reason: "Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions:
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
+
+platform_tests/test_advanced_reboot.py::test_warm_reboot_sad:
+  skip:
+    reason: "Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions:
       - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 platform_tests/test_cont_warm_reboot.py:
@@ -5739,6 +5770,12 @@ upgrade_path/test_multi_hop_upgrade_path.py:
     conditions:
       - "'t0' not in topo_type"
 
+upgrade_path/test_multi_hop_upgrade_path.py::test_multi_hop_warm_upgrade_sad_path:
+  skip:
+    reason: "Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions:
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
+
 upgrade_path/test_upgrade_path.py::test_upgrade_path_t2:
   skip:
     reason: "Only supported on T2 topology"
@@ -5750,6 +5787,18 @@ upgrade_path/test_upgrade_path.py::test_upgrade_path_t2_delayed:
     reason: "Only supported on T2 topology"
     conditions:
       - "'t2' not in topo_type"
+
+upgrade_path/test_upgrade_path.py::test_warm_upgrade_sad_path:
+  skip:
+    reason: "Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions:
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
+
+upgrade_path/test_warmboot_data_consistency.py::test_warmboot_data_consistency:
+  skip:
+    reason: "Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions:
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 #######################################
 #####            vlan             #####
@@ -5889,9 +5938,11 @@ vrf/test_vrf.py::TestVrfWarmReboot::test_vrf_swss_warm_reboot:
 
 vrf/test_vrf.py::TestVrfWarmReboot::test_vrf_system_warm_reboot:
   skip:
-    reason: "Dualtor topology doesn't support advanced-reboot"
+    reason: "Dualtor topology doesn't support advanced-reboot. Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions_logical_operator: or
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 vrf/test_vrf_attr.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3345,12 +3345,6 @@ hash/test_generic_hash.py::test_reboot[CRC_CCITT-INNER_IP_PROTOCOL:
     conditions:
     - "asic_type in ['broadcom', 'mellanox']"
 
-hash/test_generic_hash.py::test_reboot[CRC_CCITT-INNER_L4_SRC_PORT-ipv6-ipv4-vxlan-warm]:
-  skip:
-    reason: "Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
-    conditions:
-      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
-
 hash/test_generic_hash.py::test_reboot[CRC_CCITT-IN_PORT:
   skip:
     reason: "On Mellanox platforms, due to HW limitation, when ecmp and lag hash at the same time, it would not support
@@ -3363,6 +3357,13 @@ hash/test_generic_hash.py::test_reboot[CRC_CCITT-IP_PROTOCOL-ipv4:
     reason: "With IP Protocol alone, we don't have enough entropy to distribute the packets evenly"
     conditions:
       - "asic_type in ['cisco-8000']"
+
+hash/test_generic_hash.py::test_reboot\[.*-warm\]:
+  regex: true
+  skip:
+    reason: "Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions:
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 #######################################
 #####             hft             #####
@@ -4871,12 +4872,12 @@ route/test_route_perf.py:
 
 route/test_static_route.py:
   skip:
-    reason: "Test not supported for 201911 images or older. Does not apply to standalone topos. Not supported on cisco-8122 platform. Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    reason: "Test not supported for 201911 images or older. Does not apply to standalone topos. Not supported on cisco-8122 platform"
     conditions_logical_operator: OR
     conditions:
       - "release in ['201811', '201911']"
       - "'standalone' in topo_name"
-      - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0', 'x86_64-nvidia_sn6600_ld-r0']"
+      - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
 
 route/test_static_route.py::test_static_route[:
   xfail:
@@ -4903,11 +4904,12 @@ route/test_static_route.py::test_static_route_ecmp_ipv6:
 
 route/test_static_route.py::test_static_route_ecmp_warmboot:
   skip:
-    reason: "Warm reboot is not supported on dualtor, m0, m1, or mx topologies"
+    reason: "Warm reboot is not supported on dualtor, m0, m1, or mx topologies, or on x86_64-nvidia_sn6600_ld-r0"
     conditions_logical_operator: OR
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
       - "topo_type in ['m0', 'm1', 'mx']"
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 route/test_static_route.py::test_static_route_ipv6:
   xfail:
@@ -4917,19 +4919,21 @@ route/test_static_route.py::test_static_route_ipv6:
 
 route/test_static_route.py::test_static_route_ipv6_warmboot:
   skip:
-    reason: "Warm reboot is not supported on dualtor, m0, m1, or mx topologies"
+    reason: "Warm reboot is not supported on dualtor, m0, m1, or mx topologies, or on x86_64-nvidia_sn6600_ld-r0"
     conditions_logical_operator: OR
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
       - "topo_type in ['m0', 'm1', 'mx']"
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 route/test_static_route.py::test_static_route_warmboot:
   skip:
-    reason: "Warm reboot is not supported on dualtor, m0, m1, or mx topologies"
+    reason: "Warm reboot is not supported on dualtor, m0, m1, or mx topologies, or on x86_64-nvidia_sn6600_ld-r0"
     conditions_logical_operator: OR
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
       - "topo_type in ['m0', 'm1', 'mx']"
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 #######################################
 #####           sai_qualify       #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3366,13 +3366,6 @@ hash/test_generic_hash.py::test_reboot[CRC_CCITT-IP_PROTOCOL-ipv4:
     conditions:
       - "asic_type in ['cisco-8000']"
 
-hash/test_generic_hash.py::test_reboot\[.*-warm\]:
-  regex: true
-  skip:
-    reason: "Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
-    conditions:
-      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
-
 #######################################
 #####             hft             #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -584,6 +584,12 @@ bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot:
       - "hwsku in ['Arista-7050CX3-32S-C28S4']"
       - "'f2' in topo_name"
 
+bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot[warm:
+  skip:
+    reason: "Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions:
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
+
 bgp/test_bgp_speaker.py:
   skip:
     reason: "Not supported on topology backend."
@@ -3339,6 +3345,12 @@ hash/test_generic_hash.py::test_reboot[CRC_CCITT-INNER_IP_PROTOCOL:
     conditions:
     - "asic_type in ['broadcom', 'mellanox']"
 
+hash/test_generic_hash.py::test_reboot[CRC_CCITT-INNER_L4_SRC_PORT-ipv6-ipv4-vxlan-warm]:
+  skip:
+    reason: "Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions:
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
+
 hash/test_generic_hash.py::test_reboot[CRC_CCITT-IN_PORT:
   skip:
     reason: "On Mellanox platforms, due to HW limitation, when ecmp and lag hash at the same time, it would not support
@@ -3800,9 +3812,11 @@ mvrf/test_mgmtvrf.py::TestReboot::test_fastboot:
 
 mvrf/test_mgmtvrf.py::TestReboot::test_warmboot:
   skip:
-    reason: "Dualtor topology doesn't support advanced-reboot"
+    reason: "Dualtor topology doesn't support advanced-reboot. Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions_logical_operator: or
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 #######################################
 #####           mx              #####
@@ -4121,15 +4135,19 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info:
 
 platform_tests/test_advanced_reboot.py:
   skip:
-    reason: "Advanced reboot tests are not supported on lossy topologies."
+    reason: "Advanced reboot tests are not supported on lossy topologies. Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions_logical_operator: or
     conditions:
       - *lossyTopos
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 platform_tests/test_cont_warm_reboot.py:
   skip:
-    reason: "Continuous warm reboot tests are not supported on lossy topologies."
+    reason: "Continuous warm reboot tests are not supported on lossy topologies. Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions_logical_operator: or
     conditions:
       - *lossyTopos
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 platform_tests/test_intf_fec.py::test_verify_fec_stats_counters:
   skip:
@@ -4157,9 +4175,11 @@ platform_tests/test_reboot.py::test_soft_reboot:
 
 platform_tests/test_reboot.py::test_warm_reboot:
   skip:
-    reason: "warm-reboot is not supported on BMC SONiC image"
+    reason: "warm-reboot is not supported on BMC SONiC image. Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
+    conditions_logical_operator: or
     conditions:
       - "'bmc' in topo_type"
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 platform_tests/test_reboot.py::test_watchdog_reboot:
   skip:
@@ -4198,13 +4218,14 @@ portstat/test_portstat.py:
 #######################################
 process_monitoring/test_critical_process_monitoring.py::test_orchagent_heartbeat:
   skip:
-    reason: "This test is intended for Orchagent freeze scenario during warm-reboot. It is not required for T1 devices, and not supported on 202412 release. Also not applicable on BMC platforms which have no orchagent."
+    reason: "This test is intended for Orchagent freeze scenario during warm-reboot. It is not required for T1 devices, and not supported on 202412 release. Also not applicable on BMC platforms which have no orchagent. Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
     conditions_logical_operator: or
     conditions:
       - "'t1' in topo_name"
       - "release in ['202412']"
       - "is_smartswitch==True" # t0 and t1 should all be skipped on smartswitch
       - "'bmc' in topo_type"
+      - "platform in ['x86_64-nvidia_sn6600_ld-r0']"
 
 #######################################
 #####     ptftests      #####
@@ -4850,12 +4871,12 @@ route/test_route_perf.py:
 
 route/test_static_route.py:
   skip:
-    reason: "Test not supported for 201911 images or older. Does not apply to standalone topos. Not supported on cisco-8122 platform"
+    reason: "Test not supported for 201911 images or older. Does not apply to standalone topos. Not supported on cisco-8122 platform. Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0"
     conditions_logical_operator: OR
     conditions:
       - "release in ['201811', '201911']"
       - "'standalone' in topo_name"
-      - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
+      - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0', 'x86_64-nvidia_sn6600_ld-r0']"
 
 route/test_static_route.py::test_static_route[:
   xfail:
@@ -4966,11 +4987,11 @@ sflow/test_sflow.py::TestReboot::testFastreboot:
 
 sflow/test_sflow.py::TestReboot::testWarmreboot:
   skip:
-    reason: "Dualtor topology doesn't support advanced-reboot or Warmreboot is not supported on sn5640 SP5 platform."
+    reason: "Dualtor topology doesn't support advanced-reboot or Warmreboot is not supported on sn5640 SP5 / sn6600_ld platforms."
     conditions_logical_operator: or
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
-      - "platform in ['x86_64-nvidia_sn5640-r0']"
+      - "platform in ['x86_64-nvidia_sn5640-r0', 'x86_64-nvidia_sn6600_ld-r0']"
   xfail:
     reason: "testWarmreboot sflow failure: VS SAI warm reboot bug (sonic-net/sonic-buildimage#26594)"
     conditions:

--- a/tests/hash/test_generic_hash.py
+++ b/tests/hash/test_generic_hash.py
@@ -692,6 +692,10 @@ def test_reboot(rand_selected_dut, tbinfo, ptfhost, localhost, fine_params, mg_f
         restore_vxlan_port: fixture to restore vxlan port to default
         global_hash_capabilities: module level fixture to get the dut hash capabilities
     """
+    # Remove this skip once warm/fast reboot is supported on SN6600 LD.
+    if reboot_type in ("warm", "fast") \
+            and "sn6600_ld" in rand_selected_dut.facts.get("platform", ""):
+        pytest.skip("warm/fast reboot is not supported on SN6600 LD")
     ecmp_algorithm, ecmp_test_hash_field, ipver, inner_ipver, encap_type = fine_params.split('-')
     skip_unsupported_field_for_ecmp_test(ecmp_test_hash_field, encap_type)
     with allure.step('Randomly select an ecmp hash field to test '

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -646,6 +646,8 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             and not is_th5_device
             and "dualtor" not in topo_name
             and "t1" not in topo_name
+            # Remove this check once warm reboot is supported on SN6600 LD.
+            and "sn6600_ld" not in duthost.facts.get("platform", "")
         ):
             with allure.step("Do warm-reboot"):
                 reboot(duthost, localhost, reboot_type="warm", safe_reboot=True, check_intf_up_ports=True,

--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -167,10 +167,14 @@ def vlan_members(duthosts, rand_one_dut_hostname, tbinfo):
 def is_support_warm_fast_reboot(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     support_warm_fast_reboot = True
+    # Remove the SN6600 LD check once warm/fast reboot is supported on the platform.
+    sn6600_ld_warm_unsupported = "sn6600_ld" in duthost.facts.get("platform", "")
     if 'isolated' in duthosts.tbinfo['topo']['name'] or \
-            duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch"):
+            duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch") or \
+            sn6600_ld_warm_unsupported:
         support_warm_fast_reboot = False
-        logging.info("Skipping warm and fast reboot tests for isolated topology or smartswitch")
+        logging.info("Skipping warm and fast reboot tests for isolated topology, smartswitch, "
+                     "or unsupported SN6600 LD platform")
         logging.info("Applying cert config")
         apply_cert_config(duthost)
 

--- a/tests/syslog/test_syslog_source_ip.py
+++ b/tests/syslog/test_syslog_source_ip.py
@@ -738,9 +738,17 @@ class TestSSIP:
             self.duthost.command("sudo config save -y")
 
         reboot_type = request.config.getoption("--ssip_reboot_type")
+        # Remove this override once warm/fast reboot is supported on SN6600 LD.
+        sn6600_ld_warm_unsupported = "sn6600_ld" in self.duthost.facts.get("platform", "")
         if reboot_type == "random":
             reboot_type_list = ["cold", "warm", "fast", "soft"]
+            if sn6600_ld_warm_unsupported:
+                reboot_type_list = [rt for rt in reboot_type_list if rt not in ("warm", "fast")]
             reboot_type = random.choice(reboot_type_list)
+        elif reboot_type in ("warm", "fast") and sn6600_ld_warm_unsupported:
+            logger.info("Overriding {} reboot with cold reboot on SN6600 LD because "
+                        "warm/fast reboot is unsupported on this platform".format(reboot_type))
+            reboot_type = "cold"
         with allure.step("Do {}".format(reboot_type)):
             reboot(self.duthost, localhost, reboot_type=reboot_type, reboot_helper=None, reboot_kwargs=None)
 


### PR DESCRIPTION
Warm reboot is not supported on x86_64-nvidia_sn6600_ld-r0.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip warm-reboot related tests on NVIDIA SN6600 LD (`x86_64-nvidia_sn6600_ld-r0`). Warm reboot is not supported on this platform.

Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Approach
#### What is the motivation for this PR?
Warm reboot is not supported on `x86_64-nvidia_sn6600_ld-r0`. Tests that exercise warm reboot fail or are not applicable and should be skipped on this platform.

#### How did you do it?
Updated `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` to skip warm-reboot tests when `platform in ['x86_64-nvidia_sn6600_ld-r0']`:

- `arp/test_wr_arp.py`
- `bgp/test_bgp_aggregate_address_resilience.py::test_aggregate_persists_warm_reboot`
- `bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot[warm`
- `gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm`
- `hash/test_generic_hash.py::test_reboot\[.*-warm\]` (regex: all warm parametrizations)
- `mvrf/test_mgmtvrf.py::TestReboot::test_warmboot`
- `pfcwd/test_pfcwd_warm_reboot.py`
- `platform_tests/test_advanced_reboot.py::test_warm_reboot`
- `platform_tests/test_advanced_reboot.py::test_warm_reboot_mac_jump`
- `platform_tests/test_advanced_reboot.py::test_warm_reboot_sad`
- `platform_tests/test_advanced_reboot.py::test_cancelled_warm_reboot`
- `platform_tests/test_cont_warm_reboot.py`
- `platform_tests/test_reboot.py::test_warm_reboot`
- `process_monitoring/test_critical_process_monitoring.py::test_orchagent_heartbeat`
- `route/test_static_route.py::test_static_route_warmboot`
- `route/test_static_route.py::test_static_route_ecmp_warmboot`
- `route/test_static_route.py::test_static_route_ipv6_warmboot`
- `sflow/test_sflow.py::TestReboot::testWarmreboot`
- `upgrade_path/test_multi_hop_upgrade_path.py::test_multi_hop_warm_upgrade_sad_path`
- `upgrade_path/test_upgrade_path.py::test_warm_upgrade_sad_path`
- `upgrade_path/test_warmboot_data_consistency.py::test_warmboot_data_consistency`
- `vrf/test_vrf.py::TestVrfWarmReboot::test_vrf_system_warm_reboot`


#### Any platform specific information?
NVIDIA SN6600 LD: `x86_64-nvidia_sn6600_ld-r0`. Warm reboot is not supported.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A