### PR TITLE
[snappi][pfcwd] Reset PFCWD action in start_pfcwd to prevent forward-mode leak

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -830,6 +830,7 @@ def get_pfcwd_stats(duthost, port, prio, asic_value=None):
 def start_pfcwd(duthost, asic_value=None):
     """
     Start PFC watchdog with default setting
+    Stops the PFCWD cleanly before restarting it with the default (drop) action.
     Args:
         duthost (AnsibleHost): Device Under Test (DUT)
         asic_value: asic value of the host
@@ -837,9 +838,13 @@ def start_pfcwd(duthost, asic_value=None):
     Returns:
         N/A
     """
+    # 'pfcwd start_default' is a no-op if PFCWD is already running, so a prior
+    # forward-mode run would leak into a drop test. Stop first to force the reset.
     if asic_value is None:
+        stop_pfcwd(duthost)
         duthost.shell('sudo pfcwd start_default')
     else:
+        stop_pfcwd(duthost, asic_value)
         duthost.shell('sudo ip netns exec {} pfcwd start_default'.format(asic_value))
 
 


### PR DESCRIPTION
### Description of PR

`start_pfcwd()` in `tests/common/snappi_tests/common_helpers.py` only runs `sudo pfcwd start_default`. However, **`pfcwd start_default` is a no-op when PFCWD is already running** — it does not change the running action.

When a drop-mode test (e.g. `test_pfcwd_drop_over_subs_40_09`) runs immediately after a forward-mode test (`start_pfcwd_fwd()` leaves PFCWD running in the `forward` action), the drop test inherits the **forward** action. The lossless queue then **forwards instead of drops**, the egress queue frame count increases, and the test fails with:

```
Failed: Egress queue frame count should not increase when test traffic is paused
```

This only reproduces with that specific test ordering (forward test → drop test), which is why it passes when the test is run in isolation and looked like a flake.

#### Evidence (from a hardware run on a Broadcom DNX/VOQ pizzabox)
During the failing `drop_over_subs` episode, the DUT PFCWD counters showed:

```
TX_LAST_OK/DROP = 5,823,754,788 / 0
```

i.e. ~5.8B lossless frames **forwarded** and **0 dropped** — confirming PFCWD was in the forward action, not drop. Running the same test in isolation (no preceding forward test) passes every time, with the egress queue frozen at 0.

#### Fix
Stop PFCWD before `start_default` so the drop action is always applied, mirroring `start_pfcwd_fwd()` which already stops first (`stop_pfcwd()` already exists in the same module).

### How did you verify/test it?
Root-caused from a hardware nightly re-run where `drop_over_subs` failed 2/2 in module ordering but passed 9/9 in isolation; the PFCWD action timeline and per-episode `TX_OK/DROP` counters pinpointed the forward-mode leak. This change removes the ordering dependency without weakening the assertion.

### Which release branch to backport (if applicable)?
- [x] 202511
