### PR TITLE
[macsec] test-side MACsec support: PTF monkeypatch rework, reload bootstrap, T2 test fixes

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -28,6 +28,7 @@ import fib
 
 import ptf
 import ptf.packet as scapy
+import macsec  # noqa F401
 
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask

--- a/ansible/roles/test/files/ptftests/macsec.py
+++ b/ansible/roles/test/files/ptftests/macsec.py
@@ -1,48 +1,164 @@
 import os
 import pickle
+import struct
 import cryptography.exceptions
 import time
 
 import ptf
+import ptf.dataplane
 import scapy.all as scapy
 MACSEC_SUPPORTED = False
 if hasattr(scapy, "VERSION") and tuple(map(int, scapy.VERSION.split('.'))) >= (2, 4, 5):
     MACSEC_SUPPORTED = True
 if MACSEC_SUPPORTED:
     import scapy.contrib.macsec as scapy_macsec
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 MACSEC_INFO_FILE = "macsec_info.pickle"
-MACSEC_GLOBAL_PN_OFFSET = 1000
-MACSEC_GLOBAL_PN_INCR = 100
+# Rewriting the outer src MAC to the peer's MAC is required on Broadcom, where
+# the ASIC derives the ingress SCI from {outer_src_MAC, port}. On platforms that
+# take the SCI from the SecTAG the rewrite can break SA lookup, so
+# create_macsec_info() drops this opt-out marker on non-Broadcom DUTs.
+# Default stays rewrite-on so pre-existing pickles keep working.
+MACSEC_SMAC_NO_REWRITE_FLAG = "/root/macsec_no_rewrite_outer_smac"
+_REWRITE_OUTER_SMAC = not os.path.exists(MACSEC_SMAC_NO_REWRITE_FLAG)
+ETH_P_MACSEC = 0x88e5
 
 MACSEC_INFOS = {}
+# Per-port next PN to send. Initialized to pn_at_pickle+1 on first use so PTF frames are
+# always just ahead of the real peer, rather than a shared global that grows by 100 per
+# send and inflates highest_PN on the ASIC far beyond the peer's actual position.
+MACSEC_PORT_NEXT_PN = {}
+# Per-port SA bundle cache. Pre-computes the AES-GCM key schedule and the
+# parts of the SecTAG that are constant for an SA so the hot path only
+# touches PN/SL/plaintext per packet.
+_SA_CACHE = {}
+
+
+def _build_sa(port_number):
+    """Build and cache an immutable SA bundle for `port_number`.
+
+    The cache key is implicit (port_number); callers must ensure
+    MACSEC_INFOS[port_number] is the SA they want before first call.
+    """
+    encrypt, send_sci, xpn_en, _sci, _an, sak, _ssci, _salt, \
+        peer_sci, peer_an, peer_ssci, _pn = MACSEC_INFOS[port_number]
+
+    sak_bytes = sak if isinstance(sak, bytes) else bytes(sak)
+    peer_sci_bytes = struct.pack('!Q', peer_sci) if isinstance(peer_sci, int) \
+        else peer_sci
+
+    # TCI byte without AN: Ver=0, ES=0, SC=send_sci, SCB=0, E=encrypt,
+    # C=encrypt (with default ICV len 16). AN is OR-ed in per-call.
+    tci_base = ((1 << 5) if send_sci else 0) \
+        | ((1 << 3) if encrypt else 0) \
+        | ((1 << 2) if encrypt else 0)
+
+    sa = {
+        "encrypt": bool(encrypt),
+        "send_sci": bool(send_sci),
+        "xpn_en": bool(xpn_en),
+        "peer_an": peer_an & 0x3,
+        "peer_sci_bytes": peer_sci_bytes,
+        "peer_mac_bytes": peer_sci_bytes[:6],
+        "aesgcm": AESGCM(sak_bytes),
+        "tci_base": tci_base,
+        # AAD region length on the wire (outer Ether 14 + SecTAG 6 [+ SCI 8])
+    }
+    if xpn_en:
+        sa["ssci_bytes"] = struct.pack('!L', peer_ssci) \
+            if isinstance(peer_ssci, int) else peer_ssci
+        sa["salt_bytes"] = _salt
+    _SA_CACHE[port_number] = sa
+    return sa
+
+
+def _macsec_encap_encrypt(sa, eth_bytes, send_pn):
+    """Build a wire MACsec frame from a cleartext Ether bytes buffer.
+
+    Avoids scapy layer rebuilding and reuses a cached AESGCM cipher so the
+    per-packet cost is one AES-GCM encrypt instead of also re-initializing
+    the key schedule. Drop-in equivalent of scapy_macsec.MACsecSA.encap+encrypt
+    for the wire output bytes.
+
+    eth_bytes layout: dst(6) | src(6) | type(2) | payload(N)
+    Returns wire bytes for the encrypted MACsec frame, byte-identical to
+    what scapy would produce for the same SA/PN/plaintext.
+    """
+    outer_macs = eth_bytes[:12]            # outer dst + src (src already overwritten by caller)
+    inner_type = eth_bytes[12:14]
+    inner_payload = eth_bytes[14:]
+
+    # SecTAG
+    tci_an = sa["tci_base"] | sa["peer_an"]
+    # SL is set to the byte count after the source MAC (= inner_type + payload)
+    # when that count is < 48; else 0. Matches scapy_macsec.MACsecSA.shortlen.
+    data_after_macs = 2 + len(inner_payload)
+    sl_byte = data_after_macs if data_after_macs < 48 else 0
+    pn32 = send_pn & 0xFFFFFFFF
+    sectag = struct.pack('!BBI', tci_an, sl_byte, pn32)
+    if sa["send_sci"]:
+        sectag += sa["peer_sci_bytes"]
+
+    # IV (12 bytes): non-XPN = SCI || PN(32); XPN = (SSCI || PN(64)) XOR salt
+    if sa["xpn_en"]:
+        tmp_iv = sa["ssci_bytes"] + struct.pack('!Q', send_pn & 0xFFFFFFFFFFFFFFFF)
+        iv = bytes(a ^ b for a, b in zip(tmp_iv, sa["salt_bytes"]))
+    else:
+        iv = sa["peer_sci_bytes"] + struct.pack('!I', pn32)
+
+    aad = outer_macs + struct.pack('!H', ETH_P_MACSEC) + sectag
+
+    if sa["encrypt"]:
+        # Confidentiality: plaintext = inner_type + inner_payload; AAD = headers only.
+        pt = inner_type + inner_payload
+        return aad + sa["aesgcm"].encrypt(iv, pt, aad)
+    # Integrity-only: AAD = full frame, plaintext empty, just append the 16-byte tag.
+    cleartext = inner_type + inner_payload
+    tag = sa["aesgcm"].encrypt(iv, b'', aad + cleartext)
+    return aad + cleartext + tag
+
+
+# When the PTF image carries the native MACsec codec (per-port DataPlane
+# transforms registered from macsec_info.pickle — see
+# ptf.dataplane.NATIVE_MACSEC_CAPABLE, added by sonic-buildimage
+# src/ptf-py3.patch), this module must NOT also encrypt: both layers active
+# would encrypt every injected frame twice. NATIVE_MACSEC_CAPABLE is only set
+# once a DataPlane is constructed, which happens after this module is
+# imported — so it must be read lazily at call time, never snapshotted here.
+def _native_macsec_active():
+    return bool(getattr(ptf.dataplane, "NATIVE_MACSEC_CAPABLE", False))
 
 
 def macsec_send(test, port_id, pkt, count=1):
-    # Check if the port is macsec enabled, if so send the macsec encap/encrypted frame
-    global MACSEC_GLOBAL_PN_OFFSET
-    global MACSEC_GLOBAL_PN_INCR
-
+    if _native_macsec_active():
+        return __origin_send_packet(test, port_id, pkt, count)
+    # Check if the port is macsec enabled; if so send the macsec encap/encrypted frame.
     device, port_number = ptf.testutils.port_to_tuple(port_id)
-    if port_number in MACSEC_INFOS and MACSEC_INFOS[port_number]:
-        encrypt, send_sci, xpn_en, sci, an, sak, ssci, salt, peer_sci, peer_an, peer_ssci, pn = \
-                                                                                MACSEC_INFOS[port_number]
-
-        for n in range(count):
-            if isinstance(pkt, bytes):
-                # If in bytes, convert it to an Ether packet
-                pkt = scapy.Ether(pkt)
-
-            # Increment the PN by an offset so that the macsec frames are not late on DUT
-            MACSEC_GLOBAL_PN_OFFSET += MACSEC_GLOBAL_PN_INCR
-            pn += MACSEC_GLOBAL_PN_OFFSET
-
-            macsec_pkt = encap_macsec_pkt(pkt, peer_sci, peer_an, sak, encrypt, send_sci, pn, xpn_en, peer_ssci, salt)
-            # send the packet
-            __origin_send_packet(test, port_id, macsec_pkt, 1)
-    else:
-        # send the packet
+    if port_number not in MACSEC_INFOS or not MACSEC_INFOS[port_number]:
         __origin_send_packet(test, port_id, pkt, count)
+        return
+
+    sa = _SA_CACHE.get(port_number)
+    if sa is None:
+        sa = _build_sa(port_number)
+
+    if port_number not in MACSEC_PORT_NEXT_PN:
+        MACSEC_PORT_NEXT_PN[port_number] = MACSEC_INFOS[port_number][-1] + 1
+
+    # Serialize the input scapy packet ONCE outside the count loop.
+    if isinstance(pkt, bytes):
+        eth_bytes = pkt
+    else:
+        eth_bytes = bytes(pkt)
+    if _REWRITE_OUTER_SMAC:
+        eth_bytes = eth_bytes[:6] + sa["peer_mac_bytes"] + eth_bytes[12:]
+
+    for _ in range(count):
+        send_pn = MACSEC_PORT_NEXT_PN[port_number]
+        MACSEC_PORT_NEXT_PN[port_number] += 1
+        wire = _macsec_encap_encrypt(sa, eth_bytes, send_pn)
+        __origin_send_packet(test, port_id, wire, 1)
 
 
 def encap_macsec_pkt(macsec_pkt, sci, an, sak, encrypt, send_sci, pn, xpn_en=False, ssci=None, salt=None):
@@ -82,6 +198,9 @@ def __decap_macsec_pkt(macsec_pkt, sci, an, sak, encrypt, send_sci, pn, xpn_en=F
 
 
 def __macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_pkt=None):
+    if _native_macsec_active():
+        return __origin_dp_poll(test, device_number=device_number, port_number=port_number,
+                                timeout=timeout, exp_pkt=exp_pkt)
     recent_packets = []
     packet_count = 0
     if timeout is None:
@@ -122,7 +241,15 @@ def __macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_
     return test.dataplane.PollFailure(exp_pkt, recent_packets, packet_count)
 
 
-if MACSEC_SUPPORTED and os.path.exists(MACSEC_INFO_FILE):
+# Native-codec opt-in: when sonic-mgmt requests native mode it drops this
+# marker before launching PTF; the codec-carrying docker-ptf image activates
+# its DataPlane transforms and this monkeypatch must stand down entirely.
+# Without the marker (the default) this module behaves exactly as before,
+# so existing topo runs are undisturbed even on codec-carrying images.
+MACSEC_NATIVE_MODE_FLAG = "/root/macsec_native_codec"
+
+if MACSEC_SUPPORTED and os.path.exists(MACSEC_INFO_FILE) \
+        and not os.path.exists(MACSEC_NATIVE_MODE_FLAG):
     with open(MACSEC_INFO_FILE, "rb") as f:
         MACSEC_INFOS = pickle.load(f, encoding="bytes")
         if MACSEC_INFOS:

--- a/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
@@ -54,12 +54,16 @@ import time
 import ptf
 import ptf.packet as scapy
 import ptf.testutils as testutils
+# macsec must be imported BEFORE any `from ptf.testutils import ...` that pulls
+# in send_packet/dp_poll: it monkeypatches those functions in ptf.testutils to
+# MACsec-encrypt injected frames / decrypt sniffed frames on macsec-enabled
+# ports. A from-import binds the original object if it runs first.
+import macsec  # noqa F401
 from ptf.testutils import simple_ip_only_packet, simple_tcpv6_packet, simple_ipv4ip_packet, simple_ipv6ip_packet
 from ptf.testutils import send_packet, verify_packet_any_port
 from ptf.mask import Mask
 from ptf.base_tests import BaseTest
 
-import macsec  # noqa F401
 
 
 class DecapPacketTest(BaseTest):

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -42,6 +42,7 @@ import ptf.testutils as testutils
 
 from ptf.base_tests import BaseTest
 from ptf import config
+from ptf.mask import Mask
 
 
 class ControlPlaneBaseTest(BaseTest):
@@ -189,10 +190,29 @@ class ControlPlaneBaseTest(BaseTest):
             time.sleep(1.0 / float(self.default_server_send_rate_limit_pps))
 
         self.log("Sent out %d packets in %ds" % (send_count, self.DEFAULT_SEND_INTERVAL_SEC))
+        # The policer only emits trapped frames while the send loop pressures it,
+        # so the send-loop duration is the correct rx_pps divisor. Capture it here,
+        # before the drain sleep and packet-parse overhead below inflate the window
+        # (and deflate the measured rate toward the PPS_LIMIT_MIN boundary).
+        recv_window_sec = (datetime.datetime.now() - start_time).total_seconds()
         # Wait a little bit for all the packets to make it through
         time.sleep(self.DEFAULT_RECEIVE_WAIT_TIME)
+        # Wildcard the outer Ether.src field when matching. macsec.py:macsec_send
+        # overrides the outer source MAC to the peer's MAC for the Broadcom ASIC
+        # ingress-SCI quirk, so the wire frame -- and the trapped frame that comes
+        # back through swap_syncd -- carries peer_MAC instead of the value used to
+        # build `packet`. On non-MACsec testbeds the mask is a no-op (incoming
+        # frame's src already equals packet.src).
+        # `packet` is bytes here (one_port_test passes bytes(packet)); rehydrate
+        # before wrapping in Mask. Some tests use simple_eth_packet with an
+        # eth_type < 0x0600 (e.g. UDLD uses 0x0067 as 802.3 length), which
+        # scapy parses as Dot3, not Ether -- use the parsed outermost layer's
+        # class so the Mask field lookup succeeds for both encapsulations.
+        parsed = scapy.Ether(packet)
+        match_pkt = Mask(parsed)
+        match_pkt.set_do_not_care_scapy(type(parsed), "src")
         recv_count = testutils.count_matched_packets_all_ports(
-            self, packet, [recv_intf[1]], recv_intf[0], timeout=self.PTF_TIMEOUT)
+            self, match_pkt, [recv_intf[1]], recv_intf[0], timeout=self.PTF_TIMEOUT)
         self.log("Received %d packets after sleep %ds" % (recv_count, self.DEFAULT_RECEIVE_WAIT_TIME))
 
         ptf_tx_count = int(post_test_ptf_tx_counter[1] - pre_test_ptf_tx_counter[1])
@@ -221,7 +241,28 @@ class ControlPlaneBaseTest(BaseTest):
         time_delta = second_capture_time - first_capture_time
         time_delta_ms = (time_delta.microseconds + time_delta.seconds * 10**6) / 1000
         tx_pps = int(nn_tx_count / (float(time_delta_ms) / 1000))
-        rx_pps = int(nn_rx_count / (float(time_delta_ms) / 1000))
+        # Count only test-protocol-classified packets, not raw interface receives.
+        # On MACsec-enabled links the ptftests/macsec.py dp_poll wrapper decrypts
+        # background control-plane frames (BGP keepalives, MKA hellos, LLDP) and
+        # delivers them to the dataplane, where they get tallied into nn_rx_count
+        # but never match the test packet template. Using nn_rx_count made the
+        # NoPolicyApplied constraint (rx_pps <= PPS_LIMIT_MIN = 0) fail with a
+        # couple of pps of background noise even when zero protocol responses
+        # came back. recv_count comes from count_matched_packets_all_ports and
+        # only includes frames matching the expected reply.
+        #
+        # recv_count is accumulated by the dataplane queue from dataplane.flush()
+        # until count_matched_packets_all_ports returns, not over the bracketed
+        # time_delta_ms (~20s middle window) that nn_tx/nn_rx counters use, so
+        # we divide by the wall-clock recv window captured above.
+        # Keep the original nn-counter measurement on non-MACsec testbeds:
+        # matched counting is only needed where decrypted background frames
+        # pollute nn_rx_count, and some trap paths may legitimately mutate
+        # the returned frame beyond the masked src field.
+        if getattr(macsec, 'MACSEC_INFOS', None):
+            rx_pps = int(recv_count / recv_window_sec) if recv_window_sec > 0 else 0
+        else:
+            rx_pps = int(nn_rx_count / (float(time_delta_ms) / 1000))
 
         return send_count, recv_count, time_delta, time_delta_ms, tx_pps, rx_pps
 

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -19,6 +19,11 @@ import ptf.packet as scapy
 from utilities import retry_call
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
+# macsec must be imported BEFORE any `from ptf.testutils import ...` that pulls
+# in send_packet/dp_poll: it monkeypatches those functions in ptf.testutils to
+# MACsec-encrypt injected frames / decrypt sniffed frames on macsec-enabled
+# ports. A from-import binds the original object if it runs first.
+import macsec  # noqa F401
 from ptf.testutils import test_params_get
 from ptf.testutils import simple_tcp_packet
 from ptf.testutils import simple_tcpv6_packet
@@ -31,7 +36,6 @@ from ptf.testutils import simple_vxlanv6_packet
 from ptf.testutils import simple_nvgre_packet
 import fib
 import lpm
-import macsec  # noqa F401
 
 
 class HashTest(BaseTest):
@@ -772,14 +776,17 @@ class IPinIPHashTest(HashTest):
         return (matched_port, received)
 
     def check_hash(self, hash_key):
-        # Use dummy IPv4 address for outer_src_ip and outer_dst_ip
-        # We don't care the actually value as long as the outer_dst_ip is routed by default routed
-        # The outer_src_ip and outer_dst_ip are fixed
-        outer_src_ip = '80.1.0.31'
-        outer_dst_ip = '80.1.0.32'
-        if self.is_v6_topo:
-            outer_src_ip = '80::31'
-            outer_dst_ip = '80::32'
+        # Use routable outer IPs from test params if provided (e.g. for T2 topologies).
+        # Fall back to dummy IPs that assume a default route is present.
+        outer_src_ip = self.test_params.get('outer_src_ip', None)
+        outer_dst_ip = self.test_params.get('outer_dst_ip', None)
+        if outer_src_ip is None or outer_dst_ip is None:
+            if self.is_v6_topo:
+                outer_src_ip = '80::31'
+                outer_dst_ip = '80::32'
+            else:
+                outer_src_ip = '80.1.0.31'
+                outer_dst_ip = '80.1.0.32'
         src_port, exp_port_lists, next_hops = self.get_src_and_exp_ports(
             outer_dst_ip)
         if self.switch_type == "chassis-packet":
@@ -984,15 +991,17 @@ class VxlanHashTest(HashTest):
         return (matched_port, received)
 
     def check_hash(self, hash_key):
-        # Use dummy IPv4/v6 address for outer_src_ip and outer_dst_ip
-        # We don't care the actually value as long as the outer_dst_ip is routed by default routed
-        # The outer_src_ip and outer_dst_ip are fixed
-        if self.ipver == 'ipv4-ipv4' or self.ipver == 'ipv4-ipv6':
-            outer_src_ip = '80.1.0.31'
-            outer_dst_ip = '80.1.0.32'
-        else:
-            outer_src_ip = '80::31'
-            outer_dst_ip = '80::32'
+        # Use routable outer IPs from test params if provided (e.g. for T2 topologies without a
+        # default route).  Fall back to dummy IPs that assume a default route is present.
+        outer_src_ip = self.test_params.get('outer_src_ip', None)
+        outer_dst_ip = self.test_params.get('outer_dst_ip', None)
+        if outer_src_ip is None or outer_dst_ip is None:
+            if self.ipver == 'ipv4-ipv4' or self.ipver == 'ipv4-ipv6':
+                outer_src_ip = '80.1.0.31'
+                outer_dst_ip = '80.1.0.32'
+            else:
+                outer_src_ip = '80::31'
+                outer_dst_ip = '80::32'
         src_port, exp_port_lists, next_hops = self.get_src_and_exp_ports(
             outer_dst_ip)
         if self.switch_type == "chassis-packet":

--- a/ansible/roles/test/files/ptftests/py3/mtu_test.py
+++ b/ansible/roles/test/files/ptftests/py3/mtu_test.py
@@ -25,9 +25,13 @@ import ptf.packet as scapy
 
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
+# macsec must be imported BEFORE any `from ptf.testutils import ...` that pulls
+# in send_packet/dp_poll: it monkeypatches those functions in ptf.testutils to
+# MACsec-encrypt injected frames / decrypt sniffed frames on macsec-enabled
+# ports. A from-import binds the original object if it runs first.
+import macsec  # noqa F401
 from ptf.testutils import test_params_get, simple_icmp_packet, simple_icmpv6_packet, send_packet, \
     simple_ip_packet, simple_tcpv6_packet, verify_packet_any_port
-import macsec  # noqa F401
 
 
 class MtuTest(BaseTest):

--- a/ansible/roles/test/files/ptftests/py3/pfc_pause_test.py
+++ b/ansible/roles/test/files/ptftests/py3/pfc_pause_test.py
@@ -11,8 +11,12 @@ import scapy as sc
 
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
-from ptf.testutils import add_filter, reset_filters, dp_poll, simple_udp_packet, send_packet, test_params_get
+# macsec must be imported BEFORE any `from ptf.testutils import ...` that pulls
+# in send_packet/dp_poll: it monkeypatches those functions in ptf.testutils to
+# MACsec-encrypt injected frames / decrypt sniffed frames on macsec-enabled
+# ports. A from-import binds the original object if it runs first.
 import macsec  # noqa F401
+from ptf.testutils import add_filter, reset_filters, dp_poll, simple_udp_packet, send_packet, test_params_get
 
 
 def udp_filter(pkt_str):

--- a/ansible/roles/test/files/ptftests/py3/pfc_wd.py
+++ b/ansible/roles/test/files/ptftests/py3/pfc_wd.py
@@ -9,6 +9,11 @@ import ptf.packet as scapy
 
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
+# macsec must be imported BEFORE any `from ptf.testutils import ...` that pulls
+# in send_packet/dp_poll: it monkeypatches those functions in ptf.testutils to
+# MACsec-encrypt injected frames / decrypt sniffed frames on macsec-enabled
+# ports. A from-import binds the original object if it runs first.
+import macsec  # noqa F401
 from ptf.testutils import (
     test_params_get,
     simple_tcp_packet,
@@ -17,7 +22,6 @@ from ptf.testutils import (
     verify_no_packet_any,
     verify_packet_any_port
 )
-import macsec  # noqa F401
 
 
 class PfcWdTest(BaseTest):

--- a/ansible/roles/test/files/ptftests/py3/pfc_wd_background_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/pfc_wd_background_traffic.py
@@ -4,8 +4,12 @@ import logging
 import random
 from ptf.base_tests import BaseTest
 import time
-from ptf.testutils import test_params_get, simple_udp_packet, simple_udpv6_packet, send_packet
+# macsec must be imported BEFORE any `from ptf.testutils import ...` that pulls
+# in send_packet/dp_poll: it monkeypatches those functions in ptf.testutils to
+# MACsec-encrypt injected frames / decrypt sniffed frames on macsec-enabled
+# ports. A from-import binds the original object if it runs first.
 import macsec  # noqa F401
+from ptf.testutils import test_params_get, simple_udp_packet, simple_udpv6_packet, send_packet
 
 
 class PfcWdBackgroundTrafficTest(BaseTest):

--- a/ansible/roles/test/files/ptftests/py3/pfcwd_background_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/pfcwd_background_traffic.py
@@ -23,13 +23,17 @@
         --relax --platform remote
 '''
 
+# macsec must be imported BEFORE any `from ptf.testutils import ...` that pulls
+# in send_packet/dp_poll: it monkeypatches those functions in ptf.testutils to
+# MACsec-encrypt injected frames / decrypt sniffed frames on macsec-enabled
+# ports. A from-import binds the original object if it runs first.
+import macsec  # noqa F401
 from ptf.testutils import test_params_get, verify_packet, simple_udp_packet
 from ptf.base_tests import BaseTest
 from scapy.all import sendp
 import ptf.packet as scapy
 from ptf.mask import Mask
 import ptf
-import macsec  # noqa F401
 
 
 class BG_pkt_sender(BaseTest):

--- a/ansible/roles/test/files/ptftests/py3/voq.py
+++ b/ansible/roles/test/files/ptftests/py3/voq.py
@@ -4,6 +4,11 @@ import ptf.packet as scapy
 from ptf.mask import Mask
 from ptf import config
 from ptf.base_tests import BaseTest
+# macsec must be imported BEFORE any `from ptf.testutils import ...` that pulls
+# in send_packet/dp_poll: it monkeypatches those functions in ptf.testutils to
+# MACsec-encrypt injected frames / decrypt sniffed frames on macsec-enabled
+# ports. A from-import binds the original object if it runs first.
+import macsec  # noqa F401
 import ptf.testutils as testutils
 from ptf.testutils import test_params_get, MINSIZE, ip_make_tos, reset_filters, send, send_packet, dp_poll, \
     simple_udp_packet, simple_udpv6_packet, simple_icmp_packet, simple_icmpv6_packet, simple_ip_packet, \
@@ -11,7 +16,6 @@ from ptf.testutils import test_params_get, MINSIZE, ip_make_tos, reset_filters, 
 from scapy.all import Ether
 from scapy.layers.l2 import Dot1Q
 from scapy.layers.inet6 import IPv6, ICMPv6ND_NA, ICMPv6NDOptDstLLAddr
-import macsec  # noqa F401
 
 import logging
 

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -295,11 +295,22 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         # Extend ignore fabric port msgs for T2 chassis with DNX chipset on Linecards
         ignore_t2_syslog_msgs(sonic_host)
 
-    # Retrieve the enable_macsec passed by user for this test run
-    # If macsec is enabled, use the override option to get macsec profile from golden config
-    request = sonic_host.duthosts.request
+    # If MACsec is in play, use the override option so load_minigraph re-applies
+    # the golden config that carries MACSEC_PROFILE/PORT.macsec. Detect it from
+    # the DUT itself (any PORT.macsec binding in CONFIG_DB) as well as from the
+    # --enable_macsec option: always-on MACsec testbeds rely on auto-detection
+    # and pass no flag, and a plain load_minigraph would silently strip MACsec
+    # and then persist the stripped config via 'config save' below.
+    macsec_en = False
+    request = getattr(sonic_host.duthosts, "request", None)
     if request:
         macsec_en = request.config.getoption("--enable_macsec", default=False)
+    if not macsec_en:
+        out = sonic_host.shell(
+            "sonic-db-cli CONFIG_DB KEYS 'PORT|*' | while read k; do "
+            "sonic-db-cli CONFIG_DB HGET \"$k\" macsec; done | grep -c . || true",
+            module_ignore_errors=True)
+        macsec_en = bool(int((out.get("stdout") or "0").strip() or 0))
 
     if config_source == 'minigraph':
         if start_dynamic_buffer and sonic_host.facts['asic_type'] == 'mellanox':
@@ -326,6 +337,25 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
                 'sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" zebra_nexthop {}'.format(zebra_nexthop)
             )
         time.sleep(60)
+
+        # Restore MACsec on PortChannel-member ports after load_minigraph.  On
+        # images without the wpa_supplicant CP state-machine fix
+        # (sonic-net/sonic-wpa-supplicant#122) MKA can wedge on PC-member ports;
+        # the bootstrap detaches the members, re-pokes PORT.macsec, waits for
+        # MACSEC_PORT_TABLE.state=ok, and reattaches.  No-op when there are no
+        # PC-member macsec ports or MKA is already ok on them; the bootstrap
+        # raises when MKA never establishes.  Log that at ERROR but still finish the reload
+        # (bgp startup / config save below), so a MACsec failure doesn't also
+        # leave BGP administratively down with unsaved config.
+        # Only this minigraph reload path restores PC-member MACsec; plain
+        # 'config reload' sources are not covered.
+        if is_dut:
+            from tests.common.macsec.macsec_pc_bootstrap import bootstrap_pc_member_macsec
+            try:
+                bootstrap_pc_member_macsec(sonic_host)
+            except Exception:
+                logger.error("MACsec PC bootstrap failed", exc_info=True)
+
         if start_bgp:
             sonic_host.shell('config bgp startup all')
         if is_buffer_model_dynamic:

--- a/tests/common/macsec/macsec_pc_bootstrap.py
+++ b/tests/common/macsec/macsec_pc_bootstrap.py
@@ -1,0 +1,166 @@
+"""DUT-side bootstrap for MACsec on PortChannel-member ports.
+
+After `config reload` / `config load_minigraph --override_config`, CONFIG_DB
+has `PORT.<p>.macsec` and `PORTCHANNEL_MEMBER|<pc>|<p>` set for the same
+ports.  On images without the wpa_supplicant CP state-machine fix
+(sonic-net/sonic-wpa-supplicant#122) MKA can wedge on a port that is already
+a PortChannel member, so the MACsec session never establishes and the
+PortChannel stays partially up.
+
+Recovery helper for that case, run from the sonic-mgmt controller side so
+tests that trigger a config reload can recover MACsec without re-running
+ansible.  With the fix present MKA comes up unaided and this is a no-op.
+
+Sequence per PC-member macsec port:
+    1. DEL PORTCHANNEL_MEMBER|<pc>|<p>  — detach port from LAG.
+    2. HDEL + HSET PORT|<p>.macsec  — macsecmgrd does not watch
+       PORTCHANNEL_MEMBER, so re-poke the binding to force re-evaluation.
+    3. Wait STATE_DB MACSEC_PORT_TABLE|<p>.state == 'ok'  — MKA negotiates.
+    4. HSET PORTCHANNEL_MEMBER|<pc>|<p> NULL NULL  — reattach.
+LACP then forms over the already-active MACsec tunnel.
+
+No-op when:
+    - macsec feature is not enabled in CONFIG_DB.FEATURE.macsec.state.
+    - No PORT.<p>.macsec entries reference a port that's also a
+      PORTCHANNEL_MEMBER.
+"""
+
+import logging
+import time
+
+from tests.common.utilities import wait_until
+
+logger = logging.getLogger(__name__)
+
+
+def _macsec_feature_enabled(duthost):
+    out = duthost.shell(
+        "sonic-db-cli CONFIG_DB HGET 'FEATURE|macsec' state",
+        module_ignore_errors=True,
+    )
+    return out["stdout"].strip() == "enabled"
+
+
+def _collect_pc_member_macsec_ports(duthost):
+    """Return [(port, pc, profile), ...] for every PORT.macsec port that's also a PC member."""
+    pc_member_keys = duthost.shell(
+        "sonic-db-cli CONFIG_DB KEYS 'PORTCHANNEL_MEMBER|*'",
+        module_ignore_errors=True,
+    )["stdout"].splitlines()
+
+    port_to_pc = {}
+    for key in pc_member_keys:
+        parts = key.split("|")
+        if len(parts) == 3:
+            _, pc, port = parts
+            port_to_pc[port] = pc
+
+    if not port_to_pc:
+        return []
+
+    port_keys = duthost.shell(
+        "sonic-db-cli CONFIG_DB KEYS 'PORT|*'",
+        module_ignore_errors=True,
+    )["stdout"].splitlines()
+
+    pairs = []
+    for key in port_keys:
+        if "|" not in key:
+            continue
+        port = key.split("|", 1)[1]
+        if port not in port_to_pc:
+            continue
+        macsec_val = duthost.shell(
+            "sonic-db-cli CONFIG_DB HGET '{}' macsec".format(key),
+            module_ignore_errors=True,
+        )["stdout"].strip()
+        if macsec_val:
+            pairs.append((port, port_to_pc[port], macsec_val))
+
+    return sorted(pairs)
+
+
+def bootstrap_pc_member_macsec(duthost, timeout=600, grace=120):
+    """Detach → re-poke PORT.macsec → wait MKA → reattach every PC-member macsec port.
+
+    Collection is host-namespace only (single-ASIC DUTs); on multi-ASIC DUTs
+    this no-ops, matching the golden-config merge's single-ASIC scope.
+
+    grace is how long MKA gets to come up unaided before any port is touched;
+    with the wpa_supplicant fix every port reaches state=ok in this window and
+    the function returns without flapping a LAG.  timeout is the MKA budget
+    for the ports that still need the dance (MKA runs in parallel on all
+    detached ports, so one shared deadline).
+
+    Returns:
+        list of (port, pc) pairs that were processed.  Empty if no-op.
+
+    Raises:
+        RuntimeError when any port never reaches MACSEC_PORT_TABLE.state=ok
+        (ports are still reattached first so the LAG is not left broken).
+    """
+    if not _macsec_feature_enabled(duthost):
+        logger.info("macsec feature disabled — skipping PC bootstrap")
+        return []
+
+    triples = _collect_pc_member_macsec_ports(duthost)
+    if not triples:
+        logger.info("No PortChannel-member macsec ports found — skipping PC bootstrap")
+        return []
+
+    grace_deadline = time.time() + grace
+    pending = [
+        t for t in triples
+        if not wait_until(max(grace_deadline - time.time(), 1), 5, 0,
+                          duthost.iface_macsec_ok, t[0])
+    ]
+    if not pending:
+        logger.info("MACsec PC bootstrap: MKA already ok on %s — nothing to do", triples)
+        return []
+    triples = pending
+
+    logger.info("MACsec PC bootstrap: detaching %s", triples)
+    for port, pc, _ in triples:
+        duthost.shell(
+            "sonic-db-cli CONFIG_DB DEL 'PORTCHANNEL_MEMBER|{}|{}'".format(pc, port)
+        )
+
+    # Brief settle so orchagent observes the DEL before macsecmgrd retries.
+    time.sleep(5)
+
+    # macsecmgrd does not watch PORTCHANNEL_MEMBER; re-poke the PORT.macsec
+    # binding so it re-evaluates the now-standalone port (mirrors the playbook).
+    for port, _, _ in triples:
+        duthost.shell("sonic-db-cli CONFIG_DB HDEL 'PORT|{}' macsec".format(port))
+    time.sleep(2)
+    for port, _, profile in triples:
+        duthost.shell(
+            "sonic-db-cli CONFIG_DB HSET 'PORT|{}' macsec '{}'".format(port, profile)
+        )
+
+    # One shared deadline: MKA negotiates concurrently on every detached port.
+    # iface_macsec_ok resolves the port's namespace on multi-ASIC hosts.
+    deadline = time.time() + timeout
+    failed = [
+        port for port, _, _ in triples
+        if not wait_until(max(deadline - time.time(), 1), 2, 0,
+                          duthost.iface_macsec_ok, port)
+    ]
+
+    logger.info("MACsec PC bootstrap: reattaching %s", triples)
+    for port, pc, _ in triples:
+        duthost.shell(
+            "sonic-db-cli CONFIG_DB HSET 'PORTCHANNEL_MEMBER|{}|{}' NULL NULL".format(pc, port)
+        )
+
+    if len(failed) < len(triples):
+        # Let LACP re-form over MACsec before callers save config / start BGP.
+        time.sleep(15)
+
+    if failed:
+        raise RuntimeError(
+            "MACsec PC bootstrap: MACSEC_PORT_TABLE state != ok for {} "
+            "within {}s".format(failed, timeout)
+        )
+
+    return [(port, pc) for port, pc, _ in triples]

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -413,6 +413,7 @@ def load_basic_facts(dut_name, session):
 
     results['topo_type'] = tbinfo['topo']['type']
     results['topo_name'] = tbinfo['topo']['name']
+    results['macsec_topo'] = bool(tbinfo['topo'].get('properties', {}).get('macsec_links'))
     results['testbed'] = testbed_name
     if session.config.option.customize_inventory_file:
         inv_name = session.config.option.customize_inventory_file

--- a/tests/everflow/conftest.py
+++ b/tests/everflow/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def skip_egress_acl_everflow_on_dnx_macsec(request, duthosts, rand_one_dut_hostname,
+                                           is_macsec_enabled_for_test):
+    # Mirrors the egress-ACL skip in tests/acl/test_acl.py::stage: egress-ACL
+    # everflow variants are not supported with MACsec on broadcom-dnx ASICs.
+    if not is_macsec_enabled_for_test:
+        return
+    duthost = duthosts[rand_one_dut_hostname]
+    if duthost.facts.get("platform_asic") != "broadcom-dnx":
+        return
+    inst = request.instance
+    if inst is None:
+        return
+    fn = getattr(inst, "acl_stage", None)
+    if callable(fn) and fn() == "egress":
+        pytest.skip("Egress ACL everflow tests not supported with MACSEC on "
+                    "\"{}\" ASICs".format(duthost.facts.get("asic_type")))

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -48,6 +48,13 @@ SRC_IP_RANGE = ['8.0.0.0', '8.255.255.255']
 DST_IP_RANGE = ['9.0.0.0', '9.255.255.255']
 SRC_IPV6_RANGE = ['20D0:A800:0:00::', '20D0:FFFF:0:00::FFFF']
 DST_IPV6_RANGE = ['20D0:A800:0:01::', '20D0:FFFF:0:01::FFFF']
+
+# T2: outer IPs in the default-route space (8.x/9.x, 20D0:*) so both the exported FIB
+# and the ASIC LPM lookup consistently hit 0.0.0.0/0 [T3-ports] / ::/0 for outer headers.
+T2_VXLAN_OUTER_SRC_IPV4 = '8.0.0.1'
+T2_VXLAN_OUTER_DST_IPV4 = '9.0.0.1'
+T2_VXLAN_OUTER_SRC_IPV6 = '20D0:A800:0:00::1'
+T2_VXLAN_OUTER_DST_IPV6 = '20D0:A800:0:01::1'
 VLANIDS = list(range(1032, 1279))
 VLANIP = '192.168.{}.1/24'
 PTF_QLEN = 20000
@@ -423,9 +430,13 @@ def hash_keys(duthost, tbinfo):
     # In multi asic platform each asic has different hash seed,
     # the same packet coming in different asic
     # could egress out of different port
-    # the hash_test condition for hash_key == ingress_port will fail
-    if duthost.sonichost.is_multi_asic:
-        hash_keys.remove('ingress-port')
+    # the hash_test condition for hash_key == ingress_port will fail.
+    # VoQ (switch_type=voq) exhibits the same per-port hash seed variation
+    # even on single-ASIC platforms, so skip the ingress-port test there too.
+    dut_switch_type = duthost.facts.get('switch_type', '')
+    if duthost.sonichost.is_multi_asic or dut_switch_type == 'voq':
+        if 'ingress-port' in hash_keys:
+            hash_keys.remove('ingress-port')
 
     return hash_keys
 
@@ -668,27 +679,36 @@ def test_ipinip_hash_negative(add_default_route_to_dut, duthosts,           # no
     else:
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
+    ptf_params = {"fib_info_files": fib_files[:3],   # Test at most 3 DUTs
+                  "ptf_test_port_map": ptf_test_port_map_active_active(
+                      ptfhost, tbinfo, duthosts, mux_server_url,
+                      duts_running_config_facts, duts_minigraph_facts,
+                      mux_status_from_nic_simulator()
+                  ),
+                  "hash_keys": hash_keys,
+                  "src_ip_range": ",".join(src_ip_range),
+                  "dst_ip_range": ",".join(dst_ip_range),
+                  "vlan_ids": VLANIDS,
+                  "ignore_ttl": ignore_ttl,
+                  "single_fib_for_duts": single_fib_for_duts,
+                  "ipver": ipver,
+                  "topo_name": tbinfo['topo']['name'],
+                  "topo_type": tbinfo['topo']['type'],
+                  "is_v6_topo": is_ipv6_only_topology(tbinfo),
+                  }
+    if tbinfo['topo']['type'] == 't2':
+        # IPinIPHashTest picks the OUTER header version from is_v6_topo, not ipver.
+        if is_ipv6_only_topology(tbinfo):
+            ptf_params["outer_src_ip"] = T2_VXLAN_OUTER_SRC_IPV6
+            ptf_params["outer_dst_ip"] = T2_VXLAN_OUTER_DST_IPV6
+        else:
+            ptf_params["outer_src_ip"] = T2_VXLAN_OUTER_SRC_IPV4
+            ptf_params["outer_dst_ip"] = T2_VXLAN_OUTER_DST_IPV4
     ptf_runner(ptfhost,
                "ptftests",
                "hash_test.IPinIPHashTest",
                platform_dir="ptftests",
-               params={"fib_info_files": fib_files[:3],   # Test at most 3 DUTs
-                       "ptf_test_port_map": ptf_test_port_map_active_active(
-                           ptfhost, tbinfo, duthosts, mux_server_url,
-                           duts_running_config_facts, duts_minigraph_facts,
-                           mux_status_from_nic_simulator()
-               ),
-                   "hash_keys": hash_keys,
-                   "src_ip_range": ",".join(src_ip_range),
-                   "dst_ip_range": ",".join(dst_ip_range),
-                   "vlan_ids": VLANIDS,
-                   "ignore_ttl": ignore_ttl,
-                   "single_fib_for_duts": single_fib_for_duts,
-                   "ipver": ipver,
-                   "topo_name": tbinfo['topo']['name'],
-                   "topo_type": tbinfo['topo']['type'],
-                   "is_v6_topo": is_ipv6_only_topology(tbinfo),
-               },
+               params=ptf_params,
                log_file=log_file,
                qlen=PTF_QLEN,
                socket_recv_size=16384,
@@ -728,28 +748,37 @@ def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts,                
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
     switch_type = duthosts[0].facts.get('switch_type')
+    vxlan_params = {
+        "fib_info_files": fib_files[:3],   # Test at most 3 DUTs
+        "ptf_test_port_map": ptf_test_port_map_active_active(
+            ptfhost, tbinfo, duthosts, mux_server_url,
+            duts_running_config_facts, duts_minigraph_facts,
+            mux_status_from_nic_simulator()),
+        "hash_keys": hash_keys,
+        "src_ip_range": ",".join(src_ip_range),
+        "dst_ip_range": ",".join(dst_ip_range),
+        "vxlan_dest_port": vxlan_dest_port,
+        "vlan_ids": VLANIDS,
+        "ignore_ttl": ignore_ttl,
+        "single_fib_for_duts": single_fib_for_duts,
+        "switch_type": switch_type,
+        "ipver": vxlan_ipver,
+        "topo_name": tbinfo['topo']['name'],
+        "topo_type": tbinfo['topo']['type'],
+        "is_v6_topo": is_ipv6_only_topology(tbinfo),
+    }
+    if tbinfo['topo']['type'] == 't2':
+        if vxlan_ipver in ("ipv4-ipv4", "ipv4-ipv6"):
+            vxlan_params["outer_src_ip"] = T2_VXLAN_OUTER_SRC_IPV4
+            vxlan_params["outer_dst_ip"] = T2_VXLAN_OUTER_DST_IPV4
+        else:
+            vxlan_params["outer_src_ip"] = T2_VXLAN_OUTER_SRC_IPV6
+            vxlan_params["outer_dst_ip"] = T2_VXLAN_OUTER_DST_IPV6
     ptf_runner(ptfhost,
                "ptftests",
                "hash_test.VxlanHashTest",
                platform_dir="ptftests",
-               params={"fib_info_files": fib_files[:3],   # Test at most 3 DUTs
-                       "ptf_test_port_map": ptf_test_port_map_active_active(
-                                                                    ptfhost, tbinfo, duthosts, mux_server_url,
-                                                                    duts_running_config_facts, duts_minigraph_facts,
-                                                                    mux_status_from_nic_simulator()),
-                       "hash_keys": hash_keys,
-                       "src_ip_range": ",".join(src_ip_range),
-                       "dst_ip_range": ",".join(dst_ip_range),
-                       "vxlan_dest_port": vxlan_dest_port,
-                       "vlan_ids": VLANIDS,
-                       "ignore_ttl": ignore_ttl,
-                       "single_fib_for_duts": single_fib_for_duts,
-                       "switch_type": switch_type,
-                       "ipver": vxlan_ipver,
-                       "topo_name": tbinfo['topo']['name'],
-                       "topo_type": tbinfo['topo']['type'],
-                       "is_v6_topo": is_ipv6_only_topology(tbinfo),
-                       },
+               params=vxlan_params,
                log_file=log_file,
                qlen=PTF_QLEN,
                socket_recv_size=16384,


### PR DESCRIPTION
### Description of PR

Summary: Test-side half of always-on MACsec topology support. Depends on #24406 (deploy/golden-config infra). `ptftests/macsec.py` overlaps between the two (this PR's rework includes the small stand-down gate #24406 introduces) — merge #24406 first and this PR will be rebased.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
- master: Broadcom T2 single-node testbed with always-on MACsec — fib suite passes in both default (monkeypatch) and `--macsec_ptf_native` modes; config reload restores MKA on PortChannel-member ports.

### Approach
#### What is the motivation for this PR?
With #24406, MACsec-enabled topologies deploy at add-topo/deploy-mg time. The test framework's legacy PTF MACsec path and several tests need updates to run reliably on such testbeds.

#### How did you do it?
- `ptftests/macsec.py` rework: per-port PN tracking, cached SA bundles (struct fast path meeting CoPP's unpaced-send rate budget), Broadcom outer-src-MAC rewrite (ASIC derives ingress SCI from {outer_src_MAC, port}; opt-out marker for other platforms).
- `import macsec` ordered before `ptf.testutils` from-imports in PTF test files — later monkeypatching cannot rebind already-imported names.
- `config_reload` restores MACsec on the minigraph path: golden-config override is applied whenever the DUT carries PORT.macsec bindings (not only with `--enable_macsec`), and the PortChannel-member MKA bootstrap re-establishes sessions only on ports whose MKA is not ok after a grace window (a no-op with sonic-net/sonic-wpa-supplicant#122; recovery for images without it).
- T2 outer-IP parameters for IPinIP/VxLAN hash tests; `macsec_topo` fact for conditional_mark; everflow egress-ACL variants skip on broadcom-dnx MACsec testbeds (unsupported).

#### How did you verify/test it?
fib suite in both default (monkeypatch) and `--macsec_ptf_native` modes on a Broadcom T2 single-node always-on MACsec testbed; reload path leaves healthy PC-member MKA untouched and recovers it when wedged.

#### Any platform specific information?
The outer-src-MAC rewrite is Broadcom-specific (opt-out marker written for other ASIC types); everflow egress-ACL skip applies to broadcom-dnx only.

#### Supported testbed topology if it's a new test case?
Topologies declaring `macsec_links` (e.g. `t2_single_node_min_macsec` from #24406).

### Documentation
N/A

