### PR TITLE
[setup-container]: Refresh default Docker image

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -107,8 +107,8 @@ function show_help_and_exit() {
     echo "  -e <VAR=value>      set environment variable inside the container (can be used multiple times)"
     echo "  -i <image_id>        specify Docker image to use. This can be an image ID (hashed value) or an image name."
     echo "                       If no value is provided, defaults to the following images in the specified order:"
-    echo "                         1. The local image named \"docker-sonic-mgmt\""
-    echo "                         2. The remote image at \"sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest\""
+    echo "                         1. The latest remote image at \"sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest\""
+    echo "                         2. The cached local image named \"docker-sonic-mgmt\" if the remote image cannot be pulled"
     echo "  -d <directory>       specify directory inside container to bind mount to sonic-mgmt root (default: \"/var/src\")"
     echo "  -m <mount_point>     specify directory to bind mount to container"
     echo "  -p <port>            publish container port to the host"
@@ -173,10 +173,11 @@ function pull_docker_image_with_retry() {
 
 function pull_sonic_mgmt_docker_image() {
     if [[ -z "${IMAGE_ID}" ]]; then
-        if docker image inspect "${DOCKER_SONIC_MGMT}" &> /dev/null; then
-            IMAGE_ID="${DOCKER_SONIC_MGMT}"
-        elif pull_docker_image_with_retry "${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}"; then
+        if pull_docker_image_with_retry "${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}"; then
             IMAGE_ID="${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}"
+        elif docker image inspect "${DOCKER_SONIC_MGMT}" &> /dev/null; then
+            log_notice "unable to pull the latest default docker image; using cached local image"
+            IMAGE_ID="${DOCKER_SONIC_MGMT}"
         else
             exit_failure "unable to find a usable default docker image, please specify one manually"
         fi


### PR DESCRIPTION
### Description of PR

Summary:
Refresh the default `docker-sonic-mgmt:latest` image from the registry before creating a sonic-mgmt container. This prevents hosts with an existing local tag from indefinitely reusing an outdated image.

Fixes # (issue): N/A

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: regression

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `bash -n setup-container.sh`
- Verified with mocked image-selection checks that a successful registry pull selects the remote image, a failed pull falls back to the cached local image, and an explicit `-i` image remains unchanged.

### Approach
#### What is the motivation for this PR?

`setup-container.sh` currently selects `docker-sonic-mgmt:latest` immediately when that local tag exists. As a result, long-lived test hosts never check whether the registry tag has changed and can continue creating containers from an outdated image that lacks recently added dependencies.

#### How did you do it?

Changed the default image-selection order to use the existing retrying registry pull first. If the registry cannot be reached after all retries, the script falls back to the cached local image when available. Explicit images supplied with `-i` retain their existing behavior. The command help text now documents the updated selection order.

#### How did you verify/test it?

Validated shell syntax with `bash -n setup-container.sh`. Ran focused mocked checks for registry success, registry failure with a local fallback, and explicit image selection.

#### Any platform specific information?

Applies to hosts that use `setup-container.sh` to create sonic-mgmt containers. Hosts require working registry connectivity or their configured proxy to receive the latest image. A cached local image remains available when the registry is temporarily unreachable.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

Updated the built-in `setup-container.sh` help text to describe the new default image-selection order.
