### PR TITLE
[fib] Relax ingress-port hash negative test on multi-core VOQ ASICs

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -212,11 +212,29 @@ class HashTest(BaseTest):
                 hit_count_map[matched_port] = hit_count_map.get(
                     matched_port, 0) + 1
             logging.info("hit count map: {}".format(hit_count_map))
-            # if the packet from the ingress port could go to both ToRs(active-active dualtor), we should
-            # expect that the packets go to the same ToR has same egress port, so there should be two entries
-            # in the hit count map.
-            assert len(hit_count_map.keys()) == len(
-                self.ptf_test_port_map[str(ingress_port)]["target_dut"])
+            # On a multi-core VOQ ASIC the same fixed 5-tuple can resolve to a
+            # different -- but still valid -- ECMP member depending on which
+            # ingress core the packet arrives on, so the same flow injected from
+            # different ingress ports may egress different ports. This mirrors
+            # the existing multi-ASIC handling, where 'ingress-port' is excluded
+            # from the hash keys for the same reason. Every packet is already
+            # validated to land on a valid ECMP member (verify_packet_any_port),
+            # and this negative subtest only runs on ECMP routes (each
+            # exp_port_list is asserted to have >1 nexthop above), so relaxing
+            # the single-global-egress check does not mask a single-next-hop
+            # route that should have one deterministic egress.
+            is_ecmp_route = all(len(exp_ports) > 1 for exp_ports in exp_port_lists)
+            if self.switch_type == 'voq' and is_ecmp_route:
+                logging.info(
+                    "switch_type is voq and route is ECMP: skipping the "
+                    "single-egress-port assertion for 'ingress-port' (the ingress "
+                    "core may select a different but valid ECMP member)")
+            else:
+                # if the packet from the ingress port could go to both ToRs(active-active dualtor), we
+                # should expect that the packets go to the same ToR has same egress port, so there should
+                # be two entries in the hit count map.
+                assert len(hit_count_map.keys()) == len(
+                    self.ptf_test_port_map[str(ingress_port)]["target_dut"])
         else:
             for _ in range(0, self.balancing_test_times * len(list(itertools.chain(*exp_port_lists)))):
                 logging.info('Checking hash key {}, src_port={}, exp_ports={}, dst_ip={}'


### PR DESCRIPTION
### Description of PR

Fix a flaky failure of `fib/test_fib.py::test_hash` on single-ASIC multi-core VOQ ASICs (`switch_type == voq`).

The `ingress-port` key is a **negative** hash subtest: it injects the same fixed 5-tuple packet from many different ingress ports and, today, asserts that the flow always egresses a **single** global port regardless of ingress port.

On a single-ASIC multi-core VOQ ASIC this assumption does not hold in practice. Empirically, the same fixed 5-tuple sent from different ingress ports resolves to a **different but still valid** ECMP member. On hardware, the two observed egress ports belong to **two distinct ECMP next hops** (two separate single-member port-channels) that land on different forwarding cores — so this is legitimate ingress-dependent ECMP member selection, not a forwarding error. It produces intermittent failures where `hit_count_map` has more than one key (observed: `hit count map: {20: 35, 12: 13}` — two valid ECMP members of the same next-hop group).

This mirrors the existing handling for multi-ASIC in `tests/fib/test_fib.py`, where `ingress-port` is already removed from the hash keys because "each asic has different hash seed ... the same packet coming in different asic could egress out of different port". A single-ASIC multi-core VOQ exhibits the same ingress-dependent behavior, but was not covered.

#### Type of change

- [x] Bug fix

#### Approach

Every packet in the `ingress-port` loop is already validated to arrive on a valid ECMP member via `verify_packet_any_port` (inside `check_ip_route`), so forwarding correctness from every ingress port is still exercised. This change only relaxes the final "all ingress ports resolve to a single egress port" assertion, and only when `self.switch_type == 'voq'` **and the route is ECMP** (each expected next-hop group has more than one member — which this negative subtest already requires). Non-VOQ platforms, and single-next-hop routes, keep the original strict assertion (behavior is byte-identical for them).

#### How did you verify/test it?

Ran `fib/test_fib.py::test_hash[ipv4]` on a single-ASIC multi-core VOQ DUT (`switch_type=voq`) on a T2 topology:

- Before: `1 failed` at the `ingress-port` assertion (`hit_count_map` = `{20: 35, 12: 13}` — two valid ECMP members reached from two different ingress ports).
- After: `1 passed`. The PTF log shows the same `{20: 35, 12: 13}` split and the new gate log line `switch_type is voq and route is ECMP: skipping the single-egress-port assertion for 'ingress-port'`. The balancing subtests (`src-ip`/`dst-ip`/`src-port`/`dst-port`) remain evenly distributed across all ECMP members.
