### PR TITLE
[202511] Fix UT2 golden_config_db AttributeError for bgp_confd_asn/peers (#27582)

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -63,7 +63,9 @@ class GenerateGoldenConfigDBModule(object):
                                     npu_index=dict(required=False, type='int', default=0),
                                     duts_list=dict(required=False, type='list', default=[]),
                                     dut_loopbacks=dict(required=False, type='dict', default={}),
-                                    console_ports=dict(required=False, type='dict', default=None)),
+                                    console_ports=dict(required=False, type='dict', default=None),
+                                    bgp_confd_asn=dict(required=False, type='str', default=None),
+                                    bgp_confd_peers=dict(required=False, type='str', default=None)),
                                     supports_check_mode=True)
         self.topo_name = self.module.params['topo_name']
         self.port_index_map = self.module.params['port_index_map']
@@ -77,6 +79,8 @@ class GenerateGoldenConfigDBModule(object):
         self.duts_list = self.module.params['duts_list']
         self.dut_loopbacks = self.module.params['dut_loopbacks']
         self.console_ports = self.module.params['console_ports']
+        self.bgp_confd_asn = self.module.params['bgp_confd_asn']
+        self.bgp_confd_peers = self.module.params['bgp_confd_peers']
 
     def _update_config_db_in_ns(self, config, table, value, namespaces_to_update='asic'):
         """Update a table entry across all ASIC namespaces for multi-ASIC platforms.


### PR DESCRIPTION
### Description of PR

Fixes #27582.

Deploying **T2 single-node min/mix (and `lt2`/`ft2`) topologies on 202511** fails at the `Generate golden_config_db.json` task with:

```
'GenerateGoldenConfigDBModule' object has no attribute 'bgp_confd_asn'
```

**Root cause:** PR #26241 (cherry-pick of #24415) brought `generate_ut2_golden_config_db()` onto 202511. That method reads `self.bgp_confd_asn` / `self.bgp_confd_peers`, which are defined by PR #22417 (`argument_spec` + `__init__` + Ansible task inputs). #22417 was **never backported to 202511**, so the consumer landed without its provider and the attribute lookup raises `AttributeError` at deploy time. (master is unaffected — #22417 merged there before the consumers.)

**Fix:** define `bgp_confd_asn` / `bgp_confd_peers` in the module `argument_spec` (default `None`) and assign them in `__init__`, mirroring #22417. This is the minimal, faithful slice — it does **not** pull in the broader BGP-confederation test infra (intentionally absent from 202511, see #25188). When confed isn't configured (the 202511 default), the existing `if self.bgp_confd_asn and self.bgp_confd_peers:` guards simply evaluate to `None` and are skipped, so no `CONFED` block is emitted. If confed inputs are ever supplied, the rendering path still works.

### Type of change

- [x] Bug fix

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

N/A — this change targets the 202511 branch directly (the regression is 202511-only).

### Approach

#### What is the motivation for this PR?

Unblock T2 single-node / `lt2` / `ft2` deployments on 202511 that regressed after #26241 merged.

#### How did you do it?

Added the two missing module parameters and their `__init__` assignments (a 4-line subset of #22417). No `config_sonic_basedon_testbed.yml` change is required — with `default=None`, the params resolve to `None` when the task does not pass them, and the confed guards no-op.

#### How did you verify/test it?

Isolated the exact failing code path (`generate_ut2_golden_config_db()`), stubbing the minigraph/macsec helpers, and drove it against the pre-fix and post-fix module across three scenarios:

| Scenario | File | confed inputs | Result |
|---|---|---|---|
| 1 — reproduce the bug | 202511 pre-fix | none | `AttributeError: 'GenerateGoldenConfigDBModule' object has no attribute 'bgp_confd_asn'` |
| 2 — deploy path (default) | this PR | none | OK — no crash, valid JSON, **no** `CONFED` block emitted |
| 3 — forward compatibility | this PR | asn+peers set | OK — no crash, valid JSON, `BGP_DEVICE_GLOBAL.CONFED` rendered |

Raw output:

```
==== SCENARIO 1: OLD 202511 (pre-fix), no confed ====
RESULT: AttributeError -> 'GenerateGoldenConfigDBModule' object has no attribute 'bgp_confd_asn'

==== SCENARIO 2: NEW fixed, no confed (the 202511 deploy path) ====
RESULT: OK (no crash); valid JSON; CONFED_rendered=False

==== SCENARIO 3: NEW fixed, WITH confed ====
RESULT: OK (no crash); valid JSON; CONFED_rendered=True
```

`py_compile` and `flake8 --max-line-length=120` are clean on the changed file.
