### PR TITLE
[202511][cherry-pick] Improve test infra to support BGP confederation (#22417) (#27582)

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -487,6 +487,11 @@
       - name: Load variables from topology file for topo_{{ topo }}.yml
         include_vars: "vars/topo_{{ topo }}.yml"
 
+      - name: set BGP confd ASN facts
+        set_fact:
+          bgp_confd_asn: "{{ hostvars[inventory_hostname]['configuration_properties']['common']['dut_confed_asn'] | default(None) }}"
+          bgp_confd_peers: "{{ hostvars[inventory_hostname]['configuration_properties']['common']['dut_confed_peers'] | default(None) }}"
+
       - name: saved original minigraph file in SONiC DUT(ignore errors when file does not exist)
         shell: mv /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.orig
         become: true
@@ -738,10 +743,13 @@
           vm_configuration: "{{ configuration if topo == 't1-filterleaf-lag' else omit }}"
           is_lit_mode: "{{ is_lit_mode | default(true) }}"
           npu_index: "{{ dut_index | default(0) | int }}"
+          bgp_confd_asn: "{{ bgp_confd_asn }}"
+          bgp_confd_peers: "{{ bgp_confd_peers }}"
           duts_list: "{{ testbed_facts['duts'] | default([]) }}"
           dut_loopbacks: "{{ topology.DUT.loopback | default({}) }}"
           console_ports: "{{ device_serial_link[inventory_hostname] | default(omit) if 'c0' in topo else omit }}"
         become: true
+        when: enable_macsec is not defined
 
       - name: Copy macsec profile json to dut
         copy: src=../tests/common/macsec/profile.json
@@ -760,8 +768,10 @@
           topo_name: "{{ topo }}"
           macsec_profile: "{{ macsec_profile }}"
           num_asics: "{{ num_asics }}"
+          bgp_confd_asn: "{{ bgp_confd_asn }}"
+          bgp_confd_peers: "{{ bgp_confd_peers }}"
         become: true
-        when: "('t2' in topo) and (macsec_profile is defined)"
+        when: "('t2' in topo) and (enable_macsec is defined)"
 
       - name: Use minigraph case
         block:

--- a/ansible/library/bgp_facts.py
+++ b/ansible/library/bgp_facts.py
@@ -120,6 +120,7 @@ class BgpModule(object):
     def parse_neighbors(self):
         regex_ipv4 = re.compile(
             r'^BGP neighbor is \*?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})')
+        regex_confed_link = re.compile(r'^BGP neighbor is .*(confed-(?:internal|external) link)')
         regex_ipv6 = re.compile(r'^BGP neighbor is \*?([0-9a-fA-F:]+)')
         regex_remote_as = re.compile(r'.*remote AS (\d+)')
         regex_local_as = re.compile(r'.*local AS (\d+)')
@@ -165,6 +166,10 @@ class BgpModule(object):
                     neighbor_ip = None
 
                     for line in lines:
+                        if regex_confed_link.match(line):
+                            neighbor['confed_peer'] = True
+                            confed_peer_type = regex_confed_link.match(line).group(1)
+                            neighbor['confed_peer_type'] = 'external' if confed_peer_type == 'confed-external link' else 'internal'  # noqa: E501
                         if regex_ipv4.match(line):
                             neighbor_ip = regex_ipv4.match(line).group(1)
                             neighbor['ip_version'] = 4

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -63,7 +63,9 @@ class GenerateGoldenConfigDBModule(object):
                                     npu_index=dict(required=False, type='int', default=0),
                                     duts_list=dict(required=False, type='list', default=[]),
                                     dut_loopbacks=dict(required=False, type='dict', default={}),
-                                    console_ports=dict(required=False, type='dict', default=None)),
+                                    console_ports=dict(required=False, type='dict', default=None),
+                                    bgp_confd_asn=dict(required=False, type='str', default=None),
+                                    bgp_confd_peers=dict(required=False, type='str', default=None)),
                                     supports_check_mode=True)
         self.topo_name = self.module.params['topo_name']
         self.port_index_map = self.module.params['port_index_map']
@@ -73,6 +75,8 @@ class GenerateGoldenConfigDBModule(object):
 
         self.vm_configuration = self.module.params['vm_configuration']
         self.is_lit_mode = self.module.params['is_lit_mode']
+        self.bgp_confd_asn = self.module.params['bgp_confd_asn']
+        self.bgp_confd_peers = self.module.params['bgp_confd_peers']
         self.npu_index = self.module.params['npu_index']
         self.duts_list = self.module.params['duts_list']
         self.dut_loopbacks = self.module.params['dut_loopbacks']
@@ -886,21 +890,28 @@ class GenerateGoldenConfigDBModule(object):
 
     def generate_lt2_ft2_golden_config_db(self):
         """
-        Generate golden_config for FT2 to enable FEC.
-        **Only PORT table is updated**.
+        Generate golden_config for FT2 to enable FEC and set BGP confed.
         """
         SUPPORTED_TOPO = ["ft2-64", "lt2-p32o64", "lt2-o128", "ft2-o128", "lt2-u32d128"]
         if self.topo_name not in SUPPORTED_TOPO:
             return "{}"
         SUPPORTED_PORT_SPEED = ["200000", "400000", "800000"]
         ori_config = json.loads(self.get_config_from_minigraph())
-        port_config = ori_config.get("PORT", {})
-        for name, config in port_config.items():
+        golden_config = ori_config
+        golden_config["PORT"] = ori_config.get("PORT", {})
+        for _, config in golden_config["PORT"].items():
             # Enable FEC for ports with supported speed
             if config["speed"] in SUPPORTED_PORT_SPEED and "fec" not in config:
                 config["fec"] = "rs"
 
-        return json.dumps({"PORT": port_config}, indent=4)
+        # Add BGP confederation config
+        if self.bgp_confd_asn and self.bgp_confd_peers:
+            golden_config["BGP_DEVICE_GLOBAL"] = ori_config.get("BGP_DEVICE_GLOBAL", {})
+            # Replace space in confg_peers with ; to align with NDM
+            golden_config["BGP_DEVICE_GLOBAL"]["CONFED"] = \
+                {"asn": str(self.bgp_confd_asn), "peers": str(self.bgp_confd_peers).replace(' ', ';')}
+
+        return json.dumps(golden_config, indent=4)
 
     def generate_t0_f2_golden_config_db(self):
         """

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -206,8 +206,12 @@ class ParseTestbedTopoinfo():
 
                 # bgp
                 vmconfig[vm]['bgp_asn'] = topo_definition['configuration'][vm]['bgp']['asn']
-                dut_asn = topo_definition['configuration_properties']['common']['dut_asn']
-                for ipstr in topo_definition['configuration'][vm]['bgp']['peers'][dut_asn]:
+                peer_in_bgp_confed = topo_definition['configuration'][vm]['bgp'].get('peer_in_bgp_confed', False)
+                if peer_in_bgp_confed:
+                    peer_asn = topo_definition['configuration_properties']['common']['dut_confed_asn']
+                else:
+                    peer_asn = topo_definition['configuration_properties']['common']['dut_asn']
+                for ipstr in topo_definition['configuration'][vm]['bgp']['peers'][peer_asn]:
                     ip_mask = None
                     if '/' in ipstr:
                         (ipstr, ip_mask) = ipstr.split('/')

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -370,7 +370,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                        "Arista-7800R3A-36DM2-D36"]:
             for i in range(1, 37):
                 sonic_name = "Ethernet%d" % ((i - 1) * 8)
-                port_alias_to_name_map["Ethernet{}/{}".format(i, 1)] = sonic_name
+                port_alias_to_name_map["etp{}".format(i)] = sonic_name
         elif hwsku in ["Arista-7280R4-32QF-32DF-64O",
                        "Arista-7280R4K-32QF-32DF-64O"]:
             for i in range(1, 65):

--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -232,13 +232,18 @@ router bgp {{ host['bgp']['asn'] }}
  exit
  router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
-    {% for asn, remote_ips in host['bgp']['peers'].items() %}
-        {% for remote_ip in remote_ips %}
+{% if host['bgp']['confed_asn'] is defined and host['bgp']['confed_peers'] is defined %}
+ bgp confederation identifier {{ host['bgp']['confed_asn'] }}
+ bgp confederation peers {{ host['bgp']['confed_peers'] }}
+ !
+{% endif %}
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+    {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
 {# set LT2/FT2 as reflector to advertise route to DUT #}
-            {% if props.swrole is defined and props.swrole in ("lowerspine", "fabricspine") %}
+{% if props.swrole is defined and props.swrole in ("lowerspine", "fabricspine") and host['bgp']['confed_asn'] is not defined %}
  neighbor {{ remote_ip }} route-reflector-client
  neighbor {{ remote_ip }} additional-paths send any
             {% endif %}

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -107,6 +107,11 @@ router bgp {{ host['bgp']['asn'] }}
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
  !
+{% if host['bgp']['confed_asn'] is defined and host['bgp']['confed_peers'] is defined %}
+ bgp confederation identifier {{ host['bgp']['confed_asn'] }}
+ bgp confederation peers {{ host['bgp']['confed_peers'] }}
+!
+{% endif %}
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -232,8 +232,13 @@ router bgp {{ host['bgp']['asn'] }}
  exit
  router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
-    {% for asn, remote_ips in host['bgp']['peers'].items() %}
-        {% for remote_ip in remote_ips %}
+{% if host['bgp']['confed_asn'] is defined and host['bgp']['confed_peers'] is defined %}
+ bgp confederation identifier {{ host['bgp']['confed_asn'] }}
+ bgp confederation peers {{ host['bgp']['confed_peers'] }}
+!
+{% endif %}
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+    {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self

--- a/ansible/roles/eos/templates/t2-leaf.j2
+++ b/ansible/roles/eos/templates/t2-leaf.j2
@@ -109,6 +109,12 @@ interface {{ bp_ifname }}
 router bgp {{ host['bgp']['asn'] }}
  router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
+{% if host['bgp']['confed_asn'] is defined and host['bgp']['confed_peers'] is defined %}
+ bgp confederation identifier {{ host['bgp']['confed_asn'] }}
+ bgp confederation peers {{ host['bgp']['confed_peers'] }}
+ !
+ {% endif %}
+
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -704,6 +704,9 @@ def bgpmon_setup_teardown(ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_ho
     peer_addr = connection['neighbor_addr'].split("/")[0]
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     asn = mg_facts['minigraph_bgp_asn']
+    confed_asn = duthost.get_bgp_confed_asn()
+    if confed_asn:
+        asn = confed_asn
     # TODO: Add a common method to load BGPMON config for test_bgpmon and test_traffic_shift
     logger.info("Configuring bgp monitor session on DUT")
     bgpmon_args = {

--- a/tests/bgp/route_checker.py
+++ b/tests/bgp/route_checker.py
@@ -64,6 +64,7 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver, exp_community=[]):
     mg_facts = dut_host.minigraph_facts(
         host=dut_host.hostname)['ansible_facts']
     confed_asn = dut_host.get_bgp_confed_asn()
+
     all_routes = {}
     BGP_ENTRY_HEADING = r"BGP routing table entry for "
     BGP_COMMUNITY_HEADING = r"Community: "


### PR DESCRIPTION
### Description of PR

Full backport of #22417 *"[DT2] Improve test infra to support BGP confederation"* to **202511**. This is the complete-feature resolution for #27582 (supersedes the minimal forward-fix #27697 and the revert #27698 — pick this one if BGP confederation support is wanted on 202511).

**Why:** deploying T2 single-node min/mix (and `lt2`/`ft2`) topologies on 202511 fails at `Generate golden_config_db.json` with `'GenerateGoldenConfigDBModule' object has no attribute 'bgp_confd_asn'`. Root cause (RCA in #27582): #26241 cherry-picked the golden_config *consumer* of `bgp_confd_asn`/`bgp_confd_peers` onto 202511, but the *provider* #22417 that defines them was never backported. This PR brings the full provider + the rest of the confederation test infra, so both the deploy path and confed tests work.

Cherry-picked with `-x` (original author `bingwang-ms` preserved). One conflict in `generate_golden_config_db.py` was resolved by keeping the 202511 side for two unrelated methods (`generate_default_init_config_db`/`update_zmq_config`) that #22417 does **not** modify (they were three-way-merge context, absent on 202511); the net change to that file is exactly #22417's confed additions.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

N/A — this PR *is* the 202511 backport (targets 202511 directly). Original change: #22417 (master).

### Scope (12 files, faithful to #22417)

| File | Purpose |
|---|---|
| `ansible/library/generate_golden_config_db.py` | define `bgp_confd_asn`/`bgp_confd_peers` (argument_spec + `__init__`); render `BGP_DEVICE_GLOBAL.CONFED` in the `lt2/ft2` path (fixes the deploy crash) |
| `ansible/config_sonic_basedon_testbed.yml` | set `bgp_confd_asn`/`bgp_confd_peers` facts from inventory (`default(None)`) and pass them to the module |
| `ansible/library/bgp_facts.py` | parse `confed-internal/external link` → `confed_peer`/`confed_peer_type` |
| `ansible/library/topo_facts.py` | use `dut_confed_asn` when a VM has `peer_in_bgp_confed` |
| `ansible/module_utils/port_utils.py` | Arista 36DM2 port-alias mapping fix (part of #22417) |
| `ansible/roles/eos/templates/{t0-leaf,t1-64-lag-tor,t1-lag-spine,t2-leaf}.j2` | EOS confed peer config |
| `tests/bgp/conftest.py`, `tests/bgp/route_checker.py`, `tests/common/helpers/bgp.py` | confed-aware bgpmon/route/local-AS checks |

### How did you verify/test it?

**Dependency check (no hidden gaps on 202511):** the only external symbol #22417's hunks call, `duthost.get_bgp_confed_asn()`, already exists on 202511 (`tests/common/devices/multi_asic.py:934`). `confed_peer` consumed in `helpers/bgp.py` is produced by the new `bgp_facts.py` regex in this same PR.

**Static:** all 7 changed Python files pass `py_compile`; `flake8 --max-line-length=120 --ignore=E1,E2,E3,E5,E7,W5` (the repo's pre-commit config) is clean.

**Functional (golden_config generation — the regressed path):** isolated harness driving the exact methods, minigraph/macsec helpers stubbed:

| Case | Path | confed inputs | Result |
|---|---|---|---|
| Repro (pre-backport 202511) | `generate_ut2` | none | `AttributeError: … 'bgp_confd_asn'` |
| Deploy default | `generate_ut2` | none | OK — no crash, **no** `CONFED` emitted |
| Confed configured | `generate_ut2` | asn+peers | OK — `BGP_DEVICE_GLOBAL.CONFED` rendered |
| Deploy default | `generate_lt2_ft2` | none | OK — `PORT.fec=rs` preserved, no `CONFED` |
| Confed configured | `generate_lt2_ft2` | asn+peers | OK — `PORT.fec=rs` + `CONFED` rendered |

Raw output:

```
-- ut2 noconfed (OLD 202511):  AttributeError -> 'GenerateGoldenConfigDBModule' object has no attribute 'bgp_confd_asn'
-- ut2 noconfed (backport):    OK; CONFED_rendered=False
-- ut2 confed  (backport):     OK; CONFED_rendered=True
-- lt2ft2 noconfed (backport): OK; CONFED_rendered=False; PORT.Ethernet0.fec=rs
-- lt2ft2 confed  (backport):  OK; CONFED_rendered=True; PORT.Ethernet0.fec=rs
```

**Backward compatibility:** when confed is not configured (the 202511 default — confed topo config was intentionally reverted in #25188), `bgp_confd_asn`/`peers` resolve to `None`, the `if self.bgp_confd_asn and self.bgp_confd_peers:` guards are skipped, and no `CONFED`/`BGP_DEVICE_GLOBAL` is emitted — identical golden_config to today, minus the crash.
