### PR TITLE
[platform_tests]: Skip pddf_ledutil and sfp_thermal_state_db tests on BMC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1037,6 +1037,45 @@ platform_tests/broadcom/test_ser.py:
     conditions:
       - "release in ['202412','202503'] and 'Arista-7060X6' in hwsku"
 
+####################################
+#####  cli/test_pddf_ledutil.py  #####
+####################################
+platform_tests/cli/test_pddf_ledutil.py::test_pddf_ledutil_leds:
+  skip:
+    reason: "LED util tests are not supported on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
+platform_tests/cli/test_pddf_ledutil.py::test_getstatusled_valid_led:
+  skip:
+    reason: "LED util tests are not supported on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
+platform_tests/cli/test_pddf_ledutil.py::test_getstatusled_invalid_led:
+  skip:
+    reason: "LED util tests are not supported on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
+platform_tests/cli/test_pddf_ledutil.py::test_setstatusled_valid_led_valid_color:
+  skip:
+    reason: "LED util tests are not supported on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
+platform_tests/cli/test_pddf_ledutil.py::test_setstatusled_valid_led_invalid_color:
+  skip:
+    reason: "LED util tests are not supported on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
+platform_tests/cli/test_pddf_ledutil.py::test_setstatusled_invalid_led:
+  skip:
+    reason: "LED util tests are not supported on BMC"
+    conditions:
+      - "'bmc' in topo_type"
+
 ##################################
 #####  cli/test_show_bmc.py  #####
 ##################################
@@ -1737,6 +1776,15 @@ platform_tests/test_service_warm_restart.py:
     conditions:
       - "asic_type in ['mellanox', 'nvidia']"
       - "topo_type not in ['t0']"
+
+##########################################
+#####  test_sfp_thermal_state_db.py  #####
+##########################################
+platform_tests/test_sfp_thermal_state_db.py::TestSfpThermalStateDb::test_no_sfp_entries_in_temperature_info:
+  skip:
+    reason: "SFP thermal state DB test is not supported on BMC"
+    conditions:
+      - "'bmc' in topo_type"
 
 #######################################
 #####   test_xcvr_info_in_db.py   #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1750,7 +1750,7 @@ platform_tests/test_service_warm_restart.py:
 ##########################################
 #####  test_sfp_thermal_state_db.py  #####
 ##########################################
-platform_tests/test_sfp_thermal_state_db.py::TestSfpThermalStateDb::test_no_sfp_entries_in_temperature_info:
+platform_tests/test_sfp_thermal_state_db.py:
   skip:
     reason: "SFP thermal state DB test is not supported on BMC"
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1040,37 +1040,7 @@ platform_tests/broadcom/test_ser.py:
 ####################################
 #####  cli/test_pddf_ledutil.py  #####
 ####################################
-platform_tests/cli/test_pddf_ledutil.py::test_pddf_ledutil_leds:
-  skip:
-    reason: "LED util tests are not supported on BMC"
-    conditions:
-      - "'bmc' in topo_type"
-
-platform_tests/cli/test_pddf_ledutil.py::test_getstatusled_valid_led:
-  skip:
-    reason: "LED util tests are not supported on BMC"
-    conditions:
-      - "'bmc' in topo_type"
-
-platform_tests/cli/test_pddf_ledutil.py::test_getstatusled_invalid_led:
-  skip:
-    reason: "LED util tests are not supported on BMC"
-    conditions:
-      - "'bmc' in topo_type"
-
-platform_tests/cli/test_pddf_ledutil.py::test_setstatusled_valid_led_valid_color:
-  skip:
-    reason: "LED util tests are not supported on BMC"
-    conditions:
-      - "'bmc' in topo_type"
-
-platform_tests/cli/test_pddf_ledutil.py::test_setstatusled_valid_led_invalid_color:
-  skip:
-    reason: "LED util tests are not supported on BMC"
-    conditions:
-      - "'bmc' in topo_type"
-
-platform_tests/cli/test_pddf_ledutil.py::test_setstatusled_invalid_led:
+platform_tests/cli/test_pddf_ledutil.py:
   skip:
     reason: "LED util tests are not supported on BMC"
     conditions:


### PR DESCRIPTION
### Description of PR
Summary:
Skip platform CLI/thermal tests that are not applicable on BMC topologies, using the `conditional_mark` mechanism.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202608

### Approach
#### What is the motivation for this PR?
The following tests are not supported on BMC topologies (e.g. Nokia-7220-Th6p) and should be skipped there:
- `platform_tests/cli/test_pddf_ledutil.py` — all 6 LED util tests
- `platform_tests/test_sfp_thermal_state_db.py::TestSfpThermalStateDb::test_no_sfp_entries_in_temperature_info`

`platform_tests/cli/test_show_platform.py::test_show_platform_fan` already skips on BMC, so no change was needed there.

#### How did you do it?
Added `skip` entries with the condition `"'bmc' in topo_type"` to `tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml`, following the existing pattern used by other BMC-related skips in the file.

#### How did you verify/test it?
Validated the YAML parses correctly and that all new keys are registered.

#### Any platform specific information?
Applies to BMC topologies (`topo_type` contains `bmc`).

#### Supported testbed topology if it's a new test case?
N/A — no new test cases.

### Documentation
N/A