### PR TITLE
[uma][lma] Mark the ten m1 modules proven to run on the DMA topologies

### DIFF
--- a/tests/arp/test_arpall.py
+++ b/tests/arp/test_arpall.py
@@ -11,7 +11,7 @@ from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # no
 
 
 pytestmark = [
-    pytest.mark.topology('t1', 't2', 'lrh', 'urh', 'm1', 'c0')
+    pytest.mark.topology('t1', 't2', 'lrh', 'urh', 'm1', 'uma', 'lma', 'c0')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -9,7 +9,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('m1', 't1', 'ptf', 'c0')
+    pytest.mark.topology('m1', 'uma', 'lma', 't1', 'ptf', 'c0')
 ]
 
 

--- a/tests/bgp/test_bgp_aggregate_address.py
+++ b/tests/bgp/test_bgp_aggregate_address.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 # ---- Topology & device-type markers (register in pytest.ini to avoid warnings) ----
 pytestmark = [
-    pytest.mark.topology("m1"),
+    pytest.mark.topology("m1", "uma", "lma"),
 ]
 
 

--- a/tests/bgp/test_bgp_aggregate_address_resilience.py
+++ b/tests/bgp/test_bgp_aggregate_address_resilience.py
@@ -45,7 +45,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("m1"),
+    pytest.mark.topology("m1", "uma", "lma"),
 ]
 
 # ---- Constants ----

--- a/tests/crm/test_crm_available.py
+++ b/tests/crm/test_crm_available.py
@@ -3,7 +3,7 @@ import logging
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 'm0', 'mx', 'm1'),
+    pytest.mark.topology('t0', 't1', 'm0', 'mx', 'm1', 'uma', 'lma'),
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -23,7 +23,7 @@ CISCO_NHOP_GROUP_FILL_PERCENTAGE = 0.92
 PTF_QUEUE_LEN = 100000
 
 pytestmark = [
-    pytest.mark.topology('t1', 't2', 'lrh', 'urh', 'm1', "lt2", "ft2")
+    pytest.mark.topology('t1', 't2', 'lrh', 'urh', 'm1', 'uma', 'lma', "lt2", "ft2")
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/snmp/test_snmp_default_route.py
+++ b/tests/snmp/test_snmp_default_route.py
@@ -4,7 +4,8 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'm0', 'mx', 'm1', 't1-multi-asic', 'lt2', 'ft2', 'c0'),
+    pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'm0', 'mx', 'm1', 'uma', 'lma',
+                         't1-multi-asic', 'lt2', 'ft2', 'c0'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_link_local.py
+++ b/tests/snmp/test_snmp_link_local.py
@@ -4,7 +4,8 @@ from tests.common import config_reload
 from tests.common.utilities import wait_until
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'm0', 'mx', 'm1', 't1-multi-asic', 'lt2', 'ft2', 'c0'),
+    pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'm0', 'mx', 'm1', 'uma', 'lma',
+                         't1-multi-asic', 'lt2', 'ft2', 'c0'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_loopback.py
+++ b/tests/snmp/test_snmp_loopback.py
@@ -5,7 +5,8 @@ from tests.common.devices.eos import EosHost
 from tests.common.utilities import skip_release
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'm0', 'mx', 'm1', 't1-multi-asic', 'lt2', 'ft2', 'c0'),
+    pytest.mark.topology('t0', 't1', 't2', 'lrh', 'urh', 'm0', 'mx', 'm1', 'uma', 'lma',
+                         't1-multi-asic', 'lt2', 'ft2', 'c0'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -15,7 +15,7 @@ MAX_WAIT_TIME = 120
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 'm0', 'mx', 'm1', 't2', 'lrh', 'urh', 'lt2', 'ft2')
+    pytest.mark.topology('t0', 't1', 'm0', 'mx', 'm1', 'uma', 'lma', 't2', 'lrh', 'urh', 'lt2', 'ft2')
 ]
 
 


### PR DESCRIPTION
### Description of PR

Summary:
The `uma` and `lma` topologies were added recently. Modules that already run in the m1 nightly are marked for `m1` only, so on a uma or lma testbed they are never collected and **silently skip**. The run reports green while the coverage is simply absent, which is the worst way for a gap to present itself.

This adds `uma` and `lma` to the topology marker of ten modules that are proven to run there. No test logic changes, only the marker.

ADO: 39355502

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Backport is requested to **msft-202603** via the `Request for msft-202603 branch` label, since that branch is not on the list above. That is the branch the DMA testbeds qualify against, so it is where the missing coverage actually matters.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): ADO 39355502

Failure type: other. This is a test coverage gap rather than a failure fix. No test is currently failing because of it; the modules are simply not collected.

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Also tested on **202603**, which is not on the list above and is the branch these testbeds run.

### Test result

- **202603**: hardware, both DMA testbeds, native topology.

| Testbed | Modules | Result |
| --- | --- | --- |
| uma | 10 | **28 passed, 0 failed, 0 errored** |
| lma | 10 | 9 modules clean, 1 with a pre-existing intermittent error, see below |

### Approach

#### What is the motivation for this PR?

MA qualification is measured against M1 coverage. If a module is marked `m1` but not `uma`/`lma`, it does not run on the DMA testbeds and does not report a skip reason worth noticing, so the qualification looks more complete than it is. This closes that gap for the modules that are known to work.

#### How did you do it?

Added `uma` and `lma` to `pytest.mark.topology(...)` in ten files:

```
arp/test_arpall.py
arp/test_neighbor_mac.py
bgp/test_bgp_aggregate_address.py
bgp/test_bgp_aggregate_address_resilience.py
crm/test_crm_available.py
ipfwd/test_nhop_group.py
snmp/test_snmp_default_route.py
snmp/test_snmp_link_local.py
snmp/test_snmp_loopback.py
stress/test_stress_routes.py
```

One line per file. Nothing removed, no test logic touched.

#### How did you verify/test it?

Two stages, deliberately.

**Stage 1, probe.** Ran the m1 marked modules on both DMA testbeds forcing `--topology m1`, with no code change, to find which ones work there.

**Stage 2, confirm.** Re-ran each candidate under its **native** topology with the marker applied. The probe only shows a module works when m1 is forced; it does not show the marker behaves the same way once the real topology selects it.

**One known intermittent case, and why it is still included.** `bgp/test_bgp_aggregate_address_resilience.py::test_aggregate_bbr_required_inactive_persists_bgp_restart` errored twice in three native lma runs. Before concluding anything about DMA, I checked how the same case behaves where it already runs today, over the last 30 days:

| Topology | Passed | Errored | Error rate |
| --- | --- | --- | --- |
| m1-48 | 10 | 9 | **47%** |
| m1-128 | 12 | 6 | **33%** |
| lma | 6 | 2 | 25% |
| uma | 25 | 0 | **0%** |

The case is already the least reliable in the m1 nightly and has been for a month. It is **more** stable on lma than on either m1 variant, and completely clean on uma. So this is a pre-existing test defect, not something the marker introduces or worsens, and excluding the module from DMA would only hide it further.

The underlying cause is in cleanup rather than in the test body. The `finally` block calls `gcu_remove_aggregate`, which pushes `no aggregate-address <prefix>` even when the aggregate is already gone. bgpd rejects it and bgpcfgd logs an ERR:

```
ERR bgp#bgpcfgd: command execution returned 13
  line: no aggregate-address <prefix>
  % There is no aggregate-address configuration.
```

LogAnalyzer then matches that ERR and errors the case at teardown. The test catches the Python exception from the removal but cannot unwrite the syslog line. Making the cleanup idempotent would fix it, which belongs in its own change against the owning feature rather than in a marker PR.

#### Any platform specific information?

None. This is topology marker only and not platform specific.

#### Supported testbed topology if it's a new test case?

Not a new test case. The ten modules gain `uma` and `lma` in addition to every topology they already supported.

### Documentation

No documentation change needed.
