### PR TITLE
[202605][backport] Fix: gNOI upgrade set_package fails when target_version is not provided

### DIFF
--- a/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
@@ -99,7 +99,8 @@ def test_upgrade_one_dpu_via_gnoi(
     ) = smartswitch_gnoi_upgrade_lists
 
     assert to_image, "target_image_list must be set (used as TransferToRemote remote_download.path)"
-    assert to_version, "target_version must be set (used as SetPackage package.version)"
+    if not to_version:
+        logger.info("target_version not provided; version will be extracted from the transferred image on the DUT")
 
     logger.info("SmartSwitch DPU gNOI upgrade: from=%s to=%s version=%s dpu_index=%s",
                 from_image, to_image, to_version, dpu_index)
@@ -153,7 +154,8 @@ def test_upgrade_multiple_dpus_via_gnoi_parallel(
         pytest.skip("--ss-target-indices not set; skipping parallel multi-DPU gNOI upgrade")
 
     assert to_image, "target_image_list must be set"
-    assert to_version, "target_version must be set"
+    if not to_version:
+        logger.info("target_version not provided; version will be extracted from the transferred image on the DUT")
 
     workers = max_workers or len(dpu_indices)
 


### PR DESCRIPTION
### Description of PR

Summary:
`test_upgrade_one_dpu_via_gnoi` and `test_upgrade_multiple_dpus_via_gnoi_parallel`
hard-required `--target_version` via `assert to_version, "target_version must be set"`.
This aborted the test before `File.TransferToRemote` ever ran, so an operator upgrading
to an image whose version string is not known in advance had no way to run these tests.

That assert is obsolete. `perform_gnoi_upgrade()` already resolves the version itself:
if `cfg.to_version` is not provided, it extracts it from the DUT with
`sonic_installer binary_version` after `file_transfer_to_remote`, and uses the result as
the `SetPackage` `package.version` and as the expected value for post-reboot validation.
The test-level assert was the only thing blocking callers from reaching that path.

This PR removes the two asserts so `--target_version` becomes optional, and logs an
informational message noting the version will be derived from the transferred image.
`assert to_image` is unchanged - the image path is still mandatory.

This is a manual backport of #24640 to `202605`. It reproduces the exact same code diff
as the auto-created cherry-pick PR #27448, which is blocked by an EasyCLA failure because
its commit carries a `Co-authored-by: Copilot` trailer that is not CLA-authorized. This
PR carries a single, CLA-signed author instead.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512

### Approach
#### What is the motivation for this PR?

The SmartSwitch gNOI upgrade tests could not run without an explicitly supplied
`--target_version`, even though `perform_gnoi_upgrade()` is already capable of deriving
it from the image binary on the DUT.

#### How did you do it?

Replaced the `assert to_version` guard in both tests with a `logger.info()` noting that
the version will be resolved from the transferred image. Left `perform_gnoi_upgrade()`
untouched so `sonic_installer binary_version` extraction and the post-reboot
`images["current"] == target_version` assertion continue to apply in all cases.

#### How did you verify/test it?

- With `--target_version` supplied: behavior unchanged; version validation asserts
  against the supplied value.
- Without `--target_version`: the test proceeds, the version is extracted from the image
  on the DUT, `SetPackage` carries the extracted version, and post-reboot validation
  asserts against that same extracted version.

#### Any platform specific information?

SmartSwitch platforms with DPUs; requires gNOI/gNMI enabled on the DUT.

#### Supported testbed topology if it's a new test case?

N/A - existing test cases.

### Documentation

N/A - no user-facing behavior change and no new feature.
