### PR TITLE
[transceiver] Add standard port verification to upgrade tests

### DIFF
--- a/tests/transceiver/cdb_firmware_upgrade/firmware_operations.py
+++ b/tests/transceiver/cdb_firmware_upgrade/firmware_operations.py
@@ -12,6 +12,12 @@ from tests.transceiver.attribute_parser.attribute_keys import (
 )
 from tests.transceiver.common import cli_helpers, dmesg_helpers, scenario_ops
 from tests.transceiver.common.db_helpers import resolve_port_namespace
+from tests.transceiver.common.health_checks import capture_baseline
+from tests.transceiver.common.verification import (
+    assert_no_flap_since,
+    capture_flap_sentinels,
+    standard_port_recovery_and_verification,
+)
 from tests.transceiver.cdb_firmware_upgrade.utils.firmware_utils import resolve_binary_path
 from tests.transceiver.dom import dom_helpers
 from tests.transceiver.eeprom import eeprom_content
@@ -185,6 +191,21 @@ def verify_dom_recovered_after_operation(duthost, port_attributes_dict, ports,
     )
 
 
+def verify_standard_port_recovery(duthost, port_attributes_dict, ports, link_up_timeout_sec,
+                                  health_baseline, lport_to_first_subport_mapping):
+    """Run the Standard Port Recovery and Verification Procedure over ``ports``."""
+    result = standard_port_recovery_and_verification(
+        duthost, ports, {port: port_attributes_dict[port] for port in ports},
+        link_up_timeout_sec=link_up_timeout_sec,
+        health_baseline=health_baseline,
+        lport_to_first_subport_mapping=lport_to_first_subport_mapping,
+    )
+    return [
+        outcome["details"] for outcome in result["per_port"].values()
+        if not outcome["passed"]
+    ]
+
+
 def verify_firmware_downloaded(duthost, port, before_banks, target_version, download_err):
     """Active/Running/Committed banks unchanged, the inactive bank has ``target_version``."""
     if download_err:
@@ -213,11 +234,15 @@ def perform_firmware_download(duthost, port, port_context, metadata_map,
                               target_version=None, expect_link_up=True):
     """Download firmware to ``port`` and verify the firmware downloaded successfully.
 
+    When ``expect_link_up`` is true, every sub-port must remain up without a
+    flap for the entire download.
+
     Returns a list of per-port failure strings (empty on success).
     """
     cdb_attrs = port_context["cdb_attrs"]
     vendor, pn = port_context["vendor"], port_context["pn"]
     physical_index = port_context["physical_index"]
+    subports = port_context["subports"]
 
     before_banks, err = cli_helpers.sfputil_show_fwversion(duthost, port)
     if err:
@@ -232,9 +257,12 @@ def perform_firmware_download(duthost, port, port_context, metadata_map,
     if err:
         return [err]
 
+    flap_sentinels = {}
     if expect_link_up:
-        if wait_ports_oper_status(duthost, [port], "up", 0):
-            return ["port must be operationally up before download"]
+        down_subports = wait_ports_oper_status(duthost, subports, "up", 0)
+        if down_subports:
+            return [f"sub-port not up before download: {failure}" for failure in down_subports]
+        flap_sentinels = capture_flap_sentinels(duthost, subports)
 
     failures = []
     with thermalctld_stopped_if_required(duthost, cdb_attrs, failures):
@@ -258,11 +286,17 @@ def perform_firmware_download(duthost, port, port_context, metadata_map,
                     duthost, port, before_banks, target_version, dl_err,
                 )
                 if expect_link_up and not dl_err:
-                    if wait_ports_oper_status(duthost, [port], "up", 0):
-                        failures.append("link went down during firmware download")
-
-                # TODO: no link flap should occur during firmware download,
-                # need to add check for link flap.
+                    failures += [
+                        f"link down after firmware download: {failure}"
+                        for failure in wait_ports_oper_status(duthost, subports, "up", 0)
+                    ]
+                    failures += [
+                        result["details"]
+                        for result in assert_no_flap_since(
+                            duthost, subports, flap_sentinels, elapsed_sec=elapsed,
+                        ).values()
+                        if not result["passed"]
+                    ]
 
                 failures += _scan_i2c_errors(duthost, dmesg_start_uptime, "download")
     return failures
@@ -533,9 +567,10 @@ def execute_on_ports(duthost, port_attributes_dict, qualifying_ports, lport_to_p
     ``prefetch(duthost, qualifying_ports, lport_to_pport)`` runs once before the
     loop and its result is exposed as ``port_context["prefetched"]``.
 
-    ``verify_post_operation`` runs the checks once every port is done: static
-    EEPROM unchanged, then DOM polling re-enabled and in operational range. It
-    requires ``lport_to_first_subport_mapping``.
+    ``verify_post_operation`` runs the Standard Port Recovery and Verification
+    Procedure over every sub-port of the modules under test both before and
+    after the operation, and additionally verifies static EEPROM and DOM
+    recovery once every port is done. It requires ``lport_to_first_subport_mapping``.
 
     Returns ``(all_failures, num_ports)``, the caller ``pytest.fail``s or logs.
     """
@@ -545,6 +580,26 @@ def execute_on_ports(duthost, port_attributes_dict, qualifying_ports, lport_to_p
     pport_to_lport = get_physical_to_logical_port_mapping(lport_to_pport)
     prefetched = prefetch(duthost, qualifying_ports, lport_to_pport) if prefetch else None
     all_failures = []
+
+    if verify_post_operation and qualifying_ports:
+        recovery_ports = sorted({
+            subport
+            for port in qualifying_ports
+            for subport in pport_to_lport.get(lport_to_pport.get(port), [port])
+            if subport in port_attributes_dict
+        })
+        link_up_timeout_sec = max(
+            port_attributes_dict[port][SYSTEM_ATTRIBUTES_KEY]["port_startup_wait_sec"]
+            for port in qualifying_ports
+        )
+        health_baseline = capture_baseline(duthost)
+        pre_failures = verify_standard_port_recovery(
+            duthost, port_attributes_dict, recovery_ports, link_up_timeout_sec,
+            health_baseline, lport_to_first_subport_mapping,
+        )
+        if pre_failures:
+            return [f"pre-operation: {failure}" for failure in pre_failures], len(qualifying_ports)
+
     for port in qualifying_ports:
         base_attrs = port_attributes_dict[port].get(BASE_ATTRIBUTES_KEY, {})
         vendor = base_attrs.get("normalized_vendor_name")
@@ -568,5 +623,9 @@ def execute_on_ports(duthost, port_attributes_dict, qualifying_ports, lport_to_p
         )
         all_failures += verify_dom_recovered_after_operation(
             duthost, port_attributes_dict, qualifying_ports, lport_to_first_subport_mapping,
+        )
+        all_failures += verify_standard_port_recovery(
+            duthost, port_attributes_dict, recovery_ports, link_up_timeout_sec,
+            health_baseline, lport_to_first_subport_mapping,
         )
     return all_failures, len(qualifying_ports)

--- a/tests/transceiver/cdb_firmware_upgrade/firmware_operations.py
+++ b/tests/transceiver/cdb_firmware_upgrade/firmware_operations.py
@@ -257,12 +257,10 @@ def perform_firmware_download(duthost, port, port_context, metadata_map,
     if err:
         return [err]
 
-    flap_sentinels = {}
     if expect_link_up:
         down_subports = wait_ports_oper_status(duthost, subports, "up", 0)
         if down_subports:
             return [f"sub-port not up before download: {failure}" for failure in down_subports]
-        flap_sentinels = capture_flap_sentinels(duthost, subports)
 
     failures = []
     with thermalctld_stopped_if_required(duthost, cdb_attrs, failures):
@@ -279,6 +277,7 @@ def perform_firmware_download(duthost, port, port_context, metadata_map,
                 failures.append(dmesg_start_err)
             else:
                 timeout_sec = cdb_attrs["firmware_download_timeout_minutes"] * 60
+                flap_sentinels = capture_flap_sentinels(duthost, subports) if expect_link_up else {}
                 elapsed, dl_err = cli_helpers.sfputil_firmware_download(duthost, port, fwfile, timeout_sec)
                 logger.info("Port %s: firmware download %s took %ss", port, target_version, elapsed)
 


### PR DESCRIPTION
### Description of PR

Summary:
Wires the shared **Standard Port Recovery and Verification Procedure** into the CDB firmware-upgrade suite, and adds the missing no-link-flap assertion for firmware downloads.

Fixes # N/A

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Approach

#### What is the motivation for this PR?

Two gaps in the CDB firmware suite:

1. The test plan's Standard Port Recovery requirement was not implemented.
2. Only the first sub-port of a breakout module was ever checked. Firmware operations are issued against the first sub-port of each physical module, but a module reset or activation cycles *every* sub-port. So, checking all subports for port verification.

#### How did you do it?

- **New `verify_standard_port_recovery()`** — thin bridge to `standard_port_recovery_and_verification()` that returns per-port failure strings.
- **`execute_on_ports()`** now captures the health baseline and runs the procedure *before* the operation, and runs it again *after*, alongside the existing EEPROM and DOM checks.
- **Sub-port scoping.** The recovery procedure runs over every logical sub-port of each module under test. EEPROM and DOM stay scoped to the first sub-port, because both read module-level state that is published once per physical module.
- **No-flap across download only.** `perform_firmware_download()` snapshots `flap_count`/`last_up_time` on all sub-ports and asserts no flap across the download window, gated on the existing `expect_link_up` parameter.

#### How did you verify/test it?

- Ran full `tests/transceiver/cdb_firmware_upgrade` suite on dut and verified all the tests passed.
- Captured logs for standard port verification to confirm we are calling the helper.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

### Test logs

```
root@sonic:sonic-mgmt/tests# grep -nE "Standard Port Recovery|Stability check|Link-up check|pre-operation:|sub-port not up before download|link down after firmware download" logs/test.log
9957:02/09/2026 18:06:42 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
10651:02/09/2026 18:08:42 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
10659:02/09/2026 18:08:48 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=117, last_up_time=Fri Aug 28 22:48:51 2026)
10662:02/09/2026 18:08:48 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=111, last_up_time=Fri Aug 28 22:48:51 2026)
10678:02/09/2026 18:08:51 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
10679:02/09/2026 18:08:51 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
10897:02/09/2026 18:10:19 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
10905:02/09/2026 18:10:24 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=119, last_up_time=Wed Sep 02 16:55:10 2026)
10908:02/09/2026 18:10:25 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=113, last_up_time=Wed Sep 02 16:55:08 2026)
10924:02/09/2026 18:10:29 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
10925:02/09/2026 18:10:29 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
11181:02/09/2026 18:11:04 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
11189:02/09/2026 18:11:10 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=119, last_up_time=Wed Sep 02 16:55:10 2026)
11192:02/09/2026 18:11:10 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=113, last_up_time=Wed Sep 02 16:55:08 2026)
11208:02/09/2026 18:11:13 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
11209:02/09/2026 18:11:13 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
11236:02/09/2026 18:20:08 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 525.1s window (flap_count=119, last_up_time=Wed Sep 02 16:55:10 2026)
11239:02/09/2026 18:20:09 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 525.1s window (flap_count=113, last_up_time=Wed Sep 02 16:55:08 2026)
11453:02/09/2026 18:21:26 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
11461:02/09/2026 18:21:31 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=119, last_up_time=Wed Sep 02 16:55:10 2026)
11464:02/09/2026 18:21:32 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=113, last_up_time=Wed Sep 02 16:55:08 2026)
11480:02/09/2026 18:21:35 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
11481:02/09/2026 18:21:35 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
11705:02/09/2026 18:22:08 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
11713:02/09/2026 18:22:14 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=119, last_up_time=Wed Sep 02 16:55:10 2026)
11716:02/09/2026 18:22:14 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=113, last_up_time=Wed Sep 02 16:55:08 2026)
11732:02/09/2026 18:22:18 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
11733:02/09/2026 18:22:18 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
11762:02/09/2026 18:31:11 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 521.7s window (flap_count=119, last_up_time=Wed Sep 02 16:55:10 2026)
11765:02/09/2026 18:31:11 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 521.7s window (flap_count=113, last_up_time=Wed Sep 02 16:55:08 2026)
11965:02/09/2026 18:32:18 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
11973:02/09/2026 18:32:24 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=121, last_up_time=Wed Sep 02 17:17:09 2026)
11976:02/09/2026 18:32:25 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=115, last_up_time=Wed Sep 02 17:17:09 2026)
11992:02/09/2026 18:32:28 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
11993:02/09/2026 18:32:28 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
12217:02/09/2026 18:33:02 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
12225:02/09/2026 18:33:07 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=121, last_up_time=Wed Sep 02 17:17:09 2026)
12228:02/09/2026 18:33:08 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=115, last_up_time=Wed Sep 02 17:17:09 2026)
12244:02/09/2026 18:33:11 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
12245:02/09/2026 18:33:11 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
12468:02/09/2026 18:43:38 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
12476:02/09/2026 18:43:44 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=123, last_up_time=Wed Sep 02 17:28:11 2026)
12479:02/09/2026 18:43:44 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=117, last_up_time=Wed Sep 02 17:28:11 2026)
12495:02/09/2026 18:43:47 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
12496:02/09/2026 18:43:47 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
12720:02/09/2026 18:44:20 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
12728:02/09/2026 18:44:26 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=123, last_up_time=Wed Sep 02 17:28:11 2026)
12731:02/09/2026 18:44:26 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=117, last_up_time=Wed Sep 02 17:28:11 2026)
12747:02/09/2026 18:44:30 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
12748:02/09/2026 18:44:30 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
13013:02/09/2026 18:52:24 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
13021:02/09/2026 18:52:30 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=125, last_up_time=Wed Sep 02 17:36:36 2026)
13024:02/09/2026 18:52:30 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=119, last_up_time=Wed Sep 02 17:36:36 2026)
13040:02/09/2026 18:52:33 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
13041:02/09/2026 18:52:33 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
13297:02/09/2026 18:53:08 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
13305:02/09/2026 18:53:14 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=125, last_up_time=Wed Sep 02 17:36:36 2026)
13308:02/09/2026 18:53:15 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=119, last_up_time=Wed Sep 02 17:36:36 2026)
13324:02/09/2026 18:53:18 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
13325:02/09/2026 18:53:18 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
13353:02/09/2026 19:02:09 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 520.6s window (flap_count=125, last_up_time=Wed Sep 02 17:36:36 2026)
13356:02/09/2026 19:02:09 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 520.6s window (flap_count=119, last_up_time=Wed Sep 02 17:36:36 2026)
13570:02/09/2026 19:03:35 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
13578:02/09/2026 19:03:41 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=127, last_up_time=Wed Sep 02 17:48:28 2026)
13581:02/09/2026 19:03:42 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=121, last_up_time=Wed Sep 02 17:48:27 2026)
13597:02/09/2026 19:03:45 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
13598:02/09/2026 19:03:45 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
13822:02/09/2026 19:04:17 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
13830:02/09/2026 19:04:23 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=127, last_up_time=Wed Sep 02 17:48:28 2026)
13833:02/09/2026 19:04:23 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=121, last_up_time=Wed Sep 02 17:48:27 2026)
13849:02/09/2026 19:04:26 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
13850:02/09/2026 19:04:26 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
13880:02/09/2026 19:13:20 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 522.2s window (flap_count=127, last_up_time=Wed Sep 02 17:48:28 2026)
13883:02/09/2026 19:13:21 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 522.2s window (flap_count=121, last_up_time=Wed Sep 02 17:48:27 2026)
14167:02/09/2026 19:15:33 prerequisites.check_links_up             L0274 INFO   | Link-up check: 2/2 transceiver ports admin-up and oper-up
14175:02/09/2026 19:15:38 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=129, last_up_time=Wed Sep 02 17:59:39 2026)
14178:02/09/2026 19:15:39 verification.assert_no_flap_since        L0206 INFO   | Stability check PASSED: EthernetXX: stable for 5s window (flap_count=123, last_up_time=Wed Sep 02 17:59:38 2026)
14194:02/09/2026 19:15:42 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
14195:02/09/2026 19:15:42 verification.standard_port_recovery_and_ L0475 INFO   | Standard Port Recovery PASSED: EthernetXX: stability + health all OK
```
### Negative test failure message
```
transceiver/cdb_firmware_upgrade/test_firmware_download.py::test_firmware_download 
-------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------
02/09/2026 21:59:16 verification.assert_no_flap_since        L0199 WARNING| Stability check FAILED: Ethernet52: flap detected during 526.3s window (flap_count 123->125, last_up_time Wed Sep 02 17:59:38 2026->Wed Sep 02 20:37:15 2026)
FAILED

-------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml --------------------------------------------------------
=========================================================================== short test summary info ===========================================================================
FAILED transceiver/cdb_firmware_upgrade/test_firmware_download.py::test_firmware_download - Failed: Firmware download failures:
======================================================================== 1 failed in 1256.58s (0:20:56) =======================================================================
```

MSFT ADO - 39434067