### PR TITLE
[everflow] Compare ACL rule count deltas, not absolutes, in programming check (backport #25582 to 202511)

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -519,27 +519,28 @@ def validate_acl_rule_rids(duthost):
     return True
 
 
-def validate_acl_rules_in_asic_db(duthost):
+def get_acl_rule_counts(duthost):
     """
-    Validate that the number of ACL rules in ASIC DB is the same as the number of ACL rules in CONFIG DB.
-    Also check that the ACL rule RIDs are not empty.
-    For multi-ASIC DUTs, validates ACL rules in each frontend ASIC's ASIC_DB and CONFIG_DB.
+    Snapshot the number of ACL rules in CONFIG DB and ASIC DB, per frontend ASIC.
+
+    Returns a list with one (config_count, asic_count) tuple per frontend ASIC
+    (a single tuple for single-ASIC DUTs). Use this to capture a baseline before
+    applying ACL rules so the readiness check can compare deltas (see
+    validate_acl_rules_in_asic_db).
 
     Args:
         duthost: DUT host object
 
     Returns:
-        bool: True if ACL rules count matches and RIDs are valid in all frontend ASICs, False otherwise
+        list[tuple[int, int]]: [(config_count, asic_count), ...] indexed by frontend ASIC
     """
-    # Get all frontend ASIC instances
     if duthost.is_multi_asic:
         asic_instances = [duthost.asic_instance(asic_id) for asic_id in duthost.get_frontend_asic_ids()]
     else:
         asic_instances = [duthost]
 
-    # Validate ACL rules in each ASIC
+    counts = []
     for asic in asic_instances:
-        # Get namespace-specific command prefix
         if duthost.is_multi_asic:
             namespace = asic.get_asic_namespace()
             config_cmd = "sonic-db-cli -n {} CONFIG_DB KEYS *ACL_RULE*".format(namespace)
@@ -548,34 +549,93 @@ def validate_acl_rules_in_asic_db(duthost):
             config_cmd = "sonic-db-cli CONFIG_DB KEYS *ACL_RULE*"
             asic_cmd = "sonic-db-cli ASIC_DB KEYS *SAI_OBJECT_TYPE_ACL_ENTRY*"
 
-        config_rules = asic.shell(config_cmd)['stdout_lines']
-        asic_rules = asic.shell(asic_cmd)['stdout_lines']
+        config_count = len(asic.shell(config_cmd)['stdout_lines'])
+        asic_count = len(asic.shell(asic_cmd)['stdout_lines'])
+        counts.append((config_count, asic_count))
 
-        if len(config_rules) != len(asic_rules):
-            logging.error("ACL rules count mismatch in ASIC {}: CONFIG_DB={}, ASIC_DB={}".format(
-                asic.asic_index if duthost.is_multi_asic else "single",
-                len(config_rules), len(asic_rules)))
+    return counts
+
+
+def validate_acl_rules_in_asic_db(duthost, baseline_counts=None):
+    """
+    Validate that the ACL rules added since a baseline have all been programmed into ASIC DB.
+    Also check that the ACL rule RIDs are not empty.
+    For multi-ASIC DUTs, validates ACL rules in each frontend ASIC's ASIC_DB and CONFIG_DB.
+
+    The check compares the CHANGE in entry counts rather than absolute counts: the
+    number of new ASIC_DB ACL entries must be at least the number of new CONFIG_DB
+    ACL rules since `baseline_counts` was captured. This cancels any constant,
+    pre-existing offset between the two DBs caused by ASIC ACL entries that have no
+    CONFIG_DB ACL_RULE key.
+
+    On dualtor, the standby ToR carries exactly such an entry: MuxOrch programs a
+    DROP-all-ingress-ports ACL (matching IN_PORTS + traffic-class) directly into the
+    ASIC -- not via CONFIG_DB ACL_RULE/ACL_TABLE -- to black-hole server traffic on
+    the standby side. So on the standby ToR ASIC_DB has one more ACL entry than
+    CONFIG_DB, and the old absolute-equality check spun until timeout (observed on
+    Broadcom dualtor: a stable CONFIG_DB=28, ASIC_DB=29 on the standby ToR on every
+    retry).
+
+    Args:
+        duthost: DUT host object
+        baseline_counts: optional list of (config_count, asic_count) tuples captured
+            by get_acl_rule_counts() BEFORE the rules under test were applied. When
+            None, a zero baseline is assumed, which requires ASIC_DB >= CONFIG_DB
+            (every configured rule is programmed) without assuming the two counts
+            are exactly equal.
+
+    Returns:
+        bool: True if the per-ASIC ACL delta matches and RIDs are valid in all
+        frontend ASICs, False otherwise
+    """
+    # Get all frontend ASIC instances
+    if duthost.is_multi_asic:
+        asic_instances = [duthost.asic_instance(asic_id) for asic_id in duthost.get_frontend_asic_ids()]
+    else:
+        asic_instances = [duthost]
+
+    if baseline_counts is None:
+        baseline_counts = [(0, 0)] * len(asic_instances)
+
+    current_counts = get_acl_rule_counts(duthost)
+
+    # Validate ACL rules in each ASIC by comparing deltas against the baseline
+    for index, asic in enumerate(asic_instances):
+        config_now, asic_now = current_counts[index]
+        config_base, asic_base = baseline_counts[index]
+        config_delta = config_now - config_base
+        asic_delta = asic_now - asic_base
+
+        if asic_delta < config_delta:
+            logging.warning("Not all ACL rules are programmed in ASIC {}: "
+                            "CONFIG_DB delta={}, ASIC_DB delta={} (CONFIG_DB={}, ASIC_DB={})".format(
+                                asic.asic_index if duthost.is_multi_asic else "single",
+                                config_delta, asic_delta, config_now, asic_now))
             return False
 
     # Validate ACL rule RIDs across all ASICs
     return validate_acl_rule_rids(duthost)
 
 
-def wait_for_acl_rules_in_asic_db(duthost):
+def wait_for_acl_rules_in_asic_db(duthost, baseline_counts=None):
     """
-    Wait until the ACL rules in ASIC DB match CONFIG DB and RIDs are valid.
+    Wait until the ACL rules added since a baseline are programmed in ASIC DB and RIDs are valid.
 
     Uses the platform-specific wait time from get_plt_wait_time (key "everflow"),
     defaulting to 120 seconds if not configured.
 
     Args:
         duthost: DUT host object
+        baseline_counts: optional ACL-count baseline from get_acl_rule_counts(),
+            captured before the rules under test were applied. Passed through to
+            validate_acl_rules_in_asic_db so the readiness check compares deltas.
     """
     acl_rule_wait_time = get_plt_wait_time(duthost, "everflow").get("wait", 120)
     pytest_assert(
-        wait_until(acl_rule_wait_time, 10, 0, validate_acl_rules_in_asic_db, duthost),
+        wait_until(acl_rule_wait_time, 10, 0, validate_acl_rules_in_asic_db, duthost, baseline_counts),
         "ACL rules in ASIC DB did not match CONFIG DB within {} seconds".format(acl_rule_wait_time)
     )
+    logging.info("Successfully validated ACL rules")
 
 
 # TODO: This should be refactored to some common area of sonic-mgmt.

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -222,11 +222,18 @@ class EverflowIPv6Tests(BaseEverflowTest):
                     self.apply_acl_table_config(duthost, table_name, "MIRRORV6", config_method,
                                                 bind_namespace=getattr(inst, 'namespace', None))
 
+            # Snapshot the ACL rule counts BEFORE applying the everflow rules so the
+            # readiness check can compare deltas instead of absolute counts. On dualtor
+            # the standby ToR already carries a MuxOrch-installed DROP-all-ingress ACL
+            # entry in ASIC_DB that has no CONFIG_DB ACL_RULE key; capturing the baseline
+            # here folds that constant offset into the baseline so it cancels out.
+            baseline_counts = everflow_utils.get_acl_rule_counts(duthost)
+
             self.apply_acl_rule_config(duthost, table_name, setup_mirror_session["session_name"],
                                        config_method, rules=EVERFLOW_V6_RULES)
             self.apply_ip_type_rule(duthost, 6)
             # Wait for ACL rules to be programmed
-            everflow_utils.wait_for_acl_rules_in_asic_db(duthost)
+            everflow_utils.wait_for_acl_rules_in_asic_db(duthost, baseline_counts)
 
         everflow_utils.wait_for_acl_rules_in_asic_db(everflow_dut)
 


### PR DESCRIPTION
### Description of PR

Summary:
Backports #25582 to the `202511` branch.

`validate_acl_rules_in_asic_db()` compared CONFIG_DB `ACL_RULE` count against ASIC_DB
`SAI_OBJECT_TYPE_ACL_ENTRY` count for exact equality. This fails whenever the ASIC has an
extra ACL entry with no CONFIG_DB `ACL_RULE` counterpart, e.g.:

- dualtor: `MuxOrch` programs a DROP-all-ingress-ports ACL directly into the standby ToR's
  ASIC to black-hole server traffic (no CONFIG_DB `ACL_RULE`/`ACL_TABLE` counterpart).
- PFC Watchdog (non-shared-egress-table platforms, e.g. Nokia TH6p): the egress ACL
  table/rule created for the first PFC storm on a given queue index is cached and reused,
  but the ASIC object is never deleted after the storm restores (only the port binding is
  removed), leaving a leftover ASIC_DB ACL entry per queue index that has ever stormed.
  Observed live on `str4-Nokia-7220-Th6p-1`:
  `ACL rules count mismatch in ASIC single: CONFIG_DB=11, ASIC_DB=12`.

This PR was already merged to `master` as #25582, and its backport checklist included
`202511`, but that backport was never completed. `origin/202511` still has the old
vulnerable absolute-count check, so the test still intermittently/permanently fails
(until `swss` is restarted / device rebooted) any time a platform has one of the above
untracked extra ASIC_DB ACL entries.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_everflow_ipv6` (and other everflow tests using `validate_acl_rules_in_asic_db`) can
fail with false-positive ACL count mismatches whenever the ASIC has any ACL entry that
doesn't map 1:1 to a CONFIG_DB `ACL_RULE`, even though the actual everflow rules were
programmed correctly. This backport brings `202511` in line with `master`/`202605`,
closing the gap left when #25582's `202511` backport checkbox was checked but not acted
on.

#### How did you do it?
Cherry-picked `6df9e18e9dbf5297b341afc35b0bc192f75ff466` (#25582) onto `202511` and
resolved conflicts caused by local branch drift. Replaced the absolute
`len(config_rules) != len(asic_rules)` check with:
- `get_acl_rule_counts(duthost)` — snapshots (config_count, asic_count) per frontend ASIC.
- `validate_acl_rules_in_asic_db(duthost, baseline_counts=None)` /
  `wait_for_acl_rules_in_asic_db(duthost, baseline_counts=None)` — require the ASIC_DB
  delta since baseline to be `>=` the CONFIG_DB delta since baseline (falls back to
  `asic_count >= config_count` with no baseline).
- `test_everflow_ipv6.py` captures a baseline via `get_acl_rule_counts()` before applying
  the everflow ACL rules and passes it through to `wait_for_acl_rules_in_asic_db`.

Rule identity/correctness is still verified separately by the existing
`validate_acl_rule_rids()` call, so a genuinely missing/unprogrammed rule is still caught
— this change only relaxes the raw count comparison to tolerate pre-existing, untracked
ASIC_DB entries.

#### How did you verify/test it?
- Verified the cherry-picked result is byte-identical to `master`'s current version of
  `everflow_test_utilities.py` for the changed functions.
- Verified `git diff origin/202511...HEAD --name-only` only touches the two intended
  files, and `git log origin/202511..HEAD` contains only this one commit.
- Verified Python syntax compiles cleanly and local pre-commit hooks (flake8, etc.) pass.
- Root-caused the underlying PFC-Watchdog leaked-egress-ACL-entry orchagent behavior on a
  live Nokia TH6p testbed (`str4-Nokia-7220-Th6p-1`) that was hitting exactly this false
  ACL count mismatch, confirming the delta-based check tolerates it correctly.

#### Any platform specific information?
The PFC-Watchdog leaked-entry scenario this also fixes is specific to platforms that do
not set `shared_egress_acl_table` (e.g. Nokia TH6p / non-Broadcom-DNX platforms), where
each queue index that has ever stormed leaves one orphaned egress ACL table/entry in
ASIC_DB until `swss` restarts.

#### Supported testbed topology if it's a new test case?
N/A — no new test case, existing everflow test infrastructure fix.

### Documentation
N/A
