### PR TITLE
[generic_config_updater]: Skip test_apply_patch_perf on BMC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2579,6 +2579,10 @@ generic_config_updater/add_cluster/test_port_speed_upgrade.py:
       - "hwsku not in ['x86_64-88_lc0_36fh-r0']"
 
 generic_config_updater/test_apply_patch_perf.py:
+  skip:
+    reason: "GCU apply-patch perf test relies on ACL tables and front-panel data ports; not applicable on BMC"
+    conditions:
+      - "'bmc' in topo_type"
   xfail:
     reason: "This test has been failing since https://github.com/sonic-net/sonic-buildimage/pull/26584, awaiting feature owner to triage, tracked by https://github.com/sonic-net/sonic-mgmt/issues/24984"
     conditions:


### PR DESCRIPTION
### Description of PR
Summary:
Skip `generic_config_updater/test_apply_patch_perf.py` on BMC topologies. The GCU apply-patch performance test relies on ACL tables and front-panel data ports, neither of which exist on the BMC SONiC image, so the test is not applicable there.

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202608

### Approach
#### What is the motivation for this PR?
`test_apply_patch_perf.py` exercises GCU apply-patch performance using ACL tables (`/ACL_TABLE/...`) and per-port leaf-list operations that require front-panel data ports. BMC runs a minimal SONiC image without a data plane, ACL tables, or front-panel ports, so this test cannot run meaningfully there.

#### How did you do it?
Added a `skip` mark for `'bmc' in topo_type` to the existing `generic_config_updater/test_apply_patch_perf.py` entry in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`, following the same BMC-skip pattern already used for other data-plane/ACL dependent tests in that file. The pre-existing `xfail` condition is preserved.

#### How did you verify/test it?
Validated the YAML parses correctly and the entry resolves to both the new `skip` (bmc) and existing `xfail` (vs) marks.

#### Any platform specific information?
Only affects BMC topologies (`topo_type` containing `bmc`).

#### Supported testbed topology if it's a new test case?
N/A — not a new test case.

### Documentation
N/A