### PR TITLE
Support BMC platforms without a Base MAC EEPROM TLV

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -34,6 +34,7 @@ pytestmark = [
 
 REGEX_MAC_ADDRESS = r'^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$'
 REGEX_SERIAL_NUMBER = r'^[A-Za-z0-9\-]+$'
+PLATFORMS_WITHOUT_BASE_MAC_TLV = {'arm64-arista_goldfinch-r0',}
 
 # Chassis API tests that are not available/applicable on BMC topologies
 BMC_SKIPPED_CHASSIS_TESTS = {
@@ -115,6 +116,10 @@ class TestChassisApi(PlatformApiTestBase):
     #
     # Helper functions
     #
+    @staticmethod
+    def lacks_base_mac_tlv(duthost):
+        return duthost.facts.get('platform') in PLATFORMS_WITHOUT_BASE_MAC_TLV
+
     def compare_value_with_platform_facts(self, duthost, key, value):
         expected_value = None
 
@@ -243,11 +248,13 @@ class TestChassisApi(PlatformApiTestBase):
 
         MINIMUM_REQUIRED_TYPE_CODES_LIST = [
             ONIE_TLVINFO_TYPE_CODE_SERIAL_NUMBER,
-            ONIE_TLVINFO_TYPE_CODE_BASE_MAC_ADDR,
             ONIE_TLVINFO_TYPE_CODE_CRC32
         ]
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        base_mac_tlv_missing = self.lacks_base_mac_tlv(duthost)
+        if not base_mac_tlv_missing:
+            MINIMUM_REQUIRED_TYPE_CODES_LIST.append(ONIE_TLVINFO_TYPE_CODE_BASE_MAC_ADDR)
         syseeprom_info_dict = chassis.get_system_eeprom_info(platform_api_conn)
         # Convert all keys of syseeprom_info_dict into lower case
         syseeprom_info_dict = {k.lower(): v for k, v in list(syseeprom_info_dict.items())}
@@ -266,11 +273,11 @@ class TestChassisApi(PlatformApiTestBase):
         # Ensure that we were able to obtain the minimum required type codes
         pytest_assert(set(MINIMUM_REQUIRED_TYPE_CODES_LIST) <= set(syseeprom_type_codes_list),
                       "Minimum required TlvInfo type codes not provided")
-
-        # Ensure the base MAC address is sane
-        base_mac = syseeprom_info_dict[ONIE_TLVINFO_TYPE_CODE_BASE_MAC_ADDR]
-        pytest_assert(base_mac is not None, "Failed to retrieve base MAC address")
-        pytest_assert(re.match(REGEX_MAC_ADDRESS, base_mac), "Base MAC address appears to be incorrect")
+        if not base_mac_tlv_missing:
+            # Ensure the base MAC address is sane
+            base_mac = syseeprom_info_dict[ONIE_TLVINFO_TYPE_CODE_BASE_MAC_ADDR]
+            pytest_assert(base_mac is not None, "Failed to retrieve base MAC address")
+            pytest_assert(re.match(REGEX_MAC_ADDRESS, base_mac), "Base MAC address appears to be incorrect")
 
         # Ensure the serial number is sane
         serial = syseeprom_info_dict[ONIE_TLVINFO_TYPE_CODE_SERIAL_NUMBER]
@@ -282,6 +289,9 @@ class TestChassisApi(PlatformApiTestBase):
         expected_syseeprom_info_dict = {k.lower(): v for k, v in list(expected_syseeprom_info_dict.items())}
 
         for field in expected_syseeprom_info_dict:
+            if (base_mac_tlv_missing and field == ONIE_TLVINFO_TYPE_CODE_BASE_MAC_ADDR.lower()):
+                # Platform does not have a Base MAC TLV.
+                continue
             pytest_assert(field in syseeprom_info_dict, "Expected field '{}' not present in syseeprom on '{}'"
                           .format(field, duthost.hostname))
 

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -34,7 +34,7 @@ pytestmark = [
 
 REGEX_MAC_ADDRESS = r'^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$'
 REGEX_SERIAL_NUMBER = r'^[A-Za-z0-9\-]+$'
-PLATFORMS_WITHOUT_BASE_MAC_TLV = {'arm64-arista_goldfinch-r0',}
+PLATFORMS_WITHOUT_BASE_MAC_TLV = {'arm64-arista_goldfinch-r0', }
 
 # Chassis API tests that are not available/applicable on BMC topologies
 BMC_SKIPPED_CHASSIS_TESTS = {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Update the chassis EEPROM test to support Goldfinch BMC, whose BMC EEPROM does not contain a Base MAC TLV.

Fixes #27553 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [X] 202608

Tracking issue: https://github.com/sonic-net/sonic-mgmt/issues/27553

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [X] 202608
- [ ] N/A

### Test result
<!--
Provide the tested im
age version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
Kusto GUID: 106ff985-4a86-4a7c-8bae-36c5b01eb1ca
[test_get_eeprom.log](https://github.com/user-attachments/files/31677653/test_get_eeprom.log)
### Approach

#### What is the motivation for this PR?

The chassis EEPROM test requires a Base MAC TLV, but the Goldfinch BMC EEPROM does not provide one.
#### How did you do it?

Added Goldfinch to the list of platforms without a Base MAC TLV and conditionally skipped the Base MAC presence and value checks
#### How did you verify/test it?

Ran `TestChassisApi::test_get_system_eeprom_info` on Goldfinch BMC and confirmed that the remaining EEPROM fields were still validated.
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

Platform: `arm64-arista_goldfinch-r0`. The BMC management MAC is derived from the host CPU EEPROM MAC using an offset of [`3`.](url)

