### PR TITLE
[smartswitch]: Disable loganalyzer for entire test_reload_dpu.py

### DIFF
--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -25,7 +25,8 @@ from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 
 pytestmark = [
-    pytest.mark.topology('smartswitch')
+    pytest.mark.topology('smartswitch'),
+    pytest.mark.disable_loganalyzer
 ]
 
 kernel_panic_cmd = "sudo nohup bash -c 'sleep 5 && echo c > /proc/sysrq-trigger' &"
@@ -79,7 +80,6 @@ def mellanox_dpu_shutdown_check(duthost, dpu_on_list):
                   f"(delta={delta:.2f}s)")  # noqa: E231
 
 
-@pytest.mark.disable_loganalyzer
 def test_dpu_status_post_switch_reboot(duthosts, dpuhosts,
                                        enum_rand_one_per_hwsku_hostname,
                                        localhost,
@@ -148,7 +148,6 @@ def test_dpu_status_post_switch_config_reload(duthosts, dpuhosts,
                          num_dpu_modules, None)
 
 
-@pytest.mark.disable_loganalyzer
 def test_dpu_status_post_switch_mem_exhaustion(duthosts, dpuhosts,
                                                enum_rand_one_per_hwsku_hostname,  # noqa: E501
                                                localhost,
@@ -198,7 +197,6 @@ def test_dpu_status_post_switch_mem_exhaustion(duthosts, dpuhosts,
                          pre_boot_times=pre_boot_times)
 
 
-@pytest.mark.disable_loganalyzer
 def test_dpu_status_post_switch_kernel_panic(duthosts, dpuhosts,
                                              enum_rand_one_per_hwsku_hostname,
                                              localhost,
@@ -247,7 +245,6 @@ def test_dpu_status_post_switch_kernel_panic(duthosts, dpuhosts,
                          pre_boot_times=pre_boot_times)
 
 
-@pytest.mark.disable_loganalyzer
 def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
                                           enum_rand_one_per_hwsku_hostname,
                                           platform_api_conn, num_dpu_modules):  # noqa: F811, E501
@@ -317,7 +314,6 @@ def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
                          pre_boot_times=pre_boot_times)
 
 
-@pytest.mark.disable_loganalyzer
 def test_dpu_check_post_dpu_mem_exhaustion(duthosts, dpuhosts,
                                            enum_rand_one_per_hwsku_hostname,
                                            platform_api_conn, num_dpu_modules):  # noqa: F811, E501
@@ -389,7 +385,6 @@ def test_dpu_check_post_dpu_mem_exhaustion(duthosts, dpuhosts,
                          pre_boot_times=pre_boot_times)
 
 
-@pytest.mark.disable_loganalyzer
 def test_cold_reboot_dpus(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
                           platform_api_conn, num_dpu_modules,  # noqa: F811
                           invocation_type, gnmi_tls):  # noqa: F811, E501
@@ -438,7 +433,6 @@ def test_cold_reboot_dpus(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
                              pre_boot_times=pre_boot_times)
 
 
-@pytest.mark.disable_loganalyzer
 def test_cold_reboot_switch(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
                             platform_api_conn, num_dpu_modules, localhost):  # noqa: F811, E501
     """


### PR DESCRIPTION
### Description of PR

Summary:
Move the `disable_loganalyzer` marker to the module level in `tests/smartswitch/platform_tests/test_reload_dpu.py` so it applies to every test in the file. Most tests in this module already carried a per-function `@pytest.mark.disable_loganalyzer` decorator, but `test_reboot_cause` and `test_dpu_status_post_switch_config_reload` did not. These tests shut down/start up DPUs and reboot the switch, which emit expected transient errors in syslog; LogAnalyzer flags them as failures. Applying the marker at the module level covers the whole file and removes the now-redundant per-function decorators.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/39326134

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39326134
Failure type: day 1 issue

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: `python3 -m py_compile` and `flake8 --max-line-length=120` on `tests/smartswitch/platform_tests/test_reload_dpu.py` pass. Marker resolution verified — `disable_loganalyzer` now applies to all 9 tests in the module, including `test_reboot_cause`.

### Approach
#### What is the motivation for this PR?
`test_reboot_cause` (and `test_dpu_status_post_switch_config_reload`) shut down and start up DPUs / reload/reboot the switch, producing expected transient errors in syslog. Because these two tests lacked the `disable_loganalyzer` marker that the rest of the module already had, LogAnalyzer flagged the expected errors and caused spurious failures.

#### How did you do it?
Added `pytest.mark.disable_loganalyzer` to the module-level `pytestmark` list so it applies to the entire file, and removed the now-redundant per-function `@pytest.mark.disable_loganalyzer` decorators (7 of them). This follows the established convention used by other modules such as `tests/dns/test_dns_resolv_conf.py` and `tests/platform_tests/test_hw_watchdog.py`.

#### How did you verify/test it?
- `python3 -m py_compile tests/smartswitch/platform_tests/test_reload_dpu.py`
- `flake8 --max-line-length=120 tests/smartswitch/platform_tests/test_reload_dpu.py`
- Confirmed the marker now resolves for every test in the module, including `test_reboot_cause`.

#### Any platform specific information?
SmartSwitch (DPU) platforms only; topology `smartswitch`.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case.

### Documentation
N/A
