### PR TITLE
[202605 Workaround] Add BMC Redfish PDU controller for setups without SNMP PDU

### DIFF
--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -4,6 +4,7 @@ import re
 
 import pytest
 from .pdu_manager import pdu_manager_factory
+from .bmc_pdu_controller import get_bmc_controller
 from tests.common.utilities import get_host_visible_vars, get_sup_node_or_random_node
 
 
@@ -73,6 +74,28 @@ def get_pdu_visible_vars(inventories, pdu_hostnames):
     return pdu_hosts_vars
 
 
+def _get_bmc_controller_from_inventory(duthost):
+    """
+    Check if the DUT's inventory defines an BMC PDU host (protocol=bmc).
+    If so, create and return an BmcPduController.
+
+    @return: BmcPduController instance or None.
+    """
+    pdu_hosts = get_pdu_hosts(duthost)
+    for pdu_name, pdu_vars in pdu_hosts.items():
+        protocol = pdu_vars.get("protocol", "")
+        if protocol == "bmc":
+            bmc_host = pdu_vars.get("ansible_host", pdu_name)
+            resolved_vars = resolve_env_variables(pdu_vars)
+            controller = get_bmc_controller(bmc_host, resolved_vars, duthost.hostname)
+            if controller:
+                logger.info(f"Created BMC PDU controller for {duthost.hostname} via BMC {bmc_host}")
+                return controller
+            else:
+                logger.warning(f"Failed to create BMC PDU controller for BMC {bmc_host}")
+    return None
+
+
 def _get_pdu_controller(duthost, conn_graph_facts):
     hostname = duthost.hostname
     # To adapt to the kvm testbed, conn_graph_facts is None for kvm.
@@ -88,7 +111,14 @@ def _get_pdu_controller(duthost, conn_graph_facts):
     pdu_info = device_pdu_info.get(hostname, {})
     pdu_vars = get_pdu_visible_vars(duthost.host.options["inventory_manager"]._sources, pdu_info.keys())
 
-    return pdu_manager_factory(duthost.hostname, pdu_links, pdu_info, pdu_vars)
+    controller = pdu_manager_factory(duthost.hostname, pdu_links, pdu_info, pdu_vars)
+
+    # Fallback: if the connection graph did not yield a controller, check inventory
+    # for an BMC PDU host (protocol=bmc).
+    if controller is None:
+        controller = _get_bmc_controller_from_inventory(duthost)
+
+    return controller
 
 
 @pytest.fixture(scope="module")

--- a/tests/common/plugins/pdu_controller/bmc_pdu_controller.py
+++ b/tests/common/plugins/pdu_controller/bmc_pdu_controller.py
@@ -1,0 +1,182 @@
+"""
+BMC PDU controller implementation using Redfish API.
+
+This controller uses the Redfish ComputerSystem.Reset action exposed by
+BMCs to perform power-off, power-on, and power-cycle
+operations.  It implements the same PduControllerBase interface used by
+SNMP-based controllers so that it can be used transparently by the
+existing test infrastructure.
+
+Inventory configuration example (INI format):
+    [pdu]
+    pdu-sn6600_ld-bmc  ansible_host=sn6600_ld-bmc  protocol=bmc  bmc_user=<user>  bmc_password=<password>
+
+Inventory configuration example (YAML format):
+    pdu:
+      hosts:
+        pdu-sn6600_ld-bmc:
+          ansible_host: sn6600_ld-bmc
+          protocol: bmc
+          bmc_user: <user>
+          bmc_password: <password>
+"""
+
+import logging
+
+from .controller_base import PduControllerBase
+
+logger = logging.getLogger(__name__)
+
+try:
+    import requests
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
+
+
+class BmcPduController(PduControllerBase):
+    """
+    PDU controller that drives power operations through an BMC Redfish interface.
+
+    The controller discovers the system resource URI from the BMC at init time
+    and uses the ComputerSystem.Reset action for turn_off / turn_on.
+    """
+
+    RESET_ACTION_SUFFIX = "/Actions/ComputerSystem.Reset"
+
+    def __init__(self, bmc_host, bmc_user, bmc_password, dut_hostname):
+        """
+        @param bmc_host: BMC hostname or IP address.
+        @param bmc_user: BMC username (e.g. "root").
+        @param bmc_password: BMC password.
+        """
+        super().__init__()
+
+        if not HAS_REQUESTS:
+            raise RuntimeError("The 'requests' Python package is required for BmcPduController")
+
+        self.bmc_host = bmc_host
+        self.dut_hostname = dut_hostname
+        self.base_url = f"https://{bmc_host}"  # noqa: E231
+        self.auth = (bmc_user, bmc_password)
+
+        # Discover the system resource URI (e.g. /redfish/v1/Systems/System_0)
+        self.system_uri = self._discover_system_uri()
+        self.reset_url = f"{self.base_url}{self.system_uri}{self.RESET_ACTION_SUFFIX}"
+
+        logger.info(f"BmcPduController initialised for {bmc_host} (system URI: {self.system_uri})")
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+    def _discover_system_uri(self):
+        """Query /redfish/v1/Systems/ and return the @odata.id of the first member."""
+        url = f"{self.base_url}/redfish/v1/Systems/"
+        try:
+            resp = requests.get(url, auth=self.auth, verify=False, timeout=30)
+            resp.raise_for_status()
+            members = resp.json().get("Members", [])
+            if not members:
+                raise RuntimeError(f"No system members found at {url}")
+            system_uri = members[0]["@odata.id"]
+            logger.info(f"Discovered Redfish system URI: {system_uri}")
+            return system_uri.rstrip("/")
+        except Exception as e:
+            logger.error(f"Failed to discover Redfish system URI from {url}: {e}")
+            raise
+
+    # ------------------------------------------------------------------
+    # PduControllerBase interface
+    # ------------------------------------------------------------------
+    def turn_off_outlet(self, outlet=None):
+        """
+        Power off the system via Redfish ForceOff.
+
+        @param outlet: Ignored -- BMC controls the whole system, not individual outlets.
+        @return: True if the command succeeded, False otherwise.
+        """
+        return self._send_reset("ForceOff")
+
+    def turn_on_outlet(self, outlet=None):
+        """
+        Power on the system via Redfish On.
+
+        @param outlet: Ignored.
+        @return: True if the command succeeded, False otherwise.
+        """
+        return self._send_reset("On")
+
+    def get_outlet_status(self, outlet=None, hostname=None):
+        """
+        Query the BMC for the current PowerState and return a synthetic outlet list.
+
+        @return: A list with a single dict: [{"outlet_id": "bmc", "outlet_on": True/False}]
+        """
+        url = f"{self.base_url}{self.system_uri}"
+        try:
+            resp = requests.get(url, auth=self.auth, verify=False, timeout=30)
+            resp.raise_for_status()
+            power_state = resp.json().get("PowerState", "Unknown")
+            is_on = power_state.lower() == "on"
+            logger.info(f"BMC {self.bmc_host} PowerState: {power_state}")
+            return [{"outlet_id": "bmc", "outlet_on": is_on}]
+        except Exception as e:
+            logger.error(f"Failed to get power state from {self.bmc_host}: {e}")
+            return []
+
+    def close(self):
+        """No persistent connection to close."""
+        pass
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _send_reset(self, reset_type):
+        """
+        POST the ComputerSystem.Reset action with the given ResetType.
+
+        @param reset_type: One of "ForceOff", "On", "ForceRestart", "PowerCycle", etc.
+        @return: True on success, False on failure.
+        """
+        payload = {"ResetType": reset_type}
+        logger.info(f"Sending Redfish Reset({reset_type}) to {self.bmc_host}")
+        try:
+            resp = requests.post(
+                self.reset_url,
+                auth=self.auth,
+                json=payload,
+                verify=False,
+                timeout=30,
+            )
+            if resp.ok:
+                logger.info(f"Redfish Reset({reset_type}) succeeded on {self.bmc_host}")
+                return True
+            else:
+                logger.error(f"Redfish Reset({reset_type}) failed on {self.bmc_host}: "
+                             f"HTTP {resp.status_code} - {resp.text}")
+                return False
+        except Exception as e:
+            logger.error(f"Redfish Reset({reset_type}) exception on {self.bmc_host}: {e}")
+            return False
+
+
+def get_bmc_controller(bmc_host, pdu_vars, dut_hostname):
+    """
+    Factory helper to create an BmcPduController from inventory variables.
+
+    @param bmc_host: BMC hostname or IP (from ansible_host).
+    @param pdu_vars: Dict of inventory variables for the PDU host.
+    @return: An BmcPduController instance, or None on failure.
+    """
+    bmc_user = pdu_vars.get("bmc_user")
+    bmc_password = pdu_vars.get("bmc_password")
+    if not bmc_user or not bmc_password:
+        logger.error(f"bmc_user and bmc_password must be set in inventory for BMC PDU host {bmc_host}")
+        return None
+    try:
+        return BmcPduController(bmc_host, bmc_user, bmc_password, dut_hostname)
+    except Exception as e:
+        logger.error(f"Failed to create BmcPduController for {bmc_host}: {e}")
+        return None


### PR DESCRIPTION
### Description of PR

Summary:
This is temporary workaround in 202605 to enable power cycle reboot on the devices that are not connected to a PDU but can be controlled by a BMC, eg. sn6600_ld.

Implement BmcPduController as a PduControllerBase subclass that uses the Redfish ComputerSystem.Reset API to perform power off/on operations via the BMC. The controller is configured in the inventory file with protocol=bmc and auto-discovers the system URI at init time.

This replaces the previous workaround that returned a dict instead of a proper controller object, which required isinstance checks in every consumer. The new controller works transparently with all existing tests.

Example in the inventory file:
sn6600_ld-18  ansible_host=xx.xx.xx.xx sonic_version=v2  sonic_hwsku=Mellanox-SN6600_LD-P128C2 iface_speed=800000 serial_console= ptf_host=ptf-18 ptf_portmap= **pdu_host=pdu-18-bmc**
pdu-sn6600_ld-18-bmc  ansible_host=sn6600_ld-18-bmc  **protocol=bmc**  **bmc_user**=root  **bmc_password**=xxxxx

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:other

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
202605: Fwutil CPLD test(requires power cycle) on SN6600_LD passed
<img width="989" height="243" alt="image" src="https://github.com/user-attachments/assets/d0d19206-42ac-4592-9f91-c1c08a33d163" />

202605: test_power_off_reboot passed
<img width="307" height="209" alt="image" src="https://github.com/user-attachments/assets/6f9a8ba5-3fc7-4002-a90e-db545bb7d8cb" />


### Approach
#### What is the motivation for this PR?
Enable the power cycle reboot on the devices that are not connected to a PDU but can be controlled by a BMC.
#### How did you do it?
Implement BmcPduController as a PduControllerBase subclass that uses the Redfish ComputerSystem.
#### How did you verify/test it?
Run the tests that require a power cycle on sn6600_ld in 202605 branch, for example the test_power_off_reboot, fwutil CPLD test.
```
INFO     tests.common.plugins.pdu_controller.pdu_manager:pdu_manager.py:271 Creating pdu manager object
INFO     tests.common.plugins.pdu_controller.pdu_manager:pdu_manager.py:246 Creating pdu manager
DEBUG    urllib3.connectionpool:connectionpool.py:1062 Starting new HTTPS connection (1): sn6600_ld-110-bmc:443
DEBUG    urllib3.connectionpool:connectionpool.py:544 https://sn6600_ld-110-bmc:443 "GET /redfish/v1/Systems/ HTTP/1.1" 200 261
INFO     tests.common.plugins.pdu_controller.bmc_pdu_controller:bmc_pdu_controller.py:84 Discovered Redfish system URI: /redfish/v1/Systems/System_0
INFO     tests.common.plugins.pdu_controller.bmc_pdu_controller:bmc_pdu_controller.py:69 BmcPduController initialised for sn6600_ld-110-bmc (system URI: /redfish/v1/Systems/System_0)
INFO     tests.common.plugins.pdu_controller:__init__.py:92 Created BMC PDU controller for sn6600_ld-110 via BMC sn6600_ld-110-bmc
DEBUG    urllib3.connectionpool:connectionpool.py:1062 Starting new HTTPS connection (1): sn6600_ld-110-bmc:443
DEBUG    urllib3.connectionpool:connectionpool.py:544 https://sn6600_ld-110-bmc:443 "GET /redfish/v1/Systems/System_0 HTTP/1.1" 200 2720
INFO     tests.common.plugins.pdu_controller.bmc_pdu_controller:bmc_pdu_controller.py:123 BMC sn6600_ld-110-bmc PowerState: On
DEBUG    urllib3.connectionpool:connectionpool.py:1062 Starting new HTTPS connection (1): sn6600_ld-110-bmc:443
DEBUG    urllib3.connectionpool:connectionpool.py:544 https://sn6600_ld-110-bmc:443 "GET /redfish/v1/Systems/System_0 HTTP/1.1" 200 2720
INFO     tests.common.plugins.pdu_controller.bmc_pdu_controller:bmc_pdu_controller.py:123 BMC sn6600_ld-110-bmc PowerState: On
INFO     root:test_power_off_reboot.py:152 Got all power on sequences [[{'outlet_id': 'bmc', 'outlet_on': True, 'psu_name': 'all', 'pdu_name': 'bmc', 'feed_name': 'A'}], [{'outlet_id': 'bmc', 'outlet_on': True, 'psu_name': 'all', 'pdu_name': 'bmc', 'feed_name': 'A'}]]
```

#### Any platform specific information?
The change only affect the devices with BMC.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
