### PR TITLE
[snappi][pfcwd] Apply pfcwd poll-interval override after all start_pfcwd calls

### DIFF
--- a/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
@@ -85,12 +85,18 @@ def run_pfcwd_basic_test(api,
 
     orig_poll_interval_ms = {}
     try:
-        for duthost, asic_value in ((egress_duthost, rx_port['asic_value']),
-                                    (ingress_duthost, tx_port['asic_value'])):
+        dut_asic_pairs = ((egress_duthost, rx_port['asic_value']),
+                          (ingress_duthost, tx_port['asic_value']))
+        for duthost, asic_value in dut_asic_pairs:
             # Disable packet aging only on Nexthop (VOQ/DNX) DUTs; others keep it enabled.
             packet_aging = disable_packet_aging if is_nexthop_device(duthost) else enable_packet_aging
             packet_aging(duthost, asic_value)
             start_pfcwd(duthost, asic_value)
+
+        # Apply the poll-interval override only after every start_pfcwd call: on a single-DUT
+        # testbed egress==ingress, so a second start_pfcwd (start_default) would otherwise reset
+        # the poll interval back to the platform default and drop the override.
+        for duthost, asic_value in dut_asic_pairs:
             if is_nexthop_device(duthost) and duthost not in orig_poll_interval_ms:
                 # `pfcwd interval` is host-global: once per DUT, else a repeat DUT re-reads our own override.
                 orig_poll_interval_ms[duthost] = get_pfcwd_poll_interval(duthost, asic_value)


### PR DESCRIPTION
### Description of PR

`run_pfcwd_basic_test()` lowers the pfcwd poll interval to `PFCWD_POLL_INTERVAL_MS` (100ms) so that a sub-detection PFC storm can't trip pfcwd in a single poll — this is what makes the `trigger_pfcwd=False` cases (short 0.3s storm, below the 0.6s detection time) expect **zero loss** on the lossless flow.

The override was applied **inside the same loop** that calls `start_pfcwd()`:

```python
for duthost, asic_value in ((egress_duthost, ...), (ingress_duthost, ...)):
    ...
    start_pfcwd(duthost, asic_value)          # 'pfcwd start_default' resets poll to platform default
    if is_nexthop_device(duthost) and duthost not in orig_poll_interval_ms:
        orig_poll_interval_ms[duthost] = get_pfcwd_poll_interval(...)
        update_pfc_poll_interval(duthost, PFCWD_POLL_INTERVAL_MS)
```

On a **single-DUT testbed** `egress_duthost == ingress_duthost`, so the loop runs on the same DUT twice:
- **iter 1:** `start_pfcwd` → poll 600ms → override → poll **100ms**
- **iter 2:** `start_pfcwd` (`start_default`) **resets poll back to 600ms**, and the override is **skipped** (`duthost` already in `orig_poll_interval_ms`).

The DUT ends up with **poll_interval == detection_time (600ms)**. With no margin, a 0.3s storm intermittently trips pfcwd, which drops the lossless flow → `trigger_pfcwd=False` cases fail with ~0.2–0.43 loss.

#### Evidence (hardware run on a Broadcom DNX/VOQ single-DUT testbed)
- Effective timers logged as `detection_time=0.6, poll_interval=0.6, restoration_time=0.6` (override lost).
- `single_lossless_prio[False]` → `STORM_DETECTED 9→10` (fired) → **FAIL, loss 0.43**
- `multi_lossless_prio[False]` → `STORM_DETECTED 11→11` (not fired) → **PASS**

i.e. failures correlate exactly with pfcwd (incorrectly) detecting the sub-detection storm.

#### Fix
Move the poll-interval override into a **separate loop that runs after all `start_pfcwd()` calls**, so `start_default` can no longer reset it. The DUT then keeps poll=100ms ≪ detection=600ms and the sub-detection storm can't trip pfcwd.

### How did you verify/test it?
Root-caused from a hardware nightly re-run: the `trigger_pfcwd=False` variants failed intermittently with lossless loss only on a single-DUT testbed, and the pfcwd command log showed `pfcwd interval 100` being applied and then undone by a second `pfcwd start_default`, leaving poll == detection.

### Which release branch to backport (if applicable)?
- [x] 202511
