### PR TITLE
Xfail BGP GR helper on t1-d96u4

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -461,9 +461,11 @@ bgp/test_bgp_gr_helper.py:
 
 bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved:
   xfail:
-    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
+    reason: "Test case has known issues on specific large topologies."
+    conditions_logical_operator: or
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/27135 and topo_name in ['t1-d96u4']"
 
 bgp/test_bgp_link_local.py::test_bgp_link_local[ethernet]:
   skip:


### PR DESCRIPTION
### Description of PR

Summary:
Mark `bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved` as an expected failure on the `t1-d96u4` topology because serial restoration of 100 logical neighbors exceeds the test timeout.

Related to #27135

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: other

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: case xfailed as expected
- 202605: case xfailed as expected

### Approach
#### What is the motivation for this PR?

On `t1-d96u4`, BGP graceful-restart setup and teardown restore 100 logical neighbors serially. The timeout condition is tracked by #27135; this PR only marks the affected case as expected failure.

#### How did you do it?

Added a separate issue-linked `xfail` condition for `t1-d96u4` while preserving the existing condition for the other affected topology.

#### How did you verify/test it?

Parsed `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`, verified the new xfail condition, and ran syntax and whitespace validation. Functional test evidence is not included in this PR description.

#### Any platform specific information?

No platform restriction. The condition applies only to the `t1-d96u4` topology.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change is required.


