### PR TITLE
[platform_tests]: Skip powered-off DPU rails in show platform voltage/current check

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -486,11 +486,39 @@ def test_show_platform_fan(duthosts, rand_one_dut_hostname, is_support_fan):  # 
                   " No Fans are displayed with OK status on '{}'".format(duthost.hostname))
 
 
+def _get_offline_dpu_names(duthost):
+    """
+    @summary: Return the set of DPU module names (e.g. {'DPU0', 'DPU3'}) that are
+              not operationally online, as reported by 'show chassis modules status'.
+
+              On a SmartSwitch, a powered-off DPU (e.g. dark mode) drives its
+              voltage/current rails to 0, which the platform legitimately reports
+              with Warning=True. Such rails must be excluded from the sensor
+              Warning check.
+
+              On non-SmartSwitch platforms the command reports no DPU modules, so
+              an empty set is returned and sensor validation is unchanged.
+    """
+    offline_dpus = set()
+    rows = duthost.show_and_parse("show chassis modules status", module_ignore_errors=True)
+    for row in rows:
+        name = row.get("name", "")
+        if not re.match(r"^DPU\d+$", name):
+            continue
+        oper_status = row.get("oper-status", "").strip().lower()
+        if oper_status != "online":
+            offline_dpus.add(name.upper())
+    return offline_dpus
+
+
 def check_show_platform_sensor_output(cmd, duthost):
     """
     @summary: Run and verify output of `show platform [voltage|current]`. Expected output
               is "Sensor not detected" or a table of sensor status data with 8 columns.
               Verify that the `Warning` column only shows `False`.
+
+              On a SmartSwitch, rails belonging to a powered-off DPU read 0 and are
+              legitimately reported with Warning=True, so they are excluded from the check.
     """
     num_expected_cols = 8
 
@@ -523,6 +551,8 @@ def check_show_platform_sensor_output(cmd, duthost):
                       "Output is missing the 'Warning' column on '{}' (header: {})".
                       format(duthost.hostname, header_fields))
 
+        offline_dpus = _get_offline_dpu_names(duthost)
+
         for line in raw_output_lines[2:]:
             if not line.strip():
                 continue
@@ -531,6 +561,19 @@ def check_show_platform_sensor_output(cmd, duthost):
                           "Unexpected number of fields in output row on '{}' (row: {})".
                           format(duthost.hostname, row_fields))
 
+            sensor_name = row_fields[0]
+            if isinstance(sensor_name, bytes):
+                sensor_name = sensor_name.decode('utf-8', errors='ignore')
+            sensor_name = str(sensor_name).strip()
+
+            dpu_match = re.search(r"DPU\d+", sensor_name, re.IGNORECASE)
+            if dpu_match and dpu_match.group(0).upper() in offline_dpus:
+                logging.info(
+                    "Skipping Warning check for sensor '%s' on '%s': %s is offline; "
+                    "its rails read 0 and legitimately report Warning=True",
+                    sensor_name, duthost.hostname, dpu_match.group(0).upper())
+                continue
+
             warning_value = row_fields[warning_col_idx]
             if isinstance(warning_value, bytes):
                 warning_value = warning_value.decode('utf-8', errors='ignore')
@@ -538,7 +581,7 @@ def check_show_platform_sensor_output(cmd, duthost):
 
             pytest_assert(warning_value.lower() == "false",
                           "Expected Warning to be False for sensor '{}' on '{}', got '{}' (cmd: '{}')".
-                          format(row_fields[0], duthost.hostname, warning_value, cmd))
+                          format(sensor_name, duthost.hostname, warning_value, cmd))
 
 
 def test_show_platform_voltage(duthosts, enum_rand_one_per_hwsku_hostname):


### PR DESCRIPTION
### Description of PR

Summary:
`platform_tests/cli/test_show_platform.py::test_show_platform_voltage` (and `test_show_platform_current`) assert that the `Warning` column is `False` for **every** sensor row. On a SmartSwitch, a powered-off DPU (e.g. dark mode) drives its voltage/current rails to 0, which the platform **legitimately** reports with `Warning=True`. This produces consistent, spurious nightly failures on Cisco-8102-28FH-DPU-O, e.g.:

```
Failed: Expected Warning to be False for sensor 'VP0P6_DDR0_VTT_DPU0' on 'xxx-8102-smartswitch-02', got 'True' (cmd: 'show platform voltage')
```

`check_show_platform_sensor_output` now queries `show chassis modules status` and skips the `Warning` check only for sensor rows whose DPU module is not `Online`. Non-SmartSwitch platforms report no DPU modules, so behavior is unchanged there; genuine warnings on online DPUs and on non-DPU sensors are still enforced.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/39469617

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39469617
Failure type: day-one issue (test did not account for powered-off DPU rails on SmartSwitch)

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: `python3 -m py_compile` and `flake8 --max-line-length=120` pass. The real `check_show_platform_sensor_output` / `_get_offline_dpu_names` bodies were exercised against a mocked DUT (real `util` tabulate parser) across 6 scenarios, all correct:
  - offline DPUs with `Warning=True` rails → PASS (the ADO repro)
  - online DPU with `Warning=True` → still FAILS (regression still caught)
  - multi-digit safety: `DPU1` offline does not skip `DPU10`/`DPU0` → FAILS as expected
  - non-SmartSwitch, all `False` → PASS (unchanged)
  - non-SmartSwitch genuine warning → still FAILS (unchanged)
  - SmartSwitch, DPUs online, all `False` → PASS

  Recommend a confirmation run on a Cisco-8102-28FH-DPU-O SmartSwitch nightly/testbed.

### Approach
#### What is the motivation for this PR?
Fix consistent SONiC Nightly failures of `test_show_platform_voltage` on Cisco-8102-28FH-DPU-O (T1). The DPU voltage rails (`VP0P6_DDR0_VTT_DPU0`–`DPU7`, `VP0P8` DPU rails, etc.) read 0 mV against a 558–642 mV range while the DPUs are powered off, so `Warning=True` is correct platform behavior — but the generic test flagged it as a failure.

#### How did you do it?
Added `_get_offline_dpu_names(duthost)`, which parses `show chassis modules status` (with `module_ignore_errors=True`) and returns the set of DPU module names that are not `Online`. In `check_show_platform_sensor_output`, for each sensor row whose name contains a `DPU<n>` token belonging to an offline DPU, the `Warning` assertion is skipped (and logged). All other rows are validated exactly as before.

#### How did you verify/test it?
- `py_compile` + `flake8` clean.
- Mock-based verification of the real function logic across the 6 scenarios listed above (including the exact ADO failure repro and multi-digit correctness).

#### Any platform specific information?
Only affects SmartSwitch platforms with DPU modules (e.g. Cisco-8102-28FH-DPU-O). Fixed and modular (T2) chassis are unaffected: fixed platforms return no DPU modules, and T2 module names (LINE-CARD/FABRIC-CARD/SUPERVISOR) do not match `^DPU\d+$`.

#### Supported testbed topology if it's a new test case?
N/A — existing test; topology `any` (issue observed on T1 SmartSwitch).

### Documentation
N/A
