### PR TITLE
Fix snappi ICMP test fixture import

### DIFF
--- a/tests/snappi_tests/test_orchagent_icmp_hw_offload.py
+++ b/tests/snappi_tests/test_orchagent_icmp_hw_offload.py
@@ -117,7 +117,7 @@ from tests.common.dualtor.dual_tor_utils import tor_mux_intfs  # noqa: F401, E40
 # Import Snappi/IXIA fixtures and utilities
 from tests.common.snappi_tests.snappi_fixtures import (  # noqa: F401, E402
     snappi_api_serv_ip, snappi_api_serv_port,
-    snappi_api, snappi_testbed_config)
+    snappi_api, snappi_testbed_config, is_pfc_enabled)
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp  # noqa: E402
 from tests.common.fixtures.conn_graph_facts import (  # noqa: F401, E402
     conn_graph_facts, fanout_graph_facts)


### PR DESCRIPTION
### Description of PR

Summary:
Import is_pfc_enabled in 	est_orchagent_icmp_hw_offload.py so pytest registers the fixture required by snappi_testbed_config.

ADO: https://dev.azure.com/msazure/One/_workitems/edit/39520954

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/39520954
Failure type: regression

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Validated with pre-commit run --files tests/snappi_tests/test_orchagent_icmp_hw_offload.py.

### Approach
#### What is the motivation for this PR?

Nightly 	est_icmp_orchestrator_session_creation_and_state_detection fails during setup because pytest cannot find fixture is_pfc_enabled, which is a dependency of snappi_testbed_config.

#### How did you do it?

Added is_pfc_enabled to the fixture import list from 	ests.common.snappi_tests.snappi_fixtures.

#### How did you verify/test it?

Ran pre-commit on the changed test file.

#### Any platform specific information?

Observed on Arista 7060/7260 T0 internal nightly testbeds, but the missing fixture import is test-code generic.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.