### PR TITLE
[layer1] Support MAC local fault check on optics without RX disable

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -83,6 +83,45 @@ def fanout_switch_port_lookup(fanout_switches, dut_name, dut_port):
     return None, None
 
 
+def get_primary_fanout(dut, fanouthosts):
+    """
+    The ports of a DUT may be spread over several fanouts.
+
+    Return the fanout holding most of the links of the DUT, None when the DUT has no fanout.
+    """
+    dut_port_prefix = encode_dut_port_name(dut.hostname, '')
+    link_counts = {}
+    for fanout_name, fanout in fanouthosts.items():
+        # Map may list each DUT port twice (name + alias); count unique peers.
+        peer_ports = {peer_port for dut_port, peer_port in fanout.host_to_fanout_port_map.items()
+                      if dut_port.startswith(dut_port_prefix)}
+        if peer_ports:
+            link_counts[fanout_name] = len(peer_ports)
+
+    logging.info("Number of links per fanout of {}: {}".format(dut.hostname, link_counts))
+    if not link_counts:
+        return None
+
+    return fanouthosts[max(link_counts, key=link_counts.get)]
+
+
+def get_primary_fanout_peer(dut, interface, fanouthosts):
+    """
+    Return the (fanout, fanout_port) peer of an interface on the primary fanout.
+
+    Returns (None, None) when the interface is wired to any other fanout.
+    """
+    primary_fanout = get_primary_fanout(dut, fanouthosts)
+    primary_fanouthosts = {primary_fanout.hostname: primary_fanout} if primary_fanout else {}
+
+    fanout, fanout_port = fanout_switch_port_lookup(primary_fanouthosts, dut.hostname, interface)
+    # The connection graph may hold the port alias, sfputil needs the SONiC name
+    if fanout:
+        fanout_port = fanout.fanout_port_alias_to_name.get(fanout_port, fanout_port)
+
+    return fanout, fanout_port
+
+
 def get_dut_psu_line_pattern(dut):
     if "201811" in dut.os_version or "201911" in dut.os_version:
         psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")

--- a/tests/layer1/conftest.py
+++ b/tests/layer1/conftest.py
@@ -1,0 +1,127 @@
+import json
+import logging
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert as assertion
+from tests.common.platform.device_utils import get_primary_fanout, get_primary_fanout_peer
+from tests.common.platform.interface_utils import get_physical_port_indices
+from tests.common.platform.transceiver_utils import parse_sfp_eeprom_infos
+from tests.common.mellanox_data import (
+    get_supported_available_optic_ifaces,
+    is_sw_control_feature_enabled,
+)
+
+DEFAULT_COLLECTED_PORTS_NUM = 5
+cmd_sfp_presence = "sudo sfpshow presence"
+
+
+def get_sfp_presence(host):
+    """Return the 'Port Presence' table of 'sfpshow presence' on a SONiC host as a {port: presence} map"""
+    return {entry["port"]: entry["presence"] for entry in host.show_and_parse(cmd_sfp_presence)}
+
+
+def pytest_addoption(parser):
+    """
+    Add command line options for pytest
+    """
+    parser.addoption(
+        "--collected-ports-num",
+        action="store",
+        default=DEFAULT_COLLECTED_PORTS_NUM,
+        type=int,
+        help="Number of ports to collect for testing (default: {})".format(DEFAULT_COLLECTED_PORTS_NUM)
+    )
+
+
+@pytest.fixture(scope="session")
+def collected_ports_num(request):
+    """
+    Fixture to get the number of ports to collect from command line argument
+    """
+    return request.config.getoption("--collected-ports-num")
+
+
+class TestMACFaultGeneral:
+
+    def return_available_interfaces(self, dut, parsed_presence):
+        interfaces = list(dut.show_and_parse("show interfaces status"))
+        supported_available_interfaces = [
+            intf["interface"] for intf in interfaces
+            if parsed_presence.get(intf["interface"]) == "Present"
+        ]
+
+        assertion(supported_available_interfaces,
+                  "No interfaces with SFP detected. Cannot proceed with tests.")
+        return supported_available_interfaces, []
+
+    def is_setting_support_feature(self, dut):
+        pass
+
+    @staticmethod
+    def filter_rx_disable_supported_interfaces(dut, interfaces):
+        """Exclude interfaces whose module does not support RX disable"""
+        port_index_map = get_physical_port_indices(dut, interfaces)
+        indexes = sorted({idx for idx in port_index_map.values() if idx is not None})
+        cmd = """
+cat << EOF > get_rx_disable_supported_indexes.py
+from sonic_platform.chassis import Chassis
+c = Chassis()
+supported = []
+for i in {indexes}:
+    try:
+        api = c.get_sfp(i).get_xcvr_api()
+        if api and api.get_rx_disable_support() is True:
+            supported.append(i)
+    except Exception:
+        pass
+print(supported)
+EOF
+""".format(indexes=indexes)
+        dut.shell(cmd)
+        out = dut.shell("python3 get_rx_disable_supported_indexes.py")["stdout"].strip()
+        supported_indexes = set(json.loads(out))
+        supported = [intf for intf in interfaces if port_index_map.get(intf) in supported_indexes]
+        logging.info("Excluded interfaces without RX disable support: {}".format(
+            [intf for intf in interfaces if intf not in supported]))
+        return supported
+
+    @classmethod
+    def filter_fanout_resettable_interfaces(cls, dut, interfaces, fanouthosts):
+        """Keep interfaces whose peer is a present fanout module that can be reset with sfputil"""
+        # Peers are looked up on the primary fanout only, so one presence table covers every interface
+        primary_fanout = get_primary_fanout(dut, fanouthosts)
+        # sfputil only exists on SONiC fanouts, FanoutHost also wraps onyx/eos/aos/ixia
+        if not primary_fanout or primary_fanout.os != 'sonic':
+            logging.info("{} has no SONiC fanout peer, no interface has a resettable peer".format(dut.hostname))
+            return []
+        peer_presence = get_sfp_presence(primary_fanout.host)
+
+        selected_ifaces = []
+        for intf in interfaces:
+            _, fanout_port = get_primary_fanout_peer(dut, intf, fanouthosts)
+            if fanout_port and peer_presence.get(fanout_port) == "Present":
+                selected_ifaces.append(intf)
+
+        logging.info("Excluded interfaces without a resettable peer: {}".format(
+            [intf for intf in interfaces if intf not in selected_ifaces]))
+        return selected_ifaces
+
+
+class TestMACFaultMellanox(TestMACFaultGeneral):
+
+    def return_available_interfaces(self, dut, parsed_presence):
+        supported_available_interfaces = []
+        failed_api_ports = []
+        eeprom_infos = dut.shell("sudo sfputil show eeprom -d")['stdout']
+        eeprom_infos = parse_sfp_eeprom_infos(eeprom_infos)
+        supported_available_interfaces, failed_api_ports = (
+            get_supported_available_optic_ifaces(
+                eeprom_infos, parsed_presence
+            )
+        )
+        assertion(supported_available_interfaces,
+                  "No interfaces with SFP detected. Cannot proceed with tests.")
+        return supported_available_interfaces, failed_api_ports
+
+    def is_setting_support_feature(self, dut):
+        return is_sw_control_feature_enabled(dut)

--- a/tests/layer1/test_port_error.py
+++ b/tests/layer1/test_port_error.py
@@ -4,20 +4,39 @@ import random
 import time
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.device_utils import get_primary_fanout_peer
 from tests.common.utilities import skip_release
+from tests.common.mellanox_data import is_mellanox_device
+from tests.common.utilities import wait_until
+from tests.layer1.conftest import TestMACFaultMellanox, get_sfp_presence
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
     pytest.mark.topology('any')
 ]
 
-SUPPORTED_PLATFORMS = ["arista_7060x6", "nvidia_sn5640", "nvidia_sn5600"]
-cmd_sfp_presence = "sudo sfpshow presence"
+SUPPORTED_PLATFORMS = ["arista_7060x6", "nvidia_sn6600_ld", "nvidia_sn5640", "nvidia_sn5600"]
+WAIT_FOR_PORT_SHUTDOWN = 5
+WAIT_FOR_PORT_STARTUP = 20
+WAIT_FOR_PEER_RESET_PORT_SHUTDOWN = 10
+WAIT_FOR_PEER_RESET_PORT_STARTUP = 120
+PEER_RESET_PORT_SHUTDOWN_POLL_INTERVAL = 1
+PEER_RESET_PORT_STARTUP_POLL_INTERVAL = 5
+PEER_RESET_PORT_POLL_DELAY = 0
+cmd_sfp_reset = "sudo sfputil reset"
+
+
+@pytest.fixture(scope="session")
+def vendor_specific_obj(duthost):
+    if is_mellanox_device(duthost):
+        return TestMACFaultMellanox()
+    else:
+        pytest.skip("Test is not implemented for this specific vendor")
 
 
 class TestMACFault(object):
-    @pytest.fixture(autouse=True)
-    def is_supported_platform(self, duthost, tbinfo):
+    @pytest.fixture(scope="class", autouse=True)
+    def is_supported_platform(self, duthost, tbinfo, vendor_specific_obj):
         if 'ptp' not in tbinfo['topo']['name']:
             pytest.skip("Skipping test: Not applicable for non-PTP topology")
 
@@ -25,6 +44,9 @@ class TestMACFault(object):
             skip_release(duthost, ["201811", "201911", "202012", "202205", "202211", "202305", "202405"])
         else:
             pytest.skip("DUT has platform {}, test is not supported".format(duthost.facts['platform']))
+
+        if not vendor_specific_obj.is_setting_support_feature(duthost):
+            pytest.skip("Platform setting is not supported for this test")
 
     @staticmethod
     def get_mac_fault_count(dut, interface, fault_type):
@@ -44,57 +66,148 @@ class TestMACFault(object):
     def get_interface_status(dut, interface):
         return dut.show_and_parse("show interfaces status {}".format(interface))[0].get("oper", "unknown")
 
-    @pytest.fixture
-    def select_random_interfaces(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
-        dut = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        interfaces = list(dut.show_and_parse("show interfaces status"))
+    @pytest.fixture(scope="class", autouse=True)
+    def reboot_dut(self, rand_selected_dut, localhost):
+        from tests.common.reboot import reboot
+        reboot(rand_selected_dut,
+               localhost, safe_reboot=True, check_intf_up_ports=True)
 
-        sfp_presence = dut.command(cmd_sfp_presence)
-        parsed_presence = {line.split()[0]: line.split()[1] for line in sfp_presence["stdout_lines"][2:]}
+    @pytest.fixture(scope="class")
+    def available_interfaces(self, rand_selected_dut, vendor_specific_obj):
+        dut = rand_selected_dut
+        parsed_presence = get_sfp_presence(dut)
+        test_available_ifaces, failed_api_ports = (
+            vendor_specific_obj.return_available_interfaces(dut, parsed_presence)
+        )
 
-        available_interfaces = [
-            intf["interface"] for intf in interfaces
-            if parsed_presence.get(intf["interface"]) == "Present"
+        return test_available_ifaces, failed_api_ports
+
+    @pytest.fixture(scope="class")
+    def select_random_interfaces(self, available_interfaces, collected_ports_num):
+        test_available_ifaces, failed_api_ports = available_interfaces
+        if not test_available_ifaces:
+            pytest.skip("No interfaces available for this test were found.")
+
+        test_ifaces = random.sample(test_available_ifaces,
+                                    min(collected_ports_num, len(test_available_ifaces)))
+
+        return test_ifaces, failed_api_ports
+
+    @pytest.fixture(scope="class")
+    def select_random_local_fault_interfaces(self, rand_selected_dut, available_interfaces,
+                                             collected_ports_num, fanouthosts, vendor_specific_obj):
+        dut = rand_selected_dut
+        test_available_ifaces, failed_api_ports = available_interfaces
+        rx_disable_supported = set(vendor_specific_obj.filter_rx_disable_supported_interfaces(
+            dut, test_available_ifaces))
+        peer_reset_supported = set(vendor_specific_obj.filter_fanout_resettable_interfaces(
+            dut, test_available_ifaces, fanouthosts))
+        test_available_ifaces = [
+            intf for intf in test_available_ifaces
+            if intf in rx_disable_supported or intf in peer_reset_supported
         ]
+        if not test_available_ifaces:
+            pytest.skip("No interfaces support RX disable or have a resettable fanout peer.")
 
-        pytest_assert(available_interfaces, "No interfaces with SFP detected. Cannot proceed with tests.")
+        test_ifaces = random.sample(test_available_ifaces,
+                                    min(collected_ports_num, len(test_available_ifaces)))
 
-        # Select 5 random interfaces (or fewer if not enough available)
-        selected_interfaces = random.sample(available_interfaces, min(5, len(available_interfaces)))
+        return test_ifaces, failed_api_ports
 
-        return dut, selected_interfaces
+    def toggle_iface(self, dut, interface):
+        dut.command("sudo config interface shutdown {}".format(interface))
+        pytest_assert(wait_until(10, 1, 0, lambda: self.get_interface_status(dut, interface) == "down"),
+                      "Interface {} did not go down after shutdown".format(interface))
 
-    def test_mac_local_fault_increment(self, select_random_interfaces):
-        dut, interfaces = select_random_interfaces
+        dut.command("sudo config interface startup {}".format(interface))
+        pytest_assert(wait_until(30, 1, 0, lambda: self.get_interface_status(dut, interface) == "up"),
+                      "Interface {} did not come up after startup".format(interface))
 
-        for interface in interfaces:
+    def reset_peer_module(self, dut, interface, fanout, fanout_port):
+        """
+        Reset the peer module instead of shutting the peer port: an admin down peer may keep its laser on
+        and transmit local fault ordered sets, which the DUT counts as a remote fault.
+        """
+        cmd_sfp_reset_intf = "{} {}".format(cmd_sfp_reset, fanout_port)
+        reset_result = fanout.host.command(cmd_sfp_reset_intf)
+        pytest_assert(reset_result["rc"] == 0 and
+                      "OK" in reset_result["stdout"] and
+                      "Failed" not in reset_result["stdout"],
+                      "'{}' failed on fanout {}: rc={}, stdout={}".format(
+                          cmd_sfp_reset_intf, fanout.hostname,
+                          reset_result["rc"], reset_result["stdout"]))
+
+        pytest_assert(
+            wait_until(WAIT_FOR_PEER_RESET_PORT_SHUTDOWN,
+                       PEER_RESET_PORT_SHUTDOWN_POLL_INTERVAL,
+                       PEER_RESET_PORT_POLL_DELAY,
+                       lambda: self.get_interface_status(dut, interface) == "down"),
+            "Interface {} did not go down after resetting peer port {} on fanout {}".format(
+                interface, fanout_port, fanout.hostname))
+
+        pytest_assert(
+            wait_until(WAIT_FOR_PEER_RESET_PORT_STARTUP,
+                       PEER_RESET_PORT_STARTUP_POLL_INTERVAL,
+                       PEER_RESET_PORT_POLL_DELAY,
+                       lambda: self.get_interface_status(dut, interface) == "up"),
+            "Interface {} did not come up after peer port {} on fanout {} recovered from the reset".format(
+                interface, fanout_port, fanout.hostname))
+
+    def toggle_rx_output_on_iface(self, dut, interface):
+        dut.shell("sudo sfputil debug rx-output {} disable".format(interface))
+        time.sleep(WAIT_FOR_PORT_SHUTDOWN)
+        pytest_assert(self.get_interface_status(dut, interface) == "down",
+                      "Interface {iface} did not go down after 'sudo sfputil debug rx-output {iface} disable'"
+                      .format(iface=interface))
+
+        dut.shell("sudo sfputil debug rx-output {} enable".format(interface))
+        time.sleep(WAIT_FOR_PORT_STARTUP)
+        pytest_assert(self.get_interface_status(dut, interface) == "up",
+                      "Interface {iface} did not come up after 'sudo sfputil debug rx-output {iface} enable'"
+                      .format(iface=interface))
+
+    def test_mac_local_fault_increment(self, select_random_local_fault_interfaces, rand_selected_dut,
+                                       fanouthosts, vendor_specific_obj):
+        dut = rand_selected_dut
+        selected_ifaces, failed_api_ports = select_random_local_fault_interfaces
+        rx_disable_supported = set(vendor_specific_obj.filter_rx_disable_supported_interfaces(
+            dut, selected_ifaces))
+        logging.info("Selected interfaces for tests: {}".format(selected_ifaces))
+
+        for interface in selected_ifaces:
+            self.toggle_iface(dut, interface)
+
             pytest_assert(self.get_interface_status(dut, interface) == "up",
-                          "Interface {} was not up before disabling/enabling rx-output using sfputil".format(interface))
+                          "Interface {} was not up before triggering a local fault".format(interface))
 
             local_fault_before = self.get_mac_fault_count(dut, interface, "mac local fault")
             logging.info("Initial MAC local fault count on {}: {}".format(interface, local_fault_before))
 
-            dut.shell("sudo sfputil debug rx-output {} disable".format(interface))
-            time.sleep(5)
-            pytest_assert(self.get_interface_status(dut, interface) == "down",
-                          "Interface {} did not go down after disabling rx-output using sfputil".format(interface))
-
-            dut.shell("sudo sfputil debug rx-output {} enable".format(interface))
-            time.sleep(20)
-            pytest_assert(self.get_interface_status(dut, interface) == "up",
-                          "Interface {} did not come up after enabling rx-output using sfputil".format(interface))
+            if interface in rx_disable_supported:
+                self.toggle_rx_output_on_iface(dut, interface)
+                fault_trigger = "disabling/enabling rx-output using sfputil"
+            else:
+                fanout, fanout_port = get_primary_fanout_peer(dut, interface, fanouthosts)
+                self.reset_peer_module(dut, interface, fanout, fanout_port)
+                fault_trigger = "resetting the peer module"
 
             local_fault_after = self.get_mac_fault_count(dut, interface, "mac local fault")
-            logging.info("MAC local fault count after disabling/enabling rx-output using sfputil {}: {}".format(
-                interface, local_fault_after))
+            logging.info("MAC local fault count after {} on {}: {}".format(
+                fault_trigger, interface, local_fault_after))
 
             pytest_assert(local_fault_after > local_fault_before,
-                          "MAC local fault count did not increment after disabling/enabling tx-output on the device")
+                          "MAC local fault count did not increment after {}".format(fault_trigger))
 
-    def test_mac_remote_fault_increment(self, select_random_interfaces):
-        dut, interfaces = select_random_interfaces
+        pytest_assert(len(failed_api_ports) == 0, "Interfaces with failed API ports: {}".format(failed_api_ports))
 
-        for interface in interfaces:
+    def test_mac_remote_fault_increment(self, select_random_interfaces, rand_selected_dut):
+        dut = rand_selected_dut
+        selected_ifaces, failed_api_ports = select_random_interfaces
+        logging.info("Selected interfaces for tests: {}".format(selected_ifaces))
+
+        for interface in selected_ifaces:
+            self.toggle_iface(dut, interface)
+
             pytest_assert(self.get_interface_status(dut, interface) == "up",
                           "Interface {} was not up before disabling/enabling tx-output using sfputil".format(interface))
 
@@ -102,19 +215,23 @@ class TestMACFault(object):
             logging.info("Initial MAC remote fault count on {}: {}".format(interface, remote_fault_before))
 
             dut.shell("sudo sfputil debug tx-output {} disable".format(interface))
-            time.sleep(5)
+            time.sleep(WAIT_FOR_PORT_SHUTDOWN)
             pytest_assert(self.get_interface_status(dut, interface) == "down",
-                          "Interface {} did not go down after disabling rx-output using sfputil".format(interface))
+                          "Interface {iface} did not go down after 'sudo sfputil debug tx-output {iface} disable'"
+                          .format(iface=interface))
 
             dut.shell("sudo sfputil debug tx-output {} enable".format(interface))
-            time.sleep(20)
+            time.sleep(WAIT_FOR_PORT_STARTUP)
 
             pytest_assert(self.get_interface_status(dut, interface) == "up",
-                          "Interface {} did not come up after disabling tx-output using sfputil".format(interface))
+                          "Interface {iface} did not come up after 'sudo sfputil debug tx-output {iface} enable'"
+                          .format(iface=interface))
 
             remote_fault_after = self.get_mac_fault_count(dut, interface, "mac remote fault")
-            logging.info("MAC remote fault count after disabling/enabling rx-output using sfputil {}: {}".format(
+            logging.info("MAC remote fault count after disabling/enabling tx-output using sfputil {}: {}".format(
                 interface, remote_fault_after))
 
             pytest_assert(remote_fault_after > remote_fault_before,
                           "MAC remote fault count did not increment after disabling/enabling tx-output on the device")
+
+        pytest_assert(len(failed_api_ports) == 0, "Interfaces with failed API ports: {}".format(failed_api_ports))


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Extend `test_mac_local_fault_increment` so ports whose modules do not support RX disable still get a local-fault check, by resetting the peer module.

Dependencies:
- Depends on https://github.com/sonic-net/sonic-mgmt/pull/21769

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Approach
#### What is the motivation for this PR?
RX disable is not supported by some optics, so those ports were skipped and MAC local faults were not verified.

#### How did you do it?
Keep RX disable when the module supports it. Otherwise reset the fanout peer with `sfputil reset`. Skip a port only if neither method is available.

#### How did you verify/test it?
Ran tests/layer1/test_port_error.py multiple times, all runs passed.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
arista_7060x6, nvidia_sn6600_ld, nvidia_sn5640, nvidia_sn5600