### PR TITLE
[Mellanox] Restore fan speed retry in sysfs checks

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -232,27 +232,25 @@ def _is_fan_speed_in_range(sysfs_facts):
                 int(fan_info["max_speed"]) * (1 + MAX_FAN_SPEED_THRESHOLD))
             fan_speed_set = int(fan_info["speed_set"])
             fan_speed_get = int(fan_info["speed_get"])
+        except (KeyError, TypeError, ValueError) as e:
+            logging.warning("Invalid fan speed data for fan %s: %s", fan_id, e)
+            return False
 
-            low_threshold = ((float(fan_speed_set) / 255)
-                             * fan_min_speed) * (1 - 0.5)
-            high_threshold = ((float(fan_speed_set) / 255)
-                              * fan_max_speed) * (1 + 0.5)
+        low_threshold = ((float(fan_speed_set) / 255)
+                         * fan_min_speed) * (1 - 0.5)
+        high_threshold = ((float(fan_speed_set) / 255)
+                          * fan_max_speed) * (1 + 0.5)
 
-            assert fan_min_speed > 0 and fan_max_speed > 10000, 'Invalid fan min/max speed: {}, {}'.format(
-                fan_min_speed,
-                fan_max_speed)
-            assert low_threshold < fan_speed_get < high_threshold, 'Fan speed {} not in range: [{}, {}]'.format(
-                fan_speed_get, low_threshold, high_threshold
-            )
+        if fan_min_speed <= 0 or fan_max_speed <= 10000:
+            logging.warning("Invalid fan %s min/max speed: %s, %s",
+                            fan_id, fan_min_speed, fan_max_speed)
+            return False
 
-        except Exception as e:
-            assert False, 'Invalid fan speed: actual speed={}, set speed={}, min={}, max={}, exception={}'.format(
-                fan_info["speed_get"],
-                fan_info["speed_set"],
-                fan_info["min_speed"],
-                fan_info["max_speed"],
-                e
-            )
+        if not low_threshold < fan_speed_get < high_threshold:
+            logging.warning("Fan %s speed %s not in range: [%s, %s]",
+                            fan_id, fan_speed_get, low_threshold, high_threshold)
+            return False
+
     return True
 
 

--- a/tests/platform_tests/mellanox/unit_tests/unit_test_check_sysfs.py
+++ b/tests/platform_tests/mellanox/unit_tests/unit_test_check_sysfs.py
@@ -1,0 +1,46 @@
+from tests.platform_tests.mellanox.check_sysfs import _is_fan_speed_in_range
+
+
+def _fan_info(speed_get, speed_set=63, min_speed=4500, max_speed=25000):
+    return {
+        "min_speed": str(min_speed),
+        "max_speed": str(max_speed),
+        "speed_set": str(speed_set),
+        "speed_get": str(speed_get),
+    }
+
+
+def test_fan_speeds_in_range():
+    sysfs_facts = {
+        "fan_info": {
+            "1": _fan_info(10000),
+            "2": _fan_info(9000),
+        }
+    }
+
+    assert _is_fan_speed_in_range(sysfs_facts)
+
+
+def test_transient_fan_speed_mismatch_returns_false(caplog):
+    sysfs_facts = {"fan_info": {"1": _fan_info(12157)}}
+
+    assert not _is_fan_speed_in_range(sysfs_facts)
+    assert "Fan 1 speed 12157 not in range" in caplog.text
+
+
+def test_invalid_fan_speed_data_returns_false(caplog):
+    sysfs_facts = {"fan_info": {"1": _fan_info("unavailable")}}
+
+    assert not _is_fan_speed_in_range(sysfs_facts)
+    assert "Invalid fan speed data for fan 1" in caplog.text
+
+
+def test_all_fans_are_validated():
+    sysfs_facts = {
+        "fan_info": {
+            "1": _fan_info(10000),
+            "2": _fan_info(12157),
+        }
+    }
+
+    assert not _is_fan_speed_in_range(sysfs_facts)


### PR DESCRIPTION
Return False for transient or invalid fan speed readings instead of raising immediately, allowing the existing wait_until retry to run. Persistent fan speed failures continue to fail after the retry timeout.

Add unit coverage for valid, transient, invalid, and multi-fan readings.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Restore the intended retry behavior for Mellanox fan-speed sysfs validation. Transient or malformed fan-speed readings now return  False , allowing the existing  wait_until()  loop to retry every five seconds for up to 30 seconds. Persistent mismatches still fail after the timeout, while fan presence and fault checks remain immediate.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
https://elastictest.org/scheduler/testplan/6a965e391216df40f087aec8
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
Mellanox fan RPM may take time to converge to the newly requested PWM level after reboot or service recovery. The existing retry mechanism was ineffective because  _is_fan_speed_in_range()  raised an assertion on the first out-of-range reading instead of returning  False .

This caused intermittent failures such as  test_continuous_reboot  even when the fan reported no hardware fault and stabilized shortly afterward.

#### How did you do it?
• Return  False  for transient out-of-range fan speeds, invalid thresholds, and malformed sensor values.
• Preserve  True  only when every reported fan speed is within its calculated range.
• Let the existing 30-second  wait_until()  retry handle stabilization.
• Preserve the final assertion for readings that remain invalid after the retry period.
• Add focused unit tests for valid readings, transient mismatches, malformed data, and multiple fans.

#### How did you verify/test it?
Added unit coverage for:

• Multiple valid fan readings.
• The observed transient  12157 RPM  mismatch.
• Invalid sensor values.
• Validation of every fan rather than only the first fan.

A focused physical test plan is also running on  vms64-t0-4700-1 , covering the direct sysfs check and all affected reload, reboot, SWSS restart, and syncd restart paths:
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
This change is specific to Mellanox/NVIDIA platforms using the  hw-management  sysfs fan interfaces. The reported failure was observed on:

• Platform: Mellanox SN4700
• ASIC: Spectrum-3
• Topology: T0

Immediate fan status and hardware-fault checks are unchanged.

#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
