### PR TITLE
optimize logic for multi asic port toggle in lldp test

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -579,11 +579,17 @@ def test_lldp_entry_table_after_all_batched_flap(
     logger.info("Using bulk interface flap for {} interfaces".format(len(testable_interfaces)))
     asic_interface_map = group_interfaces_by_asic(duthost, testable_interfaces)
     lldpctl_lookup_map = _build_lldpctl_lookup_map(lldpctl_interfaces)
-    for asic_str, asic_interfaces in asic_interface_map.items():
-        logger.info("Flapping interfaces: {}".format(asic_interfaces))
-        # Interface range shutdown/startup is not supported in multi-asic platforms.
-        for interface in asic_interfaces:
-            _shutdown_startup_interface(duthost, interface, asic_str)
+    if duthost.is_multi_asic:
+        for asic_str, asic_interfaces in asic_interface_map.items():
+            logger.info("Flapping interfaces: {}".format(asic_interfaces))
+            # Interface range shutdown/startup is not supported in multi-asic platforms.
+            for interface in asic_interfaces:
+                _shutdown_startup_interface(duthost, interface, asic_str)
+    else:
+        asic_str, asic_interfaces = next(iter(asic_interface_map.items()))
+        interface_list = ",".join(asic_interfaces)
+        logger.info("Flapping interfaces: {}".format(interface_list))
+        _shutdown_startup_interface(duthost, interface_list, asic_str)
     # Single wait_until call checking all interfaces together
     _verify_interface_lldp_recovery(db_instance, testable_interfaces, lldpctl_lookup_map, delay=10)
 


### PR DESCRIPTION
### Description of PR

Summary:

Fixes #27563, separate port toggle logic for multi asic and single asic and keep previous logic for single asic switch to avoid toggling port one-by-one, which will save much time and avoid generating huge amount of records in swss.rec, which might occupy /var/log/ space and lead to other issues.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #27563
Failure type: Others

### Test result
tested on 202605:
 <img width="247" height="233" alt="image" src="https://github.com/user-attachments/assets/75c8235c-dc34-4b30-88af-5aa0080a6cdf" />



### Approach
#### What is the motivation for this PR?
optimize port toggle flow in lldp test for multi/single asic
#### How did you do it?
combine the logic together
#### How did you verify/test it?
running tests with updates and passed
#### Any platform specific information?
the issue is more likely to happen on single asic platform with small /var/log/ partition space
#### Supported testbed topology if it's a new test case?

### Documentation
