### PR TITLE
Fix platform fan test on fanless liquid-cooled systems

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -453,6 +453,7 @@ def verify_show_platform_fan_output(duthost, raw_output_lines):
 
     return fans
 
+
 def is_liquid_cooled(duthost):
     output = duthost.shell(
         "python3 -c 'from sonic_platform.chassis import Chassis; "
@@ -460,6 +461,7 @@ def is_liquid_cooled(duthost):
         module_ignore_errors=True
     )
     return output.get("stdout", "").strip() == "True"
+
 
 def check_fan_status(duthost, cmd):
     logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -453,6 +453,13 @@ def verify_show_platform_fan_output(duthost, raw_output_lines):
 
     return fans
 
+def is_liquid_cooled(duthost):
+    output = duthost.shell(
+        "python3 -c 'from sonic_platform.chassis import Chassis; "
+        "print(Chassis().is_liquid_cooled())'",
+        module_ignore_errors=True
+    )
+    return output.get("stdout", "").strip() == "True"
 
 def check_fan_status(duthost, cmd):
     logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))
@@ -460,8 +467,8 @@ def check_fan_status(duthost, cmd):
     fans = verify_show_platform_fan_output(duthost, fan_status_output_lines)
 
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-    if not fans and (config_facts['DEVICE_METADATA']['localhost'].get('switch_type', '') == 'dpu'
-                     or duthost.is_bmc()):
+    is_dpu = config_facts['DEVICE_METADATA']['localhost'].get('switch_type', '') == 'dpu'
+    if not fans and (is_dpu or is_liquid_cooled(duthost)):
         return True
     if duthost.facts["asic_type"] == "vs":
         return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #27546 
<!--

If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [X] 202608 


### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

Tested on: 202608
### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
[test_show_platform_fan.log] (https://github.com/user-attachments/files/31689075/test_show_platform_fan.log)
Kusto GUID: 106ff985-4a86-4a7c-8bae-36c5b01eb1ca
### Approach
#### What is the motivation for this PR?
Fixes #27546. The platform fan test incorrectly requires an `OK` fan on fanless, liquid-cooled BMCs.
#### How did you do it?
Detect liquid-cooled chassis using `Chassis().is_liquid_cooled()` and accept `Fan Not detected` when no physical fans are expected.
#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran `test_show_platform_fan` on a fanless, liquid-cooled BMC and confirmed it passed while still validating the CLI output.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
