### PR TITLE
[route][202511] Backport test_route_consistency timing fixes (#22596, #23098, #25892)

### DIFF
--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -206,7 +206,15 @@ class TestRouteConsistency():
             logger.info("advertise ipv4 and ipv6 routes for {}".format(topo_name))
             localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
 
-            assert wait_until(self.sleep_interval + 300, 10, 0, self.route_snapshots_match,
+            # The withdraw + re-advertise cycle re-installs the entire route table twice. On very
+            # large-scale VOQ topologies (~100k+ prefixes) exact ASIC_DB reconvergence takes far longer
+            # than the default margin (measured ~1400s for ~102k prefixes on a large-scale VOQ max topology,
+            # where sleep_interval + 300 = 455s was not enough). wait_until() returns as soon as the
+            # route snapshots match, so smaller/faster testbeds are unaffected by the larger ceiling.
+            route_reconverge_timeout = self.sleep_interval + 300
+            if self.sleep_interval > 150:
+                route_reconverge_timeout = self.sleep_interval + 1500
+            assert wait_until(route_reconverge_timeout, 10, 0, self.route_snapshots_match,
                               duthosts, self.pre_test_route_snapshot), (
                 "Route snapshots did not match within the specified timeout for DUT hosts: '{}'.".format(
                     duthosts

--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -214,13 +214,13 @@ class TestRouteConsistency():
             )
 
             logger.info("Route table is consistent across all the DUTs")
-        except Exception as e:
-            logger.error("Exception occurred: {}".format(e))
+        except (Exception, pytest.fail.Exception) as e:
+            logger.error("Exception occurred: {}. Re-announcing routes to recover!".format(e))
             # announce the routes back in case of any exception
             localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
             wait_until(self.sleep_interval, 10, 0, self.route_snapshots_match,
                        duthosts, self.pre_test_route_snapshot)
-            raise e
+            raise
 
     def test_bgp_shut_noshut(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, localhost):
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
@@ -255,10 +255,12 @@ class TestRouteConsistency():
             for dut_instance_name in self.pre_test_route_snapshot.keys():
                 assert self.pre_test_route_snapshot[dut_instance_name] == post_test_route_snapshot[dut_instance_name]
             logger.info("Route table is consistent across all the DUTs")
-        except Exception:
+        except (Exception, pytest.fail.Exception) as e:
             # startup bgp back in case of any exception
+            logger.error("Exception occurred: {}. Starting up BGP to recover!".format(e))
             duthost.shell("sudo config bgp startup all")
             wait_until(self.sleep_interval, 10, 0, is_all_neighbor_session_established, duthost)
+            raise
 
     @pytest.mark.disable_loganalyzer
     @pytest.mark.parametrize("container_name, program_name", [
@@ -311,8 +313,9 @@ class TestRouteConsistency():
             for dut_instance_name in self.pre_test_route_snapshot.keys():
                 assert self.pre_test_route_snapshot[dut_instance_name] == post_test_route_snapshot[dut_instance_name]
             logger.info("Route table is consistent across all the DUTs")
-        except Exception:
+        except (Exception, pytest.fail.Exception) as e:
             # startup bgpd back in case of any exception
-            logger.info("Encountered error. Perform a config reload to recover!")
+            logger.error("Encountered error: {}. Perform a config reload to recover!".format(e))
             config_reload(duthost)
             wait_until(self.sleep_interval, 10, 0, is_all_neighbor_session_established, duthost)
+            raise

--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -3,8 +3,8 @@ import logging
 import threading
 import queue
 import re
-import time
 import math
+import time
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.dut_utils import get_program_info
 from tests.common.config_reload import config_reload
@@ -128,6 +128,22 @@ class TestRouteConsistency():
                 return False
         return True
 
+    def routes_have_changed(self, duthosts, previous_route_snapshot):
+        """Check that the route table has changed from a previous snapshot on ANY DUT.
+
+        Returns True when at least one DUT's route table differs from the previous snapshot,
+        indicating that convergence has started. On non-VOQ single-asic topologies the snapshot
+        is empty (get_route_prefix_snapshot_from_asicdb only collects VOQ/chassis data), so
+        return True immediately to avoid blocking on an always-empty comparison.
+        """
+        if not previous_route_snapshot:
+            return True
+        new_route_snapshot, _ = self.get_route_prefix_snapshot_from_asicdb(duthosts)
+        for dut_instance_name in previous_route_snapshot.keys():
+            if previous_route_snapshot[dut_instance_name] != new_route_snapshot[dut_instance_name]:
+                return True
+        return False
+
     def test_route_withdraw_advertise(self, duthosts, tbinfo, localhost):
 
         # withdraw the routes
@@ -137,7 +153,9 @@ class TestRouteConsistency():
         try:
             logger.info("withdraw ipv4 and ipv6 routes for {}".format(topo_name))
             localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
-            time.sleep(self.sleep_interval)
+            pytest_assert(wait_until(self.sleep_interval, 10, 15, self.routes_have_changed,
+                                     duthosts, self.pre_test_route_snapshot),
+                          "Routes were not withdrawn within {} seconds".format(self.sleep_interval))
 
             """ compare the number of routes withdrawn from all the DUTs. In working condition, the number of routes
                 withdrawn should be same across all the DUTs.
@@ -165,15 +183,21 @@ class TestRouteConsistency():
 
             logger.info("advertise ipv4 and ipv6 routes for {}".format(topo_name))
             localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
-            time.sleep(self.sleep_interval)
 
-            assert wait_until(300, 10, 0, self.route_snapshots_match, duthosts, self.pre_test_route_snapshot)
+            assert wait_until(self.sleep_interval + 300, 10, 0, self.route_snapshots_match,
+                              duthosts, self.pre_test_route_snapshot), (
+                "Route snapshots did not match within the specified timeout for DUT hosts: '{}'.".format(
+                    duthosts
+                )
+            )
+
             logger.info("Route table is consistent across all the DUTs")
         except Exception as e:
             logger.error("Exception occurred: {}".format(e))
             # announce the routes back in case of any exception
             localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
-            time.sleep(self.sleep_interval)
+            wait_until(self.sleep_interval, 10, 0, self.route_snapshots_match,
+                       duthosts, self.pre_test_route_snapshot)
             raise e
 
     def test_bgp_shut_noshut(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, localhost):
@@ -183,7 +207,9 @@ class TestRouteConsistency():
         try:
             logger.info("shutdown bgp sessions for {}".format(duthost.hostname))
             duthost.shell("sudo config bgp shutdown all")
-            time.sleep(self.sleep_interval)
+            pytest_assert(wait_until(self.sleep_interval, 10, 15, self.routes_have_changed,
+                                     duthosts, self.pre_test_route_snapshot),
+                          "Routes did not change after BGP shutdown within {} seconds".format(self.sleep_interval))
 
             post_withdraw_route_snapshot, _ = self.get_route_prefix_snapshot_from_asicdb(duthosts)
             num_routes_withdrawn = 0
@@ -198,7 +224,9 @@ class TestRouteConsistency():
 
             logger.info("startup bgp sessions for {}".format(duthost.hostname))
             duthost.shell("sudo config bgp startup all")
-            time.sleep(self.sleep_interval)
+            pytest_assert(wait_until(self.sleep_interval, 10, 0, self.route_snapshots_match,
+                                     duthosts, self.pre_test_route_snapshot),
+                          "Routes did not recover after BGP startup within {} seconds".format(self.sleep_interval))
 
             # take the snapshot of route table from all the DUTs
             post_test_route_snapshot, _ = self.get_route_prefix_snapshot_from_asicdb(duthosts)
@@ -208,7 +236,7 @@ class TestRouteConsistency():
         except Exception:
             # startup bgp back in case of any exception
             duthost.shell("sudo config bgp startup all")
-            time.sleep(self.sleep_interval)
+            wait_until(self.sleep_interval, 10, 0, is_all_neighbor_session_established, duthost)
 
     @pytest.mark.disable_loganalyzer
     @pytest.mark.parametrize("container_name, program_name", [
@@ -236,7 +264,8 @@ class TestRouteConsistency():
                 if id is None:
                     id = ""
                 check_and_kill_process(duthost, container_name + str(id), program_name)
-            time.sleep(30)
+            wait_until(60, 5, 15, self.routes_have_changed,
+                       duthosts, self.pre_test_route_snapshot)
 
             post_withdraw_route_snapshot, _ = self.get_route_prefix_snapshot_from_asicdb(duthosts)
             num_routes_withdrawn = 0
@@ -252,7 +281,8 @@ class TestRouteConsistency():
             logger.info("Recover containers on {}".format(duthost.hostname))
             config_reload(duthost)
             wait_until(300, 10, 0, is_all_neighbor_session_established, duthost)
-            time.sleep(self.sleep_interval)
+            wait_until(self.sleep_interval, 10, 0, self.route_snapshots_match,
+                       duthosts, self.pre_test_route_snapshot)
 
             # take the snapshot of route table from all the DUTs
             post_test_route_snapshot, _ = self.get_route_prefix_snapshot_from_asicdb(duthosts)
@@ -263,4 +293,4 @@ class TestRouteConsistency():
             # startup bgpd back in case of any exception
             logger.info("Encountered error. Perform a config reload to recover!")
             config_reload(duthost)
-            time.sleep(self.sleep_interval)
+            wait_until(self.sleep_interval, 10, 0, is_all_neighbor_session_established, duthost)

--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -49,6 +49,10 @@ def is_all_neighbor_session_established(duthost):
     return True
 
 
+def routes_count_tracking():
+    return {"last_counts": {}, "stable_count": 0}
+
+
 class TestRouteConsistency():
     """ TestRouteConsistency class for testing route consistency across all the Frontend DUTs in the testbed
         It verifies route consistency by taking a snapshot of route table from ASIC_DB from all the DUTs before the test
@@ -128,20 +132,38 @@ class TestRouteConsistency():
                 return False
         return True
 
-    def routes_have_changed(self, duthosts, previous_route_snapshot):
-        """Check that the route table has changed from a previous snapshot on ANY DUT.
+    def routes_have_changed(self, duthosts, previous_route_snapshot, stable_threshold, tracking):
+        """Check that the route table has stabilized after a change.
 
-        Returns True when at least one DUT's route table differs from the previous snapshot,
-        indicating that convergence has started. On non-VOQ single-asic topologies the snapshot
-        is empty (get_route_prefix_snapshot_from_asicdb only collects VOQ/chassis data), so
-        return True immediately to avoid blocking on an always-empty comparison.
+        Waits until the route count per DUT has stopped changing for stable_threshold
+        consecutive checks, ensuring the DUT has fully completed updating the route table.
+
+        Args:
+            duthosts: DUT hosts to check.
+            previous_route_snapshot: The pre-test route snapshot to compare against.
+            stable_threshold: Number of consecutive unchanged checks required.
+            tracking: A mutable dict with keys "last_counts" (dict) and "stable_count" (int)
+                      used to track state across calls from wait_until.
+
+        On non-VOQ single-asic topologies the snapshot is empty, so return True
+        immediately to avoid blocking on an always-empty comparison.
         """
         if not previous_route_snapshot:
             return True
+
         new_route_snapshot, _ = self.get_route_prefix_snapshot_from_asicdb(duthosts)
-        for dut_instance_name in previous_route_snapshot.keys():
-            if previous_route_snapshot[dut_instance_name] != new_route_snapshot[dut_instance_name]:
-                return True
+        current_counts = {name: len(routes) for name, routes in new_route_snapshot.items()}
+        original_counts = {name: len(routes) for name, routes in previous_route_snapshot.items()}
+
+        if current_counts == tracking["last_counts"]:
+            tracking["stable_count"] += 1
+        else:
+            tracking["stable_count"] = 0
+            tracking["last_counts"] = current_counts
+
+        if current_counts != original_counts and tracking["stable_count"] >= stable_threshold:
+            return True
+
         return False
 
     def test_route_withdraw_advertise(self, duthosts, tbinfo, localhost):
@@ -154,7 +176,7 @@ class TestRouteConsistency():
             logger.info("withdraw ipv4 and ipv6 routes for {}".format(topo_name))
             localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
             pytest_assert(wait_until(self.sleep_interval, 10, 15, self.routes_have_changed,
-                                     duthosts, self.pre_test_route_snapshot),
+                                     duthosts, self.pre_test_route_snapshot, 2, routes_count_tracking()),
                           "Routes were not withdrawn within {} seconds".format(self.sleep_interval))
 
             """ compare the number of routes withdrawn from all the DUTs. In working condition, the number of routes
@@ -208,7 +230,7 @@ class TestRouteConsistency():
             logger.info("shutdown bgp sessions for {}".format(duthost.hostname))
             duthost.shell("sudo config bgp shutdown all")
             pytest_assert(wait_until(self.sleep_interval, 10, 15, self.routes_have_changed,
-                                     duthosts, self.pre_test_route_snapshot),
+                                     duthosts, self.pre_test_route_snapshot, 2, routes_count_tracking()),
                           "Routes did not change after BGP shutdown within {} seconds".format(self.sleep_interval))
 
             post_withdraw_route_snapshot, _ = self.get_route_prefix_snapshot_from_asicdb(duthosts)
@@ -265,7 +287,7 @@ class TestRouteConsistency():
                     id = ""
                 check_and_kill_process(duthost, container_name + str(id), program_name)
             wait_until(60, 5, 15, self.routes_have_changed,
-                       duthosts, self.pre_test_route_snapshot)
+                       duthosts, self.pre_test_route_snapshot, 2, routes_count_tracking())
 
             post_withdraw_route_snapshot, _ = self.get_route_prefix_snapshot_from_asicdb(duthosts)
             num_routes_withdrawn = 0


### PR DESCRIPTION
#### Description of PR

Backport of three `test_route_consistency.py` fixes to `202511`. `TestRouteConsistency::test_route_withdraw_advertise` fails on large-scale (VOQ max-topology, ~100k routes) testbeds because the announce-match uses a hardcoded `wait_until(300, ...)`, which is too short for the full route set to re-install into ASIC_DB after withdraw+re-announce.

Cherry-picks (in order):
- **#22596** — [route] Replace time.sleep with wait_until in test_route_consistency (scales the announce-match wait to `self.sleep_interval + 300`)
- **#23098** — Ensure route table update is finalized (stability-based `routes_have_changed` withdraw wait)
- **#25892** — Fix TestRouteConsistency to re-announce on pytest assert failure (recover on `pytest.fail.Exception`)

These are already on `master` but were never backported to `202511`, so the `202511`-based release/qual branches still fail on large-scale beds.

#### Type of change
- [x] Bug fix (backport)

#### Approach
Straight cherry-pick of the three upstream commits. One trivial conflict on the announce-match line was resolved in favor of the incoming (scaled-timeout) version. Only the timing-related changes are included; unrelated cosmetic assert-message changes from master are intentionally not pulled in.

#### Back port request
- [x] 202511
