### PR TITLE
Xfail CRM nexthop on t1-d96u4

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -943,6 +943,12 @@ crm/test_crm.py::test_crm_fdb_entry:
     conditions:
       - "'t0' not in topo_name and topo_type not in ['m0', 'mx']"
 
+crm/test_crm.py::test_crm_nexthop:
+  xfail:
+    reason: "On multi-VRF (converged) cEOS, IPv6 is disabled on remapped neighbor iface; Linux ip addr add fails. https://github.com/sonic-net/sonic-mgmt/issues/27131"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/27131 and topo_name == 't1-d96u4'"
+
 crm/test_crm_available.py:
   xfail:
     reason: "There is a known issue with broadcom dualtor (https://github.com/sonic-net/sonic-mgmt/issues/18873) or xfail for IPv6-only topologies, as it try to excute ipv4 command"


### PR DESCRIPTION
### Description of PR

Summary:
Mark `test_crm_nexthop` as expected to fail on the `t1-d96u4` converged topology for the cEOS neighbor-interface IPv6 condition tracked by #27131.

Related to #27131

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: other

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: case xfailed as expected
- 202605: case xfailed as expected

### Approach
#### What is the motivation for this PR?

The IPv6 CRM nexthop setup encounters a cEOS neighbor interface with IPv6 disabled on `t1-d96u4`. The affected run should be classified as an expected failure under the condition tracked by #27131.

#### How did you do it?

Added a conditional xfail for `test_crm_nexthop` scoped to `t1-d96u4`.

#### How did you verify/test it?

Parsed `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`, verified that the xfail condition is scoped to `t1-d96u4`, and ran syntax and whitespace validation. Functional test evidence is not included in this PR description.

#### Any platform specific information?

Generic. The condition is scoped by topology.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No documentation change is required.


