### PR TITLE
[Mellanox] Skip ASIC thermal sysfs check on LD systems

### DIFF
--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -1350,6 +1350,12 @@ def get_chip_type(dut):
     return platform_data.get("chip_type")
 
 
+def is_ld_system(duthost):
+    logger.info(f"Checking if {duthost.facts['platform']} is LD system")
+    chassis_name = duthost.facts.get("chassis", {}).get("name", "")
+    return 'ld' in chassis_name.lower()
+
+
 @read_only_cache()
 def get_hardware_version(duthost, platform):
     if platform in MULTI_HARDWARE_TYPE_PLATFORMS:

--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -6,10 +6,19 @@ This script contains re-usable functions for checking status of hw-management re
 import logging
 import re
 from pkg_resources import parse_version
-from tests.common.mellanox_data import get_hw_management_version, get_platform_data
+from tests.common.mellanox_data import get_hw_management_version, get_platform_data, is_ld_system
 from tests.common.utilities import wait_until
 
 MAX_FAN_SPEED_THRESHOLD = 0.15
+
+
+def check_asic_thermal_sysfs(sysfs_facts):
+    """
+    @summary: Check asic thermal related sysfs under /var/run/hw-management/thermal
+    """
+    asic_temp = float(sysfs_facts['asic_info']['temp']) / 1000
+    assert 0 < asic_temp < 105, "Abnormal ASIC temperature: {}".format(
+        sysfs_facts['asic_info']['temp'])
 
 
 def skip_ignored_broken_symbolinks(broken_symbolinks):
@@ -55,13 +64,14 @@ def check_sysfs(dut, expected_module_temp_fault_value=['0']):
             str(broken_symbolinks_updated))
 
     logging.info("Check ASIC related sysfs")
-    try:
-        asic_temp = float(sysfs_facts['asic_info']['temp']) / 1000
-        assert 0 < asic_temp < 105, "Abnormal ASIC temperature: {}".format(
-            sysfs_facts['asic_info']['temp'])
-    except Exception as e:
-        assert False, "Bad content in /var/run/hw-management/thermal/asic: {}".format(
-            repr(e))
+    if is_ld_system(dut):
+        logging.info("LD system, skipping ASIC thermal sysfs check")
+    else:
+        try:
+            check_asic_thermal_sysfs(sysfs_facts)
+        except Exception as e:
+            assert False, "Bad content in /var/run/hw-management/thermal/asic: {}".format(
+                repr(e))
 
     logging.info("Check fan related sysfs")
     for fan_id, fan_info in list(sysfs_facts['fan_info'].items()):


### PR DESCRIPTION
### Description of PR
The ASIC thermal sysfs check under /var/run/hw-management/thermal is not applicable to LD systems, so check_sysfs() fails there when it asserts on the ASIC temperature.

Extract the ASIC temperature validation from check_sysfs() into check_asic_thermal_sysfs() and skip it on LD systems, detected with the new is_ld_system() helper in tests/common/mellanox_data.py.

LD detection reads the chassis name defensively, since the chassis fact is only present when the platform ships a platform.json, and it runs outside the try/except that reports bad ASIC sysfs content so a detection failure is not misreported as a sysfs error.


Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
`tests/platform_tests/mellanox/test_check_sysfs.py::test_check_hw_mgmt_sysfs` is the test that
exercises `check_sysfs()`. Results over 2026-08-23 .. 2026-09-02:

- LD platforms: 43 passed, 0 failed, across 4 platforms (SN6600_LD, SN6600_LD simx, SN6810_LD,
  SN6810_LD simx) and 12 setups.
- Non-LD platforms: 145 passed, 0 failed, across 9 platforms and 22 setups, confirming the
  extracted `check_asic_thermal_sysfs()` still runs and passes where it applies.

### Approach
#### What is the motivation for this PR?
The ASIC thermal sysfs check under /var/run/hw-management/thermal is not applicable to LD systems, so check_sysfs() fails there when it asserts on the ASIC temperature.

#### How did you do it?
- Added `is_ld_system(duthost)` to `tests/common/mellanox_data.py`, which returns `True` when the
  DUT's `chassis.name` fact contains `ld`. The fact is read defensively, because `chassis` is only
  present when the platform ships a `platform.json`.
- `check_sysfs()` now calls that helper only for non-LD systems and logs a skip message otherwise.
  The platform check runs outside the `try`/`except` that reports bad ASIC sysfs content, so a
  detection problem cannot be misreported as a sysfs content error.


#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
internal regression

#### Any platform specific information?
_ld platforms 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
