### PR TITLE
[BMC] Skip fdb/test_fdb_mac_move.py on BMC topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2346,6 +2346,12 @@ fdb/test_fdb_mac_learning.py::TestFdbMacLearning::testFdbMacLearning:
     conditions:
       - "'dualtor-aa' in topo_name and https://github.com/sonic-net/sonic-mgmt/issues/16110"
 
+fdb/test_fdb_mac_move.py:
+  skip:
+    reason: "FDB tests require switching ASIC, not available on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 fdb/test_fdb_mac_move.py::test_fdb_mac_move_guard_disable_mac_learning:
   skip:
     reason: "Currently not supported on virtual switch."


### PR DESCRIPTION
### Description of PR

Summary:
On `bmc` topology testbeds, `tests/fdb/test_fdb_mac_move.py` is the only fdb testfile that runs (it is marked `topology('any')`; the rest of the suite skips via `t0`/`m0`/`mx` topology marks or runtime VLAN checks), and all of its tests fail because the BMC has no switching ASIC, front-panel ports, or VLAN configuration (`KeyError: 'VLAN'` / "DUT has no VLAN/VLAN_MEMBER configuration"). FDB/MAC-move is a switching-ASIC function, so these tests are not applicable on BMC and should be skipped.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: verified on a SONiC BMC testbed — with this change the `test_fdb_mac_move.py` testcases are skipped.

### Approach
#### What is the motivation for this PR?

The fdb suite fails on SONiC BMC testbeds: the three tests in `test_fdb_mac_move.py` run on `bmc` topology and fail, since the BMC has no switching ASIC or VLAN configuration to exercise MAC learning and MAC move.

#### How did you do it?

Added a file-level entry to `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` skipping `fdb/test_fdb_mac_move.py` when `'bmc' in topo_type`, with reason "FDB tests require switching ASIC, not available on BMC".

#### How did you verify/test it?

- Ran the fdb suite on a SONiC BMC testbed: the `test_fdb_mac_move.py` testcases are skipped with this change.

#### Any platform specific information?

Applies only to `bmc` topology testbeds. No effect on switch platforms or virtual switch (the existing per-test `vs` skip entries still apply).

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
