### PR TITLE
[test] ntp_helper: skip mgmt-iface listen restriction when PTF has no mgmt

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -28,7 +28,16 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
         ntp_conf_path = '/etc/ntp.conf'
         ntp_service_name = 'ntp'
 
-    if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP):
+    # Whether the PTF host exposes an interface literally named "mgmt".
+    # Full-topology PTFs have a `mgmt` veth pair; standalone Docker PTF
+    # containers typically only have `eth0`, and ntpsec cannot bind to those
+    # aliases. Restrict listen directives to the `mgmt` interface only when
+    # it actually exists; otherwise fall through to the default wildcard bind
+    # so the daemon can still serve on eth0.
+    ptf_has_mgmt_iface = ptfhost.command(
+        "ip link show mgmt", module_ignore_errors=True).get("rc", 1) == 0
+
+    if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP) and ptf_has_mgmt_iface:
         # Limit listening to the mgmt interface, to prevent socket allocation
         # exhaustion
         ptfhost.lineinfile(path=ntp_conf_path, line="interface ignore wildcard")
@@ -106,7 +115,7 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
 
     ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^server.*127.127.1.0.*prefer")
 
-    if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP):
+    if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP) and ptf_has_mgmt_iface:
         ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.ignore.wildcard")
         ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.listen.mgmt")
         if ptf_use_ipv6 and ptfhost.mgmt_ipv6:


### PR DESCRIPTION
#### Why I did it

Split out from #27246 so the PTF `mgmt` interface assumption can land independently of the ntpsec local-clock syntax fix.

`setup_ntp_context` in `tests/common/helpers/ntp_helper.py` unconditionally writes

```
interface ignore wildcard
interface listen mgmt
```

(and the IPv6 companion) to the PTF's ntp/ntpsec config. That works on full-topology testbeds where the PTF has a `mgmt` veth pair, but fails on standalone Docker PTF containers that only have `eth0`:

- ntp classic silently binds to nothing.
- ntpsec cannot bind to a non-existent iface name at all — the daemon comes up bound to nothing.

Either way the DUT can't reach the NTP server and every `ntp/test_ntp.py` case aborts with `NTP server was not started in PTF container`.

#### How I did it

Probe once for a literal `mgmt` interface via `ip link show mgmt` in setup, cache the result, and apply the interface listen/ignore-wildcard directives (and their matching teardown removals) only when it exists. When absent, fall through to the default wildcard bind so the daemon still serves on `eth0`.

- Full-topology PTFs: `mgmt` exists → code path unchanged.
- Standalone Docker PTF: probe fails → skip the interface directives → ntpsec/ntpd binds on `eth0`, DUT syncs successfully.

#### How to verify it

- Full-topology testbed: `ntp/test_ntp.py` still passes with unchanged config output on the PTF.
- Standalone Docker PTF (e.g. BMC testbed with `docker-ptf:internal` on Debian 12): before this change 3 errors "NTP server was not started"; after this change ntpd/ntpsec binds on `eth0` and the DUT synchronizes.
