### PR TITLE
[pipeline]: Make test plan status polling resilient

### DIFF
--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -35,6 +35,8 @@ PR_TEST_SCRIPTS_FILE = "pr_test_scripts.yaml"
 SPECIFIC_PARAM_KEYWORD = "specific_param"
 MAX_POLL_RETRY_TIMES = 10
 MAX_GET_TOKEN_RETRY_TIMES = 3
+POLL_CONNECT_TIMEOUT_SECONDS = 10
+POLL_READ_TIMEOUT_SECONDS = 60
 TEST_PLAN_STATUS_UNSUCCESSFUL_FINISHED = ["FAILED", "CANCELLED"]
 TEST_PLAN_STEP_STATUS_UNFINISHED = ["EXECUTING", None]
 
@@ -493,7 +495,13 @@ class TestPlanManager(object):
 
             resp = None
             try:
-                resp = requests.get(poll_url, headers=headers, timeout=10).json()
+                raw_resp = requests.get(
+                    poll_url,
+                    headers=headers,
+                    timeout=(POLL_CONNECT_TIMEOUT_SECONDS, POLL_READ_TIMEOUT_SECONDS)
+                )
+                raw_resp.raise_for_status()
+                resp = raw_resp.json()
 
                 if not resp:
                     raise Exception("Poll test plan status failed with request error, no response!")
@@ -505,18 +513,22 @@ class TestPlanManager(object):
                 if not resp_data:
                     raise Exception("No valid data in response.")
 
+                poll_retry_times = 0
+
             except Exception as exception:
                 print(f"Failed to get valid response, url: {poll_url}, raw_resp: {resp}, exception: {str(exception)}")
 
-                # Refresh headers token to address token expiration issue
-                headers = {
-                    "Authorization": f"Bearer {self.get_token()}",
-                    "Content-Type": "application/json"
-                }
+                if isinstance(exception, requests.exceptions.HTTPError):
+                    error_response = exception.response
+                    if error_response is not None and error_response.status_code == requests.codes.unauthorized:
+                        headers = {
+                            "Authorization": f"Bearer {self.get_token()}",
+                            "Content-Type": "application/json"
+                        }
 
                 poll_retry_times = poll_retry_times + 1
                 if poll_retry_times >= MAX_POLL_RETRY_TIMES:
-                    raise Exception("Poll test plan status failed, exceeded the maximum number of retries.")
+                    raise Exception("Poll test plan status failed, exceeded the maximum number of consecutive retries.")
                 else:
                     time.sleep(interval)
                 continue

--- a/.azure-pipelines/test_plan_test.py
+++ b/.azure-pipelines/test_plan_test.py
@@ -1,0 +1,141 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+
+MODULE_PATH = Path(__file__).with_name("test_plan.py")
+SPEC = importlib.util.spec_from_file_location(
+    "pipeline_test_plan",
+    MODULE_PATH,
+)
+test_plan = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(test_plan)
+
+
+def _response(payload=None, status_code=200):
+    response = Mock(status_code=status_code)
+    response.json.return_value = payload
+    if status_code >= 400:
+        response.raise_for_status.side_effect = requests.HTTPError(
+            response=response,
+        )
+    return response
+
+
+def _executing_response():
+    return _response({
+        "success": True,
+        "data": {
+            "status": "EXECUTING",
+            "result": None,
+            "runtime": {},
+        },
+    })
+
+
+def _finished_response():
+    return _response({
+        "success": True,
+        "data": {
+            "status": "FINISHED",
+            "result": "SUCCESS",
+            "runtime": {
+                "steps": [
+                    {
+                        "step": "EXECUTING",
+                        "status": "FINISHED",
+                    },
+                ],
+            },
+        },
+    })
+
+
+@pytest.fixture
+def manager(monkeypatch):
+    """Create a test-plan manager without invoking Azure CLI."""
+    manager = test_plan.TestPlanManager(
+        scheduler_url="https://scheduler.example",
+        frontend_url="https://frontend.example",
+        client_id="client-id",
+        managed_identity_id="managed-identity-id",
+    )
+    manager.get_token = Mock(return_value="token")
+    monkeypatch.setattr(test_plan.time, "sleep", Mock())
+    return manager
+
+
+def test_success_resets_consecutive_poll_failures(manager, monkeypatch):
+    """Verify successful polling resets the consecutive failure budget."""
+    timeout = requests.ReadTimeout("status request timed out")
+    responses = (
+        [timeout] * (test_plan.MAX_POLL_RETRY_TIMES - 1)
+        + [_executing_response()]
+        + [timeout] * (test_plan.MAX_POLL_RETRY_TIMES - 1)
+        + [_finished_response()]
+    )
+    get = Mock(side_effect=responses)
+    monkeypatch.setattr(test_plan.requests, "get", get)
+
+    manager.poll("test-plan-id", interval=0, expected_state="EXECUTING")
+
+    assert get.call_count == len(responses)
+    assert all(
+        call.kwargs["timeout"] == (
+            test_plan.POLL_CONNECT_TIMEOUT_SECONDS,
+            test_plan.POLL_READ_TIMEOUT_SECONDS,
+        )
+        for call in get.call_args_list
+    )
+
+
+def test_read_timeout_does_not_refresh_token(manager, monkeypatch):
+    """Verify a read timeout retries without refreshing the access token."""
+    get = Mock(side_effect=[
+        requests.ReadTimeout("status request timed out"),
+        _finished_response(),
+    ])
+    monkeypatch.setattr(test_plan.requests, "get", get)
+
+    manager.poll("test-plan-id", interval=0, expected_state="EXECUTING")
+
+    manager.get_token.assert_called_once_with()
+
+
+def test_consecutive_poll_failures_exhaust_retry_budget(manager, monkeypatch):
+    """Verify consecutive failures still stop polling at the retry limit."""
+    get = Mock(side_effect=[
+        requests.ReadTimeout("status request timed out")
+        for _ in range(test_plan.MAX_POLL_RETRY_TIMES)
+    ])
+    monkeypatch.setattr(test_plan.requests, "get", get)
+
+    with pytest.raises(
+        Exception,
+        match="maximum number of consecutive retries",
+    ):
+        manager.poll("test-plan-id", interval=0, expected_state="EXECUTING")
+
+    assert get.call_count == test_plan.MAX_POLL_RETRY_TIMES
+    manager.get_token.assert_called_once_with()
+
+
+def test_unauthorized_response_refreshes_token(manager, monkeypatch):
+    """Verify an unauthorized response refreshes the access token."""
+    manager.get_token.side_effect = ["initial-token", "refreshed-token"]
+    get = Mock(side_effect=[
+        _response(status_code=requests.codes.unauthorized),
+        _finished_response(),
+    ])
+    monkeypatch.setattr(test_plan.requests, "get", get)
+
+    manager.poll("test-plan-id", interval=0, expected_state="EXECUTING")
+
+    assert manager.get_token.call_count == 2
+    assert (
+        get.call_args_list[1].kwargs["headers"]["Authorization"]
+        == "Bearer refreshed-token"
+    )


### PR DESCRIPTION
### Description of PR

Summary:
Make Elastictest status polling resilient to transient scheduler latency. Use separate connection and read timeouts, reset the retry budget after a successful response, and refresh the managed-identity token only after an HTTP 401 response.

ADO: https://dev.azure.com/msazure/One/_workitems/edit/39520152

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: 62 pipeline unit tests passed

### Approach
#### What is the motivation for this PR?

The PR pipeline polls Elastictest once per minute with a 10-second request timeout. Transient scheduler delays were counted across the lifetime of a test plan because successful responses did not reset the retry counter. A plan could therefore fail after 10 non-consecutive timeouts despite many successful polls between them. Every exception also refreshed the managed-identity token, causing unnecessary `az login` calls for ordinary read timeouts.

#### How did you do it?

- Use a 10-second connection timeout and a 60-second read timeout.
- Call `raise_for_status()` to distinguish HTTP failures.
- Reset the polling retry counter after every valid status response.
- Refresh the access token only for HTTP 401 responses.
- Retain the existing limit of 10 retries, now applied to consecutive failures.
- Add focused regression tests for timeout recovery, retry exhaustion, token refresh, and request timeout configuration.

#### How did you verify/test it?

Ran the new polling tests together with the existing impacted-area pipeline tests. All 62 tests passed.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
