### PR TITLE
[gnmi] Drop telemetry-container fallback from ha/dash GNMIEnvironment copies

### DIFF
--- a/tests/dash/gnmi_utils.py
+++ b/tests/dash/gnmi_utils.py
@@ -36,18 +36,7 @@ class GNMIEnvironment(object):
                 return
             else:
                 pytest.fail("GNMI is not running")
-        cmd = "docker images | grep -w sonic-telemetry"
-        if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-            cmd = "docker ps | grep -w telemetry"
-            if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-                self.gnmi_config_table = "TELEMETRY"
-                self.gnmi_container = "telemetry"
-                self.gnmi_program = "telemetry"
-                self.gnmi_port = 50051
-                return
-            else:
-                pytest.fail("Telemetry is not running")
-        pytest.fail("Can't find telemetry and gnmi image")
+        pytest.fail("Can't find gnmi image")
 
 
 def create_ext_conf(ip, filename):

--- a/tests/ha/gnmi_utils.py
+++ b/tests/ha/gnmi_utils.py
@@ -57,18 +57,7 @@ class GNMIEnvironment(object):
                 return
             else:
                 pytest.fail("GNMI is not running")
-        cmd = "docker images | grep -w sonic-telemetry"
-        if my_duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-            cmd = "docker ps | grep -w telemetry"
-            if my_duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-                self.gnmi_config_table = "TELEMETRY"
-                self.gnmi_container = "telemetry"
-                self.gnmi_program = "telemetry"
-                self.gnmi_port = 50051
-                return
-            else:
-                pytest.fail("Telemetry is not running")
-        pytest.fail("Can't find telemetry and gnmi image")
+        pytest.fail("Can't find gnmi image")
 
 
 def create_ext_conf(ip, filename):


### PR DESCRIPTION
### Description of PR

Summary:
`tests/ha/gnmi_utils.py` and `tests/dash/gnmi_utils.py` each carry a private copy of `GNMIEnvironment` whose `__init__` falls back to a telemetry-container detection branch (`docker images | grep sonic-telemetry`, `TELEMETRY` table, container `telemetry`, port 50051). The telemetry container has been renamed to gnmi, so remove that branch in both copies; each now resolves the gnmi container only (and fails clearly if the gnmi image is absent), matching the shared `tests/common/helpers/gnmi_utils.py`.

The functional in-container process references (pkill / relaunch of the running binary, which may still be named `telemetry` during the rename transition) are intentionally left unchanged.

This is independent of the other telemetry->gnmi cleanup PRs.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Tested branch

- [x] master

### Test result

Framework refactor. Both modules compile and pass flake8. On gnmi-container images (which CI runs) the resolved container/table/port are unchanged.
