### PR TITLE
[everflow]: drop the redundant line continuation that fails pre-commit

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -324,7 +324,7 @@ def gen_setup_information(dutHost, downStreamDutHost, upStreamDutHost, tbinfo, t
                 "vlan_mac": upstream_vlan_mac,
                 "src_port": downstream_ports[0],
                 # DUT whose downstream are servers doesn't have lag connect to server
-                "src_port_lag_name": "Not Applicable" \
+                "src_port_lag_name": "Not Applicable"
                 if topo_type in DOWNSTREAM_SERVER_TOPO else downstream_dest_lag_name[0],
                 "src_port_ptf_id": str(mg_facts_list[0]["minigraph_ptf_indices"][downstream_ports[0]]),
                 "dest_port": upstream_dest_ports,


### PR DESCRIPTION
### Description of PR

Summary:
Removes a redundant line continuation in `tests/everflow/everflow_test_utilities.py` that makes the pre-commit Static Analysis job fail on 202605.

flake8 reports:

```
tests/everflow/everflow_test_utilities.py:327:55: E502 the backslash is redundant between brackets
```

The backslash sits inside a dict literal, so Python already continues the line and the continuation does nothing.

This has been latent on 202605. pre-commit only lints the files a PR touches, and nothing had touched this file on this branch, so it was never reported. The first PR that does touch it then fails Static Analysis on an error it did not introduce.

That is currently blocking #27507, the cherry-pick of #27369 to 202605, whose own diff only changes lines 448 and 456 and is nowhere near line 327.

`master` already carries this line without the backslash, so this brings 202605 back in line rather than changing behaviour.

#### Why this rather than waiting for #26573

#26573 backports the full flake8 7.1.1 bump plus #26073 and #26085 to 202605, and would fix this along with 31 other findings. That is the better long-term fix, but its author has said they intend to hold it until after the 202605 nightly qualification finishes, since it touches 100 files and we are close to the end of the cycle. That is a reasonable call.

This PR is the minimal alternative: one line, one file, no behaviour change, so #27507 can land without pulling in a large change late in qualification. It does not conflict with #26573 landing later.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A, this PR targets 202605 directly and master is already correct.
Failure type: day-one issue on this branch

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

Static check only, no functional behaviour is affected.

Verified with **flake8 7.1.1**, the version pinned by `.pre-commit-config.yaml`. This matters: older flake8 does not report this finding, so a local run with an older version looks clean and misses it.

| | flake8 7.1.1, `--max-line-length=120` |
| --- | --- |
| 202605 before | `327:55: E502 the backslash is redundant between brackets` |
| 202605 after | clean, exit 0 |
| master (control) | clean, exit 0 |

Also confirmed the module still parses (`ast.parse`), and that the conditional evaluates identically with and without the backslash on both branches:

```
topo in DOWNSTREAM_SERVER_TOPO     -> 'Not Applicable'   both forms
topo not in DOWNSTREAM_SERVER_TOPO -> 'PortChannel001'   both forms
```

### Approach
#### What is the motivation for this PR?

Unblock Static Analysis on 202605 for #27507 and for any other PR that touches this file, without waiting on a 100-file change during qualification.

#### How did you do it?

Deleted the trailing `\` on line 327. One line, no logic change.

#### How did you verify/test it?

Reproduced the exact CI failure locally by pinning flake8 to 7.1.1 to match pre-commit, then confirmed the file is clean after the change. Details in the Test result section.

#### Any platform specific information?

None.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change needed.
