### PR TITLE
[redfish]: xfail PowerCycle test asserts the wrong CPU-reset oracle

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4770,6 +4770,15 @@ reboot/test_reboot_blocking_mode.py:
       - "(is_multi_asic==True) and (asic_type in ['vs']) and https://github.com/sonic-net/sonic-mgmt/issues/23879"
 
 #######################################
+#####           redfish           #####
+#######################################
+redfish/test_redfish_computer_reset.py::TestRedfishComputerReset::test_reset_power_cycle
+  xfail:
+    reason: "Xfail due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/27212"
+    conditions:
+      - "('bmc' in topo_type) and https://github.com/sonic-net/sonic-mgmt/issues/27212"
+
+#######################################
 #####      reset_factory          #####
 #######################################
 reset_factory:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4772,7 +4772,7 @@ reboot/test_reboot_blocking_mode.py:
 #######################################
 #####           redfish           #####
 #######################################
-redfish/test_redfish_computer_reset.py::TestRedfishComputerReset::test_reset_power_cycle
+redfish/test_redfish_computer_reset.py::TestRedfishComputerReset::test_reset_power_cycle:
   xfail:
     reason: "Xfail due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/27212"
     conditions:


### PR DESCRIPTION

### Description of PR


Summary: [redfish]: xfail PowerCycle test asserts the wrong CPU-reset oracle
Fixes # (issue) [redfish]: xfail PowerCycle test asserts the wrong CPU-reset oracle
### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [X] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [X] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: https://github.com/sonic-net/sonic-mgmt/issues/27212

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608
- [ ] N/A

### Test result

master: pass
202608: pass

### Approach
#### What is the motivation for this PR?
skip a test that is currently fail due to https://github.com/sonic-net/sonic-mgmt/issues/27212

#### How did you do it?
xfail it

#### How did you verify/test it?
run against a regression.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
N/A
