### PR TITLE
[qos][mellanox] Relax SN4700 lossy watermark tolerances

### DIFF
--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -302,7 +302,15 @@ class QosParamMellanox(object):
                     else:
                         qos_params_dict[sub_qos_config_key] = sub_qos_config_value
 
-        if int(self.asic_type.split('spc')[1]) >= 4:
+        asic_generation = int(self.asic_type.split('spc')[1])
+        lower_bound_margin_ratio = 0.001
+        if asic_generation >= 3:
+            self.qos_params_mlnx['wm_pg_shared_lossy']['pkts_num_margin_lower_bound'] = max(
+                self.qos_params_mlnx['wm_pg_shared_lossy'].get('pkts_num_margin_lower_bound', 0),
+                int(self.qos_params_mlnx['wm_pg_shared_lossy']['pkts_num_trig_egr_drp']
+                    * lower_bound_margin_ratio))
+
+        if asic_generation >= 4:
             margin_ratio = 0.02
             self.qos_params_mlnx['lossy_queue_1']['pkts_num_margin'] = int(
                 self.qos_params_mlnx['lossy_queue_1']['pkts_num_trig_egr_drp'] * margin_ratio)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -6486,7 +6486,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 assert (q_wm_res[queue] <= (margin + 1) * cell_size)
             elif pkts_num_fill_min:
                 assert (q_wm_res[queue] == 0)
-            elif 'cisco-8000' in asic_type or "SN56" in hwsku or "SN5400" in hwsku:
+            elif 'cisco-8000' in asic_type or "SN56" in hwsku or "SN5400" in hwsku or "SN4700" in hwsku:
                 assert (q_wm_res[queue] <= (margin + 1) * cell_size)
             else:
                 if platform_asic and platform_asic == "broadcom-dnx":


### PR DESCRIPTION
Add a lower-bound margin for SPC3+ PG shared-watermark checks to accommodate hardware watermark sampling granularity.

Use the configured queue watermark margin during the SN4700 initial queue check instead of enforcing a strict one-cell limit. This prevents intermittent false failures while retaining bounded watermark checks.

Adapt the lower-bound margin independently so the existing Spectrum-4+ watermark margin on public master remains unchanged.

Internal-source-commit: d4e94fd79018f474344b5c62bdf797396a0ac13a

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
QoS watermark tests can fail intermittently on Mellanox/NVIDIA SN4700 systems because hardware watermark sampling granularity produces small deviations from the exact expected values. The existing strict lower-bound and initial queue-watermark checks can therefore report false failures even when the observed watermark remains within a small, bounded range.

#### How did you do it?
Added a 0.1% lower-bound packet margin for PG shared-lossy watermark validation on Spectrum-3 and newer ASICs. Also added SN4700 to the platforms that use the configured queue-watermark margin during the initial queue check.

While porting the internal change to public `master`, the lower-bound ratio was kept separate from the existing Spectrum-4+ 0.2% watermark margin so that current public behavior is not regressed

#### How did you verify/test it?
The change was ported from the internal SN4700 branch and reconciled with the current public `master` implementation.
Ran test plan
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?
The initial queue-watermark relaxation is specific to Mellanox/NVIDIA SN4700 systems. The PG shared-lossy lower-bound margin applies to Spectrum-3 and newer Mellanox/NVIDIA ASIC generations.

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
