### PR TITLE
Stabilize VXLAN PTF packet collection

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/vxlan_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan_traffic.py
@@ -140,7 +140,7 @@ class VXLAN(BaseTest):
             2. Load the configs from the input files.
             3. Ready the mapping of destination->nexthops.
         '''
-        self.PACKETS_PER_ITERATION = 1000  # Number of packets to send before polling for responses
+        self.PACKETS_PER_ITERATION = 250  # Keep bursts below the PTF queue capacity.
         self.check_underlay_ecmp = True
         self.dataplane = ptf.dataplane_instance
         self.test_params = test_params_get()

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -514,7 +514,7 @@ class Test_VxLAN():
                    else "vxlan_traffic.VXLAN",
                    platform_dir="ptftests",
                    params=ptf_params,
-                   qlen=1000,
+                   qlen=4096,
                    log_file="/tmp/vxlan-tests.{}.{}.{}.log".format(
                        tcname,
                        encap_type,


### PR DESCRIPTION
### Description of PR

Summary:

Stabilize VXLAN packet collection during high-volume entropy tests. The test currently sends up to 1,000 packets before polling while using a receive queue of the same size, which can overflow before responses are consumed and cause packet-accounting failures.

Fixes #27755

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #27755
Failure type: other

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: passed
- 202605: passed

### Approach
#### What is the motivation for this PR?

Large VXLAN traffic bursts can fill the PTF receive queue before polling starts. Dropped responses then make packet accounting and ECMP validation fail even when forwarding is correct.

#### How did you do it?

Reduce each send batch from 1,000 to 250 packets so responses are polled more frequently, and increase the PTF receive queue depth from 1,000 to 4,096 for additional headroom.

#### How did you verify/test it?

Ran Python compilation checks for both modified files, verified the patch with `git diff --check`, and reviewed the public PR CI result.

#### Any platform specific information?

No platform-specific behavior is introduced.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No user-facing behavior or interface changed.