### PR TITLE
Revert "[202511][cherry-pick] update golden_config_db rendering for UT2 

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -723,13 +723,6 @@
         rescue:
           - debug: msg="SOC properties may not be defined in the device config file. Skipping adjustment of SOC properties."
 
-      # t2_single_node golden_config needs port_config from generated minigraph so
-      # that golden config does not inherit stale admin_status from old minigraph
-      - name: Apply minigraph prior to generating golden_config_db.json
-        become: true
-        shell: config load_minigraph -y
-        when: "'t2_single_node' in topo"
-
       - name: Generate golden_config_db.json
         generate_golden_config_db:
           topo_name: "{{ topo }}"

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -78,54 +78,6 @@ class GenerateGoldenConfigDBModule(object):
         self.dut_loopbacks = self.module.params['dut_loopbacks']
         self.console_ports = self.module.params['console_ports']
 
-    def _update_config_db_in_ns(self, config, table, value, namespaces_to_update='asic'):
-        """Update a table entry across all ASIC namespaces for multi-ASIC platforms.
-
-        Args:
-            config: Dict with the original config db content to update.
-            table: The config table path to update, using '/' to denote nested levels.
-                   e.g. "DEVICE_METADATA/localhost" navigates to asicN -> DEVICE_METADATA -> localhost.
-            value: A dict of field-value pairs to merge at the resolved path.
-            namespaces_to_update: Specifies which namespaces to update. can be "asic" or "localhost" or "all"
-
-        Returns:
-            Updated config as a JSON string.
-        """
-
-        if namespaces_to_update == "localhost":
-            ns_to_update = ["localhost"]
-        elif namespaces_to_update == "all":
-            ns_to_update = ["localhost"] + ["asic{}".format(asic) for asic in range(self.num_asics)]
-        else:
-            ns_to_update = ["asic{}".format(asic) for asic in range(self.num_asics)]
-        path_parts = table.split("/")
-        for ns in ns_to_update:
-            ns_cfg = config.get(ns)
-            if ns_cfg is None:
-                continue
-            target = ns_cfg
-            for part in path_parts:
-                target = target.setdefault(part, {})
-            target.update(value)
-        return config
-
-    def _render_macsec_config(self):
-        if not self.macsec_profile:
-            return {}
-
-        with open(MACSEC_PROFILE_PATH) as f:
-            macsec_profiles = json.load(f)
-
-        profile = macsec_profiles.get(self.macsec_profile)
-        if not profile:
-            return {}
-
-        profile['macsec_profile'] = self.macsec_profile
-        profile['asic_cnt'] = self.num_asics
-
-        with open(GOLDEN_CONFIG_TEMPLATE_PATH) as template_file:
-            return json.loads(Template(template_file.read()).render(profile))
-
     def generate_mgfx_golden_config_db(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
         if rc != 0:
@@ -211,34 +163,6 @@ class GenerateGoldenConfigDBModule(object):
             return False
         repos = [line.strip().lower() for line in out.splitlines() if line.strip()]
         return "docker-sonic-otel" in repos
-
-    def get_port_config_path(self, asic_id):
-        platform = device_info.get_platform()
-        hwsku = device_info.get_hwsku()
-
-        return "/usr/share/sonic/device/{}/{}/{}/port_config.ini".format(
-                platform, hwsku, asic_id)
-
-    def get_config_from_minigraph_multiasic(self):
-        full_config = {}
-        cmd = "sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data"
-        # get the config for the host
-        rc, out, err = self.module.run_command(cmd)
-        if rc != 0:
-            self.module.fail_json(
-                msg="Failed to get config from minigraph for namespace {}: {}".format("localhost", err))
-        full_config["localhost"] = json.loads(out)
-
-        # get the config for asic namespaces
-        for asic_id in range(self.num_asics):
-            ns = "asic{}".format(asic_id)
-            port_config_path = self.get_port_config_path(asic_id)
-            asic_cmd = f"{cmd} -n {ns} -p {port_config_path}"
-            rc, out, err = self.module.run_command(asic_cmd)
-            if rc != 0:
-                self.module.fail_json(msg="Failed to get config from minigraph for namespace {}: {}".format(ns, err))
-            full_config[ns] = json.loads(out)
-        return full_config
 
     def get_config_from_minigraph(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
@@ -746,38 +670,6 @@ class GenerateGoldenConfigDBModule(object):
 
         return ha_config
 
-    def generate_ut2_golden_config_db(self):
-        full_config = {}
-        if self.num_asics > 1:
-            full_config = self.get_config_from_minigraph_multiasic()
-        else:
-            full_config = json.loads(self.get_config_from_minigraph())
-
-        macsec_config = self._render_macsec_config()
-
-        if self.num_asics > 1:
-            for asic in range(self.num_asics):
-                asic_name = f"asic{asic}"
-                if macsec_config:
-                    full_config[asic_name].update(macsec_config[asic_name])
-
-                if self.bgp_confd_asn and self.bgp_confd_peers:
-                    bgp_device_global = full_config[asic_name].setdefault("BGP_DEVICE_GLOBAL", {})
-                    bgp_device_global["CONFED"] = {
-                        "asn": str(self.bgp_confd_asn),
-                        "peers": str(self.bgp_confd_peers).replace(' ', ';')
-                    }
-        else:
-            full_config.update(macsec_config)
-            if self.bgp_confd_asn and self.bgp_confd_peers:
-                bgp_device_global = full_config.setdefault("BGP_DEVICE_GLOBAL", {})
-                bgp_device_global["CONFED"] = {
-                    "asn": str(self.bgp_confd_asn),
-                    "peers": str(self.bgp_confd_peers).replace(' ', ';')
-                }
-
-        return json.dumps(full_config, indent=4)
-
     def generate_t2_golden_config_db(self):
         with open(MACSEC_PROFILE_PATH) as f:
             macsec_profiles = json.load(f)
@@ -865,23 +757,18 @@ class GenerateGoldenConfigDBModule(object):
             self.module.fail_json(
                 msg="Invalid zebra_nexthop value '{}': must be 'enabled' or 'disabled'".format(zebra_nexthop))
         ori_config_db = json.loads(config)
-        if self.num_asics > 1:
-            ori_config_db = self._update_config_db_in_ns(
-                ori_config_db, "DEVICE_METADATA/localhost",
-                {"zebra_nexthop": zebra_nexthop})
-        else:
-            if "DEVICE_METADATA" not in ori_config_db or \
-                    "localhost" not in ori_config_db["DEVICE_METADATA"]:
-                # When DEVICE_METADATA is absent from the golden config (e.g. T0/T1
-                # topologies), do not inject a minigraph-derived entry here.
-                # config_reload.py already restores zebra_nexthop via an additive
-                # hset after every minigraph-based config reload, so no golden-config
-                # override is needed.  Injecting a full minigraph entry here would
-                # cause config override-config-table (which uses set_entry / REPLACE
-                # semantics) to wipe fields such as default_pfcwd_status that are
-                # present in the running config_db but absent from minigraph output.
-                return config
-            ori_config_db["DEVICE_METADATA"]["localhost"]["zebra_nexthop"] = zebra_nexthop
+        if "DEVICE_METADATA" not in ori_config_db or \
+                "localhost" not in ori_config_db["DEVICE_METADATA"]:
+            # When DEVICE_METADATA is absent from the golden config (e.g. T0/T1
+            # topologies), do not inject a minigraph-derived entry here.
+            # config_reload.py already restores zebra_nexthop via an additive
+            # hset after every minigraph-based config reload, so no golden-config
+            # override is needed.  Injecting a full minigraph entry here would
+            # cause config override-config-table (which uses set_entry / REPLACE
+            # semantics) to wipe fields such as default_pfcwd_status that are
+            # present in the running config_db but absent from minigraph output.
+            return config
+        ori_config_db["DEVICE_METADATA"]["localhost"]["zebra_nexthop"] = zebra_nexthop
         return json.dumps(ori_config_db, indent=4)
 
     def generate_lt2_ft2_golden_config_db(self):
@@ -936,11 +823,6 @@ class GenerateGoldenConfigDBModule(object):
             module_msg = module_msg + " for t0-f2"
         elif "ft2" in self.topo_name or "lt2" in self.topo_name:
             config = self.generate_lt2_ft2_golden_config_db()
-        elif "t2_single_node" in self.topo_name:
-            config = self.generate_ut2_golden_config_db()
-            self.module.run_command("sudo rm -f {}".format(MACSEC_PROFILE_PATH))
-            self.module.run_command("sudo rm -f {}".format(GOLDEN_CONFIG_TEMPLATE_PATH))
-            module_msg = module_msg + " for ut2 device"
         elif "t2" in self.topo_name and self.macsec_profile:
             config = self.generate_t2_golden_config_db()
             module_msg = module_msg + " for t2"


### PR DESCRIPTION
### Description of PR

Alternative resolution for #27582 (see also the forward-fix #27697 — **only one of the two should be merged**).

This reverts #26241 *"[202511][cherry-pick] update golden_config_db rendering for UT2 (#24415)"*, which regressed 202511: it added `generate_ut2_golden_config_db()` reading `self.bgp_confd_asn` / `self.bgp_confd_peers`, but the provider PR #22417 that defines those attributes was never backported to 202511. As a result, deploying **T2 single-node min/mix (and `lt2`/`ft2`) topologies** fails at the `Generate golden_config_db.json` task with:

```
'GenerateGoldenConfigDBModule' object has no attribute 'bgp_confd_asn'
```

Reverting #26241 restores the pre-regression deployment behavior on 202511 by removing the UT2 golden_config rendering that depends on the missing confed plumbing.

### Which fix to take?

- **If the UT2 golden_config rendering is wanted on 202511:** merge the forward-fix **#27697** instead (adds the 4 missing `argument_spec` + `__init__` definitions; keeps the feature, confed guards no-op when not configured). Do **not** merge this revert.
- **If the feature is not needed on 202511 right now:** merge this revert to unblock deployment immediately.

### Type of change

- [x] Bug fix (revert)

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

N/A — targets 202511 directly (202511-only regression).

### Approach

#### How did you verify/test it?

- Clean `git revert` of the squash commit `018533ec9` (#26241); 2 files changed, −137 lines.
- After revert, `generate_golden_config_db.py` contains **no** references to `generate_ut2_golden_config_db` or `bgp_confd_*` (grep count 0), and `py_compile` is clean.
- The same isolated harness used for #27697 confirms the pre-regression module has no `bgp_confd_asn` code path to fail on.
