### PR TITLE
test_wr_arp_advance: fix warm reboot CPA traffic validation

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/py3/wr_arp.py
@@ -32,10 +32,10 @@ import ipaddress
 
 
 class ArpTest(BaseTest):
-    COUNTERS_UPDATE_INTERVAL = 10
-    RETRIVE_COUNTER_UPLIMIT = 10
-    EVERFLOW_TABLE_WAIT = 30
     VXLAN_TUNNEL_NAME = 'neigh_adv'
+    PING_TIMEOUT = 0.2
+    PING_STABLE_COUNT = 3
+    STATE_POLL_INTERVAL = 1
 
     def __init__(self):
         BaseTest.__init__(self)
@@ -195,6 +195,7 @@ class ArpTest(BaseTest):
 
     def generatePackets(self):
         self.gen_pkts = {}
+        self.gen_erspan_pkts = {}
         for test in self.tests:
             for port in test['acc_ports']:
                 gw = test['vlan_gw']
@@ -207,8 +208,53 @@ class ArpTest(BaseTest):
                     vlan_id = 0
                 self.gen_pkts[port] = self.generatePkts(
                     gw, port_ip, port_mac, vlan_id)
+                if self.advance:
+                    pkt, _ = self.gen_pkts[port]
+                    self.gen_erspan_pkts[port] = self.generateErspanRequest(pkt)
 
         return
+
+    def generateErspanRequest(self, arp_request):
+        payload = arp_request
+        if self.asic_type == 'mellanox':
+            payload = b'\x00' * 22 + bytes(arp_request)
+
+        if self.asic_type == 'barefoot':
+            exp_pkt = testutils.ipv4_erspan_pkt(
+                eth_src=self.dut_mac,
+                ip_src=self.dut_loopback_ip,
+                ip_dst=self.ferret_endpoint_ip,
+                inner_frame=bytes(arp_request)
+            )
+        elif self.asic_type == 'cisco-8000':
+            exp_pkt = testutils.ipv4_erspan_pkt(
+                eth_src=self.dut_mac,
+                ip_src=self.dut_loopback_ip,
+                ip_dst=self.ferret_endpoint_ip,
+                inner_frame=bytes(arp_request),
+                version=1
+            )
+            exp_pkt['ERSPAN II'].ver = 1
+        else:
+            exp_pkt = testutils.simple_gre_packet(
+                pktlen=0,
+                eth_src=self.dut_mac,
+                ip_src=self.dut_loopback_ip,
+                ip_dst=self.ferret_endpoint_ip,
+                inner_frame=payload
+            )
+
+        masked_exp_pkt = Mask(exp_pkt)
+        inner_frame_offset = len(bytes(exp_pkt)) - len(bytes(arp_request))
+
+        # Match only outer Ethernet source, outer IP source/destination, and
+        # the complete inner ARP request.
+        masked_exp_pkt.set_do_not_care(0, 6 * 8)
+        masked_exp_pkt.set_do_not_care(12 * 8, 14 * 8)
+        masked_exp_pkt.set_do_not_care(
+            34 * 8, (inner_frame_offset - 34) * 8)
+        masked_exp_pkt.set_ignore_extra_bytes()
+        return masked_exp_pkt
 
     def get_param(self, param_name, required=True, default=None):
         params = testutils.test_params_get()
@@ -223,11 +269,6 @@ class ArpTest(BaseTest):
 
     def setUp(self):
         self.dataplane = ptf.dataplane_instance
-
-        # Apply filters
-        for p in self.dataplane.ports.values():
-            port = p.get_packet_source()
-            attach_filter(port.socket, 'arp and not ether dst ff:ff:ff:ff:ff:ff', port.interface_name)
 
         config = self.get_param('config_file')
         self.ferret_ip = self.get_param('ferret_ip')
@@ -248,6 +289,29 @@ class ArpTest(BaseTest):
 
         with open(config) as fp:
             graph = json.load(fp)
+
+        packet_filter = 'arp and not ether dst ff:ff:ff:ff:ff:ff'
+        if self.advance:
+            self.asic_type = self.get_param('asic_type')
+            self.ferret_endpoint_ip = self.get_param('ferret_endpoint_ip')
+            for data in graph['minigraph_lo_interfaces']:
+                if int(data['prefixlen']) == 32:
+                    self.dut_loopback_ip = data['addr']
+                    break
+            else:
+                raise Exception("IPv4 loopback interface not found")
+
+            packet_filter = '({}) or ip proto 47'.format(packet_filter)
+        for p in self.dataplane.ports.values():
+            packet_source = p.get_packet_source()
+            attach_filter(packet_source.socket, packet_filter,
+                          packet_source.interface_name)
+
+        self.portchannel_ports = sorted({
+            graph['minigraph_port_indices'][member]
+            for portchannel in graph['minigraph_portchannels'].values()
+            for member in portchannel['members']
+        })
 
         self.tests = []
         vni_base = 0
@@ -422,8 +486,17 @@ class ArpTest(BaseTest):
                 self.log(f"Sleeping for {self.how_long - final_elapsed} seconds before next test")
                 time.sleep(self.how_long - final_elapsed)
             port = random.choice(test['acc_ports'])
-            test_non_broadcast_reply_thread = threading.Thread(target=self.test_non_broadcast_reply_thr,
-                                                               kwargs={'port': port})
+            thread_errors = []
+
+            def _run_non_broadcast_reply():
+                try:
+                    self.test_non_broadcast_reply_thr(port=port)
+                except Exception as e:
+                    self.log("test_non_broadcast_reply_thr failed: {!r}".format(e))
+                    thread_errors.append(e)
+
+            test_non_broadcast_reply_thread = threading.Thread(
+                target=_run_non_broadcast_reply)
             test_non_broadcast_reply_thread.setDaemon(True)
             test_non_broadcast_reply_thread.start()
 
@@ -441,6 +514,11 @@ class ArpTest(BaseTest):
                 self.assertTrue(
                     False, "Timed out waiting for test_non_broadcast_reply_thread")
 
+            if thread_errors:
+                self.assertTrue(
+                    False,
+                    "test_non_broadcast_reply_thr failed: {}".format(thread_errors[0]))
+
             uptime_after = self.get_uptime()
             if uptime_before == uptime_after:
                 self.log("The DUT wasn't rebooted. Uptime: %s vs %s" %
@@ -452,76 +530,133 @@ class ArpTest(BaseTest):
 
     def test_non_broadcast_reply_thr(self, port):
         pkt, exp_pkt = self.gen_pkts[port]
+        exp_erspan_pkt = self.gen_erspan_pkts[port]
 
-        # everflow table creation check
         stop_at = time.time() + self.how_long
-        while True:
-            # 1 second as interval to check if everflow created
-            if self.get_everflow_acl_counter(1) == -1:
-                if time.time() >= stop_at:
-                    self.log("ERR: everflow rule_arp table seems not up")
-                    self.assertTrue(
-                        False, "everflow rule_arp table seems not up")
-                else:
-                    continue
-            else:
-                break
+        reachable = None
+        reboot_downtime_observed = False
 
-        failure_check = 0
-        while True:
-            ef_count_before = self.get_everflow_acl_counter(1)
-            if ef_count_before == -1:
-                if failure_check >= self.RETRIVE_COUNTER_UPLIMIT:
-                    self.log("everflow rule_arp seems closed, test will close")
-                    return
-                else:
-                    failure_check += 1
-                    continue
-
-            # vxlan tunnel should be there
-            self.check_neighbor_advertise_vxlan()
-
-            testutils.send_packet(self, port, pkt)
-            # check arp reply should come from same port
-            # clean arp, test broadcast reply if needed
-            testutils.verify_packet_any_port(self, exp_pkt, ports=[port])
-
-            ef_count_after = self.get_everflow_acl_counter()
-            if ef_count_after == -1:
+        while time.time() < stop_at:
+            send_pkt = False
+            reachable = self.get_stable_ping_state(reachable)
+            if reachable is None:
+                # Test just started and ping is not stable
+                time.sleep(self.STATE_POLL_INTERVAL)
                 continue
 
-            self.assertTrue(ef_count_after >= ef_count_before + 1,
-                            "Unexpected results, counter_after {} <= counter_before {}".format(
-                                ef_count_after, ef_count_before))
+            if not reachable:
+                # DUT is rebooting, CPA should work
+                if not reboot_downtime_observed:
+                    self.log("DUT becomes unreachable; reboot downtime detected")
+                self.log("DUT is unreachable; sending ARP")
+                reboot_downtime_observed = True
+                send_pkt = True
+            elif not reboot_downtime_observed:
+                # Reboot has not started; CPA state may be transient, so do not query it or send traffic.
+                self.log("Wait for reboot to begin")
+            else:
+                cpa_state = self.get_cpa_state()
+                if cpa_state is True:
+                    self.log("CPA is still enabled; keep sending ARP")
+                    send_pkt = True
+                elif cpa_state is None:
+                    self.log("CPA state is unavailable after downtime; continue sending ARP while DUT recovers")
+                    send_pkt = True
+                else:
+                    self.log("DUT finalized warm reboot and disabled CPA; stopping test")
+                    return
 
-    def get_everflow_acl_counter(self, timeout=COUNTERS_UPDATE_INTERVAL):
-        # Wait for orchagent to update the ACL counters
-        time.sleep(timeout)
-        output, _, _ = self.dut_connection.execCommand('aclshow -a')
+            if not send_pkt:
+                time.sleep(self.STATE_POLL_INTERVAL)
+                continue
+
+            self.dataplane.flush()
+            testutils.send_packet(self, port, pkt)
+            try:
+                self.log("Verifying mirrored ARP request in ERSPAN packet")
+                testutils.verify_packet_any_port(
+                    self, exp_erspan_pkt, ports=self.portchannel_ports)
+                # check arp reply should come from same port
+                # clean arp, test broadcast reply if needed
+                self.log("Verifying ARP reply on requester port {}".format(port))
+                testutils.verify_packet_any_port(self, exp_pkt, ports=[port])
+            except AssertionError:
+                # CPA may be disabled between the state check and ARP transmission.
+                # Recheck its state to determine whether verification overlapped teardown.
+                if reboot_downtime_observed:
+                    time.sleep(self.STATE_POLL_INTERVAL)
+                    if self.ping_dut() and self.get_cpa_state() is False:
+                        self.log("Packet verification overlapped CPA teardown; stopping test")
+                        return
+                raise
+
+        self.assertTrue(False, "Timed out waiting for CPA teardown")
+
+    def ping_dut(self):
+        _, _, return_code = self.cmd([
+            'ping', '-n', '-q', '-c', '1',
+            '-W', str(self.PING_TIMEOUT), self.dut_ssh
+        ])
+        return return_code == 0
+
+    def get_stable_ping_state(self, current_state):
+        observed_state = self.ping_dut()
+        if observed_state == current_state:
+            return current_state
+
+        for _ in range(self.PING_STABLE_COUNT - 1):
+            if self.ping_dut() != observed_state:
+                return current_state
+
+        self.log("DUT ping state changed to {}".format(
+            "reachable" if observed_state else "unreachable"))
+        return observed_state
+
+    def get_cpa_state(self):
+        everflow_acl_state = self.get_everflow_acl_state()
+        vxlan_state = self.check_neighbor_advertise_vxlan()
+
+        if everflow_acl_state is None or vxlan_state is None:
+            return None
+        elif everflow_acl_state and vxlan_state:
+            return True
+        return False
+
+    def get_everflow_acl_state(self):
+        try:
+            output, _, return_code = self.dut_connection.execCommand(
+                'aclshow -a', timeout=3)
+        except Exception:
+            return None
+        if not output or return_code != 0:
+            return None
         result = parse_show(output)
 
         if len(result) == 0:
             self.log("Failed to retrieve acl counter {}".format(output))
-            return -1
+            return False
         for rule in result:
             if "EVERFLOW" == rule['table name'] and "rule_arp" == rule['rule name']:
                 self.log("retrieve rule_arp EVERFLOW counter {}".format(
                     rule['packets count']))
                 if rule['packets count'] == 'N/A':
-                    return 0
+                    return False
                 else:
-                    return int(rule['packets count'])
+                    return True
         # warm reboot may not started, or warm reboot finished
         self.log("Failed to retrieve acl counter for EVERFLOW|rule_arp")
-        return -1
+        return False
 
     def check_neighbor_advertise_vxlan(self):
-        output, _, _ = self.dut_connection.execCommand(
-            'show vxlan name {}'.format(self.VXLAN_TUNNEL_NAME))
+        try:
+            output, _, return_code = self.dut_connection.execCommand(
+                'show vxlan name {}'.format(self.VXLAN_TUNNEL_NAME), timeout=3)
+        except Exception:
+            return None
+        if not output or return_code != 0:
+            return None
         result = parse_show(output)
-        if len(result) == 0:
-            self.assertTrue(False, "vxlan tunnel {} not exists".format(
-                self.VXLAN_TUNNEL_NAME))
+        return len(result) > 0
 
     # master branch return None
     def get_release_version(self):

--- a/ansible/roles/test/files/ptftests/py3/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/py3/wr_arp.py
@@ -215,6 +215,7 @@ class ArpTest(BaseTest):
         return
 
     def generateErspanRequest(self, arp_request):
+        '''Generates the expected ERSPAN packet for an ARP request.'''
         payload = arp_request
         if self.asic_type == 'mellanox':
             payload = b'\x00' * 22 + bytes(arp_request)
@@ -486,14 +487,16 @@ class ArpTest(BaseTest):
                 self.log(f"Sleeping for {self.how_long - final_elapsed} seconds before next test")
                 time.sleep(self.how_long - final_elapsed)
             port = random.choice(test['acc_ports'])
-            thread_errors = []
+            thread_error = None
 
             def _run_non_broadcast_reply():
+                '''Runs non-broadcast ARP validation and captures any error.'''
+                nonlocal thread_error
                 try:
                     self.test_non_broadcast_reply_thr(port=port)
                 except Exception as e:
                     self.log("test_non_broadcast_reply_thr failed: {!r}".format(e))
-                    thread_errors.append(e)
+                    thread_error = e
 
             test_non_broadcast_reply_thread = threading.Thread(
                 target=_run_non_broadcast_reply)
@@ -514,10 +517,10 @@ class ArpTest(BaseTest):
                 self.assertTrue(
                     False, "Timed out waiting for test_non_broadcast_reply_thread")
 
-            if thread_errors:
+            if thread_error:
                 self.assertTrue(
                     False,
-                    "test_non_broadcast_reply_thr failed: {}".format(thread_errors[0]))
+                    "test_non_broadcast_reply_thr failed: {}".format(thread_error))
 
             uptime_after = self.get_uptime()
             if uptime_before == uptime_after:
@@ -572,27 +575,62 @@ class ArpTest(BaseTest):
 
             self.dataplane.flush()
             testutils.send_packet(self, port, pkt)
-            try:
-                self.log("Verifying mirrored ARP request in ERSPAN packet")
-                testutils.verify_packet_any_port(
-                    self, exp_erspan_pkt, ports=self.portchannel_ports)
-                # check arp reply should come from same port
-                # clean arp, test broadcast reply if needed
-                self.log("Verifying ARP reply on requester port {}".format(port))
-                testutils.verify_packet_any_port(self, exp_pkt, ports=[port])
-            except AssertionError:
-                # CPA may be disabled between the state check and ARP transmission.
-                # Recheck its state to determine whether verification overlapped teardown.
-                if reboot_downtime_observed:
-                    time.sleep(self.STATE_POLL_INTERVAL)
-                    if self.ping_dut() and self.get_cpa_state() is False:
-                        self.log("Packet verification overlapped CPA teardown; stopping test")
-                        return
-                raise
+
+            self.log("Polling for mirrored ARP request and ARP reply")
+            arp_reply_ports, erspan_request_ports = self.poll_erspan_and_arp_reply(
+                exp_pkt, exp_erspan_pkt)
+
+            # The ARP reply should always reach only the requester, including
+            # when CPA is being disabled and the DUT control plane has resumed.
+            self.assertTrue(
+                arp_reply_ports == {port},
+                "Expected ARP reply only on requester port {}, received on {}".format(
+                    port, sorted(arp_reply_ports)))
+
+            unexpected_erspan_ports = (erspan_request_ports - set(self.portchannel_ports))
+            self.assertTrue(
+                not unexpected_erspan_ports,
+                "Received mirrored ARP request on unexpected ports {}".format(
+                    sorted(unexpected_erspan_ports)))
+
+            if not erspan_request_ports:
+                time.sleep(self.STATE_POLL_INTERVAL)
+                if self.ping_dut() and self.get_cpa_state() is False:
+                    self.log("Packet verification overlapped CPA teardown; stopping test")
+                    return
+
+                self.assertTrue(
+                    False,
+                    "Expected mirrored ARP request on ports {}, received none".format(
+                        self.portchannel_ports))
 
         self.assertTrue(False, "Timed out waiting for CPA teardown")
 
+    def poll_erspan_and_arp_reply(self, exp_pkt, exp_erspan_pkt):
+        '''Polls each received packet once and matches both CPA packet types.'''
+        arp_reply_ports = set()
+        erspan_request_ports = set()
+        stop_at = time.time() + 2 * ptf.ptfutils.default_timeout
+
+        while not (arp_reply_ports and erspan_request_ports):
+            timeout = stop_at - time.time()
+            if timeout <= 0:
+                break
+
+            result = testutils.dp_poll(self, timeout=timeout)
+            if not isinstance(result, self.dataplane.PollSuccess):
+                break
+
+            if ptf.dataplane.match_exp_pkt(exp_pkt, result.packet):
+                arp_reply_ports.add(result.port)
+
+            if ptf.dataplane.match_exp_pkt(exp_erspan_pkt, result.packet):
+                erspan_request_ports.add(result.port)
+
+        return arp_reply_ports, erspan_request_ports
+
     def ping_dut(self):
+        '''Checks whether the DUT management interface is reachable.'''
         _, _, return_code = self.cmd([
             'ping', '-n', '-q', '-c', '1',
             '-W', str(self.PING_TIMEOUT), self.dut_ssh
@@ -600,6 +638,7 @@ class ArpTest(BaseTest):
         return return_code == 0
 
     def get_stable_ping_state(self, current_state):
+        '''Determines the DUT reachability state using consecutive pings.'''
         observed_state = self.ping_dut()
         if observed_state == current_state:
             return current_state
@@ -613,16 +652,18 @@ class ArpTest(BaseTest):
         return observed_state
 
     def get_cpa_state(self):
+        '''Determines whether all required CPA components are enabled.'''
         everflow_acl_state = self.get_everflow_acl_state()
         vxlan_state = self.check_neighbor_advertise_vxlan()
 
+        if everflow_acl_state is False or vxlan_state is False:
+            return False
         if everflow_acl_state is None or vxlan_state is None:
             return None
-        elif everflow_acl_state and vxlan_state:
-            return True
-        return False
+        return True
 
     def get_everflow_acl_state(self):
+        '''Checks whether the Everflow ARP rule is enabled on the DUT.'''
         try:
             output, _, return_code = self.dut_connection.execCommand(
                 'aclshow -a', timeout=3)
@@ -648,6 +689,7 @@ class ArpTest(BaseTest):
         return False
 
     def check_neighbor_advertise_vxlan(self):
+        '''Checks whether the neighbor advertisement VXLAN tunnel exists.'''
         try:
             output, _, return_code = self.dut_connection.execCommand(
                 'show vxlan name {}'.format(self.VXLAN_TUNNEL_NAME), timeout=3)

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -21,7 +21,7 @@ pytestmark = [
 @pytest.fixture(scope='class', autouse=True)
 def setupFerretFixture(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
-    setupFerret(duthost, ptfhost, tbinfo)
+    return setupFerret(duthost, ptfhost, tbinfo)
 
 
 @pytest.fixture(scope='class', autouse=True)
@@ -87,7 +87,7 @@ def test_wr_arp(request, duthost, ptfhost, creds):
     testWrArp(request, duthost, ptfhost, creds)
 
 
-def test_wr_arp_advance(request, duthost, ptfhost, creds):
+def test_wr_arp_advance(request, duthost, ptfhost, creds, setupFerretFixture):
     testDuration = request.config.getoption('--test_duration', default=DEFAULT_TEST_DURATION)
     ptfIp = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
     dutIp = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
@@ -105,6 +105,8 @@ def test_wr_arp_advance(request, duthost, ptfhost, creds):
         platform='remote',
         params={
             'ferret_ip': ptfIp,
+            'ferret_endpoint_ip': setupFerretFixture,
+            'asic_type': duthost.facts['asic_type'],
             'dut_ssh': dutIp,
             'dut_username': creds['sonicadmin_user'],
             'dut_password': creds['sonicadmin_password'],

--- a/tests/common/arp_utils.py
+++ b/tests/common/arp_utils.py
@@ -54,7 +54,7 @@ def setupFerret(duthost, ptfhost, tbinfo):
             ptfhost (AnsibleHost): Packet Test Framework (PTF)
 
         Returns:
-            None
+            str: Ferret data-plane endpoint IP
     '''
     ptfhost.copy(src="arp/files/ferret.py", dest="/opt")
 
@@ -96,7 +96,7 @@ def setupFerret(duthost, ptfhost, tbinfo):
 
     pytest_assert(len(result['stdout'].strip()) > 0, 'Empty DIP returned')
 
-    dip = result['stdout']
+    dip = result['stdout'].strip()
     logger.info('VxLan Sender {0}'.format(dip))
 
     vxlan_port_out = duthost.shell('redis-cli -n 0 hget "SWITCH_TABLE:switch" "vxlan_port"')
@@ -123,6 +123,7 @@ def setupFerret(duthost, ptfhost, tbinfo):
 
     logger.info('Refreshing supervisor control with ferret configuration')
     ptfhost.shell('supervisorctl reread && supervisorctl update && supervisorctl start ferret')
+    return dip
 
 
 def setupRouteToPtfhost(duthost, ptfhost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Propagate test_non_broadcast_reply_thr failures to prevent false passes.

test_wr_arp_advance used Everflow ACL counter values to guard and validate each ARP request. When SWSS starts shutting down, aclshow may return stale counter values, causing false failures. The ACL and VXLAN guards also restricted packet transmission to the period before the DUT rebooted.

Replace ACL counter-delta validation with per-packet ERSPAN verification, confirming that each ARP request is mirrored toward Ferret before checking the resulting ARP reply.

Use DUT reachability to detect actual reboot downtime. Start ARP traffic when the DUT becomes unreachable, continue after it returns during warm reboot reconciliation, and stop when CPA is disabled.

Do not query CPA before reboot because the DUT may shut down after ping succeeds, leaving the following SSH command blocked until the DUT returns.

CPA may be disabled between the state check and ARP transmission. If verification then fails, recheck DUT reachability and CPA state; stop normally only when CPA teardown is confirmed.

Fixes #27681
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202605: `arp/test_wr_arp.py::test_wr_arp_advance` passed 60 times on Arista-7050CX3-32C-C32 t0 topo.

### Approach
#### What is the motivation for this PR?
Fix `arp/test_wr_arp.py::test_wr_arp_advance` false pass or failure and missing warm reboot CPA coverage

#### How did you do it?
Fix false pass by propagating assertion to main thread.
Validate everflow packet directly instead of using everflow ACL counter.
Use ping and CPA state to cover the entire reboot period.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Run `arp/test_wr_arp.py::test_wr_arp_advance` and check `/tmp/wr_arp_test.log` in PTF container

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
