### PR TITLE
[gnmi] Remove remaining dead telemetry-container references

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -106,17 +106,6 @@ configlet/test_add_rack.py::test_add_rack:
       - "asic_type in ['vpp']"
 
 #######################################
-#####       Container Checker     #####
-#######################################
-container_checker/test_container_checker.py::test_container_checker_telemetry:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-#######################################
 #####           COPP              #####
 #######################################
 copp:

--- a/tests/common/snappi_tests/ixload/snappi_helper.py
+++ b/tests/common/snappi_tests/ixload/snappi_helper.py
@@ -122,21 +122,6 @@ def wait_for_all_dpus_online(duthost, timeout=600, interval=5, allow_partial=Tru
     return wait_for_all_dpus_status(duthost, desired, timeout=timeout, interval=interval)
 
 
-def _telemetry_run_on_dut(duthost):
-
-    cmd = (
-        "docker exec -d gnmi "
-        "/usr/sbin/telemetry -logtostderr "
-        "--server_crt /etc/sonic/tls/server.crt "
-        "--server_key /etc/sonic/tls/server.key "
-        "--port 8080 --allow_no_client_auth -v=2 "
-        "-zmq_port=8100 --threshold 100 --idle_conn_duration 5"
-    )
-    logger.info(f"Running telemetry on the DUT {duthost.hostname}")
-    # Ignore errors if it is already running; let caller proceed
-    duthost.shell(cmd, module_ignore_errors=True)
-
-
 def _ensure_remote_dir_on_dut(duthost, remote_dir):
     logger.info("Make directory on DUT to store DPU config files:")
     duthost.shell(f"sudo mkdir -p {remote_dir}")
@@ -574,7 +559,6 @@ def load_dpu_configs_on_dut(
                                                 ha_test_case)
     remote_dir = f"{remote_dir}/dpu{dpu_index}"
     _ensure_remote_dir_on_dut(duthost, remote_dir)
-    # _telemetry_run_on_dut(duthost)
     _copy_files_to_dut(duthost, local_files, remote_dir)
 
     delay = initial_delay_sec
@@ -586,10 +570,9 @@ def load_dpu_configs_on_dut(
             out = res.get("stdout", "")
             err = res.get("stderr", "")
             if "Set failed: rpc error: code = Unavailable desc = connection err" in (out + err):
-                logger.info(f"RPC unavailable for {rb}; retrying after telemetry restart")  # noqa: E702
+                logger.info(f"RPC unavailable for {rb}; retrying after delay")  # noqa: E702
                 duthost.shell("docker ps --format '{{.Names}}' | grep -w gnmi || true", module_ignore_errors=True)
                 time.sleep(120)
-                # _telemetry_run_on_dut(duthost)
                 time.sleep(retry_delay_sec)
                 _docker_run_config_on_dut(duthost, remote_dir, dpu_index, rb)
 


### PR DESCRIPTION
### Description of PR

Summary:
Final cleanup of two dead telemetry-container references left over from the telemetry->gnmi migration:

- Remove the unused `_telemetry_run_on_dut` helper in `tests/common/snappi_tests/ixload/snappi_helper.py` (it launched the old `/usr/sbin/telemetry` binary; its only call sites were already commented out) and drop the two commented-out call lines.
- Remove the inert `container_checker/test_container_checker.py::test_container_checker_telemetry` entry from the sonic_vpp conditional-mark file. `conditional_mark` matches node ids by `startswith`, and `test_container_checker` is parametrized (node id `test_container_checker[...]`), so the underscore key never matched any real test.

Independent of the other telemetry->gnmi cleanup PRs.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Tested branch

- [x] master

### Test result

Dead-code removal. Verified no `_telemetry_run_on_dut` / `test_container_checker_telemetry` references remain, the snappi helper compiles and passes flake8, and the conditional-mark YAML parses and passes the sort hook.
