### PR TITLE
[conditional_mark]: Xfail warmboot data consistency on 202605

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5732,6 +5732,16 @@ upgrade_path/test_upgrade_path.py::test_upgrade_path_t2_delayed:
     conditions:
       - "'t2' not in topo_type"
 
+upgrade_path/test_warmboot_data_consistency.py::test_warmboot_data_consistency:
+  xfail:
+    reason: >
+      Keep 202605 runs non-blocking while collecting warm-vs-cold snapshots for
+      the assertion-mask gaps tracked by
+      https://github.com/sonic-net/sonic-mgmt/issues/27541.
+    strict: false
+    conditions:
+      - "release in ['202605'] and https://github.com/sonic-net/sonic-mgmt/issues/27541"
+
 #######################################
 #####            vlan             #####
 #######################################


### PR DESCRIPTION
### Description of PR

Summary:
Make `upgrade_path.test_warmboot_data_consistency::test_warmboot_data_consistency` non-blocking on the 202605 release while preserving the complete warm/cold workflow and diagnostic collection. The non-strict xfail is tied to the public tracking issue so it stops applying when the issue is closed.

Fixes #27541

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

The test reports known warm-vs-cold assertion-mask gaps on 202605. These failures should not block release qualification, but the test must continue running so Redis snapshots, logs, and data-difference artifacts remain available for diagnosis.

#### How did you do it?

Added an exact-node conditional xfail scoped to release `202605`. The mark uses `strict: false`, so expected failures are reported as XFAIL and unexpected passes remain non-blocking XPASS. The condition includes https://github.com/sonic-net/sonic-mgmt/issues/27541, allowing the plugin to lift the xfail when the issue closes.

#### How did you verify/test it?

- Parsed `tests_mark_conditions.yaml` successfully with PyYAML.
- Exercised the production conditional-mark matching logic: 202605 with the active issue returns XFAIL with `strict: false`; 202511 returns no xfail.
- Verified `git diff --check` passes and the branch contains only the conditional-mark YAML change.

#### Any platform specific information?

No. Current 202605 evidence spans multiple HWSKUs, so the mark is release-scoped rather than platform-scoped.

#### Supported testbed topology if it's a new test case?

Not applicable; this PR does not add a test case.

### Documentation

Not applicable; this is a conditional mark for an existing test.