### PR TITLE
[202605][Backport #26460] Add loganalyzer ignore for journalctl-tagged TACACS+ transient errors

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -521,3 +521,8 @@ r, ".* ERR auditd.*: auditd queue full reporting limit reached - ending dropped 
 # ctrmgrd k8s join warnings (old k8s version incompatibility with Docker 28.x)
 r, ".* ERR ctrmgrd\.py: Refer file .* for troubleshooting tips.*"
 r, ".* ERR ctrmgrd\.py:.*\[WARNING SystemVerification\]:.*Docker version is not on the list of validated versions.*"
+
+# ignore journalctl tac_connect_single and nss_tacplus errors during config reload
+# TACACS+ is temporarily unreachable while the SONiC network stack restarts
+r, ".* ERR journalctl: tac_connect_single: connection failed with .*Transport endpoint is not connected"
+r, ".* ERR journalctl: nss_tacplus: failed to connect TACACS\+ server .*Transport endpoint is not connected"


### PR DESCRIPTION
### Description of PR
Summary:
Backport #26460 to the 202605 branch.

This change adds LogAnalyzer ignore patterns for transient `journalctl:`-tagged TACACS+ errors during `config_reload`.

Related to #26458

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: #26458
Failure type: regression

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: `branch.202605-ars.e36dabd7` (nightly 2026.06.17) — `test_active_link_admin_down_config_reload_upstream[active-active]` and `test_active_link_admin_down_config_reload_downstream[active-active]` passed teardown with the fix applied on testbed dtAA.

### Approach

#### What is the motivation for this PR?

sonic-buildimage PR [#18113](https://github.com/sonic-net/sonic-buildimage/pull/18113) migrated container-to-host syslog forwarding from UDP to RELP. The host-level TACACS+ transient errors consequently appear under the `journalctl:` tag, which was not covered by the existing LogAnalyzer ignore patterns.

This causes false-positive teardown failures during `config_reload` while the network stack is restarting.

#### How did you do it?

Cherry-picked the merged commit from PR #26460:

`b6e54bccfe57ea434d74d780c3913802a8297347`

Added two patterns matching `journalctl:`-tagged `tac_connect_single` and `nss_tacplus` errors containing `Transport endpoint is not connected`.

The positional cherry-pick conflict was resolved by retaining the existing 202605 entries and applying only the five lines introduced by the original PR.

#### How did you verify/test it?
Ran `test_active_link_admin_down_config_reload_upstream[active-active]` and `test_active_link_admin_down_config_reload_downstream[active-active]` on dualtor-AA testbed dtAA using build `branch.202605-ars.e36dabd7`. Both passed teardown with the fix applied.

#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.