### PR TITLE
[conditional_mark] Add Failure-Validated xfail feature

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -15,6 +15,7 @@ import pytest
 
 from tests.common.testbed import TestbedInfo
 from .issue import check_issues
+from .failure_signature import has_any_stored_signatures, load_signatures_for_issues, evaluate_failure
 from tests.common.utilities import get_duts_from_host_pattern
 from tests.common.cisco_data import (
     CISCO_8122_PREFIX,
@@ -609,8 +610,12 @@ def evaluate_condition(dynamic_update_skip_reason, mark_details, condition, basi
 
         condition_result = bool(eval(condition_str, safe_globals))
 
-        if condition_result and dynamic_update_skip_reason:
-            mark_details['reason'].append(condition)
+        if condition_result:
+            # Always record the matched condition so the Failure-Validated xfail
+            # logic can extract the exact issue URL that triggered the mark.
+            mark_details['matched_conditions'].append(condition)
+            if dynamic_update_skip_reason:
+                mark_details['reason'].append(condition)
         return condition_result
     except Exception:
         raise RuntimeError('Failed to evaluate condition, raw_condition={}, condition_str={}'.format(
@@ -638,6 +643,7 @@ def evaluate_conditions(dynamic_update_skip_reason, mark_details, conditions, ba
     Returns:
         bool: True or False based on condition strings evaluation result.
     """
+    mark_details['matched_conditions'] = []
     if dynamic_update_skip_reason:
         mark_details['reason'] = []
     if isinstance(conditions, list):
@@ -766,11 +772,158 @@ def pytest_collection_modifyitems(session, config, items):
                             strict = False
                             if mark_details:
                                 strict = mark_details.get('strict', False)
-                            mark = getattr(pytest.mark, mark_name)(reason=reason, strict=strict)
-                            # To generate xfail property in the report xml file
-                            item.user_properties.append(('xfail', strict))
+
+                            # --- Failure-Validated xfail ---
+                            # Check if this xfail condition references known issues that have
+                            # stored failure signatures.  If so, defer the xfail decision to
+                            # runtime (pytest_runtest_makereport) where we can compare the
+                            # actual failure against the reference signatures.
+                            matched_conditions = ' '.join(mark_details.get('matched_conditions', []))
+                            issue_urls = re.findall(r'https?://[^ )]+', matched_conditions)
+                            has_files = issue_urls and has_any_stored_signatures(issue_urls)
+                            signatures = load_signatures_for_issues(issue_urls) if has_files else {}
+                            if signatures:
+                                item._dynamic_xfail_info = {
+                                    "issue_urls": issue_urls,
+                                    "reason": reason,
+                                    "strict": strict,
+                                    "signatures": signatures,
+                                }
+                                logger.debug(
+                                    f'Deferring xfail to runtime for {item.nodeid} (issues: {issue_urls})')
+                                # Do NOT add the xfail mark - the hook will decide at runtime.
+                                # Still record the xfail property for report XML compatibility.
+                                item.user_properties.append(('xfail', strict))
+                            else:
+                                # Fall back to static xfail (current behavior).
+                                # If signature files exist but contained no valid signatures,
+                                # add a note so the engineer knows the file is broken.
+                                xfail_reason = reason
+                                if has_files:
+                                    xfail_reason = (f"{reason}\n[Failure-Validated xfail: "
+                                                    f"signature file(s) found for "
+                                                    f"{', '.join(issue_urls)} but no valid "
+                                                    f"signatures could be loaded. "
+                                                    f"Falling back to static xfail.]")
+                                    logger.warning(
+                                        f"Signature file(s) found for {issue_urls} but no "
+                                        f"valid signatures loaded. Falling back to static "
+                                        f"xfail for {item.nodeid}.")
+                                mark = getattr(pytest.mark, mark_name)(reason=xfail_reason, strict=strict)
+                                # To generate xfail property in the report xml file
+                                item.user_properties.append(('xfail', strict))
+                                logger.debug('Adding mark {} to {}'.format(mark, item.nodeid))
+                                item.add_marker(mark)
                         else:
                             mark = getattr(pytest.mark, mark_name)(reason=reason)
+                            logger.debug('Adding mark {} to {}'.format(mark, item.nodeid))
+                            item.add_marker(mark)
 
-                        logger.debug('Adding mark {} to {}'.format(mark, item.nodeid))
-                        item.add_marker(mark)
+
+def _update_allure_result_for_teardown(item, report, xfail_reason):
+    """Directly update Allure's test_result for a teardown xfail.
+
+    Allure's teardown handler only updates the test result for FAILED/BROKEN
+    status, and ignores SKIPPED. Since we set report.outcome to "skipped"
+    for pytest's benefit, we need to directly update Allure's internal
+    test_result object to show the xfail status and message.
+    """
+    try:
+        allure_listener = None
+        for plugin in item.config.pluginmanager.get_plugins():
+            if type(plugin).__name__ == "AllureListener":
+                allure_listener = plugin
+                break
+        if allure_listener is None:
+            return
+        uuid = allure_listener._cache.get(item.nodeid)
+        if uuid is None:
+            return
+        test_result = allure_listener.allure_logger.get_test(uuid)
+        if test_result is None:
+            return
+
+        from allure_commons.model2 import Status, StatusDetails
+        message = f"XFAIL {xfail_reason}\n\n{report.longreprtext}" if report.longreprtext else f"XFAIL {xfail_reason}"
+        test_result.status = Status.SKIPPED
+        test_result.statusDetails = StatusDetails(
+            message=message,
+            trace=report.longreprtext or "")
+    except Exception as e:
+        logger.debug(f"Could not update Allure result for teardown xfail: {e}")
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Hook for Failure-Validated xfail: validate test failures against known issue signatures.
+
+    When a test has ``_dynamic_xfail_info`` (set during collection), this hook intercepts the
+    test result and compares the actual failure against stored reference signatures.
+
+    - If the failure matches a known issue (same_issue): report as xfail (expected failure).
+    - If the failure is different (different_issue): report as a real failure.
+
+    This hook acts on all phases (setup, call, teardown) because failures in
+    fixture setup/teardown (e.g. yang_validation_check) are real issues that
+    should also be validated against stored signatures.
+    """
+    outcome = yield
+    report = outcome.get_result()
+    if not report.failed:
+        return
+
+    dynamic_xfail_info = getattr(item, "_dynamic_xfail_info", None)
+    if dynamic_xfail_info is None:
+        return
+
+    # If a setup failure was already handled by FV-xfail, skip the call
+    # phase (which fails with KeyError because the fixture is unavailable).
+    if report.when == "call" and getattr(item, "_fvxfail_setup_handled", False):
+        report.outcome = "skipped"
+        report.wasxfail = dynamic_xfail_info["reason"]
+        return
+
+    # Skip loganalyzer teardown failures.
+    if report.when == "teardown" and call.excinfo is not None:
+        trace_text = report.longreprtext or ""
+        if "tests/common/plugins/loganalyzer/__init__.py" in trace_text:
+            logger.debug(f"Skipping FV-xfail for {item.nodeid}: loganalyzer teardown failure.")
+            return
+
+    if call.excinfo is None:
+        logger.warning(f"Test {item.nodeid} failed in {report.when} but no excinfo available. "
+                       f"Falling back to xfail.")
+        report.outcome = "skipped"
+        report.wasxfail = dynamic_xfail_info["reason"]
+        return
+
+    current_failure = {
+        "exception_type": call.excinfo.typename,
+        "message": call.excinfo.exconly(),
+        "stack_trace": report.longreprtext,
+    }
+
+    signatures = dynamic_xfail_info.get("signatures", {})
+    decision, detail = evaluate_failure(current_failure, signatures)
+
+    logger.info(
+        f"Failure-Validated xfail for {item.nodeid} ({report.when}): decision={decision}, detail={detail}")
+
+    xfail_reason = f"{dynamic_xfail_info['reason']}\n[Failure-Validated xfail: {detail}]"
+
+    if decision == "same_issue":
+        # Override report to xfail (expected failure)
+        report.outcome = "skipped"
+        report.wasxfail = xfail_reason
+        if report.when == "setup":
+            # Mark that setup was handled so the call phase (which fails
+            # with KeyError because the fixture is unavailable) is skipped.
+            item._fvxfail_setup_handled = True
+        elif report.when == "teardown":
+            # For teardown: Allure ignores skipped teardown reports, so
+            # directly update Allure's test_result to show the xfail.
+            _update_allure_result_for_teardown(item, report, xfail_reason)
+    else:
+        issue_urls = dynamic_xfail_info.get('issue_urls', [])
+        report.wasxfail = (f"[Failure-Validated xfail: Known issues {', '.join(issue_urls)} "
+                           f"did NOT match. {detail}]")

--- a/tests/common/plugins/conditional_mark/ai_agent_client_example.py
+++ b/tests/common/plugins/conditional_mark/ai_agent_client_example.py
@@ -1,0 +1,108 @@
+"""HTTP client for the Failure-Validated xfail AI agent service.
+
+Sends a current test failure and a reference failure signature to the AI agent
+server's ``/compare-failures`` endpoint for semantic comparison.
+
+The server returns a JSON verdict::
+
+    {"is_same_issue": true, "reasoning": "...", "processing_time_ms": 1200}
+
+The client parses the response and returns a result dict with ``decision``,
+``reasoning``, and ``processing_time_ms``.
+
+If anything goes wrong (timeout, connection error, malformed response), the
+client returns ``None`` so the caller can apply fallback logic.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def consult_ai_agent(
+    current_failure: dict,
+    reference_signature: dict,
+    failure_matching_rule: str,
+    agent_url: str,
+    timeout: int = 30,
+    issue_url: str = "",
+) -> Optional[dict]:
+    """Ask the AI agent whether *current_failure* matches *reference_signature*.
+
+    Args:
+        current_failure: Dict with ``exception_type``, ``message``,
+            ``stack_trace`` fields extracted from the live pytest failure.
+        reference_signature: Dict with ``exception_type``, ``message``,
+            ``stack_trace`` fields from the stored signature.
+        failure_matching_rule: Engineer-provided rule for the LLM to use as a
+            golden rule when comparing the failures.
+        agent_url: Base URL of the AI agent server
+            (e.g. ``http://10.228.227.92/api/v1``).
+        timeout: Request timeout in seconds.
+        issue_url: Known-issue URL for context (not queried by the server).
+
+    Returns:
+        Dict with ``decision`` (``"same_issue"`` or ``"different_issue"``),
+        ``reasoning`` (str), and ``processing_time_ms`` (int).
+        Returns ``None`` on error/timeout.
+    """
+    endpoint = f"{agent_url.rstrip('/')}/compare-failures"
+
+    payload = {
+        "reference_failure": {
+            "exception_type": reference_signature.get("exception_type", ""),
+            "exception_message": reference_signature.get("message", ""),
+            "stack_trace": reference_signature.get("stack_trace", ""),
+            "failure_matching_rule": failure_matching_rule or "",
+        },
+        "current_failure": {
+            "exception_type": current_failure.get("exception_type", ""),
+            "exception_message": current_failure.get("message", ""),
+            "stack_trace": current_failure.get("stack_trace", ""),
+        },
+        "issue_url": issue_url,
+        "stream": False,
+    }
+
+    try:
+        logger.info(f"Consulting AI agent at {endpoint}")
+        response = requests.post(
+            endpoint,
+            json=payload,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+
+        verdict = response.json()
+
+        if "is_same_issue" not in verdict:
+            logger.warning(f"AI agent response missing 'is_same_issue'. Response: {verdict}")
+            return None
+
+        decision = "same_issue" if verdict["is_same_issue"] else "different_issue"
+        reasoning = verdict.get("reasoning", "")
+        processing_time = verdict.get("processing_time_ms", 0)
+
+        result = {
+            "decision": decision,
+            "reasoning": reasoning,
+            "processing_time_ms": processing_time,
+        }
+        logger.info(f"AI agent decision: {decision}, reasoning: {reasoning[:200]}, "
+                    f"processing_time: {processing_time}ms")
+        return result
+
+    except requests.exceptions.Timeout:
+        logger.warning(f"AI agent request timed out after {timeout}s")
+        return None
+    except requests.exceptions.ConnectionError:
+        logger.warning(f"Cannot connect to AI agent at {endpoint}")
+        return None
+    except Exception as e:
+        logger.warning(f"AI agent consultation failed: {e!r}")
+        return None

--- a/tests/common/plugins/conditional_mark/dice_similarity.py
+++ b/tests/common/plugins/conditional_mark/dice_similarity.py
@@ -1,0 +1,42 @@
+"""Sorensen-Dice coefficient for string similarity.
+
+Computes similarity between two strings using character bigram multisets.
+This is a self-contained copy of the algorithm from the qw2026 repository,
+inlined here to avoid adding an external dependency to sonic-mgmt.
+
+The Dice coefficient ranges from 0.0 (no shared bigrams) to 1.0 (identical
+strings).  It is used by the failure-validated xfail mechanism to score how
+similar a current test failure is to a stored reference failure signature.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+
+def _bigrams(value: str) -> Counter[str]:
+    """Return the multiset of adjacent character bigrams."""
+    return Counter(value[index: index + 2] for index in range(len(value) - 1))
+
+
+def dice_coefficient(first: str, second: str) -> float:
+    """Calculate the Sorensen-Dice similarity of two strings, in [0, 1].
+
+    Args:
+        first: First string.
+        second: Second string.
+
+    Returns:
+        float: Similarity score between 0.0 and 1.0.
+    """
+    if not isinstance(first, str) or not isinstance(second, str):
+        raise TypeError("dice_coefficient inputs must be strings")
+    if first == second:
+        return 1.0
+    if len(first) < 2 or len(second) < 2:
+        return 0.0
+
+    first_bigrams = _bigrams(first)
+    second_bigrams = _bigrams(second)
+    intersection = sum((first_bigrams & second_bigrams).values())
+    return 2.0 * intersection / (sum(first_bigrams.values()) + sum(second_bigrams.values()))

--- a/tests/common/plugins/conditional_mark/failure_signature.py
+++ b/tests/common/plugins/conditional_mark/failure_signature.py
@@ -1,0 +1,535 @@
+"""Failure-Validated xfail: signature loading, similarity scoring, and evaluation.
+
+This module implements the core logic for the Failure-Validated xfail feature.
+It loads reference failure signatures from YAML files, computes weighted Dice
+similarity scores between a current test failure and stored references, and
+orchestrates the three-tier decision logic (high -> xfail, low -> fail,
+middle -> consult AI agent).
+
+Signature files follow the naming convention::
+
+    known_issue_signatures_{source}_{number}.yaml
+
+where *source* is ``mgmt``, or ``buildimage``, and *number* is
+the issue ID extracted from the URL.
+
+See the HLD for the full YAML schema.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Dict, List, Optional, Tuple
+
+import yaml
+
+from .dice_similarity import dice_coefficient
+from .ai_agent_client import consult_ai_agent
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Weighted similarity scoring weights (must sum to 1.0)
+# W_TYPE is 0.0 by default because the exception type is easy to get wrong
+# (e.g. Failed vs AssertionError vs KeyError vs RunAnsibleModuleFail).
+W_TYPE = 0.0
+W_MESSAGE = 0.60
+W_TRACE = 0.40
+
+# Default thresholds -- can be overridden per-signature in the YAML
+XFAIL_SIMILARITY_HIGH_DEFAULT = 0.90
+XFAIL_SIMILARITY_LOW_DEFAULT = 0.60
+XFAIL_AI_AGENT_TIMEOUT_DEFAULT = 30
+
+# AI agent server URL
+XFAIL_AI_AGENT_URL = "http://10.228.227.92/api/v1"
+
+# Directory containing signature files
+SIGNATURES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "known_issue_signatures")
+
+
+# ---------------------------------------------------------------------------
+# Issue URL -> Signature filename mapping
+# ---------------------------------------------------------------------------
+
+# URL patterns for supported issue trackers
+_URL_PATTERNS = [
+    # GitHub sonic-mgmt: https://github.com/sonic-net/sonic-mgmt/issues/1234
+    (re.compile(r'https?://github\.com/sonic-net/sonic-mgmt/issues/(\d+)'), 'mgmt'),
+    # GitHub sonic-buildimage: https://github.com/sonic-net/sonic-buildimage/issues/5678
+    (re.compile(r'https?://github\.com/sonic-net/sonic-buildimage/issues/(\d+)'), 'buildimage'),
+]
+
+# Load custom URL patterns (e.g. internal issue trackers) if available
+try:
+    from .fv_custom_url_patterns import CUSTOM_URL_PATTERNS
+    _URL_PATTERNS.extend(CUSTOM_URL_PATTERNS)
+except ImportError:
+    pass
+
+
+def _issue_url_to_filename(url: str) -> Optional[str]:
+    """Derive the signature filename from an issue URL.
+
+    Args:
+        url: Issue URL (GitHub sonic-mgmt, or GitHub sonic-buildimage).
+
+    Returns:
+        Filename string like ``known_issue_signatures_mgmt_24000.yaml``,
+        or ``None`` if the URL does not match any known pattern.
+    """
+    for pattern, source in _URL_PATTERNS:
+        m = pattern.match(url)
+        if m:
+            return f"known_issue_signatures_{source}_{m.group(1)}.yaml"
+    return None
+
+
+def _find_signature_file(url: str, signatures_dir: str) -> Optional[str]:
+    """Find the signature file path for a given issue URL.
+
+    Args:
+        url: Issue URL.
+        signatures_dir: Directory to search for signature files.
+
+    Returns:
+        Full path to the signature file, or ``None`` if not found.
+    """
+    filename = _issue_url_to_filename(url)
+    if filename is None:
+        return None
+    filepath = os.path.join(signatures_dir, filename)
+    if os.path.isfile(filepath):
+        return filepath
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Signature loading
+# ---------------------------------------------------------------------------
+
+def _parse_signatures(filepath: str) -> List[dict]:
+    """Parse a signature YAML file and return a list of signature dicts.
+
+    Each signature dict must contain:
+        - message (str)
+        - stack_trace (str)
+        - failure_matching_rule (str)
+
+    And optionally:
+        - exception_type (str)
+        - name (str)
+        - xfail_similarity_high_th (float)
+        - xfail_similarity_low_th (float)
+        - xfail_ai_agent_timeout (int)
+        - w_type, w_message, w_trace (float)
+
+    The YAML format is a flat list of signature dicts under ``signatures:``::
+
+        signatures:
+          - name: descriptive_name
+            exception_type: ...
+            message: ...
+            stack_trace: ...
+            failure_matching_rule: ...
+
+    Args:
+        filepath: Path to the YAML file.
+
+    Returns:
+        List of parsed signature dicts.
+    """
+    try:
+        with open(filepath) as f:
+            data = yaml.safe_load(f)
+    except Exception as e:
+        logger.error(f"Failed to load signature file {filepath}: {e!r}")
+        return []
+
+    if not data or not isinstance(data, dict):
+        logger.warning(f"Signature file {filepath} is empty or not a dict")
+        return []
+
+    raw_signatures = data.get("signatures", [])
+    if not isinstance(raw_signatures, list):
+        logger.warning(f"'signatures' in {filepath} is not a list")
+        return []
+
+    result = []
+    for idx, entry in enumerate(raw_signatures):
+        if not isinstance(entry, dict):
+            continue
+
+        # Each entry is a flat dict with the signature fields directly:
+        #   {"exception_type": ..., "message": ..., "stack_trace": ..., ...}
+
+        # Mandatory fields -- if any is missing or empty, skip this signature
+        # so the caller falls back to the original static xfail flow.
+        message = str(entry.get("message", "")).strip()
+        stack_trace = str(entry.get("stack_trace", "")).strip()
+        failure_matching_rule = str(entry.get("failure_matching_rule", "")).strip()
+
+        name = str(entry.get("name", f"signature_{idx}")).strip()
+        exception_type = str(entry.get("exception_type", "")).strip()
+
+        if not all([message, stack_trace, failure_matching_rule]):
+            mandatory = [("message", message),
+                         ("stack_trace", stack_trace),
+                         ("failure_matching_rule", failure_matching_rule)]
+            missing = [field for field, val in mandatory if not val]
+            logger.warning(f"Signature '{name}' in {filepath} is missing mandatory "
+                           f"fields: {', '.join(missing)}. Skipping.")
+            continue
+
+        sig = {
+            "name": name,
+            "exception_type": exception_type,
+            "message": message,
+            "stack_trace": stack_trace,
+            "failure_matching_rule": failure_matching_rule,
+            "xfail_similarity_high_th": float(
+                entry.get("xfail_similarity_high_th", XFAIL_SIMILARITY_HIGH_DEFAULT)),
+            "xfail_similarity_low_th": float(
+                entry.get("xfail_similarity_low_th", XFAIL_SIMILARITY_LOW_DEFAULT)),
+            "xfail_ai_agent_timeout": int(
+                entry.get("xfail_ai_agent_timeout", XFAIL_AI_AGENT_TIMEOUT_DEFAULT)),
+            "w_type": float(entry.get("w_type", W_TYPE)),
+            "w_message": float(entry.get("w_message", W_MESSAGE)),
+            "w_trace": float(entry.get("w_trace", W_TRACE)),
+        }
+        result.append(sig)
+
+    return result
+
+
+def load_signatures_for_issues(
+    issue_urls: List[str],
+    signatures_dir: Optional[str] = None,
+) -> Dict[str, List[dict]]:
+    """Load failure signatures for the given issue URLs.
+
+    Args:
+        issue_urls: List of issue URLs to look up.
+        signatures_dir: Directory containing the signature files.
+            Defaults to the module-level SIGNATURES_DIR.
+
+    Returns:
+        Dict mapping each issue URL that has valid signatures to its list
+        of parsed signature dicts.  URLs without a matching file or with
+        only invalid signatures are omitted.
+    """
+    if signatures_dir is None:
+        signatures_dir = SIGNATURES_DIR
+    result = {}
+    for url in issue_urls:
+        filepath = _find_signature_file(url, signatures_dir)
+        if not filepath:
+            continue
+        sigs = _parse_signatures(filepath)
+        if sigs:
+            result[url] = sigs
+            logger.debug(f"Loaded {len(sigs)} signatures for {url} from {filepath}")
+    return result
+
+
+def has_any_stored_signatures(
+    issue_urls: List[str],
+    signatures_dir: Optional[str] = None,
+) -> bool:
+    """Check if any of the given issue URLs has a stored signature file.
+
+    Args:
+        issue_urls: List of issue URLs.
+        signatures_dir: Directory to search.
+            Defaults to the module-level SIGNATURES_DIR.
+
+    Returns:
+        True if at least one URL has a matching signature file.
+    """
+    if signatures_dir is None:
+        signatures_dir = SIGNATURES_DIR
+    return any(_find_signature_file(url, signatures_dir) for url in issue_urls)
+
+
+# ---------------------------------------------------------------------------
+# Similarity scoring
+# ---------------------------------------------------------------------------
+
+def compute_similarity(current: dict, reference: dict) -> float:
+    """Compute the weighted Dice similarity between a current failure and a reference.
+
+    The score is a weighted combination of three components:
+
+    - **exception_type**: exact match (1.0 if equal, 0.0 otherwise)
+    - **message**: Dice coefficient on message strings
+    - **stack_trace**: Dice coefficient on stack trace strings
+
+    Weights are read from the reference signature dict (``w_type``,
+    ``w_message``, ``w_trace``), falling back to the module-level defaults.
+
+    Args:
+        current: Dict with ``exception_type``, ``message``, ``stack_trace``
+            keys from the live test failure.
+        reference: Dict with ``exception_type``, ``message``, ``stack_trace``
+            keys from the stored signature. May also contain ``w_type``,
+            ``w_message``, ``w_trace`` for per-signature weight overrides.
+
+    Returns:
+        Weighted similarity score in [0.0, 1.0].
+    """
+    w_type = reference.get("w_type", W_TYPE)
+    w_message = reference.get("w_message", W_MESSAGE)
+    w_trace = reference.get("w_trace", W_TRACE)
+
+    # Exception type: exact match
+    cur_type = (current.get("exception_type") or "").strip().lower()
+    ref_type = (reference.get("exception_type") or "").strip().lower()
+    type_score = 1.0 if cur_type == ref_type else 0.0
+
+    # Message similarity
+    cur_msg = current.get("message") or ""
+    ref_msg = reference.get("message") or ""
+    msg_score = dice_coefficient(cur_msg, ref_msg) if cur_msg and ref_msg else 0.0
+
+    # Trace similarity
+    cur_trace = current.get("stack_trace") or ""
+    ref_trace = reference.get("stack_trace") or ""
+    trace_score = dice_coefficient(cur_trace, ref_trace) if cur_trace and ref_trace else 0.0
+
+    final_score = w_type * type_score + w_message * msg_score + w_trace * trace_score
+
+    logger.debug(
+        f"Similarity: type={type_score:.2f} (w={w_type:.2f}), "
+        f"msg={msg_score:.4f} (w={w_message:.2f}), "
+        f"trace={trace_score:.4f} (w={w_trace:.2f}) -> final={final_score:.4f}")
+    return final_score
+
+
+# ---------------------------------------------------------------------------
+# Evaluation orchestration
+# ---------------------------------------------------------------------------
+
+# Minimum gap between the top two issue scores to consider the winner
+# decisive without consulting the AI agent for both.
+_SCORE_GAP_THRESHOLD = 0.10
+
+
+def _best_score_for_issue(
+    current_failure: dict,
+    signatures: List[dict],
+) -> Tuple[float, Optional[dict]]:
+    """Return the (best_score, best_signature) for a single issue's signatures."""
+    best_score = -1.0
+    best_sig = None
+    for sig in signatures:
+        score = compute_similarity(current_failure, sig)
+        if score > best_score:
+            best_score = score
+            best_sig = sig
+    return best_score, best_sig
+
+
+def _decide_single_issue(
+    current_failure: dict,
+    best_score: float,
+    best_sig: dict,
+    issue_url: str,
+) -> Tuple[str, str]:
+    """Apply the three-tier decision logic for a single issue's best signature.
+
+    Returns (decision, detail).
+    """
+    high_th = best_sig.get("xfail_similarity_high_th", XFAIL_SIMILARITY_HIGH_DEFAULT)
+    low_th = best_sig.get("xfail_similarity_low_th", XFAIL_SIMILARITY_LOW_DEFAULT)
+    ai_timeout = best_sig.get("xfail_ai_agent_timeout", XFAIL_AI_AGENT_TIMEOUT_DEFAULT)
+    matching_rule = best_sig.get("failure_matching_rule", "")
+    sig_name = best_sig.get("name", "?")
+
+    logger.info(f"Issue {issue_url}: best score {best_score:.4f} "
+                f"(sig={sig_name}, high_th={high_th:.2f}, low_th={low_th:.2f})")
+
+    # Tier 1: High similarity -> same issue
+    if best_score >= high_th:
+        detail = (f"Issue {issue_url}: similarity {best_score:.4f} >= high threshold "
+                  f"{high_th:.2f}. Treating as same issue.")
+        logger.info(detail)
+        return "same_issue", detail
+
+    # Tier 2: Low similarity -> different issue
+    if best_score <= low_th:
+        detail = (f"Issue {issue_url}: similarity {best_score:.4f} <= low threshold "
+                  f"{low_th:.2f}. Treating as different issue.")
+        logger.info(detail)
+        return "different_issue", detail
+
+    # Tier 3: Middle range -> consult AI agent (or fallback)
+    has_matching_rule = bool(matching_rule.strip())
+    logger.info(f"Issue {issue_url}: similarity {best_score:.4f} in middle range "
+                f"({low_th:.2f}, {high_th:.2f}). Consulting AI agent "
+                f"(matching_rule={'present' if has_matching_rule else 'absent'})...")
+
+    if not XFAIL_AI_AGENT_URL:
+        detail = (f"Issue {issue_url}: similarity {best_score:.4f} in middle range "
+                  f"but AI agent URL not configured. Falling back to xfail.")
+        logger.info(detail)
+        return "same_issue", detail
+
+    ai_result = consult_ai_agent(
+        current_failure=current_failure,
+        reference_signature=best_sig,
+        failure_matching_rule=matching_rule,
+        agent_url=XFAIL_AI_AGENT_URL,
+        timeout=ai_timeout,
+        issue_url=issue_url,
+    )
+
+    if ai_result is None:
+        detail = f"Issue {issue_url}: AI agent unavailable or returned error. Falling back to xfail."
+        logger.warning(detail)
+        return "same_issue", detail
+
+    decision = ai_result["decision"]
+    reasoning = ai_result["reasoning"]
+    processing_time = ai_result["processing_time_ms"]
+    detail = (f"Issue {issue_url}: AI agent decision: {decision} "
+              f"(similarity={best_score:.4f}, processing_time={processing_time}ms). "
+              f"Reasoning: {reasoning}")
+    logger.info(detail)
+    return decision, detail
+
+
+def evaluate_failure(
+    current_failure: dict,
+    issue_signatures: Dict[str, List[dict]],
+) -> Tuple[str, str]:
+    """Evaluate whether a test failure matches any stored known-issue signature.
+
+    When multiple issues have stored signatures (e.g. from an 'or' condition),
+    the logic is:
+
+    1. Compute the best similarity score for each issue.
+    2. If the top-scoring issue is clearly ahead of all others (gap >=
+       ``_SCORE_GAP_THRESHOLD`` to every other candidate), apply the
+       three-tier decision on the winner alone.
+    3. If any candidates are within the gap of the top score, consult the
+       AI agent for all close candidates.  If at least one returns
+       ``same_issue``, use the highest-scoring one.  If none match, report
+       as ``different_issue``.
+
+    Args:
+        current_failure: Dict with ``exception_type``, ``message``, ``stack_trace``.
+        issue_signatures: Dict mapping issue URL -> list of signature dicts,
+            as returned by :func:`load_signatures_for_issues`.
+
+    Returns:
+        Tuple of (decision, detail) where decision is ``"same_issue"`` or
+        ``"different_issue"``, and detail is a human-readable explanation.
+    """
+    if not issue_signatures:
+        return "different_issue", "No signatures found for comparison"
+
+    # Score each issue's best signature and classify by threshold
+    high_matches = []    # (score, sig, url) -- score >= high_th, definitive match
+    mid_candidates = []  # (score, sig, url) -- in middle range, need AI
+
+    for url, sigs in issue_signatures.items():
+        score, sig = _best_score_for_issue(current_failure, sigs)
+        if sig is None:
+            continue
+        high_th = sig.get("xfail_similarity_high_th", XFAIL_SIMILARITY_HIGH_DEFAULT)
+        low_th = sig.get("xfail_similarity_low_th", XFAIL_SIMILARITY_LOW_DEFAULT)
+
+        if score >= high_th:
+            high_matches.append((score, sig, url))
+        elif score > low_th:
+            mid_candidates.append((score, sig, url))
+
+    # If any issue exceeds its high threshold, use the highest-scoring one
+    if high_matches:
+        high_matches.sort(key=lambda x: x[0], reverse=True)
+        score, sig, url = high_matches[0]
+        high_th = sig.get("xfail_similarity_high_th", XFAIL_SIMILARITY_HIGH_DEFAULT)
+        detail = (f"Issue {url}: similarity {score:.4f} >= high threshold "
+                  f"{high_th:.2f}. Treating as same issue.")
+        logger.info(detail)
+        return "same_issue", detail
+
+    # No high matches -- if no middle-range candidates either, all are below low
+    if not mid_candidates:
+        detail = "All candidates below their low thresholds. Treating as different issue."
+        logger.info(detail)
+        return "different_issue", detail
+
+    # Middle-range candidates exist -- check if there is a clear winner among them
+    mid_candidates.sort(key=lambda x: x[0], reverse=True)
+    top_score, top_sig, top_url = mid_candidates[0]
+
+    # Find candidates close to the top score
+    close_candidates = [
+        (score, sig, url) for score, sig, url in mid_candidates
+        if (top_score - score) < _SCORE_GAP_THRESHOLD
+    ]
+
+    # Single middle-range candidate or clear winner -- decide on it alone
+    if len(close_candidates) == 1:
+        logger.info(f"Single middle-range candidate: {top_url} with score {top_score:.4f}")
+        return _decide_single_issue(current_failure, top_score, top_sig, top_url)
+
+    # Multiple close middle-range candidates -- consult AI for all
+    logger.info(f"Multiple close middle-range candidates (gap < {_SCORE_GAP_THRESHOLD}): "
+                f"{', '.join(f'{u}={s:.4f}' for s, _, u in close_candidates)}. "
+                f"Consulting AI for all.")
+
+    if not XFAIL_AI_AGENT_URL:
+        logger.info("AI agent URL not configured. Falling back to top scorer.")
+        return _decide_single_issue(current_failure, top_score, top_sig, top_url)
+
+    results = []
+    for score, sig, url in close_candidates:
+        ai_timeout = sig.get("xfail_ai_agent_timeout", XFAIL_AI_AGENT_TIMEOUT_DEFAULT)
+        matching_rule = sig.get("failure_matching_rule", "")
+        ai_result = consult_ai_agent(
+            current_failure=current_failure,
+            reference_signature=sig,
+            failure_matching_rule=matching_rule,
+            agent_url=XFAIL_AI_AGENT_URL,
+            timeout=ai_timeout,
+            issue_url=url,
+        )
+        results.append((url, score, sig, ai_result))
+
+    # Find candidates where AI says same_issue
+    same_issue_results = [(url, score, sig, r) for url, score, sig, r in results
+                          if r is not None and r["decision"] == "same_issue"]
+
+    if same_issue_results:
+        # Use the highest-scoring same_issue match
+        url, score, sig, ai_result = same_issue_results[0]
+        detail = (f"Issue {url}: AI agent decision: same_issue "
+                  f"(similarity={score:.4f}, processing_time={ai_result['processing_time_ms']}ms). "
+                  f"Reasoning: {ai_result['reasoning']}")
+        logger.info(detail)
+        return "same_issue", detail
+
+    # Build details for reporting
+    ai_details = []
+    for url, score, sig, ai_result in results:
+        if ai_result is None:
+            ai_details.append(f"{url}: AI agent error (score={score:.4f})")
+        else:
+            ai_details.append(f"{url}: {ai_result['decision']} (score={score:.4f}, "
+                              f"reasoning={ai_result['reasoning']})")
+
+    if all(r is None for _, _, _, r in results):
+        detail = f"AI agent unavailable for all candidates. Falling back to xfail. {'; '.join(ai_details)}"
+        logger.warning(detail)
+        return "same_issue", detail
+
+    detail = f"No issue matched. {'; '.join(ai_details)}"
+    logger.info(detail)
+    return "different_issue", detail

--- a/tests/common/plugins/conditional_mark/failure_validated_xfail_README.md
+++ b/tests/common/plugins/conditional_mark/failure_validated_xfail_README.md
@@ -1,0 +1,363 @@
+# Failure-Validated xfail
+
+## Problem
+
+The `conditional_mark` plugin allows tests to be marked as `xfail` (expected
+failure) when a known issue is linked in the conditions YAML. However, if a
+test fails for a **completely different reason** than the known issue, the
+failure is still silently xfail'd. This masks new regressions behind existing
+known issues.
+
+## Solution
+
+The Failure-Validated xfail feature validates whether the actual test failure
+matches the known issue **before** accepting the xfail. It does this by:
+
+1. Storing a **failure signature** (exception type, message, stack trace, and
+   a human-authored matching rule) for each known issue.
+2. When a test fails at runtime, comparing the actual failure against the
+   stored signature using a similarity score.
+3. Using a **three-tier decision**:
+   - **High similarity** (>= high threshold): same issue, apply xfail.
+   - **Low similarity** (<= low threshold): different issue, report as failure.
+   - **Middle range**: optionally consult an external AI agent for a more
+     nuanced comparison.
+
+If no signature file exists for an issue, the test falls back to the original
+static xfail behavior. If the AI agent is unavailable, the test falls back to
+xfail (preserving current behavior).
+
+## How It Works
+
+### Collection Phase
+
+During `pytest_collection_modifyitems`, when a test has an `xfail` condition
+that references a known issue URL:
+
+1. The plugin checks if a signature file exists for any of the issue URLs.
+2. If signature files are found, the plugin does **not** add the `xfail` mark.
+   Instead, it stores the issue URLs and loaded signatures on the test item
+   as `item._dynamic_xfail_info`.
+3. If no signature files exist, the standard static xfail mark is applied
+   (current behavior, unchanged).
+
+### Runtime Phase
+
+During `pytest_runtest_makereport`, when a test with `_dynamic_xfail_info`
+fails (in any phase: setup, call, or teardown):
+
+1. The current failure signature is extracted from the pytest exception info.
+2. Each issue's stored signatures are scored against the current failure.
+3. The three-tier decision logic determines whether the failure matches.
+4. The test report is updated accordingly:
+   - `same_issue`: report is changed to xfail (expected failure).
+   - `different_issue`: report remains as a failure, with a note prepended
+     to the status message indicating that the known issue did not match.
+
+### Loganalyzer Exemption
+
+Teardown failures originating from the `loganalyzer` fixture
+(`tests/common/plugins/loganalyzer/__init__.py`) are excluded from
+Failure-Validated xfail processing, as these are reported separately by the
+bug handler.
+
+## File Structure
+
+```
+tests/common/plugins/conditional_mark/
+    __init__.py                  # Modified: collection + runtime hooks
+    failure_signature.py         # Signature loading, scoring, evaluation
+    ai_agent_client.py           # HTTP client for the AI agent service
+    dice_similarity.py           # Sorensen-Dice string similarity algorithm
+    known_issue_signatures/      # Directory for signature YAML files
+        known_issue_signatures_mgmt_1234.yaml
+        known_issue_signatures_buildimage_5678.yaml
+```
+
+## Signature YAML Format
+
+Each known issue has a YAML file under `known_issue_signatures/` named:
+
+```
+known_issue_signatures_{source}_{number}.yaml
+```
+
+Where `{source}` is derived from the issue URL (`mgmt` for sonic-mgmt,
+`buildimage` for sonic-buildimage) and `{number}` is the issue ID.
+
+### Schema
+
+```yaml
+signatures:
+  - name: descriptive_name_for_this_failure_pattern
+    exception_type: |-
+      Failed
+    message: |-
+      The pytest exception message (from exconly()).
+      Can be multi-line.
+    stack_trace: |-
+      The full stack trace (from longreprtext).
+      Can be very long.
+    failure_matching_rule: >-
+      A human-authored rule describing how to identify this failure.
+      This is used by the AI agent as a "golden rule" when the similarity
+      score is in the middle range. Example: "If the error is a timeout
+      in _wait_on_pending_results, then it is the same issue."
+    # Optional per-signature threshold overrides:
+    xfail_similarity_high_th: 0.90
+    xfail_similarity_low_th: 0.60
+    xfail_ai_agent_timeout: 30
+```
+
+### Required Fields
+
+These three fields are mandatory for each signature entry. If any is
+missing or empty, the signature is skipped and the test falls back to
+static xfail behavior:
+
+| Field | Description |
+|---|---|
+| `message` | The exception message string (from `call.excinfo.exconly()`). |
+| `stack_trace` | The full pytest stack trace (from `report.longreprtext`). |
+| `failure_matching_rule` | Engineer-authored natural language rule for the AI agent. |
+
+### Optional Fields
+
+| Field | Default | Description |
+|---|---|---|
+| `name` | `signature_N` | Human-readable name for logging. |
+| `exception_type` | (empty) | Exception class name. See details below. |
+| `xfail_similarity_high_th` | `0.90` | Score at or above this is treated as the same issue. |
+| `xfail_similarity_low_th` | `0.60` | Score at or below this is treated as a different issue. |
+| `xfail_ai_agent_timeout` | `30` | Timeout in seconds for the AI agent request. |
+| `w_type` | `0.00` | Weight for exception_type in similarity scoring. |
+| `w_message` | `0.60` | Weight for message in similarity scoring. |
+| `w_trace` | `0.40` | Weight for stack_trace in similarity scoring. |
+
+The `w_type`, `w_message`, and `w_trace` fields allow per-signature tuning
+of the similarity scoring weights. They must sum to 1.0. For example, if you
+know that the exception type is a reliable signal for a particular issue, you
+can increase its weight:
+
+```yaml
+signatures:
+  - name: specific_key_error
+    exception_type: KeyError
+    message: |-
+      ...
+    stack_trace: |-
+      ...
+    failure_matching_rule: "..."
+    w_type: "0.15"
+    w_message: "0.50"
+    w_trace: "0.35"
+```
+
+#### About exception_type
+
+The `exception_type` corresponds to `call.excinfo.typename` in pytest -- the
+class name of the exception, without the module path. Common values in
+sonic-mgmt tests:
+
+| `exception_type` | Source | Example |
+|---|---|---|
+| `Failed` | `pytest.fail("reason")` | Most explicit test failures |
+| `AssertionError` | `assert expr, "message"` | Assertion-based checks |
+| `RunAnsibleModuleFail` | Ansible module execution failure | PTF test runner failures |
+| `KeyError` | `dict[missing_key]` | Unexpected data structure |
+| `TimeoutError` | Timeout waiting for condition | Polling/wait failures |
+
+At runtime, `exception_type` is obtained from `call.excinfo.typename` in the
+`pytest_runtest_makereport` hook. In pytest terminal output, it appears on the
+lines prefixed with `E` in the traceback (e.g. `E  KeyError`,
+`E  Failed: ...`, `E  AssertionError: ...`). The `message` comes from
+`call.excinfo.exconly()` and the `stack_trace` from `report.longreprtext`.
+
+The `exception_type` weight in similarity scoring is set to 0.0 by default
+because it is easy to get wrong (the same root cause can surface as different
+exception types depending on the code path). It is still useful for
+documentation purposes and as context for the AI agent, but it does not affect
+the similarity score unless `w_type` is explicitly set in the signature YAML.
+
+### Multiple Signatures Per Issue
+
+A single issue may manifest with different failure patterns (e.g. different
+error messages in different tests). Add multiple entries under
+`signatures:` to handle this. The best-matching signature is used.
+
+### Multiple Issues Per Condition
+
+When a condition uses the `or` operator with multiple active issue URLs, signatures
+for all issues are loaded and scored. The evaluation logic:
+
+1. Classifies each issue by its score against the thresholds (high match,
+   middle range, or low reject).
+2. If any issue scores above its high threshold, it is used immediately.
+3. If multiple issues are in the middle range with close scores (gap < 0.10),
+   the AI agent is consulted for all of them.
+
+## Similarity Scoring
+
+The similarity score is a weighted combination of three components:
+
+| Component | Default Weight | Method |
+|---|---|---|
+| `exception_type` | 0.00 | Exact match (1.0 if equal, 0.0 otherwise) |
+| `message` | 0.60 | Dice coefficient on the full message strings |
+| `stack_trace` | 0.40 | Dice coefficient on the full stack trace strings |
+
+The `exception_type` weight is 0.0 by default because the same root cause
+can manifest as different exception types (e.g. `Failed` vs `AssertionError`
+vs `RunAnsibleModuleFail`). The default weights can be adjusted globally in
+`failure_signature.py` (`W_TYPE`, `W_MESSAGE`, `W_TRACE`), or per-signature
+in the YAML file using `w_type`, `w_message`, `w_trace`. Weights must sum
+to 1.0.
+
+The Sorensen-Dice coefficient computes similarity based on shared character
+bigrams, producing a score between 0.0 and 1.0.
+
+## Adding Custom Issue Tracker URL Patterns
+
+By default, the plugin recognizes GitHub sonic-mgmt and sonic-buildimage issue
+URLs. To add support for additional issue trackers (e.g. an internal bug
+tracker), create a file `fv_custom_url_patterns.py` in the
+`conditional_mark` directory:
+
+```python
+import re
+
+CUSTOM_URL_PATTERNS = [
+    # Internal tracker: https://tracker.example.com/issues/12345
+    (re.compile(r'https?://tracker\.example\.com/issues/(\d+)'), 'internal'),
+]
+```
+
+Each entry is a tuple of `(compiled_regex, source_name)`. The regex must have
+one capture group for the issue number. The `source_name` is used in the
+signature filename (e.g. `known_issue_signatures_internal_12345.yaml`).
+
+## AI Agent Backend Service (Optional)
+
+The AI agent is an optional external service that provides LLM-based failure
+comparison for cases where the similarity score is inconclusive (middle
+range). The feature works without it -- middle-range scores fall back to
+xfail when no agent is configured.
+
+### Configuration
+
+Set the `XFAIL_AI_AGENT_URL` constant in `failure_signature.py` to the base
+URL of your AI agent service. Set it to an empty string to disable the
+feature.
+
+### REST API Contract
+
+The client sends a `POST` request to `{XFAIL_AI_AGENT_URL}/compare-failures`.
+
+#### Request
+
+```http
+POST /compare-failures
+Content-Type: application/json
+```
+
+```json
+{
+  "reference_failure": {
+    "exception_type": "Failed",
+    "exception_message": "The stored exception message from the signature.",
+    "stack_trace": "The stored stack trace from the signature.",
+    "failure_matching_rule": "Engineer-authored rule for identifying this failure."
+  },
+  "current_failure": {
+    "exception_type": "Failed",
+    "exception_message": "The actual exception message from the live test.",
+    "stack_trace": "The actual stack trace from the live test."
+  },
+  "issue_url": "https://github.com/sonic-net/sonic-mgmt/issues/1234",
+  "stream": false
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `reference_failure` | Yes | The stored failure signature from the YAML file. |
+| `reference_failure.exception_type` | Yes | Exception class name. |
+| `reference_failure.exception_message` | Yes | Exception message. |
+| `reference_failure.stack_trace` | Yes | Full stack trace. |
+| `reference_failure.failure_matching_rule` | Yes | Engineer-authored matching rule. |
+| `current_failure` | Yes | The live test failure to compare against. |
+| `current_failure.exception_type` | Yes | Exception class name. |
+| `current_failure.exception_message` | Yes | Exception message. |
+| `current_failure.stack_trace` | Yes | Full stack trace. |
+| `issue_url` | No | Known issue URL, for context only (not queried). |
+| `stream` | No | Set to `false` for JSON response (default). |
+
+#### Response
+
+```json
+{
+  "is_same_issue": true,
+  "reasoning": "Both failures show the same timeout pattern in _wait_on_pending_results...",
+  "processing_time_ms": 1200
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `is_same_issue` | boolean | `true` if the failures are caused by the same issue. |
+| `reasoning` | string | Explanation of the decision. |
+| `processing_time_ms` | integer | Time taken to process the request in milliseconds. |
+
+#### Error Responses
+
+- `400`: Invalid request (missing fields, invalid values).
+- `500`: Internal server error.
+- `502`: Upstream LLM service error.
+
+### Implementation Guidelines
+
+When implementing an AI agent backend, the service should:
+
+1. Accept the request payload described above.
+2. Use the `failure_matching_rule` as a primary guide -- it is an
+   engineer-authored "golden rule" describing how to identify this specific
+   failure pattern.
+3. Compare the `reference_failure` and `current_failure` to determine if they
+   share the same root cause.
+4. Return a JSON response with `is_same_issue`, `reasoning`, and
+   `processing_time_ms`.
+5. Respond within the configured timeout (default 30 seconds).
+
+### Fallback Behavior
+
+| Scenario | Behavior |
+|---|---|
+| `XFAIL_AI_AGENT_URL` is empty | Middle-range scores fall back to xfail. |
+| AI agent is unreachable | Middle-range scores fall back to xfail. |
+| AI agent times out | Middle-range scores fall back to xfail. |
+| AI agent returns an error | Middle-range scores fall back to xfail. |
+
+## Quick Start
+
+1. **Create a signature file** for a known issue:
+
+   ```bash
+   # File: known_issue_signatures/known_issue_signatures_mgmt_1234.yaml
+   ```
+
+   Populate it with the exception type, message, and stack trace from an
+   Allure report or pytest output for the known failure, plus a matching rule.
+
+2. **Add or verify the xfail condition** in `tests_mark_conditions.yaml`:
+
+   ```yaml
+   path/to/test.py::test_name:
+     xfail:
+       reason: "Known issue: https://github.com/sonic-net/sonic-mgmt/issues/1234"
+       conditions:
+         - "https://github.com/sonic-net/sonic-mgmt/issues/1234"
+   ```
+
+3. **Run the test**. If the failure matches the stored signature, it will be
+   reported as xfail. If it does not match, it will be reported as a failure
+   with a note indicating the known issue did not match.

--- a/tests/common/plugins/conditional_mark/fv_custom_url_patterns.py
+++ b/tests/common/plugins/conditional_mark/fv_custom_url_patterns.py
@@ -1,0 +1,16 @@
+"""Custom URL patterns for Failure-Validated xfail.
+
+This file contains internal issue tracker URL patterns that should not be
+upstreamed to the SONiC community.  Patterns defined here are appended to
+the built-in patterns in failure_signature.py at import time.
+
+Each entry is a tuple of (compiled_regex, source_name).  The regex must
+have exactly one capture group for the issue number.
+"""
+
+import re
+
+CUSTOM_URL_PATTERNS = [
+    # Redmine (internal): https://redmine.mellanox.com/issues/3971501
+    (re.compile(r'https?://redmine\.mellanox\.com/issues/(\d+)'), 'redmine'),
+]

--- a/tests/common/plugins/conditional_mark/integration_test/FAILURE_VALIDATED_XFAIL_TEST_PLAN.md
+++ b/tests/common/plugins/conditional_mark/integration_test/FAILURE_VALIDATED_XFAIL_TEST_PLAN.md
@@ -1,0 +1,412 @@
+# Failure-Validated xfail Integration Test Plan
+
+## Overview
+
+This test suite validates the Failure-Validated xfail feature end-to-end using
+real pytest test functions. All tests are self-contained and do not require a
+DUT or any external infrastructure (except a mock HTTP server for AI agent
+tests, and an optional real AI agent for the real AI tests).
+
+The tests are split into two categories:
+
+1. **Mock tests** (`test_fvxfail_mock.py`): Use a mock AI server for
+   deterministic, reproducible results. These cover all feature paths.
+2. **Real AI tests** (`test_fvxfail_real_ai.py`): Hit the real AI agent
+   service to validate the end-to-end flow with a live LLM backend.
+
+Each category has a corresponding **wrapper test** that runs the test file
+as a subprocess, parses the pytest short test summary, and asserts that each
+test produced the expected outcome (xfail, failed, or passed).
+
+## Test Infrastructure
+
+### Directory Structure
+
+```
+integration_test/
+    FAILURE_VALIDATED_XFAIL_TEST_PLAN.md          # This file
+    conftest.py               # Patches SIGNATURES_DIR, installs mark conditions YAML
+    test_fvxfail_mock.py      # Mock integration test cases (TC1-TC22)
+    test_fvxfail_mock_wrapper.py    # Wrapper that validates mock test outcomes
+    test_fvxfail_real_ai.py         # Real AI integration test cases (TC23-TC24)
+    test_fvxfail_real_ai_wrapper.py # Wrapper that validates real AI test outcomes
+    tests_mark_conditions_fvxfail_integration.yaml  # Mark conditions for all integration tests
+    mocked_failures/          # Stored failure messages replayed by test functions
+        high_similarity_failure.txt
+        custom_high_th_failure.txt
+        custom_low_th_failure.txt
+        middle_range_failure.txt
+        multi_issue_interface_down.txt
+        multi_issue_close_scores.txt
+        setup_teardown_failure.txt
+    signatures/               # Per-test signature YAML files
+        known_issue_signatures_mgmt_990099001.yaml  # TC1 (high similarity)
+        known_issue_signatures_mgmt_990099002.yaml  # TC2 (low similarity)
+        known_issue_signatures_mgmt_990099003.yaml  # TC13-18, TC23 (AI agent, middle range)
+        known_issue_signatures_mgmt_990099004.yaml  # TC10 (missing mandatory field)
+        known_issue_signatures_mgmt_990099005.yaml  # TC5 (custom high threshold)
+        known_issue_signatures_mgmt_990099006.yaml  # TC6 (custom low threshold)
+        known_issue_signatures_mgmt_990099007.yaml  # TC7 (custom weights)
+        known_issue_signatures_mgmt_990099008.yaml  # TC8a-8b (setup/teardown)
+        known_issue_signatures_mgmt_990099010.yaml  # TC11-12 (multi-issue, good match)
+        known_issue_signatures_mgmt_990099011.yaml  # TC11-12 (multi-issue, bad match)
+        known_issue_signatures_mgmt_990099012.yaml  # TC19-21, TC24 (multi-issue AI, candidate 1)
+        known_issue_signatures_mgmt_990099013.yaml  # TC19-21, TC24 (multi-issue AI, candidate 2)
+```
+
+### conftest.py
+
+The conftest performs two setup actions at import time (before collection):
+
+1. **Patches `SIGNATURES_DIR`** in `failure_signature.py` to point to the
+   test's own `signatures/` directory, so integration test signature files
+   are used instead of the real `known_issue_signatures/` directory.
+2. **Copies the mark conditions file**
+   (`tests_mark_conditions_fvxfail_integration.yaml`) to the real plugin
+   directory so the `conditional_mark` plugin's `load_conditions()` picks
+   it up during `pytest_collection`. An `atexit` handler removes the
+   copied file when the session ends.
+
+### tests_mark_conditions_fvxfail_integration.yaml
+
+Contains xfail mark conditions entries for all integration test cases. Each
+entry maps a test node ID to an xfail condition with one or more issue URLs.
+Tests that should not have FV-xfail involvement (TC3, TC22) have no entry in
+this file.
+
+### mocked_failures/
+
+Contains `.txt` files with stored failure messages. Test functions load these
+via `_load(name)` and pass them to `pytest.fail()` to replay a known failure
+pattern. This ensures deterministic similarity scores against the signature
+YAML files.
+
+### Mock AI Server
+
+A mock AI HTTP server is implemented directly in `test_fvxfail_mock.py` using
+a `mock_ai` fixture:
+
+1. Starts a threaded `HTTPServer` on `127.0.0.1` with a random available port.
+2. Handles `POST /api/v1/compare-failures` requests.
+3. Returns configurable responses per request (indexed sequentially):
+   - Fixed JSON with configurable `is_same_issue`, `reasoning`,
+     `processing_time_ms`.
+   - Configurable delay (for timeout tests).
+   - Configurable HTTP status code (for error tests).
+   - Configurable response body (for malformed response tests).
+   - Per-request response sequence (for multi-issue tests where each
+     call returns a different result).
+4. Patches `XFAIL_AI_AGENT_URL` to `http://127.0.0.1:<port>/api/v1`.
+5. Shuts down the server after the test.
+
+### Wrapper Tests
+
+Each wrapper (`test_fvxfail_mock_wrapper.py`, `test_fvxfail_real_ai_wrapper.py`)
+contains a single test function that:
+
+1. Builds a pytest command for the corresponding test file, reusing relevant
+   arguments from the parent process (e.g. `--inventory`, `--host-pattern`)
+   while filtering out allure, log-level, and test-file arguments.
+2. Runs the command as a subprocess with a 600-second timeout.
+3. Parses the short test summary from combined stdout+stderr to extract
+   per-test outcomes (`xfail`, `failed`, `passed`) and detail strings.
+4. Compares each test's actual outcome against an `EXPECTED` dictionary.
+5. For xfail outcomes, also checks that specific keywords appear in the
+   detail string (e.g. `"high threshold"`, `"AI agent decision: same_issue"`).
+6. Reports all mismatches as a single `pytest.fail()` with detailed diagnostics.
+
+### How Each Test Works
+
+Each test is a real pytest test function. The function itself does one of:
+
+- `pytest.fail(loaded_message)` -- to replay a known failure message from
+  `mocked_failures/`.
+- `raise SomeException(...)` -- to produce a specific exception type.
+- `pass` -- to test the passing path or edge cases.
+- Uses a fixture that raises in setup or teardown.
+
+The mark conditions YAML maps each test to issue URL(s). The signatures
+directory contains pre-crafted YAML files with known signatures, thresholds,
+and weights. The conftest patches module constants so the integration tests
+are self-contained.
+
+---
+
+## Test Cases -- Mock Tests (test_fvxfail_mock.py)
+
+### Core Decision Logic
+
+| # | Test Name | Flow | Expected Outcome |
+|---|---|---|---|
+| 1 | `test_same_failure_high_similarity` | Score >= high threshold | **xfail** (detail contains "high threshold", "same issue") |
+| 2 | `test_different_failure_low_similarity` | Score <= low threshold | **failed** |
+| 3 | `test_no_signature_file_no_fvxfail` | No mark conditions entry | **failed** (normal failure, no FV-xfail involvement) |
+| 4 | `test_passed_no_interference` | Test passes despite having signatures | **passed** |
+
+#### Details
+
+1. **test_same_failure_high_similarity**: Test calls `pytest.fail()` with a
+   message loaded from `high_similarity_failure.txt`, which closely matches
+   the stored signature for issue 990099001. The signature sets
+   `xfail_similarity_high_th: "0.55"` and `xfail_similarity_low_th: "0.30"`
+   to guarantee the high path is hit. Expected: xfail with "high threshold"
+   and "same issue" in detail.
+
+2. **test_different_failure_low_similarity**: Test raises
+   `KeyError("completely unrelated error about missing configuration key foobar_xyz")`.
+   Message and trace are entirely different from the signature for issue
+   990099002. Score is well below the low threshold. Expected: failed.
+
+3. **test_no_signature_file_no_fvxfail**: Test calls `pytest.fail()` with an
+   arbitrary message. This test has **no entry** in the mark conditions YAML,
+   so the conditional_mark plugin does not process it at all. It is a normal
+   test failure with no FV-xfail involvement. Expected: failed.
+
+4. **test_passed_no_interference**: Test has a mark conditions entry (issue
+   990099001) with a signature file, so `_dynamic_xfail_info` is set during
+   collection. However, the test function passes. The `pytest_runtest_makereport`
+   hook only processes failures, so it does not interfere. No XPASS because
+   the xfail mark was never added. Expected: passed.
+
+### Threshold and Weight Overrides
+
+| # | Test Name | Flow | Expected Outcome |
+|---|---|---|---|
+| 5 | `test_custom_high_threshold` | Per-signature `xfail_similarity_high_th: "0.50"` | **xfail** (detail contains "high threshold", "same issue") |
+| 6 | `test_custom_low_threshold` | Per-signature `xfail_similarity_low_th: "0.85"` | **failed** |
+| 7 | `test_custom_weights` | Per-signature `w_type: "0.50"` | **xfail** (detail contains "high threshold", "same issue") |
+
+#### Details
+
+5. **test_custom_high_threshold**: Signature for issue 990099005 has
+   `xfail_similarity_high_th: "0.50"`. Test fails with a message loaded from
+   `custom_high_th_failure.txt` (BGP session timeout), which has moderate
+   similarity to the stored signature. Without the lowered threshold this
+   would be middle range; with it, the score exceeds the high threshold.
+   Expected: xfail.
+
+6. **test_custom_low_threshold**: Signature for issue 990099006 has
+   `xfail_similarity_low_th: "0.85"` and `xfail_similarity_high_th: "0.95"`.
+   Test fails with a message loaded from `custom_low_th_failure.txt` (LLDP
+   neighbor on a different interface/host). The similarity score falls below
+   the raised low threshold. Expected: failed.
+
+7. **test_custom_weights**: Signature for issue 990099007 has
+   `w_type: "0.50"`, `w_message: "0.30"`, `w_trace: "0.20"` and
+   `xfail_similarity_high_th: "0.45"`. Test raises
+   `KeyError("a_totally_different_key_error_message")`. The message content
+   doesn't match, but the exception type (`KeyError`) matches exactly. The
+   increased type weight (0.50 * 1.0 = 0.50) pushes the overall score above
+   the high threshold. Expected: xfail.
+
+### Setup and Teardown Phases
+
+| # | Test Name | Flow | Expected Outcome |
+|---|---|---|---|
+| 8a | `test_setup_failure_same_issue` | Fixture fails in setup, signature matches | **xfail** (detail contains "same issue") |
+| 8b | `test_teardown_failure_same_issue` | Fixture fails in teardown (non-loganalyzer), signature matches | **xfail** (detail contains "same issue") |
+
+#### Details
+
+8a. **test_setup_failure_same_issue**: A `setup_failure_fixture` raises
+    `pytest.fail()` with a message loaded from `setup_teardown_failure.txt`
+    (DUT health check failure) during setup. The signature for issue 990099008
+    has `xfail_similarity_high_th: "0.55"`. The hook processes the setup-phase
+    failure and reports xfail.
+
+8b. **test_teardown_failure_same_issue**: A `teardown_failure_fixture` raises
+    `pytest.fail()` with the same message during teardown. The traceback does
+    NOT contain `tests/common/plugins/loganalyzer/__init__.py`, so the
+    loganalyzer exemption does not apply. The hook processes the teardown-phase
+    failure and reports xfail.
+
+### Invalid Signature File
+
+| # | Test Name | Flow | Expected Outcome |
+|---|---|---|---|
+| 10 | `test_missing_mandatory_field_static_xfail_with_note` | Signature YAML missing `message` field | **xfail** (detail contains "no valid signatures could be loaded") |
+
+#### Details
+
+10. **test_missing_mandatory_field_static_xfail_with_note**: Signature YAML
+    for issue 990099004 exists but is missing the mandatory `message` field.
+    The parser skips it and returns an empty list. During collection,
+    `has_any_stored_signatures()` returns True (the file exists), so the
+    plugin attempts FV-xfail processing. However,
+    `load_signatures_for_issues()` returns no valid signatures. The plugin
+    falls back to static xfail with a note indicating that no valid
+    signatures could be loaded. Expected: xfail with "no valid signatures
+    could be loaded" in detail.
+
+### Multiple Issues
+
+| # | Test Name | Flow | Expected Outcome |
+|---|---|---|---|
+| 11 | `test_multi_issue_clear_winner` | Two issues (OR), one scores high | **xfail** (detail contains "high threshold", "same issue") |
+| 12 | `test_multi_issue_all_below_low` | Two issues (OR), both score low | **failed** |
+
+#### Details
+
+11. **test_multi_issue_clear_winner**: Mark conditions use
+    `conditions_logical_operator: or` with issue URLs 990099010 and 990099011.
+    Test fails with a message loaded from `multi_issue_interface_down.txt`
+    (interface down after config reload), which closely matches issue
+    990099010's signature but not 990099011's. The high-scoring issue wins
+    directly. Expected: xfail.
+
+12. **test_multi_issue_all_below_low**: Same two issue URLs. Test raises
+    `KeyError("completely_unrelated_failure_xyz_12345")`. Neither signature
+    matches. Both scores are below their low thresholds. Expected: failed.
+
+### AI Agent (Mock Server)
+
+| # | Test Name | Flow | Expected Outcome |
+|---|---|---|---|
+| 13 | `test_ai_returns_same_issue` | Middle range, AI says same | **xfail** (detail contains "AI agent decision: same_issue") |
+| 14 | `test_ai_returns_different_issue` | Middle range, AI says different | **failed** |
+| 15 | `test_ai_timeout` | Middle range, AI times out | **xfail** (detail contains "unavailable") |
+| 16 | `test_ai_error_500` | Middle range, AI returns 500 | **xfail** (detail contains "unavailable") |
+| 17 | `test_ai_malformed_response` | Middle range, AI returns invalid JSON | **xfail** (detail contains "unavailable") |
+| 18 | `test_ai_disabled_fallback` | Middle range, AI URL empty | **xfail** (detail contains "not configured") |
+
+#### Details
+
+All AI agent tests use issue 990099003 whose signature has
+`xfail_similarity_high_th: "0.95"` and `xfail_similarity_low_th: "0.30"`.
+The test fails with a message loaded from `middle_range_failure.txt` (PFC
+watchdog timer with slightly different values). The similarity score lands
+in the middle range (between 0.30 and 0.95), triggering AI agent consultation.
+
+13. **test_ai_returns_same_issue**: Mock AI returns
+    `{"is_same_issue": true, "reasoning": "Both failures are PFC watchdog
+    timer accuracy issues", "processing_time_ms": 500}`. Expected: xfail
+    with AI reasoning in detail.
+
+14. **test_ai_returns_different_issue**: Mock AI returns
+    `{"is_same_issue": false, "reasoning": "Different root cause detected",
+    "processing_time_ms": 300}`. Expected: failed.
+
+15. **test_ai_timeout**: Mock server sleeps for 60 seconds. Signature sets
+    `xfail_ai_agent_timeout: "10"`. Client times out. Expected: xfail
+    fallback with "unavailable" in detail.
+
+16. **test_ai_error_500**: Mock server returns HTTP 500. Expected: xfail
+    fallback with "unavailable" in detail.
+
+17. **test_ai_malformed_response**: Mock server returns
+    `{"garbage": true, "no_is_same_issue_field": 42}` (missing
+    `is_same_issue`). Expected: xfail fallback with "unavailable" in detail.
+
+18. **test_ai_disabled_fallback**: `XFAIL_AI_AGENT_URL` is monkeypatched
+    to an empty string. Score in middle range. Expected: xfail with
+    "not configured" in detail.
+
+### Multi-Issue AI Disambiguation
+
+| # | Test Name | Flow | Expected Outcome |
+|---|---|---|---|
+| 19 | `test_multi_issue_ai_one_match` | Close scores, AI matches one | **xfail** (detail contains "AI agent decision: same_issue") |
+| 20 | `test_multi_issue_ai_none_match` | Close scores, AI rejects all | **failed** |
+| 21 | `test_multi_issue_ai_all_error` | Close scores, AI errors for all | **xfail** (detail contains "unavailable") |
+
+#### Details
+
+All multi-issue AI tests use issues 990099012 and 990099013 (OR condition).
+Both signatures have `xfail_similarity_high_th: "0.95"`,
+`xfail_similarity_low_th: "0.30"`, and `xfail_ai_agent_timeout: "10"`. Test
+fails with a message loaded from `multi_issue_close_scores.txt` (route
+redistribution failure). Both issues produce similar middle-range scores
+(gap < 0.10), triggering AI disambiguation.
+
+19. **test_multi_issue_ai_one_match**: Mock AI returns `same_issue` for the
+    first request (BGP redistribution match) and `different_issue` for the
+    second (OSPF redistribution). Expected: xfail based on the matched issue.
+
+20. **test_multi_issue_ai_none_match**: Mock AI returns `different_issue`
+    for both requests. Expected: failed.
+
+21. **test_multi_issue_ai_all_error**: Mock AI returns HTTP 500 for all
+    requests. Expected: xfail fallback.
+
+### Edge Case
+
+| # | Test Name | Flow | Expected Outcome |
+|---|---|---|---|
+| 22 | `test_no_excinfo_fallback` | Test passes, no `_dynamic_xfail_info` | **passed** |
+
+#### Details
+
+22. **test_no_excinfo_fallback**: Test function passes. This test has no
+    entry in the mark conditions YAML, so no `_dynamic_xfail_info` is set.
+    The hook does not process it. Expected: passed.
+
+---
+
+## Test Cases -- Real AI Tests (test_fvxfail_real_ai.py)
+
+These tests hit the real AI agent service at the URL configured in
+`failure_signature.XFAIL_AI_AGENT_URL`. They validate that the end-to-end
+flow works with a live LLM backend. These tests require the AI agent service
+to be running and accessible.
+
+| # | Test Name | Flow | Expected Outcome |
+|---|---|---|---|
+| 23 | `test_real_ai_same_issue` | Middle range score, real AI evaluates | **xfail** (detail contains "AI agent decision: same_issue") |
+| 24 | `test_real_ai_multi_issue` | Two close-score issues, real AI disambiguates | **xfail** (detail contains "AI agent decision: same_issue") |
+
+#### Details
+
+23. **test_real_ai_same_issue**: Uses issue 990099003 (PFC watchdog timer).
+    Test fails with a message loaded from `middle_range_failure.txt`. The
+    similarity score lands in the middle range, triggering a real AI agent
+    call. The AI should recognize the same PFC watchdog timer pattern and
+    return `same_issue`. Expected: xfail.
+
+24. **test_real_ai_multi_issue**: Uses issues 990099012 and 990099013 (route
+    redistribution, OR condition). Test fails with a message loaded from
+    `multi_issue_close_scores.txt`. Both issues produce close middle-range
+    scores. The real AI should match one of them (the BGP redistribution
+    issue). Expected: xfail.
+
+---
+
+## Not Covered (requires real DUT)
+
+- **Loganalyzer teardown exemption**: Requires a real DUT to inject syslog
+  errors and trigger the real loganalyzer fixture teardown. The exemption is
+  a simple string match (`tests/common/plugins/loganalyzer/__init__.py` in
+  `longreprtext`) and can be verified in a real regression run.
+
+## Running the Tests
+
+### Mock Tests (recommended for CI)
+
+Run the wrapper to validate all mock test outcomes automatically:
+
+```bash
+cd tests
+pytest common/plugins/conditional_mark/integration_test/test_fvxfail_mock_wrapper.py -v
+```
+
+Or run the mock tests directly to see raw pytest results:
+
+```bash
+cd tests
+pytest common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py -v --tb=short -ra
+```
+
+### Real AI Tests (requires AI agent service)
+
+Run the wrapper to validate real AI test outcomes automatically:
+
+```bash
+cd tests
+pytest common/plugins/conditional_mark/integration_test/test_fvxfail_real_ai_wrapper.py -v
+```
+
+Or run the real AI tests directly:
+
+```bash
+cd tests
+pytest common/plugins/conditional_mark/integration_test/test_fvxfail_real_ai.py -v --tb=short -ra
+```

--- a/tests/common/plugins/conditional_mark/integration_test/conftest.py
+++ b/tests/common/plugins/conditional_mark/integration_test/conftest.py
@@ -1,0 +1,186 @@
+"""Conftest for Failure-Validated xfail integration tests.
+
+Patches SIGNATURES_DIR to point to the test's own signatures/ directory
+so test signature files don't pollute the real known_issue_signatures/ folder.
+
+Copies the integration test mark conditions file to the real plugin directory
+before collection so the conditional_mark plugin picks it up, and removes it
+after the session ends.
+
+Also provides shared helpers used by the test and wrapper modules.
+"""
+
+import atexit
+import os
+import re
+import shutil
+import sys
+import logging
+
+from tests.common.plugins.conditional_mark import failure_signature
+
+logger = logging.getLogger(__name__)
+
+_THIS_DIR = os.path.dirname(__file__)
+_PLUGIN_DIR = os.path.dirname(os.path.realpath(failure_signature.__file__))
+
+# Patch SIGNATURES_DIR to the test's own signatures/ directory
+failure_signature.SIGNATURES_DIR = os.path.join(_THIS_DIR, "signatures")
+
+# Copy the integration test mark conditions file to the plugin directory
+# so load_conditions() picks it up during pytest_collection.
+_MARK_CONDITIONS_SRC = os.path.join(_THIS_DIR, "tests_mark_conditions_fvxfail_integration.yaml")
+_MARK_CONDITIONS_DST = os.path.join(_PLUGIN_DIR, "tests_mark_conditions_fvxfail_integration.yaml")
+
+if os.path.isfile(_MARK_CONDITIONS_SRC):
+    shutil.copy2(_MARK_CONDITIONS_SRC, _MARK_CONDITIONS_DST)
+    logger.info(f"Installed integration test mark conditions: {_MARK_CONDITIONS_DST}")
+
+
+def _cleanup_mark_conditions():
+    if os.path.isfile(_MARK_CONDITIONS_DST):
+        os.remove(_MARK_CONDITIONS_DST)
+        logger.info(f"Removed integration test mark conditions: {_MARK_CONDITIONS_DST}")
+
+
+atexit.register(_cleanup_mark_conditions)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for test modules and wrapper modules
+# ---------------------------------------------------------------------------
+
+MOCKED_FAILURES_DIR = os.path.join(_PLUGIN_DIR, "integration_test", "mocked_failures")
+
+
+def load_mocked_failure(name):
+    """Load a mocked failure message from the mocked_failures/ directory."""
+    with open(os.path.join(MOCKED_FAILURES_DIR, name)) as f:
+        return f.read()
+
+
+def build_pytest_cmd(test_file):
+    """Build the pytest command reusing relevant args from the parent process.
+
+    Filters out args that should not be inherited by the child subprocess:
+    -k, --rootdir, --alluredir, --allure_server, --clean-alluredir, and
+    args already set in the base command (-v, --tb, -ra, --log-cli-level).
+    Sets --rootdir to the tests/ directory so the child discovers the correct
+    conftest chain.
+    """
+    tests_dir = os.path.normpath(os.path.join(_THIS_DIR, "../../../.."))
+    cmd = [sys.executable, "-u", "-m", "pytest", test_file, "-v", "--tb=short", "-ra",
+           "--log-cli-level", "critical", "--rootdir", tests_dir]
+
+    parent_args = sys.argv[1:]
+    skip_next = False
+    for arg in parent_args:
+        if skip_next:
+            skip_next = False
+            continue
+        # Skip test file arguments
+        if arg.startswith("common/plugins/") or arg.startswith("test_"):
+            continue
+        # Skip allure-related args (don't want child to upload)
+        if arg in ("--clean-alluredir",):
+            continue
+        if arg.startswith("--alluredir"):
+            if "=" not in arg:
+                skip_next = True
+            continue
+        if arg.startswith("--allure_server"):
+            if "=" not in arg:
+                skip_next = True
+            continue
+        # Skip args already in cmd or that we override
+        if arg in ("-v", "--tb=short", "-ra"):
+            continue
+        if arg.startswith("--log-cli-level"):
+            if "=" not in arg:
+                skip_next = True
+            continue
+        # Skip -k (test selection) — the parent's -k (e.g. -k "wrapper")
+        # would deselect all child tests since their names don't match.
+        if arg == "-k":
+            skip_next = True
+            continue
+        # Skip --rootdir — we set our own above for the child process
+        if arg.startswith("--rootdir"):
+            if arg == "--rootdir":
+                skip_next = True
+            continue
+        cmd.append(arg)
+
+    return cmd
+
+
+def parse_summary(output):
+    """Parse the pytest short test summary to extract outcomes and details.
+
+    The summary format is:
+        XFAIL ...::test_name - reason line 1
+        reason line 2 (for multi-issue 'or' conditions)
+        [Failure-Validated xfail: detail...]
+        FAILED ...::test_name
+        FAILED ...::test_name - detail
+
+    Returns dict of {test_name: {"outcome": str, "detail": str}}
+    """
+    # Extract just the short test summary section
+    lines = output.splitlines()
+    summary_start = None
+    summary_end = None
+    for i, line in enumerate(lines):
+        if "short test summary info" in line:
+            summary_start = i + 1
+        elif summary_start and line.startswith("====") and "passed" in line:
+            summary_end = i
+            break
+
+    if summary_start is None:
+        return {}
+
+    summary_lines = lines[summary_start:summary_end]
+
+    results = {}
+    i = 0
+    while i < len(summary_lines):
+        line = summary_lines[i]
+
+        # Match XFAIL line
+        m = re.match(r'XFAIL\s+.*::(\w+)\s*-\s*(.*)', line)
+        if m:
+            test_name = m.group(1)
+            detail = m.group(2)
+            # Collect continuation lines (reason continuation or [FV-xfail detail])
+            while i + 1 < len(summary_lines):
+                next_line = summary_lines[i + 1]
+                if next_line.startswith("XFAIL ") or next_line.startswith("FAILED "):
+                    break
+                i += 1
+                detail += "\n" + next_line
+            results[test_name] = {"outcome": "xfail", "detail": detail}
+            i += 1
+            continue
+
+        # Match FAILED line
+        m = re.match(r'FAILED\s+.*::(\w+)', line)
+        if m:
+            test_name = m.group(1)
+            results[test_name] = {"outcome": "failed", "detail": ""}
+            i += 1
+            continue
+
+        i += 1
+
+    # Also parse the per-test result lines for PASSED tests
+    # (PASSED tests don't appear in the short summary with -ra,
+    #  so parse the verbose output lines)
+    for line in lines:
+        m = re.match(r'.*::(\w+)\s+PASSED', line)
+        if m:
+            test_name = m.group(1)
+            if test_name not in results:
+                results[test_name] = {"outcome": "passed", "detail": ""}
+
+    return results

--- a/tests/common/plugins/conditional_mark/integration_test/mocked_failures/custom_high_th_failure.txt
+++ b/tests/common/plugins/conditional_mark/integration_test/mocked_failures/custom_high_th_failure.txt
@@ -1,0 +1,1 @@
+BGP session did not establish within timeout. Neighbor 10.0.0.1 stuck in Active state after 180 seconds.

--- a/tests/common/plugins/conditional_mark/integration_test/mocked_failures/custom_low_th_failure.txt
+++ b/tests/common/plugins/conditional_mark/integration_test/mocked_failures/custom_low_th_failure.txt
@@ -1,0 +1,1 @@
+LLDP neighbor not found on interface Ethernet4. Expected neighbor r-sn2700-92 but got none after 90 seconds.

--- a/tests/common/plugins/conditional_mark/integration_test/mocked_failures/high_similarity_failure.txt
+++ b/tests/common/plugins/conditional_mark/integration_test/mocked_failures/high_similarity_failure.txt
@@ -1,0 +1,1 @@
+DUT did not come back up after warm reboot. Timeout waiting for SSH connection. Expected device to be reachable within 300 seconds but it took 450 seconds. Control plane downtime exceeded threshold: allowed=90s, actual=185s.

--- a/tests/common/plugins/conditional_mark/integration_test/mocked_failures/middle_range_failure.txt
+++ b/tests/common/plugins/conditional_mark/integration_test/mocked_failures/middle_range_failure.txt
@@ -1,0 +1,1 @@
+PFC watchdog timer accuracy test failed. Real detection time is greater than configured PFC storm detection time. Detected: 520ms, Expected max: 400ms.

--- a/tests/common/plugins/conditional_mark/integration_test/mocked_failures/multi_issue_close_scores.txt
+++ b/tests/common/plugins/conditional_mark/integration_test/mocked_failures/multi_issue_close_scores.txt
@@ -1,0 +1,1 @@
+Route not found in routing table after redistribution. Expected prefix 10.0.0.0/24 in BGP RIB but it was missing after 60 seconds.

--- a/tests/common/plugins/conditional_mark/integration_test/mocked_failures/multi_issue_interface_down.txt
+++ b/tests/common/plugins/conditional_mark/integration_test/mocked_failures/multi_issue_interface_down.txt
@@ -1,0 +1,1 @@
+Interface Ethernet4 is down after config reload. Expected state: up, actual state: down. Waited 120 seconds.

--- a/tests/common/plugins/conditional_mark/integration_test/mocked_failures/setup_teardown_failure.txt
+++ b/tests/common/plugins/conditional_mark/integration_test/mocked_failures/setup_teardown_failure.txt
@@ -1,0 +1,1 @@
+Fixture setup/teardown failed: DUT health check did not pass. Services not running: swss, syncd.

--- a/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099001.yaml
+++ b/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099001.yaml
@@ -1,0 +1,15 @@
+signatures:
+  - name: warm_reboot_timeout
+    exception_type: Failed
+    message: |-
+      Failed: DUT did not come back up after warm reboot. Timeout waiting for SSH connection. Expected device to be reachable within 300 seconds but it took 450 seconds. Control plane downtime exceeded threshold: allowed=90s, actual=185s.
+    stack_trace: |-
+      tests/upgrade_path/test_upgrade_path.py:245: in test_upgrade_path
+          advanced_reboot(reboot_type="warm")
+      tests/common/reboot.py:189: in advanced_reboot
+          pytest.fail(failure_summary)
+    failure_matching_rule: >-
+      If the failure mentions warm reboot timeout and SSH connection failure,
+      it is the same issue.
+    xfail_similarity_high_th: "0.55"
+    xfail_similarity_low_th: "0.30"

--- a/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099002.yaml
+++ b/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099002.yaml
@@ -1,0 +1,11 @@
+signatures:
+  - name: acl_rule_not_applied
+    exception_type: AssertionError
+    message: |-
+      AssertionError: ACL rule was not applied after config reload. Expected rule count 10, got 0.
+    stack_trace: |-
+      tests/acl/test_acl.py:180: in test_acl_rule_persistence
+          assert applied_rules == expected_rules
+    failure_matching_rule: >-
+      If the failure is about ACL rules not being applied after config reload,
+      it is the same issue.

--- a/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099003.yaml
+++ b/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099003.yaml
@@ -1,0 +1,14 @@
+signatures:
+  - name: pfcwd_timer_middle_range
+    exception_type: Failed
+    message: |-
+      Failed: PFC watchdog timer accuracy test failed. Real detection time is greater than configured PFC storm detection time. Detected: 450ms, Expected max: 400ms.
+    stack_trace: |-
+      tests/pfcwd/test_pfcwd_timer_accuracy.py:345: in test_pfcwd_timer_accuracy
+          pytest.fail(msg)
+    failure_matching_rule: >-
+      If the failure is about PFC watchdog timer accuracy where the detection
+      time exceeds the configured threshold, it is the same issue.
+    xfail_similarity_high_th: "0.95"
+    xfail_similarity_low_th: "0.30"
+    xfail_ai_agent_timeout: "10"

--- a/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099004.yaml
+++ b/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099004.yaml
@@ -1,0 +1,9 @@
+signatures:
+  - name: missing_message_field
+    exception_type: Failed
+    stack_trace: |-
+      tests/some/test.py:10: in test_something
+          pytest.fail("oops")
+    failure_matching_rule: >-
+      This signature is intentionally missing the message field to test
+      the mandatory field validation.

--- a/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099005.yaml
+++ b/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099005.yaml
@@ -1,0 +1,13 @@
+signatures:
+  - name: custom_low_high_threshold
+    exception_type: Failed
+    message: |-
+      Failed: BGP session did not establish within timeout. Neighbor 10.0.0.1 stuck in Active state after 180 seconds.
+    stack_trace: |-
+      tests/bgp/test_bgp.py:120: in test_bgp_session
+          pytest.fail(msg)
+    failure_matching_rule: >-
+      If the failure is about BGP session establishment timeout, it is
+      the same issue.
+    xfail_similarity_high_th: "0.50"
+    xfail_similarity_low_th: "0.30"

--- a/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099006.yaml
+++ b/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099006.yaml
@@ -1,0 +1,12 @@
+signatures:
+  - name: custom_high_low_threshold
+    exception_type: Failed
+    message: |-
+      Failed: LLDP neighbor not found on interface Ethernet0. Expected neighbor r-sn2700-90 but got none after 60 seconds.
+    stack_trace: |-
+      tests/lldp/test_lldp.py:85: in test_lldp_neighbor
+          pytest.fail(msg)
+    failure_matching_rule: >-
+      If the failure is about LLDP neighbor not found, it is the same issue.
+    xfail_similarity_high_th: "0.95"
+    xfail_similarity_low_th: "0.85"

--- a/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099007.yaml
+++ b/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099007.yaml
@@ -1,0 +1,15 @@
+signatures:
+  - name: custom_weights_type_heavy
+    exception_type: KeyError
+    message: |-
+      KeyError: 'some_completely_different_message_that_wont_match'
+    stack_trace: |-
+      tests/some/test.py:50: in test_something
+          data['missing_key']
+    failure_matching_rule: >-
+      If the exception type is KeyError, it is the same issue.
+    xfail_similarity_high_th: "0.45"
+    xfail_similarity_low_th: "0.20"
+    w_type: "0.50"
+    w_message: "0.30"
+    w_trace: "0.20"

--- a/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099008.yaml
+++ b/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099008.yaml
@@ -1,0 +1,13 @@
+signatures:
+  - name: setup_teardown_failure
+    exception_type: Failed
+    message: |-
+      Failed: Fixture setup/teardown failed: DUT health check did not pass. Services not running: swss, syncd.
+    stack_trace: |-
+      tests/common/fixtures/health.py:45: in dut_health_check
+          pytest.fail(msg)
+    failure_matching_rule: >-
+      If the failure is about DUT health check with services not running,
+      it is the same issue.
+    xfail_similarity_high_th: "0.55"
+    xfail_similarity_low_th: "0.30"

--- a/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099010.yaml
+++ b/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099010.yaml
@@ -1,0 +1,13 @@
+signatures:
+  - name: multi_issue_good_match
+    exception_type: Failed
+    message: |-
+      Failed: Interface Ethernet4 is down after config reload. Expected state: up, actual state: down. Waited 120 seconds.
+    stack_trace: |-
+      tests/platform_tests/test_reload.py:200: in test_config_reload
+          pytest.fail(msg)
+    failure_matching_rule: >-
+      If the failure is about interface being down after config reload,
+      it is the same issue.
+    xfail_similarity_high_th: "0.55"
+    xfail_similarity_low_th: "0.30"

--- a/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099011.yaml
+++ b/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099011.yaml
@@ -1,0 +1,12 @@
+signatures:
+  - name: multi_issue_bad_match
+    exception_type: AssertionError
+    message: |-
+      AssertionError: SNMP walk returned unexpected OID values for sysDescr. Expected version 20240101, got version 20230601.
+    stack_trace: |-
+      tests/snmp/test_snmp.py:90: in test_snmp_sysDescr
+          assert actual_version == expected_version
+    failure_matching_rule: >-
+      If the failure is about SNMP OID values mismatch, it is the same issue.
+    xfail_similarity_high_th: "0.55"
+    xfail_similarity_low_th: "0.30"

--- a/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099012.yaml
+++ b/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099012.yaml
@@ -1,0 +1,14 @@
+signatures:
+  - name: close_score_candidate_1
+    exception_type: Failed
+    message: |-
+      Failed: Route not found in routing table after redistribution. Expected prefix 10.0.0.0/24 in BGP RIB but it was missing after 60 seconds.
+    stack_trace: |-
+      tests/bgp/test_bgp_redistribute.py:150: in test_route_redistribution
+          pytest.fail(msg)
+    failure_matching_rule: >-
+      If the failure is about a missing route after BGP redistribution,
+      it is the same issue.
+    xfail_similarity_high_th: "0.95"
+    xfail_similarity_low_th: "0.30"
+    xfail_ai_agent_timeout: "10"

--- a/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099013.yaml
+++ b/tests/common/plugins/conditional_mark/integration_test/signatures/known_issue_signatures_mgmt_990099013.yaml
@@ -1,0 +1,14 @@
+signatures:
+  - name: close_score_candidate_2
+    exception_type: Failed
+    message: |-
+      Failed: Route not found in routing table after redistribution. Expected prefix 192.168.0.0/16 in OSPF RIB but it was missing after 90 seconds.
+    stack_trace: |-
+      tests/routing/test_ospf_redistribute.py:200: in test_route_redistribution
+          pytest.fail(msg)
+    failure_matching_rule: >-
+      If the failure is about a missing route after OSPF redistribution,
+      it is the same issue.
+    xfail_similarity_high_th: "0.95"
+    xfail_similarity_low_th: "0.30"
+    xfail_ai_agent_timeout: "10"

--- a/tests/common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py
+++ b/tests/common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py
@@ -1,0 +1,296 @@
+"""Integration tests for the Failure-Validated xfail feature.
+
+Tests go through the real collection phase via mark conditions entries in
+tests_mark_conditions_fvxfail_integration.yaml (copied to the plugin dir
+by conftest.py). The pytest_runtest_makereport hook from the conditional_mark
+plugin processes failures and decides whether to xfail or fail.
+
+Run directly to see raw pytest results:
+    pytest common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py ...
+
+Or run the wrapper test to validate results automatically:
+    pytest common/plugins/conditional_mark/integration_test/test_fvxfail_mock_wrapper.py ...
+"""
+
+import json
+import threading
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import time
+import pytest
+
+from tests.common.plugins.conditional_mark import failure_signature
+from tests.common.plugins.conditional_mark.integration_test.conftest import load_mocked_failure
+
+pytestmark = [pytest.mark.disable_memory_utilization, pytest.mark.skip_check_dut_health,
+              pytest.mark.disable_loganalyzer]
+
+
+# ---------------------------------------------------------------------------
+# Mock AI agent server
+# ---------------------------------------------------------------------------
+
+_mock_ai_responses = []
+_mock_ai_request_count = 0
+_mock_ai_lock = threading.Lock()
+
+
+class _MockAIHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        global _mock_ai_request_count
+        if self.path != "/api/v1/compare-failures":
+            self.send_error(404)
+            return
+
+        content_length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(content_length)
+
+        with _mock_ai_lock:
+            idx = _mock_ai_request_count
+            _mock_ai_request_count += 1
+
+        if idx < len(_mock_ai_responses):
+            resp_config = _mock_ai_responses[idx]
+        else:
+            resp_config = _mock_ai_responses[-1] if _mock_ai_responses else {}
+
+        delay = resp_config.get("delay", 0)
+        if delay:
+            time.sleep(delay)
+
+        status = resp_config.get("status", 200)
+        body = resp_config.get("body", {})
+
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.fixture
+def mock_ai(request, monkeypatch):
+    """Fixture that starts a mock AI server and patches the URL."""
+    servers = []
+
+    def _setup(responses):
+        global _mock_ai_responses, _mock_ai_request_count
+        _mock_ai_responses = responses
+        _mock_ai_request_count = 0
+
+        server = HTTPServer(("127.0.0.1", 0), _MockAIHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        servers.append(server)
+
+        url = f"http://127.0.0.1:{port}/api/v1"
+        monkeypatch.setattr(failure_signature, "XFAIL_AI_AGENT_URL", url)
+
+    yield _setup
+
+    for server in servers:
+        server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures for setup/teardown phase tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def setup_failure_fixture():
+    """Fixture that fails during setup with a known message."""
+    msg = load_mocked_failure("setup_teardown_failure.txt")
+    pytest.fail(msg)
+    yield
+
+
+@pytest.fixture
+def teardown_failure_fixture():
+    """Fixture that fails during teardown with a known message."""
+    yield
+    msg = load_mocked_failure("setup_teardown_failure.txt")
+    pytest.fail(msg)
+
+
+# ============================= TEST CASES =====================================
+
+# --- Core Decision Logic ---
+
+def test_same_failure_high_similarity():
+    """TC1: Score >= high threshold -> xfail, no AI triggered."""
+    pytest.fail(load_mocked_failure("high_similarity_failure.txt"))
+
+
+def test_different_failure_low_similarity():
+    """TC2: Score <= low threshold -> failed."""
+    raise KeyError("completely unrelated error about missing configuration key foobar_xyz")
+
+
+def test_no_signature_file_no_fvxfail():
+    """TC3: No mark conditions entry -> normal failure, no FV-xfail."""
+    pytest.fail("some random failure with no FV-xfail involvement")
+
+
+def test_passed_no_interference():
+    """TC4: Test passes -> PASSED."""
+    pass
+
+
+# --- Threshold and Weight Overrides ---
+
+def test_custom_high_threshold():
+    """TC5: Per-signature low high_th -> xfail."""
+    pytest.fail(load_mocked_failure("custom_high_th_failure.txt"))
+
+
+def test_custom_low_threshold():
+    """TC6: Per-signature high low_th -> failed."""
+    pytest.fail(load_mocked_failure("custom_low_th_failure.txt"))
+
+
+def test_custom_weights():
+    """TC7: Per-signature w_type=0.50 -> KeyError type matches, xfail."""
+    raise KeyError("a_totally_different_key_error_message")
+
+
+# --- Setup and Teardown Phases ---
+
+def test_setup_failure_same_issue(setup_failure_fixture):
+    """TC8a: Fixture fails in setup with matching signature -> xfail."""
+    pass
+
+
+def test_teardown_failure_same_issue(teardown_failure_fixture):
+    """TC8b: Fixture fails in teardown with matching signature -> xfail."""
+    pass
+
+
+# --- Invalid Signature File ---
+
+def test_missing_mandatory_field_static_xfail_with_note():
+    """TC10: Signature file exists but missing mandatory field -> static xfail with note."""
+    pytest.fail("this failure should be caught by static xfail with note")
+
+
+# --- Multiple Issues ---
+
+def test_multi_issue_clear_winner():
+    """TC11: Two issues, one scores high -> xfail on winner."""
+    pytest.fail(load_mocked_failure("multi_issue_interface_down.txt"))
+
+
+def test_multi_issue_all_below_low():
+    """TC12: Two issues, both score low -> failed."""
+    raise KeyError("completely_unrelated_failure_xyz_12345")
+
+
+# --- AI Agent (Mock Server) ---
+
+def test_ai_returns_same_issue(mock_ai):
+    """TC13: Middle range, AI says same_issue -> xfail."""
+    mock_ai([{
+        "status": 200,
+        "body": {
+            "is_same_issue": True,
+            "reasoning": "Both failures are PFC watchdog timer accuracy issues",
+            "processing_time_ms": 500,
+        },
+    }])
+    pytest.fail(load_mocked_failure("middle_range_failure.txt"))
+
+
+def test_ai_returns_different_issue(mock_ai):
+    """TC14: Middle range, AI says different_issue -> failed."""
+    mock_ai([{
+        "status": 200,
+        "body": {
+            "is_same_issue": False,
+            "reasoning": "Different root cause detected",
+            "processing_time_ms": 300,
+        },
+    }])
+    pytest.fail(load_mocked_failure("middle_range_failure.txt"))
+
+
+def test_ai_timeout(mock_ai):
+    """TC15: Middle range, AI times out -> xfail fallback."""
+    mock_ai([{
+        "delay": 60,
+        "status": 200,
+        "body": {"is_same_issue": True, "reasoning": "too late", "processing_time_ms": 0},
+    }])
+    pytest.fail(load_mocked_failure("middle_range_failure.txt"))
+
+
+def test_ai_error_500(mock_ai):
+    """TC16: Middle range, AI returns 500 -> xfail fallback."""
+    mock_ai([{
+        "status": 500,
+        "body": {"error": "internal server error"},
+    }])
+    pytest.fail(load_mocked_failure("middle_range_failure.txt"))
+
+
+def test_ai_malformed_response(mock_ai):
+    """TC17: Middle range, AI returns invalid JSON -> xfail fallback."""
+    mock_ai([{
+        "status": 200,
+        "body": {"garbage": True, "no_is_same_issue_field": 42},
+    }])
+    pytest.fail(load_mocked_failure("middle_range_failure.txt"))
+
+
+def test_ai_disabled_fallback(monkeypatch):
+    """TC18: Middle range, AI URL empty -> xfail fallback."""
+    monkeypatch.setattr(failure_signature, "XFAIL_AI_AGENT_URL", "")
+    pytest.fail(load_mocked_failure("middle_range_failure.txt"))
+
+
+# --- Multi-Issue AI Disambiguation ---
+
+def test_multi_issue_ai_one_match(mock_ai):
+    """TC19: Two issues close scores, AI matches one -> xfail."""
+    mock_ai([
+        {"status": 200, "body": {
+            "is_same_issue": True,
+            "reasoning": "BGP route redistribution failure matches",
+            "processing_time_ms": 600}},
+        {"status": 200, "body": {
+            "is_same_issue": False,
+            "reasoning": "OSPF redistribution is a different issue",
+            "processing_time_ms": 400}},
+    ])
+    pytest.fail(load_mocked_failure("multi_issue_close_scores.txt"))
+
+
+def test_multi_issue_ai_none_match(mock_ai):
+    """TC20: Two issues close scores, AI rejects both -> failed."""
+    mock_ai([
+        {"status": 200, "body": {
+            "is_same_issue": False,
+            "reasoning": "Not a BGP redistribution issue",
+            "processing_time_ms": 500}},
+        {"status": 200, "body": {
+            "is_same_issue": False,
+            "reasoning": "Not an OSPF redistribution issue",
+            "processing_time_ms": 500}},
+    ])
+    pytest.fail(load_mocked_failure("multi_issue_close_scores.txt"))
+
+
+def test_multi_issue_ai_all_error(mock_ai):
+    """TC21: Two issues close scores, AI errors -> xfail fallback."""
+    mock_ai([
+        {"status": 500, "body": {"error": "server error"}},
+        {"status": 500, "body": {"error": "server error"}},
+    ])
+    pytest.fail(load_mocked_failure("multi_issue_close_scores.txt"))
+
+
+# --- Edge Case ---
+
+def test_no_excinfo_fallback():
+    """TC22: Test passes with no _dynamic_xfail_info -> PASSED."""
+    pass

--- a/tests/common/plugins/conditional_mark/integration_test/test_fvxfail_mock_wrapper.py
+++ b/tests/common/plugins/conditional_mark/integration_test/test_fvxfail_mock_wrapper.py
@@ -1,0 +1,170 @@
+"""Wrapper test that runs the FV-xfail mock integration tests as a subprocess
+and validates the pytest results.
+
+This test runs test_fvxfail_mock.py via subprocess, parses the short test
+summary, and asserts that each test case produced the expected outcome.
+
+Usage:
+    pytest common/plugins/conditional_mark/integration_test/test_fvxfail_mock_wrapper.py ...
+"""
+
+import os
+import subprocess
+import pytest
+
+from tests.common.plugins.conditional_mark.integration_test.conftest import (
+    build_pytest_cmd, parse_summary,
+)
+
+pytestmark = [pytest.mark.disable_memory_utilization, pytest.mark.skip_check_dut_health,
+              pytest.mark.disable_loganalyzer]
+
+_THIS_DIR = os.path.dirname(__file__)
+
+
+# Expected outcomes for each test in test_fvxfail_mock.py
+EXPECTED = {
+    # Core Decision Logic
+    "test_same_failure_high_similarity": {
+        "outcome": "xfail",
+        "detail_contains": ["high threshold", "same issue"],
+    },
+    "test_different_failure_low_similarity": {
+        "outcome": "failed",
+    },
+    "test_no_signature_file_no_fvxfail": {
+        "outcome": "failed",
+    },
+    "test_passed_no_interference": {
+        "outcome": "passed",
+    },
+    # Threshold and Weight Overrides
+    "test_custom_high_threshold": {
+        "outcome": "xfail",
+        "detail_contains": ["high threshold", "same issue"],
+    },
+    "test_custom_low_threshold": {
+        "outcome": "failed",
+    },
+    "test_custom_weights": {
+        "outcome": "xfail",
+        "detail_contains": ["high threshold", "same issue"],
+    },
+    # Setup and Teardown Phases
+    "test_setup_failure_same_issue": {
+        "outcome": "xfail",
+        "detail_contains": ["same issue"],
+    },
+    "test_teardown_failure_same_issue": {
+        "outcome": "xfail",
+        "detail_contains": ["same issue"],
+    },
+    # Invalid Signature File
+    "test_missing_mandatory_field_static_xfail_with_note": {
+        "outcome": "xfail",
+        "detail_contains": ["no valid signatures could be loaded"],
+    },
+    # Multiple Issues
+    "test_multi_issue_clear_winner": {
+        "outcome": "xfail",
+        "detail_contains": ["high threshold", "same issue"],
+    },
+    "test_multi_issue_all_below_low": {
+        "outcome": "failed",
+    },
+    # AI Agent (Mock Server)
+    "test_ai_returns_same_issue": {
+        "outcome": "xfail",
+        "detail_contains": ["AI agent decision: same_issue"],
+    },
+    "test_ai_returns_different_issue": {
+        "outcome": "failed",
+    },
+    "test_ai_timeout": {
+        "outcome": "xfail",
+        "detail_contains": ["unavailable"],
+    },
+    "test_ai_error_500": {
+        "outcome": "xfail",
+        "detail_contains": ["unavailable"],
+    },
+    "test_ai_malformed_response": {
+        "outcome": "xfail",
+        "detail_contains": ["unavailable"],
+    },
+    "test_ai_disabled_fallback": {
+        "outcome": "xfail",
+        "detail_contains": ["not configured"],
+    },
+    # Multi-Issue AI Disambiguation
+    "test_multi_issue_ai_one_match": {
+        "outcome": "xfail",
+        "detail_contains": ["AI agent decision: same_issue"],
+    },
+    "test_multi_issue_ai_none_match": {
+        "outcome": "failed",
+    },
+    "test_multi_issue_ai_all_error": {
+        "outcome": "xfail",
+        "detail_contains": ["unavailable"],
+    },
+    # Edge Case
+    "test_no_excinfo_fallback": {
+        "outcome": "passed",
+    },
+}
+
+
+def test_fvxfail_mock_all():
+    """Run all mock FV-xfail tests and validate outcomes."""
+    test_file = "common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py"
+    cmd = build_pytest_cmd(test_file)
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        cwd=os.path.join(_THIS_DIR, "../../../.."),
+        env=env,
+    )
+
+    output = result.stdout + result.stderr
+    parsed = parse_summary(output)
+
+    errors = []
+
+    for test_name, expected in EXPECTED.items():
+        if test_name not in parsed:
+            errors.append(f"{test_name}: not found in results")
+            continue
+
+        actual = parsed[test_name]
+        expected_outcome = expected["outcome"]
+
+        if actual["outcome"] != expected_outcome:
+            errors.append(f"{test_name}: expected {expected_outcome}, "
+                          f"got {actual['outcome']}")
+
+        if "detail_contains" in expected:
+            for keyword in expected["detail_contains"]:
+                if keyword not in actual["detail"]:
+                    errors.append(
+                        f"{test_name}: expected '{keyword}' in detail, "
+                        f"not found. detail='{actual['detail'][:200]}'")
+
+    if errors:
+        error_report = "\n".join(errors)
+        # Include the raw summary for debugging
+        summary_section = ""
+        in_summary = False
+        for line in output.splitlines():
+            if "short test summary" in line:
+                in_summary = True
+            if in_summary:
+                summary_section += line + "\n"
+        pytest.fail(f"FV-xfail mock integration test validation failed:\n"
+                    f"{error_report}\n\n"
+                    f"Raw summary:\n{summary_section[:2000]}")

--- a/tests/common/plugins/conditional_mark/integration_test/test_fvxfail_real_ai.py
+++ b/tests/common/plugins/conditional_mark/integration_test/test_fvxfail_real_ai.py
@@ -1,0 +1,29 @@
+"""Integration tests using the real AI agent service.
+
+These tests hit the real AI agent at the URL configured in
+failure_signature.XFAIL_AI_AGENT_URL. They validate that the end-to-end
+flow works with a live LLM backend.
+
+Run directly to see raw pytest results:
+    pytest common/plugins/conditional_mark/integration_test/test_fvxfail_real_ai.py ...
+
+Or run the wrapper test to validate results automatically:
+    pytest common/plugins/conditional_mark/integration_test/test_fvxfail_real_ai_wrapper.py ...
+"""
+
+import pytest
+
+from tests.common.plugins.conditional_mark.integration_test.conftest import load_mocked_failure
+
+pytestmark = [pytest.mark.disable_memory_utilization, pytest.mark.skip_check_dut_health,
+              pytest.mark.disable_loganalyzer]
+
+
+def test_real_ai_same_issue():
+    """Middle range score, real AI should say same_issue."""
+    pytest.fail(load_mocked_failure("middle_range_failure.txt"))
+
+
+def test_real_ai_multi_issue():
+    """Two close-score issues, real AI should match one."""
+    pytest.fail(load_mocked_failure("multi_issue_close_scores.txt"))

--- a/tests/common/plugins/conditional_mark/integration_test/test_fvxfail_real_ai_wrapper.py
+++ b/tests/common/plugins/conditional_mark/integration_test/test_fvxfail_real_ai_wrapper.py
@@ -1,0 +1,85 @@
+"""Wrapper test that runs the FV-xfail real AI integration tests as a
+subprocess and validates the pytest results.
+
+Usage:
+    pytest common/plugins/conditional_mark/integration_test/test_fvxfail_real_ai_wrapper.py ...
+"""
+
+import os
+import subprocess
+import pytest
+
+from tests.common.plugins.conditional_mark.integration_test.conftest import (
+    build_pytest_cmd, parse_summary,
+)
+
+pytestmark = [pytest.mark.disable_memory_utilization, pytest.mark.skip_check_dut_health,
+              pytest.mark.disable_loganalyzer]
+
+_THIS_DIR = os.path.dirname(__file__)
+
+
+EXPECTED = {
+    "test_real_ai_same_issue": {
+        "outcome": "xfail",
+        "detail_contains": ["AI agent decision: same_issue"],
+    },
+    "test_real_ai_multi_issue": {
+        "outcome": "xfail",
+        "detail_contains": ["AI agent decision: same_issue"],
+    },
+}
+
+
+def test_fvxfail_real_ai_all():
+    """Run all real AI FV-xfail tests and validate outcomes."""
+    test_file = "common/plugins/conditional_mark/integration_test/test_fvxfail_real_ai.py"
+    cmd = build_pytest_cmd(test_file)
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        cwd=os.path.join(_THIS_DIR, "../../../.."),
+        env=env,
+    )
+
+    output = result.stdout + result.stderr
+    parsed = parse_summary(output)
+
+    errors = []
+
+    for test_name, expected in EXPECTED.items():
+        if test_name not in parsed:
+            errors.append(f"{test_name}: not found in results")
+            continue
+
+        actual = parsed[test_name]
+        expected_outcome = expected["outcome"]
+
+        if actual["outcome"] != expected_outcome:
+            errors.append(f"{test_name}: expected {expected_outcome}, "
+                          f"got {actual['outcome']}")
+
+        if "detail_contains" in expected:
+            for keyword in expected["detail_contains"]:
+                if keyword not in actual["detail"]:
+                    errors.append(
+                        f"{test_name}: expected '{keyword}' in detail, "
+                        f"not found. detail='{actual['detail'][:200]}'")
+
+    if errors:
+        error_report = "\n".join(errors)
+        summary_section = ""
+        in_summary = False
+        for line in output.splitlines():
+            if "short test summary" in line:
+                in_summary = True
+            if in_summary:
+                summary_section += line + "\n"
+        pytest.fail(f"FV-xfail real AI integration test validation failed:\n"
+                    f"{error_report}\n\n"
+                    f"Raw summary:\n{summary_section[:2000]}")

--- a/tests/common/plugins/conditional_mark/integration_test/tests_mark_conditions_fvxfail_integration.yaml
+++ b/tests/common/plugins/conditional_mark/integration_test/tests_mark_conditions_fvxfail_integration.yaml
@@ -1,0 +1,161 @@
+# Mark conditions for Failure-Validated xfail integration tests.
+# This file is copied to the real mark conditions directory at test startup
+# and removed after tests complete.
+
+# TC18: AI disabled fallback
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_ai_disabled_fallback:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099003"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099003"
+
+# TC16: AI error 500
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_ai_error_500:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099003"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099003"
+
+# TC17: AI malformed response
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_ai_malformed_response:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099003"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099003"
+
+# TC14: AI returns different_issue
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_ai_returns_different_issue:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099003"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099003"
+
+# TC13: AI returns same_issue
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_ai_returns_same_issue:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099003"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099003"
+
+# TC15: AI timeout
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_ai_timeout:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099003"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099003"
+
+# TC5: Custom high threshold
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_custom_high_threshold:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099005"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099005"
+
+# TC6: Custom low threshold
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_custom_low_threshold:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099006"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099006"
+
+# TC7: Custom weights
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_custom_weights:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099007"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099007"
+
+# TC2: Different failure -> failed
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_different_failure_low_similarity:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099002"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099002"
+
+# TC10: Missing mandatory field -> static xfail with note
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_missing_mandatory_field_static_xfail_with_note:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099004"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099004"
+
+# TC21: Multi-issue AI all error
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_multi_issue_ai_all_error:
+  xfail:
+    reason: "Integration test: multi-issue AI"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099012"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099013"
+
+# TC20: Multi-issue AI none match
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_multi_issue_ai_none_match:
+  xfail:
+    reason: "Integration test: multi-issue AI"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099012"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099013"
+
+# TC19: Multi-issue AI one match
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_multi_issue_ai_one_match:
+  xfail:
+    reason: "Integration test: multi-issue AI"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099012"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099013"
+
+# TC12: Multi-issue all below low
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_multi_issue_all_below_low:
+  xfail:
+    reason: "Integration test: multi-issue"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099010"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099011"
+
+# TC11: Multi-issue clear winner
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_multi_issue_clear_winner:
+  xfail:
+    reason: "Integration test: multi-issue"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099010"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099011"
+
+# TC1: High similarity -> xfail
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_same_failure_high_similarity:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099001"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099001"
+
+# TC8a: Setup failure
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_setup_failure_same_issue:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099008"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099008"
+
+# TC8b: Teardown failure
+common/plugins/conditional_mark/integration_test/test_fvxfail_mock.py::test_teardown_failure_same_issue:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099008"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099008"
+
+# Real AI tests
+common/plugins/conditional_mark/integration_test/test_fvxfail_real_ai.py::test_real_ai_multi_issue:
+  xfail:
+    reason: "Integration test: multi-issue AI"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099012"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099013"
+
+common/plugins/conditional_mark/integration_test/test_fvxfail_real_ai.py::test_real_ai_same_issue:
+  xfail:
+    reason: "Integration test: https://github.com/sonic-net/sonic-mgmt/issues/990099003"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/990099003"


### PR DESCRIPTION
### Description of PR

Summary:

Validate whether actual test failures match known issues before applying xfail marks. Uses Sorensen-Dice similarity scoring with configurable thresholds and optional AI agent consultation for ambiguous cases.

- Compare runtime failure signatures against stored YAML signatures
- Three-tier decision: high similarity -> xfail, low -> fail, middle -> AI agent
- Support per-signature threshold/weight overrides and multiple issues per condition
- Exempt loganalyzer teardown failures from processing
- Add integration test suite with mock AI server and real AI wrapper tests

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: other

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result


### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
