### PR TITLE
[smartswitch]: Disable loganalyzer for DPU-restarting platform tests

### DIFF
--- a/tests/smartswitch/platform_tests/test_platform_dpu.py
+++ b/tests/smartswitch/platform_tests/test_platform_dpu.py
@@ -52,6 +52,7 @@ def test_midplane_ip(duthosts, enum_rand_one_per_hwsku_hostname, platform_api_co
     pytest_assert(ping_status == 1, "Ping to one or more DPUs has failed")
 
 
+@pytest.mark.disable_loganalyzer
 def test_pcie_link(duthosts, dpuhosts,
                    enum_rand_one_per_hwsku_hostname,
                    platform_api_conn, num_dpu_modules):   # noqa: F811
@@ -136,6 +137,7 @@ def test_restart_pmon(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
                                     re.IGNORECASE))
 
 
+@pytest.mark.disable_loganalyzer
 def test_system_health_state(duthosts, dpuhosts,
                              enum_rand_one_per_hwsku_hostname,
                              platform_api_conn, num_dpu_modules):  # noqa: F811


### PR DESCRIPTION
### Description of PR

Summary:
ADO: 39219092

`test_pcie_link` and `test_system_health_state` in
`tests/smartswitch/platform_tests/test_platform_dpu.py` shut down and restart the
DPUs (`config chassis modules shutdown/startup`). During DPU bring-up the DPU
syslog is expected to contain boot-time ERR logs — e.g. `featured` failing to
stop `lldp`/`snmp`/`restapi` units that are not shipped on the DPU, plus
transient `parseDatabaseConfig` and syncd `getStats` errors. These expected
boot-time logs were caught by the automatic LogAnalyzer teardown and failed the
two tests. This PR disables the automatic LogAnalyzer on these two
DPU-restarting tests, consistent with how reboot test cases are handled.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- pytest marker-only change. `disable_loganalyzer` is a registered marker
- Tests now does not throw errors during the teardown.


### Approach
#### What is the motivation for this PR?

`test_pcie_link` and `test_system_health_state` restart the DPUs, and the expected
DPU boot-time syslog errors were causing the automatic LogAnalyzer to fail the
tests in teardown (ADO 39219092).

#### How did you do it?

Added `@pytest.mark.disable_loganalyzer` to `test_pcie_link` and
`test_system_health_state`, matching the convention used by reboot test cases.
Only these two DPU-restarting tests are affected; the rest of the module keeps
LogAnalyzer enabled.

#### How did you verify/test it?

- Confirmed `disable_loganalyzer` is a registered marker in `tests/pytest.ini`.
- With the marker, the `loganalyzer` fixture
  (`tests/common/plugins/loganalyzer/__init__.py`) returns early, disabling both
  NPU and DPU analysis for these tests.
- `python3 -m py_compile` on the modified file passes.

#### Any platform specific information?

SmartSwitch / DPU platforms only (`topology('smartswitch')`).

#### Supported testbed topology if it's a new test case?

N/A — existing tests, `smartswitch` topology.

### Documentation

N/A
