### PR TITLE
[fib] Skip the hash tests when there is no ECMP set to hash across

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -99,6 +99,23 @@ def check_default_route_from_fib_info(ptfhost, file_path):
     return ports
 
 
+def skip_if_no_ecmp_to_hash_over(ptfhost, fib_file):
+    """Skip when the topology offers no ECMP set for the hash tests to work with.
+
+    The hash tests send traffic to destinations reached via the default route and
+    check it is distributed across the nexthops. hash_test.py asserts outright if a
+    destination resolves to a single nexthop, which reports a failure for a topology
+    that simply has one path rather than for anything the device did wrong.
+
+    Checking the installed FIB rather than the topology name keeps this correct if a
+    topology gains or loses upstream links. This mirrors what test_ecmp_group_member_flap
+    already does with the same helper.
+    """
+    if not check_default_route_from_fib_info(ptfhost, fib_file):
+        pytest.skip("Hash tests need an ECMP set to hash across, and the default route on this "
+                    "topology resolves to fewer than two nexthops.")
+
+
 def get_all_ptf_port_indices_from_mg_facts(mg_facts):
     """
     Retrieve all ptf port indices from the minigraph facts.
@@ -550,6 +567,8 @@ def test_hash(add_default_route_to_dut, duthosts, tbinfo, setup_vlan,      # noq
     fib_files = fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_facts,
                                             tbinfo, request)
 
+    skip_if_no_ecmp_to_hash_over(ptfhost, fib_files[0])
+
     is_active_active_dualtor = bool(active_active_ports)
     switch_type = duthosts[0].facts.get('switch_type')
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
@@ -658,6 +677,9 @@ def test_ipinip_hash_negative(add_default_route_to_dut, duthosts,           # no
     hash_keys = ['inner_length']
     fib_files = fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_facts,
                                             tbinfo, request)
+
+    skip_if_no_ecmp_to_hash_over(ptfhost, fib_files[0])
+
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     log_file = "/tmp/hash_test.IPinIPHashTest.{}.{}.log".format(
         ipver, timestamp)
@@ -709,6 +731,9 @@ def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts,                
 
     fib_files = fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_facts,
                                             tbinfo, request)
+
+    skip_if_no_ecmp_to_hash_over(ptfhost, fib_files[0])
+
     # Query the default VxLAN UDP port from switch's APPL_DB
     vxlan_dport_check = duthost.shell('redis-cli -n 0 hget "SWITCH_TABLE:switch" "vxlan_port"')
     if 'stdout' in vxlan_dport_check and vxlan_dport_check['stdout'].isdigit():


### PR DESCRIPTION
### Description of PR

Summary:
The hash tests in `fib/test_fib.py` send traffic to destinations reached via the default route and check that it is spread across the nexthops. `hash_test.py` asserts outright when a destination resolves to a single nexthop:

```python
for exp_port_list in exp_port_lists:
    if len(exp_port_list) <= 1 or ...:
        logging.warning("{} has only {} nexthop".format(dst_ip, exp_port_list))
        assert False
```

So on a topology with only one upstream path, all eight hash cases report a failure before a single packet is sent. Nothing is wrong with the device. There is just nothing to hash over.

This gates the three hash tests on the installed FIB, reusing `check_default_route_from_fib_info`, which already returns an empty list when the default route is missing or has fewer than two nexthops.

ADO: 39379172

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Backport is requested to **msft-202603** via the `Request for msft-202603 branch` label, since that branch is not on the list above. That is the branch these testbeds qualify against.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): ADO 39379172

Failure type: day-one issue for single homed topologies. The assertion has always behaved this way; it only became visible when a topology with one upstream path started running this module.

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Also tested on **202603**, which is not on the list above and is the branch these testbeds run.

### Test result

- **202603**: hardware, two topologies, same image and same branch, one single homed and one dual homed.

| Topology | Result | Note |
| --- | --- | --- |
| Single upstream path | 1 passed, 15 skipped, **0 failed** | was 8 failed before this change |
| Two upstream paths | **10 passed**, 6 skipped, 0 failed | identical to the run without this change |

The second row is the important one. It is the negative control. On the topology that does have ECMP the guard does not fire at all, the same 10 cases run and pass, and the 6 skips are the pre-existing platform ones. No coverage was lost.

The 8 newly skipped cases report:

```
SKIPPED [8] fib/test_fib.py:115: Hash tests need an ECMP set to hash across,
and the default route on this topology resolves to fewer than two nexthops
```

- **master**: covered by this PR's own impacted-area checks. `flake8 --max-line-length=120` clean.

### Approach

#### What is the motivation for this PR?

A topology with a single upstream path cannot demonstrate hash distribution, and the current code reports that as eight test failures rather than as an inapplicable test. That is a misleading signal during qualification and it costs time on every run.

#### How did you do it?

Added `skip_if_no_ecmp_to_hash_over()` and called it from `test_hash`, `test_ipinip_hash_negative` and `test_vxlan_hash`. 25 lines added, nothing removed, no change to any existing test's behaviour when ECMP is present.

**Why check the FIB and not the topology name.** A skip keyed on the topology name would have to be revisited by hand every time a topology changes, and it would keep skipping if that topology later gained a second upstream. That is a silent loss of coverage. Reading the FIB means a topology that gains an upstream starts running these tests on its own, and one that loses redundancy stops reporting a misleading failure.

`test_ecmp_group_member_flap` already guards itself with the same helper for the same reason, so this also makes the module internally consistent.

#### How did you verify/test it?

Run on real hardware on both a single homed and a dual homed topology, with the dual homed one acting as a negative control. Results in the Test result section above.

#### Any platform specific information?

None. This depends on the number of nexthops installed for the default route, not on platform or ASIC.

#### Supported testbed topology if it's a new test case?

Not a new test case. The three hash tests keep every topology they already supported and simply skip where there is no ECMP set to hash across.

### Documentation

No documentation change needed.

---

**Known limitation, and an open review point.** `check_default_route_from_fib_info` returns an empty list for three different conditions: the FIB info file cannot be read, there is no default route at all, and the default route has a single nexthop. Only the third is a legitimate skip. A reviewer has correctly pointed out that a device defect which removed the default route would currently skip rather than fail. A revision addressing that is in progress. It also only inspects the IPv4 default route, so the IPv6 hash cases are gated on the v4 route as a proxy, matching the existing behaviour of `test_ecmp_group_member_flap`.
