### PR TITLE
[bgp] Support port access tests on multi-ASIC DUTs

### DIFF
--- a/tests/bgp/test_bgp_port_disable.py
+++ b/tests/bgp/test_bgp_port_disable.py
@@ -3,7 +3,7 @@ import logging
 import time
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until
+from tests.common.utilities import get_image_type, wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +14,12 @@ pytestmark = [
 FRR_USER_UID = '300'
 RESTRICTED_ACCESS_PORTS = ['2605', '2616']
 UID_RESTRICTED_PORTS = ['2601', '2620']
+
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_public_image(duthost):
+    if get_image_type(duthost) == "public":
+        pytest.skip("Not supported on public images")
 
 
 def generate_iptables_rule():

--- a/tests/bgp/test_bgp_port_disable.py
+++ b/tests/bgp/test_bgp_port_disable.py
@@ -25,6 +25,43 @@ def generate_iptables_rule():
     return iptables_rules
 
 
+def get_asic_namespace_hosts(duthost):
+    if duthost.is_multi_asic:
+        return duthost.asics
+    return [duthost.sonichost]
+
+
+def get_cacl_namespace_hosts(duthost):
+    hosts = get_asic_namespace_hosts(duthost)
+    if duthost.is_multi_asic:
+        return [duthost.sonichost, *hosts]
+    return hosts
+
+
+def check_iptables_rules_exist(duthost):
+    expected_rules = {"-A OUTPUT {}".format(rule) for rule in generate_iptables_rule()}
+    for host in get_cacl_namespace_hosts(duthost):
+        result = host.command("iptables -S")
+        if not expected_rules.issubset(result["stdout_lines"]):
+            return False
+    return True
+
+
+def wait_for_iptables_rules(duthost):
+    consecutive_passes = 0
+
+    def _rules_are_stable():
+        nonlocal consecutive_passes
+        # Require consecutive passes to avoid treating stale rules as a completed caclmgrd update.
+        if check_iptables_rules_exist(duthost):
+            consecutive_passes += 1
+        else:
+            consecutive_passes = 0
+        return consecutive_passes >= 3
+
+    return wait_until(60, 1, 0, _rules_are_stable)
+
+
 def restart_caclmgrd(duthost):
     def _check_caclmgrd_running():
         command = 'pgrep -f -c caclmgrd'
@@ -33,6 +70,7 @@ def restart_caclmgrd(duthost):
     duthost.shell('sudo systemctl restart caclmgrd')
     time.sleep(10)
     pytest_assert(wait_until(20, 1, 0, _check_caclmgrd_running), "caclmgrd not running")
+    pytest_assert(wait_for_iptables_rules(duthost), "FRR access-control rules did not stabilize")
 
 
 def setup_iptables_rule(duthost, action="add"):
@@ -40,65 +78,96 @@ def setup_iptables_rule(duthost, action="add"):
         restart_caclmgrd(duthost)
     else:
         iptables_rules = generate_iptables_rule()
-
-        # Dynamically construct and execute iptables deletion commands
-        for rule in iptables_rules:
-            command = "sudo iptables -D OUTPUT {}".format(rule)
-            duthost.shell(command)
+        for host in get_cacl_namespace_hosts(duthost):
+            for rule in iptables_rules:
+                host.command("iptables -D OUTPUT {}".format(rule))
 
 
 def verify_daemon_tcp_ports(duthost):
-    # Capture local address/port to verify restrictions
-    netstat_outputs = duthost.shell("sudo netstat -tlnp |  awk '{print $4}'", module_ignore_errors=True)["stdout"]
+    for host in get_asic_namespace_hosts(duthost):
+        namespace = getattr(host, "namespace", None) or "host"
+        netstat_outputs = []
+        for line in host.command("netstat -tlnp")["stdout_lines"]:
+            fields = line.split()
+            if len(fields) >= 4 and fields[0] in ("tcp", "tcp6"):
+                netstat_outputs.append(fields[3])
 
-    for port in RESTRICTED_ACCESS_PORTS:
-        pytest_assert(port not in netstat_outputs, "port {} is accessable".format(port))
+        for port in RESTRICTED_ACCESS_PORTS:
+            pytest_assert(
+                not any(address.endswith(":{}".format(port)) for address in netstat_outputs),
+                "port {} is accessible in namespace {}".format(port, namespace)
+            )
 
-    for port in UID_RESTRICTED_PORTS:
-        pytest_assert(port in netstat_outputs, "port {} is not accessable".format(port))
+        for port in UID_RESTRICTED_PORTS:
+            pytest_assert(
+                any(address.endswith(":{}".format(port)) for address in netstat_outputs),
+                "port {} is not accessible in namespace {}".format(port, namespace)
+            )
 
 
 def verify_iptables_rules_exist(duthost):
     expected_rules = generate_iptables_rule()
-    iptables_output = duthost.command("sudo iptables -S")["stdout_lines"]
+    for host in get_cacl_namespace_hosts(duthost):
+        namespace = getattr(host, "namespace", None) or "host"
+        iptables_output = host.command("iptables -S")["stdout_lines"]
+        logger.info("iptables output in namespace %s: %s", namespace, iptables_output)
 
-    logger.info('iptables_output = {}'.format(iptables_output))
-
-    for rule in expected_rules:
-        command = "-A OUTPUT {}".format(rule)
-        pytest_assert(command in iptables_output, "'{}' is missing".format(rule))
+        for rule in expected_rules:
+            command = "-A OUTPUT {}".format(rule)
+            pytest_assert(
+                command in iptables_output,
+                "'{}' is missing in namespace {}".format(rule, namespace)
+            )
 
 
 def verify_port_accessibility_for_other_users(duthost, port, restrict=True):
-    command = ('timeout 5s bash -c "until </dev/tcp/localhost/{}; do sleep 0.1; done" '
-               '&& echo "success" || echo "fail"'.format(port))
-    output = duthost.shell(command)["stdout"]
-    if restrict:
-        pytest_assert("fail" in output, "Port {} is accessible by users other than FRR_USER_UID".format(port))
-    else:
-        pytest_assert("success" in output, "Port {} is not accessible".format(port))
+    command = (
+        "bash -c 'timeout 5s bash -c "
+        "\"until </dev/tcp/localhost/{}; do sleep 0.1; done\" "
+        "&& echo success || echo fail'"
+    ).format(port)
+    for host in get_asic_namespace_hosts(duthost):
+        namespace = getattr(host, "namespace", None) or "host"
+        output = host.command(command)["stdout"]
+        if restrict:
+            pytest_assert(
+                "fail" in output,
+                "Port {} is accessible by users other than FRR_USER_UID in namespace {}".format(port, namespace)
+            )
+        else:
+            pytest_assert(
+                "success" in output,
+                "Port {} is not accessible in namespace {}".format(port, namespace)
+            )
+
+
+def check_fpmsyncd_connection(namespace, host):
+    cmd = "ss -tupn '( sport = :2620 or dport = :2620 )'"
+    output = host.command(cmd)["stdout"]
+    logger.info("cmd = %s, namespace = %s, output = %s", cmd, namespace, output)
+    return "fpmsyncd" in output and "zebra" in output
 
 
 def verify_port_accessibility_fpmsyncd(duthost):
-    cmd = "docker exec -it bgp bash -c 'supervisorctl restart fpmsyncd'"
+    duthost.docker_cmds_on_all_asics("supervisorctl restart fpmsyncd", "bgp")
 
-    duthost.command(cmd, module_ignore_errors=True)
-    time.sleep(5)
-
-    # verify the connection between fpmsyncd and zebra
-    cmd = 'sudo ss -tupn | grep 2620'
-    output = duthost.shell(cmd)['stdout']
-    logger.info("cmd = {}, output = {}".format(cmd, output))
-    pytest_assert("fpmsyncd" in output and "zebra" in output, "Connection issue detected")
+    for host in get_asic_namespace_hosts(duthost):
+        namespace = getattr(host, "namespace", None) or "host"
+        pytest_assert(
+            wait_until(20, 1, 0, check_fpmsyncd_connection, namespace, host),
+            "Connection issue detected in namespace {}".format(namespace)
+        )
 
 
 def test_zebra_uid(duthost):
     uid_command = "ps -ef | grep /usr/lib/frr/zebra | grep -v grep | awk '{print $1}'"
-    uid_output = duthost.shell(uid_command)["stdout"].strip()
+    uid_output = duthost.shell(uid_command)["stdout_lines"]
     if not uid_output:
         pytest.fail("Failed to get zebra uid")
-    pytest_assert(uid_output == FRR_USER_UID, "uid output = {} are not equal to expected zebra uid = {}"
-                  .format(uid_output, FRR_USER_UID))
+    pytest_assert(
+        all(uid == FRR_USER_UID for uid in uid_output),
+        "uid output = {} are not equal to expected zebra uid = {}".format(uid_output, FRR_USER_UID)
+    )
 
 
 def test_daemon_tcp_port_access_restrictions(duthost):
@@ -133,4 +202,4 @@ def test_add_remove_stress(duthost, restart_caclmgrd_after_stress_test):
 def restart_caclmgrd_after_stress_test(duthost):
     yield
     # Ensure recovery action is always performed
-    duthost.shell('sudo systemctl restart caclmgrd')
+    restart_caclmgrd(duthost)

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -499,12 +499,6 @@ bgp/test_bgp_operation_in_ro.py:
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/23462"
 
-bgp/test_bgp_port_disable.py:
-  skip:
-    reason: "Not supported on public branches."
-    conditions:
-      - "'internal' not in branch"
-
 bgp/test_bgp_queue.py:
   skip:
     reason: "Not supported on mgmt device or VPP platform that doesn't have queues"


### PR DESCRIPTION
### Description of PR

Summary:

Improve the BGP port access restriction tests to support multi-ASIC DUTs. The tests now validate daemon ports, CACL iptables rules, user access, and the fpmsyncd-to-zebra connection in each applicable namespace while preserving single-ASIC behavior. Public images remain unsupported and are skipped during module setup based on the DUT image type.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39356253/
Failure type: day-one issue

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- 202511: `20251110.48` - [Elastictest](https://elastictest.org/scheduler/testplan/6a9631de1216df40f087ae76): 4 passed, 0 skipped

### Approach
#### What is the motivation for this PR?

`test_bgp_port_disable.py` assumed that services and CACL rules existed only in the host namespace. On a multi-ASIC DUT, FRR services run in ASIC namespaces and CACL rules apply to both the host and ASIC namespaces, so the existing checks could not validate the topology correctly.

The build-generated `branch` fact can be `internal-202511` or `heads/20251110.42` for internal images. Checking for `internal` therefore skips valid tag builds, so this PR uses `get_image_type(duthost)` instead.

#### How did you do it?

- Run service-port and connection checks in every ASIC namespace.
- Add, remove, and verify CACL rules in the host and ASIC namespaces where applicable.
- Restart fpmsyncd on every ASIC and wait for each fpmsyncd-to-zebra connection.
- Wait for CACL rules to stabilize after restarting caclmgrd to avoid stale-rule races.
- Replace the branch-name conditional skip with a module-scoped fixture that skips unsupported public images based on the DUT image type.

#### How did you verify/test it?

- 202511 (`20251110.48`): [Elastictest](https://elastictest.org/scheduler/testplan/6a9631de1216df40f087ae76): 4 passed, 0 skipped

#### Any platform specific information?

Supports both single-ASIC and multi-ASIC DUTs on non-public images. Public images are skipped.

#### Supported testbed topology if it's a new test case?

N/A. 

### Documentation

N/A. 
