### PR TITLE
snappi: add multi-ingress MACsec test architecture

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -140,7 +140,7 @@ def __gen_mac(id):
     Returns:
         MAC address (string)
     """
-    return '00:{:02d}:22:33:44:01'.format(id)
+    return '00:{:02x}:22:33:44:01'.format(id)
 
 
 def __gen_pc_mac(id):
@@ -1499,10 +1499,15 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
         return True
 
     global macsec_enabled_port, macsec_profile_name, reconfigure_port
-    ptype = "--snappi_macsec" in sys.argv
-    num_of_non_macsec_snappi_devices = 7
-    static_prefix_length = str(subnet_mask_from_hosts(num_of_non_macsec_snappi_devices))
-    for index, port in enumerate(snappi_ports):
+    num_of_non_macsec_snappi_devices = 7*(len(snappi_ports) - 1)
+    # +3 to ignore the network and broadcast address and plus one extra buffer
+    # since the address is already configure on the dut interface
+    static_prefix_length = str(subnet_mask_from_hosts(num_of_non_macsec_snappi_devices + 3))
+    ports = []
+    for port in snappi_ports:
+        if port['peer_device'] == duthost.hostname:
+            ports.append(port)
+    for index, port in enumerate(ports):
         if port['duthost'] == duthost:
             peer_port = port['peer_port']
             asic_inst = duthost.get_port_asic_instance(peer_port)
@@ -1551,7 +1556,7 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
         if setup:
             gen_data_flow_dest_ip(tgenIp, duthost, port['peer_port'], port['asic_value'], setup)
         port['intf_config_changed'] = True
-        if ptype and port_id == 1:
+        if port_id >= 1:
             device = config.devices.device(name='Device Port {}'.format(port_id))[-1]
             ethernet = device.ethernets.add()
             ethernet.name = 'Ethernet Port {}'.format(port_id)
@@ -1590,7 +1595,7 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
                             format(port['asic_value'], port['peer_port'], tgenIp, mac))
             # Tx Port
             ip1 = ethernet.ipv4_addresses.add()
-            ip1.name = "ip2"
+            ip1.name = "ip_{}".format(port_id)
             ip1.address = tgenIp
             ip1.prefix = int(prefix_length)
             ip1.gateway = dutIp
@@ -1603,7 +1608,7 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
             macsec1_int = macsec1.ethernet_interfaces.add()
             macsec1_int.eth_name = ethernet.name
             secy1 = macsec1_int.secure_entity
-            secy1.name = "macsec1"
+            secy1.name = "macsec{}".format(port_id)
 
             # Data plane and crypto engine
             secy1.data_plane.choice = "encapsulation"
@@ -1625,7 +1630,7 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
             secy1_key_gen_proto = secy1.key_generation_protocol
             secy1_key_gen_proto.choice = "mka"
             kay1 = secy1_key_gen_proto.mka
-            kay1.name = "mka1"
+            kay1.name = "mka1_{}".format(port_id)
             # Basic properties
             kay1.basic.key_derivation_function = all_values['snappi']['key_derivation_function']
             kay1.basic.actor_priority = all_values['snappi']['actor_priority']
@@ -1661,24 +1666,8 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
             # Tx SC
             kay1_tx = kay1.tx
             kay1_txsc1 = kay1_tx.secure_channels.add()
-            kay1_txsc1.name = "txsc1"
+            kay1_txsc1.name = "txsc{}".format(port_id)
             kay1_txsc1.system_id = mac
-            # Remaining Tx SC settings autofilled
-            eotr = config.egress_only_tracking
-            eotr1 = eotr.add()
-            eotr1.port_name = config.ports[port_id].name
-
-            # eotr filter
-            eotr1_filter1 = eotr1.filters.add()
-            eotr1_filter1.choice = "auto_macsec"
-
-            # eotr metric tag for destination MAC 3rd byte from MSB: LS 4 bits
-            eotr1_mt1 = eotr1.metric_tags.add()
-            eotr1_mt1.name = "pause traffic"
-            eotr1_mt1.rx_offset = 0
-            eotr1_mt1.length = 8
-            eotr1_mt1.tx_offset.choice = "custom"
-            eotr1_mt1.tx_offset.custom.value = 0
             port_config = SnappiPortConfig(
                                 id=port_id,
                                 ip=tgenIp,
@@ -1690,7 +1679,7 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
                                 peer_port=port['peer_port']
                             )
             port_config_list.append(port_config)
-        elif ptype and port_id == 0:
+        elif port_id == 0:
             ip_values = get_ip_addresses(tgenIp, num_of_non_macsec_snappi_devices)
             for nd in range(0, num_of_non_macsec_snappi_devices):
                 device = config.devices.device(name='Device Port {}_{}'.format(port_id, nd))[-1]
@@ -1699,7 +1688,8 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
                 ethernet.connection.port_name = config.ports[port_id].name
                 ethernet.mac = __gen_mac(nd)
                 ip_stack = ethernet.ipv4_addresses.add()
-                ip_stack.name = 'Ipv4 Port {}_{}'.format(port_id, nd)
+                left, right = divmod(nd, 7)
+                ip_stack.name = f"Ipv4 Port {left}_{right}"
                 ip_stack.address = ip_values[nd]
                 ip_stack.prefix = int(prefix_length)
                 ip_stack.gateway = dutIp

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -32,7 +32,8 @@ from tests.common.snappi_tests.uhd.uhd_helpers import (NetworkConfigSettings, cr
 logger = logging.getLogger(__name__)
 _next_system_id = 1
 
-macsec_enabled_port = {}
+macsec_enabled_ports = []
+macsec_profile_duthosts = []
 macsec_profile_name = ""
 
 speed_type = {
@@ -1228,6 +1229,23 @@ def snappi_dut_base_config(duthost_list,
         snappi_ports=new_snappi_ports))
 
 
+def _skip_macsec_portchannel_members(duthost_list, snappi_ports):
+    for duthost in duthost_list:
+        mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+        selected_ports = {
+            port['peer_port']
+            for port in snappi_ports
+            if port['peer_device'] == duthost.hostname
+        }
+
+        for portchannel, portchannel_data in (mg_facts.get('minigraph_portchannels') or {}).items():
+            unsupported_ports = selected_ports & set(portchannel_data.get('members', []))
+            if unsupported_ports:
+                pytest.skip(
+                    'Snappi MACsec supports Ethernet interfaces only; {} on {} are members of {}'.format(
+                        sorted(unsupported_ports), duthost.hostname, portchannel))
+
+
 def setup_dut_ports(
         setup,
         duthost_list,
@@ -1270,6 +1288,9 @@ def setup_dut_ports(
         return found_ports()
 
     ptype = "--snappi_macsec" in sys.argv
+
+    if ptype and setup:
+        _skip_macsec_portchannel_members(duthost_list, snappi_ports)
 
     # if not MACSEC and setup=True, find usual ports for the test.
     if ((not ptype) and setup):
@@ -1498,7 +1519,7 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
             gen_data_flow_dest_ip(port['ipAddress'], duthost, port['peer_port'], port['asic_value'], setup)
         return True
 
-    global macsec_enabled_port, macsec_profile_name, reconfigure_port
+    global macsec_enabled_ports, macsec_profile_duthosts, macsec_profile_name, reconfigure_port
     num_of_non_macsec_snappi_devices = 7*(len(snappi_ports) - 1)
     # +3 to ignore the network and broadcast address and plus one extra buffer
     # since the address is already configure on the dut interface
@@ -1569,7 +1590,6 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
                     profile_name = line.split()[1]
                     logger.info('Removing already configured Macsec profile {}'.format(profile_name))
                     delete_macsec_profile(port['duthost'], profile_name)
-            macsec_enabled_port = port
             macsec_profile_name = '256_XPN_SCI'
             cipher = all_values[macsec_profile_name]['cipher_suite']
             primary_cak = all_values[macsec_profile_name]['primary_cak']
@@ -1582,7 +1602,13 @@ def __intf_config_macsec(config, port_config_list, duthost, snappi_ports, setup=
             logger.info('Configuring MACSEC on DUT Interfaces: {}'.format(port['peer_port']))
             set_macsec_profile(port['duthost'], macsec_profile_name, priority,
                                cipher, primary_cak, primary_ckn, policy, send_sci, rekey_period)
+            if all(dut.hostname != port['duthost'].hostname for dut in macsec_profile_duthosts):
+                macsec_profile_duthosts.append(port['duthost'])
             enable_macsec_port(port['duthost'], port['peer_port'], macsec_profile_name)
+            if all(enabled_port['duthost'].hostname != port['duthost'].hostname
+                   or enabled_port['peer_port'] != port['peer_port']
+                   for enabled_port in macsec_enabled_ports):
+                macsec_enabled_ports.append(port)
             if port['asic_value'] is None:
                 duthost.command("sudo arp -i {} -s {} {} \n".
                                 format(port['peer_port'], tgenIp, mac))
@@ -1753,6 +1779,8 @@ def create_ip_list(value, count, mask=32, incr=0):
 
 
 def cleanup_config(duthost_list, snappi_ports):
+    global macsec_enabled_ports, macsec_profile_duthosts
+
     ptype = "--snappi_macsec" in sys.argv
     if not ptype:
         if (duthost_list[0].facts['asic_type'] == "cisco-8000" and
@@ -1818,14 +1846,17 @@ def cleanup_config(duthost_list, snappi_ports):
                                 format(reconfigure_port['asic_value'], reconfigure_port['peer_port'],
                                        reconfigure_port['original_subnet'].split('/')[0],
                                        reconfigure_port['original_subnet'].split('/')[1]))
-        logger.info('Disabling MACsec on {} port {}'.
-                    format(macsec_enabled_port['duthost'].hostname,
-                           macsec_enabled_port['peer_port']))
-        disable_macsec_port(macsec_enabled_port['duthost'],  macsec_enabled_port['peer_port'])
-        logger.info('Deleting macsec profile {} on {} port {}'.format(macsec_profile_name,
-                                                                      macsec_enabled_port['duthost'].hostname,
-                                                                      macsec_enabled_port['peer_port']))
-        delete_macsec_profile(macsec_enabled_port['duthost'], macsec_profile_name)
+        for port in reversed(macsec_enabled_ports):
+            logger.info('Disabling MACsec on {} port {}'.
+                        format(port['duthost'].hostname, port['peer_port']))
+            disable_macsec_port(port['duthost'], port['peer_port'])
+        macsec_enabled_ports = []
+
+        for dut in macsec_profile_duthosts:
+            logger.info('Deleting macsec profile {} on {}'.
+                        format(macsec_profile_name, dut.hostname))
+            delete_macsec_profile(dut, macsec_profile_name)
+        macsec_profile_duthosts = []
 
 
 @pytest.fixture(scope="module")

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -740,17 +740,20 @@ def _log_in_flight_stats(api, in_flight_flow_metrics, data_flow_names, ptype, sn
 
 def _log_in_flight_macsec_flow_stats(in_flight_flow_metrics, data_flow_names, snappi_extra_params):
     """Log per-flow TX/RX frame counts from in-flight MACsec TGEN flow statistics."""
-    flow_names, tx_frames, rx_frames = [], [], []
+    prio_count = 7
+    flow_names, pgids, tx_frames, rx_frames = [], [], [], []
     for fs in in_flight_flow_metrics:
-        if int(fs['PGID']) in snappi_extra_params.flow_name_prio_map.values() and \
-           fs['Rx Port'] == snappi_extra_params.base_flow_config["rx_port_name"]:
-            flow_names.append(fs['Traffic Item'] + "-" + fs['PGID'])
+        if int(fs['PGID']) % prio_count in snappi_extra_params.flow_name_prio_map.values() and \
+           fs['Rx Port'] == snappi_extra_params.base_flow_config["rx_port_name"] and \
+           int(fs['Tx Frames']) != 0:
+            flow_names.append(fs['Tx Port'] + "->" + fs['Rx Port'])
+            pgids.append(int(fs['PGID']) % prio_count)
             tx_frames.append(fs['Tx Frames'])
             rx_frames.append(fs['Rx Frames'])
-    rows = list(zip(flow_names, tx_frames, rx_frames))
+    rows = list(zip(flow_names, pgids, tx_frames, rx_frames))
     logger.info(
         "In-flight traffic statistics for flows:\n%s",
-        tabulate(rows, headers=["Flow", "Tx", "Rx"], tablefmt="psql"),
+        tabulate(rows, headers=["Flow", "Prio", "Tx", "Rx"], tablefmt="psql"),
     )
 
 
@@ -783,8 +786,13 @@ def run_traffic(duthost,
     ptype = "--snappi_macsec" in sys.argv
     if ptype:
         ixnet = api._ixnetwork
-        dp = ixnet.Topology.find().DeviceGroup.find().Ethernet.find().Mka.find().DelayProtect
-        dp.Single(False)
+        for topology in ixnet.Topology.find():
+            for device_group in topology.DeviceGroup.find():
+                for ethernet in device_group.Ethernet.find():
+                    for mka in ethernet.Mka.find():
+                        mka.DelayProtect.Single(False)
+                    for static_macsec in ethernet.StaticMacsec.find():
+                        static_macsec.SendGratArp = False
         _configure_macsec_dut_sci_macs(
             ixnet, snappi_extra_params.multi_dut_params.multi_dut_ports)
         for ti in ixnet.Traffic.TrafficItem.find():
@@ -828,7 +836,7 @@ def run_traffic(duthost,
             if row['Sessions Not Started'] != '0' or row['Sessions Down'] != '0':
                 pytest_assert(False, "Not all protocol sessions are up")
         rx_dut_port = snappi_extra_params.base_flow_config["rx_port_config"].peer_port
-        for i in range(7):
+        for i in range(7 * (len(config.ports) - 1)):
             eth_stack = config.devices[i].ethernets[0]
             mac_address = eth_stack.mac
             ip_address = eth_stack.ipv4_addresses[0].address
@@ -948,7 +956,7 @@ def run_traffic(duthost,
                 if int(metric['PGID']) in snappi_extra_params.flow_name_prio_map.values()
                 and metric['Tx Port'] == snappi_extra_params.base_flow_config["tx_port_name"]
             ]
-            if list(set(transmit_states)) == [0]:   # Issue encountered, workaround is != instead of ==
+            if list(set(transmit_states)) != [0]:   # Issue encountered, workaround is != instead of ==
                 logger.info("All test and background traffic flows stopped")
                 time.sleep(SNAPPI_POLL_DELAY_SEC)
                 break

--- a/tests/snappi_tests/docs/hld_snappi_macsec_infra_architecture.md
+++ b/tests/snappi_tests/docs/hld_snappi_macsec_infra_architecture.md
@@ -1,0 +1,587 @@
+# Snappi MACsec Ingress to Plain IPv4 Egress HLD
+
+## Document information
+
+### Authors
+
+- Varun Aiyaswamy Kannan
+- Amit Pawar
+- Amol Rawal
+- Dinesh Kumar Sellappan
+
+### Version information
+
+| Version | Date | Description |
+| --- | --- | --- |
+| 1.0 | 2026-08-31 | Initial Snappi MACsec architecture HLD |
+
+## 1. Scope
+
+This document describes the reusable Snappi MACsec architecture for a
+two-ingress, one-egress test topology:
+
+- Both ingress links use MACsec.
+- The single egress link uses plain Ethernet and IPv4.
+- Traffic from both ingress links converges on the same egress port.
+- Egress-only tracking distinguishes traffic by ingress source and priority.
+- MACsec overhead is removed before traffic reaches the plain egress link.
+
+PFC, congestion, and scheduler tests consume this architecture, but their
+individual traffic patterns and pass/fail criteria are outside this HLD.
+
+## 2. Goals
+
+- Establish MKA and MACsec on each TGEN-to-DUT ingress link.
+- Keep the DUT-to-TGEN egress link unencrypted.
+- Support priorities 0 through 6 for each ingress source.
+- Preserve per-source, per-priority traffic visibility after flows merge.
+- Provide correct packet-loss and throughput accounting across MACsec
+  decapsulation.
+- Restore all temporary DUT configuration after the test.
+
+## 3. Reference topology
+
+```text
+TGEN port 1
+MACsec endpoint, port_id 1
+        | encrypted Ethernet + IPv4
+        v
+  DUT ingress 1 -- MACsec validation and decryption --+
+                                                      |
+                                                      +--> DUT forwarding
+                                                      |        |
+  DUT ingress 2 -- MACsec validation and decryption --+        v
+        ^                                               Plain DUT egress
+        | encrypted Ethernet + IPv4                     port_id 0
+TGEN port 2                                                   |
+MACsec endpoint, port_id 2                                   | plain Ethernet + IPv4
+                                                             v
+                                                    TGEN port 0
+                                                    IPv4 endpoint bank
+                                                    and egress-only tracking
+```
+
+The port-role convention is:
+
+| `port_id` | Direction | Security | Snappi interface type |
+| --- | --- | --- | --- |
+| `0` | DUT egress / TGEN receive | Plain IPv4 | `IPInterface` |
+| `1` | TGEN transmit / DUT ingress | MACsec | `MacsecInterface` |
+| `2` | TGEN transmit / DUT ingress | MACsec | `MacsecInterface` |
+
+The implementation assumes that `port_id == 0` is the only egress and every
+`port_id >= 1` is a MACsec ingress.
+
+## 4. Architectural layers
+
+### 4.1 Link security
+
+MKA establishes keys and secure channels for each ingress link. MACsec:
+
+- Adds a SecTAG.
+- Encrypts the protected portion of the frame.
+- Adds an integrity check value (ICV).
+- Uses the SCI and packet number for secure-association and replay handling.
+
+The DUT validates and decrypts each ingress frame before normal forwarding.
+
+### 4.2 Forwarding
+
+After MACsec decapsulation, the DUT forwards an ordinary Ethernet/IPv4 packet.
+The egress interface is not configured for MACsec, so no SecTAG or ICV is
+present on the egress wire.
+
+### 4.3 QoS classification
+
+The traffic's DSCP and Ethernet PFC queue fields determine the DUT
+priority/priority-group/queue classification.
+
+PGID does **not** configure the DUT queue. PGID is a traffic-generator
+measurement identity used to distinguish flows in IxNetwork statistics.
+
+### 4.4 Measurement
+
+Traffic from two ingress sources merges at one egress port. The architecture
+therefore creates a distinct plain IPv4 egress endpoint for every combination
+of:
+
+```text
+ingress source × priority
+```
+
+Selecting one of these endpoints gives IxNetwork enough information to produce
+separate PGID statistics for otherwise similar traffic.
+
+## 5. Enabling MACsec mode
+
+The option is declared in
+[`tests/conftest.py`](../../conftest.py):
+
+```python
+parser.addoption(
+    "--snappi_macsec",
+    action="store_true",
+    default=False,
+    help="Enable macsec on tgen links of testbed",
+)
+```
+
+Append the option to the normal Snappi pytest command:
+
+```bash
+pytest <test-path> \
+    --testbed=<testbed> \
+    --inventory=<inventory> \
+    --snappi_macsec
+```
+
+`--snappi_macsec` controls the Snappi/TGEN MACsec path. It is different from
+`--enable_macsec`, which is used by the separate SONiC-link MACsec test path.
+
+The current implementation detects the option with:
+
+```python
+"--snappi_macsec" in sys.argv
+```
+
+When enabled, `setup_dut_ports()` bypasses the normal VLAN, port-channel,
+routed-interface, and fallback P2P setup paths and invokes
+`__intf_config_macsec()`.
+
+## 6. `__intf_config_macsec`
+
+The implementation is in
+[`tests/common/snappi_tests/snappi_fixtures.py`](../../common/snappi_tests/snappi_fixtures.py).
+
+### 6.1 DUT port discovery
+
+The function first selects Snappi ports whose `peer_device` matches the current
+DUT. Each selected port contains its physical peer port, `port_id`, ASIC
+namespace, and addressing information.
+
+### 6.2 Address preparation
+
+For each selected DUT interface, the function:
+
+1. Reads the existing IPv4 interface subnet.
+2. Adds a temporary address if the interface has no IPv4 subnet.
+3. Uses a `/31`-style fallback for MACsec ingress links.
+4. Ensures the plain egress subnet is large enough for all virtual egress
+   endpoints.
+5. Records original and applied subnets for cleanup.
+6. Derives the TGEN address, DUT gateway, prefix, TGEN MAC, and DUT interface
+   MAC.
+
+### 6.3 DUT MACsec configuration
+
+For every `port_id >= 1`, the function:
+
+1. Loads `256_XPN_SCI` from
+   [`macsec_profile.json`](../macsec_profile.json).
+2. Removes stale instances of the same Snappi MACsec profile.
+3. Installs the profile once per participating DUT.
+4. Enables the profile on the ingress interface.
+5. Installs a static ARP entry for the TGEN IPv4/MAC pair.
+
+The profile uses GCM-AES-XPN-256, SCI transmission, MKA PSK configuration, and
+timer-based rekeying.
+
+### 6.4 TGEN MACsec device creation
+
+For every `port_id >= 1`, the function creates:
+
+- One Snappi device.
+- One Ethernet interface attached to that physical TGEN port.
+- One IPv4 address and gateway.
+- A MACsec SecY in encapsulation/encrypt-only mode.
+- A transmit secure channel and packet-number configuration.
+- An MKA instance with PSK, cipher, actor priority, and rekey settings.
+- A `SnappiPortConfig` with type `MacsecInterface`.
+
+### 6.5 Plain egress device creation
+
+For `port_id == 0`, the function creates:
+
+- Multiple ordinary Ethernet/IPv4 devices.
+- A `SnappiPortConfig` of type `IPInterface` for every device.
+- One egress-only tracking configuration attached to physical port 0.
+
+MACsec is deliberately absent from this port.
+
+## 7. Egress endpoint count and prefix length
+
+Seven priority slots are currently supported for each ingress source:
+
+```text
+priority = 0..6
+```
+
+If `N` is the total number of physical TGEN ports, including egress:
+
+```text
+ingress_count = N - 1
+egress_endpoint_count = 7 × ingress_count
+```
+
+The fixture calculates:
+
+```python
+num_of_non_macsec_snappi_devices = 7 * (len(snappi_ports) - 1)
+static_prefix_length = subnet_mask_from_hosts(
+    num_of_non_macsec_snappi_devices + 3
+)
+```
+
+The resulting common topologies are:
+
+| Topology | Egress endpoints | Host request | Prefix |
+| --- | ---: | ---: | --- |
+| 1 ingress + 1 egress | 7 | 10 | `/28` |
+| 2 ingress + 1 egress | 14 | 17 | `/27` |
+
+The prefix is therefore calculated from endpoint capacity; it is not selected
+based on the test name.
+
+The caller adds three addresses for the DUT address and reserved headroom.
+`subnet_mask_from_hosts()` also accounts for the network and broadcast
+addresses when selecting the smallest suitable IPv4 prefix. This produces a
+conservative subnet size.
+
+If the existing egress prefix is too narrow, the fixture temporarily replaces
+it with `40.1.1.1/<calculated-prefix>` and records the original subnet for
+restoration.
+
+## 8. Flow priority to egress endpoint mapping
+
+The egress device name is generated using:
+
+```python
+left, right = divmod(device_index, 7)
+ip_stack.name = f"Ipv4 Port {left}_{right}"
+```
+
+Where:
+
+- `left` identifies the ingress-source block.
+- `right` identifies the priority slot.
+
+For two ingress sources, the intended endpoint layout is:
+
+| Device index / PGID | Ingress source | Priority |
+| ---: | ---: | ---: |
+| 0-6 | `port_id 1` | 0-6 |
+| 7-13 | `port_id 2` | 0-6 |
+
+The destination index is encoded as:
+
+```text
+PGID = (tx_port_id - 1) × 7 + priority
+```
+
+Examples:
+
+| `tx_port_id` | Priority | Destination index / PGID |
+| ---: | ---: | ---: |
+| 1 | 3 | 3 |
+| 1 | 6 | 6 |
+| 2 | 3 | 10 |
+| 2 | 6 | 13 |
+
+The flow builder must:
+
+1. Select the MACsec source device associated with the ingress port.
+2. Select the destination device from that source's seven-entry block.
+3. Set device endpoint mode to `ONE_TO_ONE`.
+4. Set DSCP and PFC queue fields for actual DUT QoS classification.
+5. Record the flow name to logical priority in `flow_name_prio_map`.
+
+The common flow generators currently select only the last MACsec device as the
+source. A two-ingress flow builder must explicitly select both source devices
+and their corresponding destination blocks.
+
+## 9. PGID to priority mapping
+
+IxNetwork Flow Statistics report the encoded endpoint identity as PGID.
+
+The logical priority is recovered with:
+
+```python
+priority = int(row["PGID"]) % 7
+```
+
+Examples:
+
+| PGID | Logical priority |
+| ---: | ---: |
+| 3 | 3 |
+| 6 | 6 |
+| 10 | 3 |
+| 13 | 6 |
+
+The modulo operation is required because both ingress sources use the same
+logical priorities but occupy different PGID blocks.
+
+A MACsec statistics row must not be selected using PGID alone. The safe
+identity is:
+
+```text
+(Tx Port, Rx Port, PGID)
+```
+
+Filter by Tx and Rx port first. Apply `PGID % 7` only when the verification
+rule needs the logical priority shared across ingress sources.
+
+## 10. Egress-only tracking
+
+Egress tracking is configured in two phases.
+
+### 10.1 Snappi configuration
+
+`__intf_config_macsec()` attaches `config.egress_only_tracking` to physical
+egress port 0:
+
+- Filter choice: `auto_macsec`
+- Metric tag name: `ipv4_dscp`
+- Receive offset: 0
+- Metric length: 8 bits
+- Transmit offset: custom offset 0
+
+The metric tag name is descriptive. The complete signature and extraction
+rules are finalized through IxNetwork after the Snappi configuration is
+applied.
+
+### 10.2 IxNetwork runtime configuration
+
+In
+[`tests/common/snappi_tests/traffic_generation.py`](../../common/snappi_tests/traffic_generation.py),
+`run_traffic()`:
+
+1. Disables automatic MACsec egress-only configuration on every traffic item.
+2. Clears normal traffic-item `TrackBy` fields.
+3. Selects a 12-byte egress-only signature.
+4. Builds the signature from the first egress endpoint MAC and IPv4 EtherType.
+5. Sets signature offset 2 and the signature mask.
+6. Configures egress extraction at offsets 0 and 52.
+7. Uses separate masks to distinguish ingress-source PGID blocks.
+
+The resulting IxNetwork Flow Statistics rows expose:
+
+- `PGID`
+- `Tx Port`
+- `Rx Port`
+- `Tx Frames`
+- `Rx Frames`
+- `Tx Frame Rate`
+
+## 11. Traffic execution
+
+After `api.set_config(config)`, MACsec mode performs additional IxNetwork
+configuration:
+
+1. Disable MKA delay protection.
+2. Disable gratuitous ARP transmission on StaticMacsec objects.
+3. Set each ingress endpoint's `DutSciMac` to the MAC of its owning DUT
+   interface.
+4. Install the egress-only tracking signature.
+5. Clear DUT MACsec and interface/QoS counters.
+6. Start all protocol sessions.
+7. Verify that no protocol sessions are down or not started.
+8. Install static ARP entries for all virtual egress endpoints.
+9. Generate every IxNetwork traffic item.
+10. Apply traffic.
+11. Start stateless traffic with the blocking IxNetwork API.
+
+For a two-ingress topology, `DutSciMac` must be resolved independently for both
+ingress interfaces, including their owning line card or ASIC namespace.
+
+## 12. Statistics differences
+
+### 12.1 Non-MACsec
+
+The non-MACsec path uses Snappi flow metric objects:
+
+```text
+metric.name
+metric.frames_tx
+metric.frames_rx
+metric.loss
+metric.transmit
+```
+
+Flows are identified directly by their configured names.
+
+### 12.2 MACsec
+
+The MACsec path uses dictionary-like rows from the IxNetwork Flow Statistics
+view:
+
+```text
+row["PGID"]
+row["Tx Port"]
+row["Rx Port"]
+row["Tx Frames"]
+row["Rx Frames"]
+row["Tx Frame Rate"]
+```
+
+`flow_name_prio_map` preserves the relationship between a configured flow name
+and its logical priority. The final statistics row is selected using Tx port,
+Rx port, and PGID.
+
+### 12.3 Loss
+
+For a selected MACsec row:
+
+```text
+loss_percent = 100 × (Tx Frames - Rx Frames) / Tx Frames
+```
+
+Rows with zero transmitted frames must be ignored or handled separately to
+avoid division by zero and false flow matches.
+
+### 12.4 Flow completion
+
+The intended MACsec completion rule is:
+
+```text
+selected rows are non-empty AND every selected Tx Frame Rate equals zero
+```
+
+The current implementation uses `!= [0]` in the MACsec stop loop. That
+condition is inverted relative to the intended behavior and can report that
+traffic stopped while it is still active.
+
+Some generic MACsec verification paths also compare `PGID == priority`, which
+only identifies the first ingress block. PGIDs 7 through 13 require Tx/Rx port
+filtering and modulo normalization.
+
+## 13. MACsec throughput accounting
+
+MACsec changes the number of bytes on the ingress wire but does not change the
+number of forwarded packets.
+
+The protected ingress frame contains:
+
+```text
+16-byte SecTAG + 16-byte ICV = 32 bytes MACsec overhead
+```
+
+The DUT removes these 32 bytes before transmitting the plain egress frame.
+
+### 13.1 Current suite convention
+
+For a configured MACsec ingress frame size `L`, the egress-equivalent rate
+factor is:
+
+```text
+scale = (L - 32 + 20) / (L + 20)
+```
+
+Where:
+
+- `32` is the SecTAG and ICV removed before egress.
+- `20` is the preamble/SFD and inter-packet gap used for line-rate accounting.
+
+For a 1024-byte frame:
+
+```text
+scale = (1024 - 32 + 20) / (1024 + 20)
+      = 1012 / 1044
+      = 0.96935
+```
+
+A 20% encrypted-ingress load therefore contributes approximately:
+
+```text
+20% × 0.96935 = 19.387%
+```
+
+of plain-egress line rate.
+
+### 13.2 Two-ingress aggregation
+
+Scale every protected ingress demand before comparing the total with the plain
+egress capacity:
+
+```text
+plain_egress_demand =
+    sum(ingress_rate[i] × scale[i] for each ingress i)
+```
+
+This scaled demand must be used for:
+
+- Oversubscription calculations.
+- Expected scheduler allocation.
+- Expected aggregate loss.
+- Ingress-byte to egress-byte throughput comparisons.
+
+Packet counts can still be compared directly after selecting the correct
+source, destination, and PGID.
+
+### 13.3 Frame-size convention
+
+The formula above assumes `L` is the encrypted ingress frame size, matching the
+current test calculation.
+
+If a traffic-generator API defines `L` as the plaintext size before MACsec
+encapsulation, the ingress denominator becomes:
+
+```text
+L + 32 + 20
+```
+
+The frame-size semantics must therefore be confirmed before reusing the factor
+in another flow builder.
+
+## 14. Cleanup
+
+MACsec cleanup is handled by `cleanup_config()` and fixture teardown:
+
+1. Remove temporary egress addressing.
+2. Restore the original egress subnet when one was replaced.
+3. Disable MACsec on every enabled ingress interface.
+4. Delete the Snappi MACsec profile from every participating DUT.
+5. Clear global bookkeeping for enabled ports and configured profiles.
+6. Remove temporary routes or destination state created by setup.
+
+Tests must invoke cleanup from a `finally` block so configuration is restored
+even after traffic generation or verification fails.
+
+## 15. Design invariants
+
+- Physical `port_id 0` is the single plain egress.
+- Every physical `port_id >= 1` is a MACsec ingress.
+- Priorities are currently limited to 0 through 6.
+- The egress endpoint bank contains seven devices per ingress source.
+- MKA sessions are up before data traffic begins.
+- `DutSciMac` matches the DUT interface connected to each MACsec endpoint.
+- Static routes and ARP entries exist for every virtual egress endpoint.
+- Every flow uses the destination block belonging to its ingress source.
+- Statistics are filtered by Tx port and Rx port before PGID normalization.
+- Teardown executes even if setup, traffic, or verification fails.
+
+## 16. Current implementation risks
+
+| Risk | Impact | Recommended hardening |
+| --- | --- | --- |
+| DUT iteration order controls `config.devices` order | Negative source indexes and destination indexes can select the wrong devices | Sort DUTs by minimum `port_id` or build an explicit endpoint registry |
+| Priority block size 7 is repeated | Priority 7 is unsupported and inconsistent constants can misattribute rows | Use one `PRIORITY_COUNT` constant and shared encode/decode helpers |
+| Common flow generators select only the final MACsec source | Both ingress ports are not automatically exercised | Select the source from an explicit `port_id` mapping |
+| Some verification uses `PGID == priority` | Second-ingress PGIDs 7-13 are omitted | Filter ports and normalize `PGID % 7` |
+| MACsec stop condition uses nonzero Tx rate as stopped | Completion can be reported while traffic remains active | Require selected rows and all rates equal zero |
+| Feature detection reads `sys.argv` directly | Options supplied indirectly may not activate every branch | Pass the parsed pytest option through fixtures and runtime parameters |
+| `found_ports()` compares only physical-port count | The much larger MACsec endpoint list can satisfy a weak completeness check | Validate exact physical roles and endpoint counts |
+| Profile path is working-directory relative | Setup can fail when pytest starts from another directory | Resolve the profile relative to the Python module |
+| Egress gateway uses the static `40.1.1.0` network | It can overlap existing lab addressing | Validate availability or allocate from testbed configuration |
+| MACsec counter verification is incomplete | Flow statistics and DUT MACsec counters are not fully cross-checked | Add per-ingress secure-association counter assertions |
+
+## 17. Code ownership
+
+| File | Responsibility |
+| --- | --- |
+| [`tests/conftest.py`](../../conftest.py) | Declares `--snappi_macsec` |
+| [`tests/common/snappi_tests/snappi_fixtures.py`](../../common/snappi_tests/snappi_fixtures.py) | MACsec fixture selection, DUT/TGEN interface setup, egress endpoint creation, and cleanup |
+| [`tests/common/snappi_tests/snappi_helpers.py`](../../common/snappi_tests/snappi_helpers.py) | Prefix calculation and IxNetwork statistics helpers |
+| [`tests/common/snappi_tests/traffic_generation.py`](../../common/snappi_tests/traffic_generation.py) | Flow endpoint selection, IxNetwork runtime setup, traffic control, statistics collection, and verification |
+| [`tests/common/snappi_tests/variables.py`](../../common/snappi_tests/variables.py) | Default non-MACsec egress gateway |
+| [`tests/snappi_tests/macsec_profile.json`](../macsec_profile.json) | DUT MACsec and Snappi MKA profile parameters |

--- a/tests/snappi_tests/docs/hld_snappi_macsec_infra_architecture.md
+++ b/tests/snappi_tests/docs/hld_snappi_macsec_infra_architecture.md
@@ -560,22 +560,7 @@ even after traffic generation or verification fails.
 - Statistics are filtered by Tx port and Rx port before PGID normalization.
 - Teardown executes even if setup, traffic, or verification fails.
 
-## 16. Current implementation risks
-
-| Risk | Impact | Recommended hardening |
-| --- | --- | --- |
-| DUT iteration order controls `config.devices` order | Negative source indexes and destination indexes can select the wrong devices | Sort DUTs by minimum `port_id` or build an explicit endpoint registry |
-| Priority block size 7 is repeated | Priority 7 is unsupported and inconsistent constants can misattribute rows | Use one `PRIORITY_COUNT` constant and shared encode/decode helpers |
-| Common flow generators select only the final MACsec source | Both ingress ports are not automatically exercised | Select the source from an explicit `port_id` mapping |
-| Some verification uses `PGID == priority` | Second-ingress PGIDs 7-13 are omitted | Filter ports and normalize `PGID % 7` |
-| MACsec stop condition uses nonzero Tx rate as stopped | Completion can be reported while traffic remains active | Require selected rows and all rates equal zero |
-| Feature detection reads `sys.argv` directly | Options supplied indirectly may not activate every branch | Pass the parsed pytest option through fixtures and runtime parameters |
-| `found_ports()` compares only physical-port count | The much larger MACsec endpoint list can satisfy a weak completeness check | Validate exact physical roles and endpoint counts |
-| Profile path is working-directory relative | Setup can fail when pytest starts from another directory | Resolve the profile relative to the Python module |
-| Egress gateway uses the static `40.1.1.0` network | It can overlap existing lab addressing | Validate availability or allocate from testbed configuration |
-| MACsec counter verification is incomplete | Flow statistics and DUT MACsec counters are not fully cross-checked | Add per-ingress secure-association counter assertions |
-
-## 17. Code ownership
+## 16. Code ownership
 
 | File | Responsibility |
 | --- | --- |

--- a/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -1,4 +1,5 @@
-import logging                                                                          # noqa: F401
+import logging
+import sys
 from tests.common.helpers.assertions import pytest_assert, pytest_require               # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                     # noqa: F401
@@ -22,6 +23,8 @@ BG_FLOW_NAME = 'Background Flow'
 BG_FLOW_AGGR_RATE_PERCENT = [20, 20]
 BG_LOSS_TOLERANCE_PERCENT = 1
 DATA_PKT_SIZE = 1024
+MACSEC_OVERHEAD_BYTES = 32
+L1_OVERHEAD_BYTES = 20
 DATA_FLOW_DURATION_SEC = 10
 DATA_FLOW_DELAY_SEC = 5
 SNAPPI_POLL_DELAY_SEC = 2
@@ -35,7 +38,8 @@ def get_expected_bg_loss_percent(egress_duthost,
                                  bg_flow_rate_percent,
                                  asic_value=None,
                                  port=None,
-                                 qos_map_profile=None):
+                                 qos_map_profile=None,
+                                 macsec_enabled=False):
     """
     Compute the expected per-Background-Flow loss percent for the m2o
     fluctuating-lossless scenario by deriving each flow's egress-queue DWRR
@@ -57,6 +61,8 @@ def get_expected_bg_loss_percent(egress_duthost,
             ``QUEUE``, which may not be the congested port on multi-port DUTs.
         qos_map_profile (str, optional): profile name inside ``DSCP_TO_TC_MAP``
             / ``TC_TO_QUEUE_MAP``. Defaults to the first profile.
+        macsec_enabled (bool): whether to adjust offered rates for MACsec
+            overhead removed before the congested egress port.
 
     Returns:
         float: expected per-Background-Flow loss percent
@@ -115,12 +121,17 @@ def get_expected_bg_loss_percent(egress_duthost,
 
     queue_demand = {}
     queue_weight = {}
+    rate_scale = 1.0
+    if macsec_enabled:
+        rate_scale = (
+            DATA_PKT_SIZE - MACSEC_OVERHEAD_BYTES + L1_OVERHEAD_BYTES
+        ) / float(DATA_PKT_SIZE + L1_OVERHEAD_BYTES)
 
     def _add_demand(prio, rate):
         q = _prio_to_queue(prio)
         pytest_assert(q in q_weight_dict,
                       "FAIL: No scheduler weight found for queue {} (TC {})".format(q, prio))
-        queue_demand[q] = queue_demand.get(q, 0.0) + rate
+        queue_demand[q] = queue_demand.get(q, 0.0) + rate * rate_scale
         queue_weight[q] = q_weight_dict[q]["weight"]
 
     # zip() silently ignores extra entries when lists differ in length; validate equal length first.
@@ -265,7 +276,8 @@ def run_m2o_fluctuating_lossless_test(api,
                   data_flow_dur_sec=DATA_FLOW_DURATION_SEC,
                   data_pkt_size=DATA_PKT_SIZE,
                   prio_dscp_map=prio_dscp_map,
-                  no_of_bg_streams=no_of_bg_streams)
+                  no_of_bg_streams=no_of_bg_streams,
+                  snappi_extra_params=snappi_extra_params)
 
     flows = testbed_config.flows
     all_flow_names = [flow.name for flow in flows]
@@ -285,23 +297,20 @@ def run_m2o_fluctuating_lossless_test(api,
     ingress_dut2 = tx_port[1]['duthost']
     ingress_port1 = tx_port[0]['peer_port']
     ingress_port2 = tx_port[1]['peer_port']
-    rx_pkts_1 = get_interface_stats(ingress_dut1, ingress_port1)[ingress_dut1.hostname][ingress_port1]['rx_ok']
-    rx_pkts_2 = get_interface_stats(ingress_dut2, ingress_port2)[ingress_dut2.hostname][ingress_port2]['rx_ok']
-    total_rx_pkts = rx_pkts_1 + rx_pkts_2
-    # Fetch relevant statistics
-    if duthost.facts['switch_type'] == "voq":
-        pkt_drop_1_ingress = get_interface_stats(
-            ingress_dut1, ingress_port1
-        )[ingress_dut1.hostname][ingress_port1]['rx_drp']
-        pkt_drop_2_ingress = get_interface_stats(
-            ingress_dut2, ingress_port2
-        )[ingress_dut2.hostname][ingress_port2]['rx_drp']
-        total_pkt_drop_ingress = pkt_drop_1_ingress + pkt_drop_2_ingress
-        drop_percentage = (100 * total_pkt_drop_ingress) / total_rx_pkts
+    ptype = "--snappi_macsec" in sys.argv
+    ingress_stats_1 = get_interface_stats(
+        ingress_dut1, ingress_port1)[ingress_dut1.hostname][ingress_port1]
+    ingress_stats_2 = get_interface_stats(
+        ingress_dut2, ingress_port2)[ingress_dut2.hostname][ingress_port2]
+    total_rx_pkts = ingress_stats_1['rx_ok'] + ingress_stats_2['rx_ok']
 
+    if egress_duthost.facts['switch_type'] == "voq":
+        total_pkt_drop = ingress_stats_1['rx_drp'] + ingress_stats_2['rx_drp']
     else:
-        pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
-        drop_percentage = (100 * pkt_drop) / total_rx_pkts
+        egress_stats = get_interface_stats(
+            egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]
+        total_pkt_drop = egress_stats['tx_drp']
+    drop_percentage = 100.0 * total_pkt_drop / total_rx_pkts
 
     expected_bg_loss_percent = get_expected_bg_loss_percent(
         egress_duthost=egress_duthost,
@@ -310,7 +319,8 @@ def run_m2o_fluctuating_lossless_test(api,
         bg_prio_list=bg_prio_list,
         bg_flow_rate_percent=BG_FLOW_AGGR_RATE_PERCENT,
         asic_value=rx_port.get('asic_value'),
-        port=dut_tx_port)
+        port=dut_tx_port,
+        macsec_enabled=ptype)
 
     expected_drop_percentage = get_expected_total_drop_percent(
         test_flow_rate_percent=TEST_FLOW_AGGR_RATE_PERCENT,
@@ -330,7 +340,8 @@ def run_m2o_fluctuating_lossless_test(api,
     verify_m2o_fluctuating_lossless_result(flow_stats,
                                            tx_port,
                                            rx_port,
-                                           expected_bg_loss_percent)
+                                           expected_bg_loss_percent,
+                                           snappi_extra_params=snappi_extra_params)
 
 
 def __gen_traffic(testbed_config,
@@ -348,7 +359,8 @@ def __gen_traffic(testbed_config,
                   data_flow_dur_sec,
                   data_pkt_size,
                   prio_dscp_map,
-                  no_of_bg_streams):
+                  no_of_bg_streams,
+                  snappi_extra_params):
     """
     Generate configurations of flows under all to all traffic pattern, including
     test flows, background flows and pause storm. Test flows and background flows
@@ -383,7 +395,8 @@ def __gen_traffic(testbed_config,
                      flow_rate_percent=TEST_FLOW_AGGR_RATE_PERCENT,
                      flow_dur_sec=data_flow_dur_sec,
                      data_pkt_size=data_pkt_size,
-                     prio_dscp_map=prio_dscp_map)
+                     prio_dscp_map=prio_dscp_map,
+                     snappi_extra_params=snappi_extra_params)
 
     __gen_data_flows(testbed_config=testbed_config,
                      port_config_list=port_config_list,
@@ -395,7 +408,9 @@ def __gen_traffic(testbed_config,
                      flow_dur_sec=data_flow_dur_sec,
                      data_pkt_size=data_pkt_size,
                      prio_dscp_map=prio_dscp_map,
-                     no_of_streams=no_of_bg_streams)
+                     snappi_extra_params=snappi_extra_params,
+                     no_of_streams=no_of_bg_streams
+                     )
 
 
 def __gen_data_flows(testbed_config,
@@ -408,6 +423,7 @@ def __gen_data_flows(testbed_config,
                      flow_dur_sec,
                      data_pkt_size,
                      prio_dscp_map,
+                     snappi_extra_params,
                      no_of_streams=1):
     """
     Generate the configuration for data flows
@@ -442,6 +458,7 @@ def __gen_data_flows(testbed_config,
                                 flow_dur_sec=flow_dur_sec,
                                 data_pkt_size=data_pkt_size,
                                 prio_dscp_map=prio_dscp_map,
+                                snappi_extra_params=snappi_extra_params,
                                 index=None,
                                 no_of_streams=1
                                 )
@@ -462,6 +479,7 @@ def __gen_data_flows(testbed_config,
                                     flow_dur_sec=flow_dur_sec,
                                     data_pkt_size=data_pkt_size,
                                     prio_dscp_map=prio_dscp_map,
+                                    snappi_extra_params=snappi_extra_params,
                                     index=index,
                                     no_of_streams=no_of_streams)
                     index += 1
@@ -477,6 +495,7 @@ def __gen_data_flow(testbed_config,
                     flow_dur_sec,
                     data_pkt_size,
                     prio_dscp_map,
+                    snappi_extra_params,
                     index,
                     no_of_streams):
     """
@@ -497,6 +516,7 @@ def __gen_data_flow(testbed_config,
     Returns:
         N/A
     """
+    ptype = "--snappi_macsec" in sys.argv
     tx_port_config = next((x for x in port_config_list if x.id == src_port_id), None)
     rx_port_config = next((x for x in port_config_list if x.id == dst_port_id), None)
     tx_mac = tx_port_config.mac
@@ -512,12 +532,76 @@ def __gen_data_flow(testbed_config,
         flow = testbed_config.flows.flow(
                 name='{} {} -> {} Rate:{}'.format(flow_name_prefix,
                                                   src_port_id, dst_port_id, flow_rate_percent))[-1]
-    flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
-    flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
-    eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
+    if ptype:
+        fp = None
+        if 'Test Flow 1 -> 0' in flow.name:
+            index = flow_prio[0]
+            flow.tx_rx.device.tx_names = [
+                testbed_config.devices[len(testbed_config.devices)-2].ethernets[0].ipv4_addresses[0].name
+            ]
+            flow.tx_rx.device.rx_names = [
+                testbed_config.devices[index].ethernets[0].ipv4_addresses[0].name
+            ]
+            fp = flow_prio[0]
+        elif 'Test Flow 2 -> 0' in flow.name:
+            index = (2 - 1) * 7 + (flow_prio[1])
+            flow.tx_rx.device.tx_names = [
+                testbed_config.devices[len(testbed_config.devices)-1].ethernets[0].ipv4_addresses[0].name
+            ]
+            flow.tx_rx.device.rx_names = [
+                testbed_config.devices[index].ethernets[0].ipv4_addresses[0].name
+            ]
+            fp = flow_prio[1]
+        if 'Background Flow' in flow.name:
+            if '1 Background Flow 1 -> 0' in flow.name:
+                fp = flow_prio[0]
+            elif '2 Background Flow 2 -> 0' in flow.name:
+                fp = flow_prio[1]
+            elif '3 Background Flow 1 -> 0' in flow.name:
+                fp = flow_prio[2]
+            elif '4 Background Flow 2 -> 0' in flow.name:
+                fp = flow_prio[3]
+            if 'Background Flow 1 -> 0' in flow.name:
+                index = fp
+                flow.tx_rx.device.tx_names = [
+                    testbed_config.devices[len(testbed_config.devices)-2].ethernets[0].ipv4_addresses[0].name
+                ]
+                flow.tx_rx.device.rx_names = [
+                    testbed_config.devices[index].ethernets[0].ipv4_addresses[0].name
+                ]
+            else:
+                index = (2 - 1) * 7 + fp
+                flow.tx_rx.device.tx_names = [
+                    testbed_config.devices[len(testbed_config.devices)-1].ethernets[0].ipv4_addresses[0].name
+                ]
+                flow.tx_rx.device.rx_names = [
+                    testbed_config.devices[index].ethernets[0].ipv4_addresses[0].name
+                ]
+        flow.tx_rx.device.mode = flow.tx_rx.device.ONE_TO_ONE
+        flow.packet.ethernet().ipv4()
+        ipv4 = flow.packet[-1]
+        eth = flow.packet[-2]
+        eth.src.value = tx_mac
+        eth.dst.value = rx_mac
+        eth.pfc_queue.value = fp
+        snappi_extra_params.flow_name_prio_map[flow.name] = fp
+    else:
+        flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
+        flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
+        eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
 
-    eth.src.value = tx_mac
-    eth.dst.value = rx_mac
+        eth.src.value = tx_mac
+        eth.dst.value = rx_mac
+
+        global UDP_PORT_START
+        src_port = UDP_PORT_START
+        UDP_PORT_START += no_of_streams
+        udp.src_port.increment.start = src_port
+        udp.src_port.increment.step = 1
+        udp.src_port.increment.count = no_of_streams
+
+        ipv4.src.value = tx_port_config.ip
+        ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
 
     if pfc_queue_group_size() == 8:
         if 'Background Flow' in flow.name:
@@ -533,17 +617,8 @@ def __gen_data_flow(testbed_config,
         elif 'Flow 2 -> 0' in flow.name:
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]
 
-    global UDP_PORT_START
-    src_port = UDP_PORT_START
-    UDP_PORT_START += no_of_streams
-    udp.src_port.increment.start = src_port
-    udp.src_port.increment.step = 1
-    udp.src_port.increment.count = no_of_streams
-
-    ipv4.src.value = tx_port_config.ip
-    ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
     ipv4.priority.choice = ipv4.priority.DSCP
-
+    flow_prio = sorted(flow_prio)
     if '1 Background Flow 1 -> 0' in flow.name:
         ipv4.priority.dscp.phb.values = prio_dscp_map[flow_prio[0]]
     elif '2 Background Flow 2 -> 0' in flow.name:
@@ -553,10 +628,12 @@ def __gen_data_flow(testbed_config,
     elif '4 Background Flow 2 -> 0' in flow.name:
         ipv4.priority.dscp.phb.values = prio_dscp_map[flow_prio[3]]
     elif 'Test Flow 1 -> 0' in flow.name:
-        ipv4.priority.dscp.phb.values = [flow_prio[0]]
+        ipv4.priority.dscp.phb.values = prio_dscp_map[flow_prio[0]]
     elif 'Test Flow 2 -> 0' in flow.name:
-        ipv4.priority.dscp.phb.values = [flow_prio[1]]
-
+        ipv4.priority.dscp.phb.values = prio_dscp_map[flow_prio[1]]
+    if len(ipv4.priority.dscp.phb.values) > 1:
+        ipv4.priority.dscp.phb.values = ipv4.priority.dscp.phb.values[:1]
+    logger.info('{} {} {}'.format(flow.name, flow_prio, ipv4.priority.dscp.phb.values))
     ipv4.priority.dscp.ecn.value = ipv4.priority.dscp.ecn.CAPABLE_TRANSPORT_1
     flow.size.fixed = data_pkt_size
     flow.rate.percentage = flow_rate_percent
@@ -568,7 +645,8 @@ def __gen_data_flow(testbed_config,
 def verify_m2o_fluctuating_lossless_result(rows,
                                            tx_port,
                                            rx_port,
-                                           expected_bg_loss_percent):
+                                           expected_bg_loss_percent,
+                                           snappi_extra_params=None):
     """
     Verifies the required loss % from the Traffic Items Statistics
 
@@ -578,9 +656,52 @@ def verify_m2o_fluctuating_lossless_result(rows,
         rx_port : Egress Port
         expected_bg_loss_percent (float): expected per-Background-Flow loss
             percent (derived from the egress DWRR scheduler weights)
+        snappi_extra_params (SnappiTestParams): MACsec flow/priority mapping
     Returns:
         N/A
     """
+    ptype = "--snappi_macsec" in sys.argv
+    if ptype:
+        test_prios = {
+            int(prio)
+            for name, prio in snappi_extra_params.flow_name_prio_map.items()
+            if 'Test Flow' in name
+        }
+        bg_prios = {
+            int(prio)
+            for name, prio in snappi_extra_params.flow_name_prio_map.items()
+            if 'Background Flow' in name
+        }
+
+        rx_port_name = snappi_extra_params.base_flow_config["rx_port_name"]
+        background_loss = 0
+        background_flow_count = 0
+
+        for row in rows:
+            tx_frames = int(row['Tx Frames'])
+            if tx_frames == 0 or row['Rx Port'] != rx_port_name:
+                continue
+
+            # MACsec PGIDs use blocks of 7 per Tx port; modulo recovers the original priority.
+            prio = int(row['PGID']) % 7
+            rx_frames = int(row['Rx Frames'])
+            loss = 100.0 * (tx_frames - rx_frames) / tx_frames
+
+            if prio in test_prios:
+                pytest_assert(int(loss) == 0,
+                              "FAIL: Test Flow priority {} must have 0% loss".format(prio))
+            elif prio in bg_prios:
+                background_flow_count += 1
+                background_loss += loss
+
+        pytest_assert(background_flow_count > 0,
+                      "FAIL: No Background Flow rows found in MACsec traffic stats")
+        avg_loss = background_loss / background_flow_count
+        pytest_assert(abs(avg_loss - expected_bg_loss_percent) < BG_LOSS_TOLERANCE_PERCENT,
+                      "Background Flows must have an avg of {:.2f}% loss (got {:.2f}%)".format(
+                          expected_bg_loss_percent, avg_loss))
+        return
+
     background_loss = 0
     background_flow_count = 0
     for row in rows:


### PR DESCRIPTION
### Description of PR

Summary:

This PR adds Snappi MACsec support to the M2O fluctuating-lossless test using a two-ingress, one-egress topology.

Both ingress links use MACsec, while the shared egress link uses plain Ethernet and IPv4. The changes add MACsec interface configuration, device-endpoint mapping, egress-only tracking, PGID-based statistics processing, MACsec overhead-aware loss calculations, and cleanup handling.

The following files are included:

- `tests/common/snappi_tests/snappi_fixtures.py`
- `tests/common/snappi_tests/traffic_generation.py`
- `tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py`
- `tests/snappi_tests/docs/snappi_macsec_two_ingress_one_egress_hld.md`

No additional Python package dependencies are introduced.

Fixes #<issue-number>

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A  
Failure type: N/A

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master:
  - Executed the M2O fluctuating-lossless test with `--snappi_macsec`.
  - Verified traffic from two MACsec ingress links to one plain IPv4 egress link.
  - Observed aggregate DUT drop: approximately 5.11%.
  - Expected aggregate DUT drop: approximately 5.93%.
  - Difference: approximately 0.81%, within the configured ±1% tolerance.
  - Verified MACsec PGID statistics for both ingress ports.
  - Verified that no debugging breakpoints remain.
  - Lint checks passed for the modified files.

### Approach

#### What is the motivation for this PR?

The existing M2O fluctuating-lossless test used port-to-port Snappi flows and standard Snappi flow metric objects. This model does not provide the endpoint mapping and statistics required when MACsec is enabled.

In MACsec mode:

- Each ingress flow uses a MACsec device endpoint.
- The egress uses plain IPv4 device endpoints.
- Traffic from both ingress ports converges on one egress port.
- IxNetwork reports Flow Statistics rows instead of standard Snappi flow metric objects.
- PGIDs are allocated in blocks of seven for each ingress port.
- MACsec removes 32 bytes of overhead before traffic reaches the plain egress, changing the expected egress demand and loss.

The Snappi fixture, traffic-generation framework, and M2O verification logic therefore require MACsec-specific handling.

#### How did you do it?

The following changes were made in `snappi_fixtures.py`:

- Added MACsec setup for all ingress ports with `port_id >= 1`.
- Kept `port_id == 0` as the plain IPv4 egress port.
- Configured the DUT MACsec profile and enabled it on ingress interfaces.
- Created Snappi Ethernet, IPv4, SecY, secure-channel, and MKA objects.
- Created seven plain IPv4 egress tracking endpoints for every ingress port.
- Calculated the required egress prefix dynamically:
  - `/28` for one ingress and one egress.
  - `/27` for two ingress ports and one egress.
- Added egress-only tracking configuration.
- Added static ARP and route configuration for tracking endpoints.
- Tracked MACsec-enabled ports and configured DUT profiles for cleanup.
- Restored temporary interface addressing and removed MACsec configuration during cleanup.

The following changes were made in `traffic_generation.py`:

- Configured every MKA and StaticMacsec endpoint after applying the Snappi configuration.
- Set the correct DUT SCI MAC for each ingress MACsec endpoint.
- Disabled gratuitous ARP generation for MACsec endpoints.
- Installed ARP entries for all `7 × ingress_count` egress tracking endpoints.
- Added MACsec in-flight statistics logging.
- Filtered zero-transmit statistics rows.
- Included normalized priority information in statistics output.
- Normalized multi-ingress PGIDs using `PGID % 7`.
- Used Tx port, Rx port, and PGID to identify MACsec statistics rows.

The following changes were made in `m2o_fluctuating_lossless_helper.py`:

- Added MACsec device-to-device flow generation.
- Mapped each ingress source and priority to a distinct egress IPv4 endpoint.
- Added `flow_name_prio_map` handling for MACsec statistics.
- Added MACsec Flow Statistics verification using:
  - `PGID`
  - `Tx Port`
  - `Rx Port`
  - `Tx Frames`
  - `Rx Frames`
- Verified zero loss for test-flow priorities.
- Verified average background-flow loss against the calculated expectation.
- Added a 32-byte MACsec overhead adjustment to the DWRR demand calculation.
- Unified VOQ and non-VOQ DUT drop calculations:
  - VOQ platforms use combined ingress `rx_drp` counters.
  - Non-VOQ platforms use the egress `tx_drp` counter.
- Replaced the fixed aggregate-drop expectation with a dynamically calculated DWRR expectation.

#### How did you verify/test it?

The test was executed using the Snappi MACsec option:

```bash
pytest tests/snappi_tests/pfc/test_m2o_fluctuating_lossless.py \
    --testbed=<testbed> \
    --inventory=<inventory> \
    --snappi_macsec