### PR TITLE
[action] [PR:21070] Add WRED queue statistics constants to CounterpollConstants

### DIFF
--- a/tests/common/constants.py
+++ b/tests/common/constants.py
@@ -51,6 +51,8 @@ class CounterpollConstants:
     ACL_TYPE = "ACL"
     PHY_TYPE = 'PHY'
     PHY = 'phy'
+    WRED_ECN_QUEUE_STAT_TYPE = 'WRED_ECN_QUEUE_STAT'
+    WRED_QUEUE = 'wredqueue'
     COUNTERPOLL_MAPPING = {PG_DROP_STAT_TYPE: PG_DROP,
                            QUEUE_STAT_TYPE: QUEUE,
                            PORT_STAT_TYPE: PORT,
@@ -61,7 +63,8 @@ class CounterpollConstants:
                            QUEUE_WATERMARK_STAT_TYPE: WATERMARK,
                            PG_WATERMARK_STAT_TYPE: WATERMARK,
                            ACL_TYPE: ACL,
-                           PHY_TYPE: PHY}
+                           PHY_TYPE: PHY,
+                           WRED_ECN_QUEUE_STAT_TYPE: WRED_QUEUE}
     PORT_BUFFER_DROP_INTERVAL = '10000'
     COUNTERPOLL_INTERVAL = {PORT_BUFFER_DROP: 10000}
     SX_SDK = 'sx_sdk'

--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -256,8 +256,10 @@ def verify_counterpoll_status(duthost, counterpoll_list, expected):
         verified_output_dict = {}
         for counterpoll_parsed_dict in counterpoll_output:
             for k, v in list(CounterpollConstants.COUNTERPOLL_MAPPING.items()):
-                if k in counterpoll_parsed_dict[CounterpollConstants.TYPE]:
-                    verified_output_dict[v] = counterpoll_parsed_dict[CounterpollConstants.STATUS]
+                if k == counterpoll_parsed_dict[CounterpollConstants.TYPE]:
+                    status = counterpoll_parsed_dict[CounterpollConstants.STATUS]
+                    logging.info(f"Setting verified_output_dict[{v}] = {status}")
+                    verified_output_dict[v] = status
 
         # Validate all of the relevant keys are disabled - QUEUE/WATERMARK/PG-DROP
         for counterpoll in counterpoll_list:


### PR DESCRIPTION
Manual cherry-pick of #21070 to the 202511 branch.

This replaces #22004: the mssonicbld auto cherry-pick hit a merge conflict in `tests/common/constants.py` (the new WRED constants landed on the same block as the existing `PHY_TYPE`/`PHY` entries). Both sets of constants are kept in `CounterpollConstants` and `COUNTERPOLL_MAPPING`.

Original PR: #21070
Supersedes: #22004