### PR TITLE
[202511] snappi/pfc: stop data flows explicitly so paused-traffic tests can finish (#26751)

### DIFF
--- a/tests/common/snappi_tests/read_pcap.py
+++ b/tests/common/snappi_tests/read_pcap.py
@@ -24,6 +24,8 @@ def validate_pfc_frame(pfc_pcap_file, SAMPLE_SIZE=15000, UTIL_THRESHOLD=0.8):
     Returns:
         True if valid PFC frame, False otherwise
     """
+    logger.info("Validating PFC frames in capture file '{}' (sample size {}, util threshold {})"
+                .format(pfc_pcap_file, SAMPLE_SIZE, UTIL_THRESHOLD))
     f = open(pfc_pcap_file, "rb")
     pcap = dpkt.pcapng.Reader(f)
     seen_non_zero_cev = False  # Flag for checking if any PFC frame has non-zero class enable vector
@@ -37,15 +39,29 @@ def validate_pfc_frame(pfc_pcap_file, SAMPLE_SIZE=15000, UTIL_THRESHOLD=0.8):
         if eth.type == PFC_MAC_CONTROL_CODE:
             dest_mac = mac_to_str(eth.dst)
             if dest_mac.lower() != PFC_DEST_MAC:
+                logger.info("PFC frame {} has destination MAC {}, expected {}"
+                            .format(curPktCount, dest_mac, PFC_DEST_MAC))
                 return False, "Destination MAC address is not 01:80:c2:00:00:01"
             pfc_packet = PFCPacket(pfc_frame_bytes=bytes(eth.data))
             if not pfc_packet.is_valid():
                 logger.info("PFC frame {} is not valid. Please check the capture file.".format(curPktCount))
                 return False, "PFC frame is not valid"
             cev = [int(i) for i in pfc_packet.class_enable_vec]
-            seen_non_zero_cev = True if sum(cev) > 0 else seen_non_zero_cev
+            cev_nonzero = sum(cev) > 0
+            # Per-frame detail at debug level so a 15k-packet sample does not flood the log.
+            logger.debug("PFC frame {} valid: dst_mac={}, cbfc_opcode={}, class_enable_vec={}, class_pause_times={}"
+                         .format(curPktCount, dest_mac, hex(pfc_packet.cbfc_opcode),
+                                 pfc_packet.class_enable_vec, pfc_packet.class_pause_times))
+            if cev_nonzero and not seen_non_zero_cev:
+                logger.info("First PFC frame with non-zero class enable vector at packet {}: "
+                            "class_enable_vec={}, class_pause_times={}"
+                            .format(curPktCount, pfc_packet.class_enable_vec, pfc_packet.class_pause_times))
+            seen_non_zero_cev = seen_non_zero_cev or cev_nonzero
             curPFCPktCount += 1
         curPktCount += 1
+
+    logger.info("Scanned {} packets, found {} valid PFC frame(s); non-zero class enable vector seen: {}"
+                .format(curPktCount, curPFCPktCount, seen_non_zero_cev))
 
     if not seen_non_zero_cev:
         logger.info("No PFC frames with non-zero class enable vector found in the capture file.")
@@ -58,9 +74,12 @@ def validate_pfc_frame(pfc_pcap_file, SAMPLE_SIZE=15000, UTIL_THRESHOLD=0.8):
         logger.info("No PFC frames found in the capture file.")
         return False, "No PFC frames found in the capture file"
     elif pfc_util < UTIL_THRESHOLD:
-        logger.info("PFC utilization is too low. Please check the capture file.")
+        logger.info("PFC utilization {:.2f} is below threshold {}. Please check the capture file."
+                    .format(pfc_util, UTIL_THRESHOLD))
         return False, "PFC utilization is too low"
 
+    logger.info("PFC frame validation passed: {} valid PFC frame(s), utilization {:.2f} (threshold {})"
+                .format(curPFCPktCount, pfc_util, UTIL_THRESHOLD))
     return True, None
 
 

--- a/tests/common/snappi_tests/snappi_helpers.py
+++ b/tests/common/snappi_tests/snappi_helpers.py
@@ -361,3 +361,57 @@ def fetch_snappi_flow_metrics(api, flow_names):
     flow_metrics = api.get_metrics(request).flow_metrics
 
     return flow_metrics
+
+
+def set_flow_transmit_state(api, operation, flow_names=None):
+    """
+    Start or stop transmit, optionally scoped to specific flows.
+
+    Scoping matters when some flows must keep running: stopping every flow also
+    stops a PFC pause storm, letting the DUT drain frames it was holding.
+
+    Args:
+    api: snappi api
+    operation (str): 'start' or 'stop'
+    flow_names (list): flows to act on; None acts on all flows. An empty list
+                       is rejected — a scoped call that resolved to no flows
+                       is a caller bug, not a stop-all.
+
+    Returns:
+    None
+    """
+    if flow_names is not None and not flow_names:
+        raise ValueError(
+            "set_flow_transmit_state: flow_names=[] would have been treated as "
+            "'{} ALL flows' (including any PFC pause storm). If you meant all "
+            "flows, pass flow_names=None; otherwise check why the scoped flow "
+            "list resolved to empty.".format(operation)
+        )
+    cs = api.control_state()
+    if flow_names is not None:
+        cs.traffic.flow_transmit.flow_names = flow_names
+    if operation == "start":
+        cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
+    elif operation == "stop":
+        cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
+    else:
+        raise ValueError("operation must be 'start' or 'stop', got {}".format(operation))
+    api.set_control_state(cs)
+
+
+def are_flows_stopped(api, flow_names):
+    """
+    Whether every named flow has reached the 'stopped' transmit state.
+
+    Args:
+    api: snappi api
+    flow_names (list): list of flow names
+
+    Returns:
+    bool: True when a metric was returned for every named flow and all report 'stopped'
+    """
+    flow_metrics = fetch_snappi_flow_metrics(api, flow_names)
+    if len(flow_metrics) != len(flow_names):
+        return False
+
+    return {metric.transmit for metric in flow_metrics} == {'stopped'}

--- a/tests/common/snappi_tests/snappi_test_params.py
+++ b/tests/common/snappi_tests/snappi_test_params.py
@@ -76,3 +76,6 @@ class SnappiTestParams():
         self.num_tx_links: Optional[int] = 1
         self.num_rx_links: Optional[int] = 1
         self.tx_dscp_values: Optional[list[int]] = []
+        # Stop the data flows (only) after in-flight stats, so a flow held under a
+        # continuous pause storm reaches 'stopped' instead of timing out the wait loop.
+        self.stop_data_flows_before_final_stats: bool = False

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -16,7 +16,8 @@ from tests.common.snappi_tests.common_helpers import config_capture_settings, ge
     traffic_flow_mode, get_pfc_count, clear_counters, get_interface_stats, get_queue_count_all_prio, \
     get_pfcwd_stats, get_interface_counters_detailed
 from tests.common.snappi_tests.port import select_ports, select_tx_port
-from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics, \
+    set_flow_transmit_state, are_flows_stopped
 from .variables import pfcQueueGroupSize, pfcQueueValueDict
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 from tests.common.cisco_data import is_cisco_device
@@ -638,9 +639,7 @@ def run_traffic(duthost,
         clear_dut_pfc_counters(host)
 
     logger.info("Starting transmit on all flows ...")
-    cs = api.control_state()
-    cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
-    api.set_control_state(cs)
+    set_flow_transmit_state(api, "start")
     if snappi_extra_params.reboot_type:
         logger.info(f"Issuing a {snappi_extra_params.reboot_type} reboot on the dut {duthost.hostname}")
         # The following reboot command waits until the DUT is accessible by SSH. It does not wait for
@@ -687,17 +686,19 @@ def run_traffic(duthost,
         in_flight_flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)  # fetch in-flight metrics from TGEN
         time.sleep(exp_dur_sec*(3/5))
 
+    # A flow held under PFC flow control never transitions to 'stopped' on its own, so stop
+    # transmit here. Only the data flows: the pause storm must keep DUT egress paused.
+    if snappi_extra_params.stop_data_flows_before_final_stats:
+        logger.info("Stopping transmit on data flows after in-flight stats collection")
+        set_flow_transmit_state(api, "stop", flow_names=data_flow_names)
+
     attempts = 0
     max_attempts = 20
 
     while attempts < max_attempts:
         logger.info("Checking if all flows have stopped. Attempt #{}".format(attempts + 1))
-        flow_metrics = fetch_snappi_flow_metrics(api, data_flow_names)
-
         # If all the data flows have stopped
-        transmit_states = [metric.transmit for metric in flow_metrics]
-        if len(flow_metrics) == len(data_flow_names) and\
-           list(set(transmit_states)) == ['stopped']:
+        if are_flows_stopped(api, data_flow_names):
             logger.info("All test and background traffic flows stopped")
             time.sleep(SNAPPI_POLL_DELAY_SEC)
             break
@@ -707,6 +708,18 @@ def run_traffic(duthost,
 
     pytest_assert(attempts < max_attempts,
                   "Flows do not stop in {} seconds".format(max_attempts))
+
+    # Capture stop + retrieval is slow enough to outlast the pause storm, which would let the
+    # DUT drain buffered frames and push a paused flow's rx_frames above 0. Read metrics first.
+    read_stats_before_capture_stop = (
+        snappi_extra_params.stop_data_flows_before_final_stats
+        and pcap_type != packet_capture.NO_CAPTURE
+    )
+
+    flow_metrics = None
+    if read_stats_before_capture_stop:
+        logger.info("Dumping per-flow statistics")
+        flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)
 
     if pcap_type != packet_capture.NO_CAPTURE:
         logger.info("Stopping packet capture ...")
@@ -720,13 +733,12 @@ def run_traffic(duthost,
         with open(snappi_extra_params.packet_capture_file + ".pcapng", 'wb') as fid:
             fid.write(pcap_bytes.getvalue())
 
-    # Dump per-flow statistics
-    logger.info("Dumping per-flow statistics")
-    flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)
+    # Dump per-flow statistics (unless already collected above before capture teardown)
+    if flow_metrics is None:
+        logger.info("Dumping per-flow statistics")
+        flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)
     logger.info("Stopping transmit on all remaining flows")
-    cs = api.control_state()
-    cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
-    api.set_control_state(cs)
+    set_flow_transmit_state(api, "stop")
     check_for_crc_errors(api, snappi_extra_params)
     return flow_metrics, switch_device_results, in_flight_flow_metrics
 

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -204,11 +204,11 @@ def run_pfc_test(api,
         # PFC pause frame capture is not requested
         valid_pfc_frame_test = False
 
-    if valid_pfc_frame_test and not is_cisco_device(egress_duthost):
-        snappi_extra_params.traffic_flow_config.pause_flow_config["flow_dur_sec"] = DATA_FLOW_DURATION_SEC + \
-            data_flow_delay_sec + SNAPPI_POLL_DELAY_SEC + PAUSE_FLOW_DUR_BASE_SEC
-        snappi_extra_params.traffic_flow_config.pause_flow_config["flow_traffic_type"] = \
-            traffic_flow_mode.FIXED_DURATION
+    # A paused test flow is backpressured by the continuous pause storm and never reaches
+    # 'stopped' on its own, so run_traffic must stop the data flows explicitly. Cisco's
+    # valid-PFC-frame path is excluded to keep its existing behavior unchanged.
+    if test_traffic_pause and not (valid_pfc_frame_test and is_cisco_device(egress_duthost)):
+        snappi_extra_params.stop_data_flows_before_final_stats = True
 
     no_of_streams = 1
     if egress_duthost.facts['asic_type'] == "cisco-8000":

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -3,12 +3,12 @@ import time
 
 from tests.common.cisco_data import is_cisco_device
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts  # noqa: F401
-from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector,\
-    get_lossless_buffer_size, get_pg_dropped_packets,\
-    disable_packet_aging, enable_packet_aging, sec_to_nanosec,\
-    get_pfc_frame_count, packet_capture, config_capture_pkt,\
+from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
+    get_lossless_buffer_size, get_pg_dropped_packets, \
+    disable_packet_aging, enable_packet_aging, sec_to_nanosec, \
+    get_pfc_frame_count, packet_capture, config_capture_pkt, \
     traffic_flow_mode, calc_pfc_pause_flow_rate, get_tx_frame_count      # noqa: F401
 from tests.common.snappi_tests.port import select_ports, select_tx_port  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id, wait_for_arp  # noqa: F401


### PR DESCRIPTION
Manual cherry-pick of #26751 to `202511` — mssonicbld reported a conflict (`Cherry Pick Conflict_202511`). The original PR is already `Approved for 202511 branch`.

### Description of PR

Same as #26751 (fixes #26748): two false failures in the snappi PFC pause tests caused by a continuous PFC pause storm interacting with `run_traffic`'s end-of-run sequencing.

- **`Flows do not stop in 20 seconds`** — a lossless test flow backpressured by the DUT's own PFC never reaches `stopped` on its own. `run_traffic` now stops the data flows explicitly (scoped to `data_flow_names`, so the pause storm keeps running) after in-flight stats, gated by the new `SnappiTestParams.stop_data_flows_before_final_stats` (default `False`). `run_pfc_test` derives it from `test_traffic_pause`, so ECN/pfcwd and every other caller are unchanged.
- **`<flow> should be paused`** — the valid-PFC-frame capture tests now read final TGEN metrics *before* capture stop/retrieval, which was slow enough to outlast the fixed-duration pause and let the DUT drain. The `FIXED_DURATION` pause reconfiguration in `run_pfc_test` is removed.
- Transmit control goes through new `set_flow_transmit_state` / `are_flows_stopped` helpers; `validate_pfc_frame` gains diagnostics (first non-zero CEV frame, scan totals, actual utilization). No behavior change there.

### Conflict resolution

Conflicts in `tests/common/snappi_tests/snappi_helpers.py` and `tests/common/snappi_tests/traffic_generation.py`, both because master has since gained the macsec (`ptype` / `fetch_flow_metrics_for_macsec`) branch and `pfc_queue_group_size`, which 202511 does not have. Applied only this PR's actual change onto the 202511 shape:

- `snappi_helpers.py`: appended only the two new helpers (`set_flow_transmit_state`, `are_flows_stopped`); did not pull in the unrelated master-only functions the merge offered.
- `traffic_generation.py`: kept the 202511 import line (`pfcQueueGroupSize`) and added the two helper imports; replaced the start/stop `control_state` blocks and the stopped-check loop with the helper calls; dropped the `and not ptype` guards from the new stop and `read_stats_before_capture_stop` conditions since 202511 has no `ptype` path (macsec branch does not exist here).

`read_pcap.py`, `snappi_test_params.py` and `snappi_tests/pfc/files/helper.py` auto-merged. Functionally identical to the original change.

### Type of change

- [x] Bug fix

### Tested branch

- [x] master (see #26751 — validated on Broadcom DNX 400G with a `202511.Nexthop` image)

cc @vmittal-msft — could you help approve/merge this 202511 cherry-pick?
