### PR TITLE
[route] Scale test_route_consistency reconverge timeout for large VOQ topologies

### DIFF
--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -226,7 +226,15 @@ class TestRouteConsistency():
             logger.info("advertise ipv4 and ipv6 routes for {}".format(topo_name))
             localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
 
-            assert wait_until(self.sleep_interval + 300, 10, 0, self.route_snapshots_match,
+            # The withdraw + re-advertise cycle re-installs the entire route table twice. On very
+            # large-scale VOQ topologies (~100k+ prefixes) exact ASIC_DB reconvergence takes far longer
+            # than the default margin (measured ~1400s for ~102k prefixes on a large-scale VOQ max topology,
+            # where sleep_interval + 300 = 455s was not enough). wait_until() returns as soon as the
+            # route snapshots match, so smaller/faster testbeds are unaffected by the larger ceiling.
+            route_reconverge_timeout = self.sleep_interval + 300
+            if self.sleep_interval > 150:
+                route_reconverge_timeout = self.sleep_interval + 1500
+            assert wait_until(route_reconverge_timeout, 10, 0, self.route_snapshots_match,
                               duthosts, self.pre_test_route_snapshot), (
                 "Route snapshots did not match within the specified timeout for DUT hosts: '{}'.".format(
                     duthosts


### PR DESCRIPTION
#### Description of PR
Fixes #27677.

`test_route_consistency.py::TestRouteConsistency::test_route_withdraw_advertise` withdraws the entire route table and re-advertises it, then waits for the ASIC_DB route snapshot to **exactly** match the pre-test snapshot within `self.sleep_interval + 300` seconds. On very large-scale VOQ topologies (~100k+ prefixes) that reconvergence takes far longer than the resulting 455s, so the case times out even though the routes do reconverge correctly.

#### Type of change
- [x] Bug fix

#### Approach
`sleep_interval = ceil(max_prefix_cnt / 3000) + 120` → 155 for ~102k prefixes → old match wait `155 + 300 = 455s`. Measured reconvergence for the full withdraw+re-advertise cycle on a large-scale VOQ max bed: the case completed in **~1420s** with a large cap (and **failed** at 455s in nightly).

This PR raises the reconvergence match ceiling only for very large route tables:
```python
route_reconverge_timeout = self.sleep_interval + 300
if self.sleep_interval > 150:            # ~ >90k prefixes (e.g. VOQ max)
    route_reconverge_timeout = self.sleep_interval + 1500
```
`self.sleep_interval > 150` corresponds to `max_prefix_cnt > 90000`. Because `wait_until()` returns as soon as the snapshots match, the larger ceiling adds **zero** runtime for any testbed that already passes — it only extends patience for the large-scale beds that need it. Smaller/typical topologies keep the exact same `sleep_interval + 300`.

#### How to verify it
Run `route/test_route_consistency.py::TestRouteConsistency::test_route_withdraw_advertise` on a ~100k-route VOQ topology; validated passing on large-scale VOQ max.
