### PR TITLE
clear buffer pool watermark after get_multiple_flows

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -6855,18 +6855,6 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         buf_pool_roid = int(self.test_params['buf_pool_roid'], 0)
         print("buf_pool_roid: 0x%lx" % (buf_pool_roid), file=sys.stderr)
 
-        buffer_pool_wm_base = 0
-        if 'cisco-8000' in asic_type:
-            # Some small amount of memory is always occupied
-            # We use dst client for cisco 8000.
-            client_to_use = self.dst_client
-            sai_thrift_clear_buffer_pool_watermark(client_to_use, buf_pool_roid)
-            buffer_pool_wm_base = sai_thrift_read_buffer_pool_watermark(
-                client_to_use, buf_pool_roid)
-        else:
-            client_to_use = self.src_client
-        print("Initial watermark: {}".format(buffer_pool_wm_base))
-
         # Prepare TCP packet data
         tos = dscp << 2
         tos |= ecn
@@ -6903,6 +6891,18 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                                     ip_dst=dst_port_ip,
                                     ip_tos=tos,
                                     ip_ttl=ttl)
+
+        buffer_pool_wm_base = 0
+        if 'cisco-8000' in asic_type:
+            # Some small amount of memory is always occupied
+            # We use dst client for cisco 8000.
+            client_to_use = self.dst_client
+            sai_thrift_clear_buffer_pool_watermark(client_to_use, buf_pool_roid)
+            buffer_pool_wm_base = sai_thrift_read_buffer_pool_watermark(
+                client_to_use, buf_pool_roid)
+        else:
+            client_to_use = self.src_client
+        print("Initial watermark: {}".format(buffer_pool_wm_base))
 
         # Add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
get_multiple_flows could bump up buffer pool watermark.
clear buffer pool watermark after it to get base value of buffer pool watermark.

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
Fix buffer pool watermark test case failure.

#### How did you do it?
get_multiple_flows could bump up buffer pool watermark.
clear buffer pool watermark after it to get base value of buffer pool watermark.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
cisco-8000

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
