### PR TITLE
[vm_set]: Enable ptf_use_docker_network for BMC topology only when the docker network exists

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -10,10 +10,21 @@
     ptf_imagetag: "latest"
   when: ptf_imagetag is not defined
 
-- name: Enable ptf_use_docker_network for BMC topology
+- name: Check whether a docker network named "{{ mgmt_bridge }}" exists
+  command: docker network inspect {{ mgmt_bridge }}
+  register: ptf_mgmt_docker_network
+  failed_when: false
+  changed_when: false
+  become: yes
+  when: "'bmc' in topo and ptf_use_docker_network is not defined"
+
+- name: Enable ptf_use_docker_network for BMC topology when that docker network exists
   set_fact:
     ptf_use_docker_network: true
-  when: "'bmc' in topo"
+  when:
+    - "'bmc' in topo"
+    - ptf_use_docker_network is not defined
+    - ptf_mgmt_docker_network.rc | default(1) == 0
 
 - name: set "PTF" container type, by default
   set_fact:

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -15,10 +15,21 @@
       ptf_imagetag: "latest"
     when: ptf_imagetag is not defined
 
-  - name: Enable ptf_use_docker_network for BMC topology
+  - name: Check whether a docker network named "{{ mgmt_bridge }}" exists
+    command: docker network inspect {{ mgmt_bridge }}
+    register: ptf_mgmt_docker_network
+    failed_when: false
+    changed_when: false
+    become: yes
+    when: "'bmc' in topo and ptf_use_docker_network is not defined"
+
+  - name: Enable ptf_use_docker_network for BMC topology when that docker network exists
     set_fact:
       ptf_use_docker_network: true
-    when: "'bmc' in topo"
+    when:
+      - "'bmc' in topo"
+      - ptf_use_docker_network is not defined
+      - ptf_mgmt_docker_network.rc | default(1) == 0
 
   - name: Detect Python major version of the existing ptf container
     shell: docker exec ptf_{{ vm_set_name }} python -c 'import sys; print(sys.version_info[0])'


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #26542

#26405 sets `ptf_use_docker_network` to true for every BMC topology. In that mode the PTF container is created with `network_mode: {{ mgmt_bridge }}` plus a static IP on a docker network of that name, and the `Bind topology` step that would otherwise give the PTF a veth on the Linux management bridge is skipped. On servers whose `mgmt_bridge` is a Linux bridge there is no docker network of that name, so `add-topo` fails at `Create ptf container` with `Parameter error: network named br0 could not be found`.

This change probes for the docker network with `docker network inspect {{ mgmt_bridge }}` and enables the mode only when the network exists. Servers that have it keep the docker network path introduced by #23813 and #26405. Servers without it keep the Linux-bridge path, where the bind step attaches a veth into the PTF netns. An explicit `ptf_use_docker_network` setting from group_vars or host_vars still wins, since both new tasks skip when the variable is already defined.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #26542
Failure type: regression

### Tested branch
- [x] master

### Test result

- master: `bmc-shared-mgmt` topology on a test server where `mgmt_bridge` is a Linux bridge and no docker network of that name exists. Before the change, `add-topo` fails at `Create ptf container` as reported in #26542. With the change, `Check whether a docker network named "br0" exists` returns rc 1, the enable task is skipped, `Create ptf container` and `Bind topology bmc-shared-mgmt to VMs` both report changed, and the play ends with `failed=0`.

### Approach
#### What is the motivation for this PR?

Restore `add-topo` for BMC topologies on servers that use a Linux management bridge, which #26405 broke by assuming a docker network named after `mgmt_bridge` is present.

#### How did you do it?

In `add_topo.yml` and `renumber_topo.yml`, replace the unconditional `set_fact: ptf_use_docker_network: true` for BMC topologies with a `docker network inspect {{ mgmt_bridge }}` probe (`failed_when: false`, `changed_when: false`) followed by the same `set_fact`, now conditioned on the probe returning rc 0. Both tasks run only when `'bmc' in topo` and `ptf_use_docker_network` is not already defined.

#### How did you verify/test it?

See Test result. The probe-positive branch (docker network present, docker mode enabled) is the same code path #26405 exercised.

#### Any platform specific information?

Applies to BMC topologies only. No change for other topologies.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
