### PR TITLE
[mellanox] Assert hw-mgmt sysfs nodes were read successfully

### DIFF
--- a/ansible/library/sysfs_facts.py
+++ b/ansible/library/sysfs_facts.py
@@ -36,6 +36,9 @@ Single check item config:
 User can get the item property value by:
 ansible_facts['item_name']['prop_name']
 
+Command rc/stderr for each property is returned as sysfs_metadata with the same key layout:
+sysfs_metadata['item_name']['prop_name'] -> {'rc': <int>, 'stderr': <str>}
+
 Increment check item config:
 {
     'name': 'item_name',
@@ -56,6 +59,7 @@ Increment check item config:
 
 User can get the first property of the first item value by:
 ansible_facts['item_name'][1]['prop1_name']
+sysfs_metadata['item_name'][1]['prop1_name'] -> {'rc': <int>, 'stderr': <str>}
 
 A example that using this facts is at tests/platform_tests/mellanox/check_sysfs.py
 '''
@@ -70,6 +74,7 @@ class SysfsModule(object):
             supports_check_mode=True)
         self.config = self.module.params['config']
         self.facts = {}
+        self.metadata = {}
 
     def run(self):
         for item in self.config:
@@ -85,30 +90,39 @@ class SysfsModule(object):
                 self.module.fail_json(
                     msg='Unsupported check item type {}'.format(item['type']))
 
-        self.module.exit_json(ansible_facts=self.facts)
+        self.module.exit_json(ansible_facts=self.facts, sysfs_metadata=self.metadata)
 
     def collect_single_item(self, item):
         facts = {}
+        metadata = {}
         for prop in item['properties']:
             prop_name = prop['name']
-            facts[prop_name] = self.run_command(prop['cmd_pattern'])
+            rc, out, err = self.run_command(prop['cmd_pattern'])
+            facts[prop_name] = out
+            metadata[prop_name] = {'rc': rc, 'stderr': err}
 
         name = item['name']
         self.facts[name] = facts
+        self.metadata[name] = metadata
 
     def collect_increment_item(self, item):
         facts = {}
+        metadata = {}
         start = item['start']
         count = item['count']
         for index in range(start, start + count):
             facts[index] = {}
+            metadata[index] = {}
             for prop in item['properties']:
                 prop_name = prop['name']
                 cmd = prop['cmd_pattern'].format(index)
-                facts[index][prop_name] = self.run_command(cmd)
+                rc, out, err = self.run_command(cmd)
+                facts[index][prop_name] = out
+                metadata[index][prop_name] = {'rc': rc, 'stderr': err}
 
         name = item['name']
         self.facts[name] = facts
+        self.metadata[name] = metadata
 
     def run_command(self, command):
         try:
@@ -118,7 +132,7 @@ class SysfsModule(object):
             self.module.fail_json(
                 msg='command {} failed with exception {}'.format(command, e))
 
-        return out.strip()
+        return rc, out.strip(), (err or '').strip()
 
 
 def main():

--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -6,10 +6,33 @@ This script contains re-usable functions for checking status of hw-management re
 import logging
 import re
 from pkg_resources import parse_version
-from tests.common.mellanox_data import get_hw_management_version, get_platform_data
+from tests.common.mellanox_data import get_hw_management_version, get_platform_data, is_ld_system
 from tests.common.utilities import wait_until
 
 MAX_FAN_SPEED_THRESHOLD = 0.15
+
+
+def sysfs_get(value, cmd_meta, name, conv=None):
+    """
+    @summary: Assert a sysfs node was read successfully and is non-empty,
+              optionally convert the value, and return it
+    """
+    assert cmd_meta['rc'] == 0, "{}: read failed (rc={}, stderr={!r}, stdout={!r})".format(
+        name, cmd_meta['rc'], cmd_meta['stderr'], value)
+    assert value != '', "{}: read succeeded but value is empty (rc=0, stderr={!r})".format(
+        name, cmd_meta['stderr'])
+    return conv(value) if conv is not None else value
+
+
+def check_asic_thermal_sysfs(sysfs_facts, sysfs_meta):
+    """
+    @summary: Check asic thermal related sysfs under /var/run/hw-management/thermal
+    """
+    asic_temp_raw = sysfs_get(sysfs_facts['asic_info']['temp'],
+                              sysfs_meta['asic_info']['temp'], 'ASIC temp')
+    asic_temp = float(asic_temp_raw) / 1000
+    assert 0 < asic_temp < 105, "Abnormal ASIC temperature: {}".format(
+        asic_temp_raw)
 
 
 def skip_ignored_broken_symbolinks(broken_symbolinks):
@@ -44,10 +67,15 @@ def check_sysfs(dut, expected_module_temp_fault_value=['0']):
     platform_data = get_platform_data(dut)
     sysfs_config = generate_sysfs_config(dut, platform_data)
     logging.info("Collect mellanox sysfs facts")
-    sysfs_facts = dut.sysfs_facts(config=sysfs_config)['ansible_facts']
+    result = dut.sysfs_facts(config=sysfs_config)
+    sysfs_facts = result['ansible_facts']
+    sysfs_meta = result['sysfs_metadata']
 
     logging.info("Check broken symbolinks")
     broken_symbolinks = sysfs_facts['symbolink_info']['broken_links']
+    broken_meta = sysfs_meta['symbolink_info']['broken_links']
+    assert broken_meta['rc'] == 0, "broken symbolinks: find failed (rc={}, stderr={!r}, stdout={!r})".format(
+        broken_meta['rc'], broken_meta['stderr'], broken_symbolinks)
     broken_symbolinks_updated = skip_ignored_broken_symbolinks(
         broken_symbolinks)
     assert len(broken_symbolinks_updated) == 0, \
@@ -56,23 +84,29 @@ def check_sysfs(dut, expected_module_temp_fault_value=['0']):
 
     logging.info("Check ASIC related sysfs")
     try:
-        asic_temp = float(sysfs_facts['asic_info']['temp']) / 1000
-        assert 0 < asic_temp < 105, "Abnormal ASIC temperature: {}".format(
-            sysfs_facts['asic_info']['temp'])
+        if not is_ld_system(dut):
+            check_asic_thermal_sysfs(sysfs_facts, sysfs_meta)
+        else:
+            logging.info("LD system, skipping ASIC thermal sysfs check")
     except Exception as e:
         assert False, "Bad content in /var/run/hw-management/thermal/asic: {}".format(
             repr(e))
 
     logging.info("Check fan related sysfs")
     for fan_id, fan_info in list(sysfs_facts['fan_info'].items()):
+        fan_meta = sysfs_meta['fan_info'][fan_id]
         if platform_data["fans"].get("hot_swappable"):
-            assert fan_info['status'] == '1', "Fan {} status {} is not 1".format(
-                fan_id, fan_info['status'])
+            fan_status = sysfs_get(fan_info['status'], fan_meta['status'],
+                                   "Fan {} status".format(fan_id))
+            assert fan_status == '1', "Fan {} status {} is not 1".format(
+                fan_id, fan_status)
 
-        assert fan_info['fault'] == '0', "Fan {} fault status {} is not 0".format(
-            fan_id, fan_info['fault'])
+        fan_fault = sysfs_get(fan_info['fault'], fan_meta['fault'],
+                              "Fan {} fault status".format(fan_id))
+        assert fan_fault == '0', "Fan {} fault status {} is not 0".format(
+            fan_id, fan_fault)
 
-    if not _is_fan_speed_in_range(sysfs_facts):
+    if not _is_fan_speed_in_range(sysfs_facts, sysfs_meta):
         sysfs_fan_config = [generate_sysfs_fan_config(platform_data)]
         assert wait_until(30, 5, 0, _check_fan_speed_in_range,
                           dut, sysfs_fan_config), "Fan speed not in range"
@@ -83,11 +117,14 @@ def check_sysfs(dut, expected_module_temp_fault_value=['0']):
     cpu_crit_temp_list = []
     cpu_pack_count = platform_data["cpu_pack"]["number"]
     if cpu_pack_count > 0:
-        cpu_pack_temp = float(sysfs_facts['cpu_pack_info']['temp']) / 1000
-        cpu_pack_max_temp = float(
-            sysfs_facts['cpu_pack_info']['max_temp']) / 1000
-        cpu_pack_crit_temp = float(
-            sysfs_facts['cpu_pack_info']['crit_temp']) / 1000
+        cpu_pack_info = sysfs_facts['cpu_pack_info']
+        cpu_pack_meta = sysfs_meta['cpu_pack_info']
+        cpu_pack_temp = sysfs_get(cpu_pack_info['temp'], cpu_pack_meta['temp'],
+                                  'CPU pack temp', conv=float) / 1000
+        cpu_pack_max_temp = sysfs_get(cpu_pack_info['max_temp'], cpu_pack_meta['max_temp'],
+                                      'CPU pack max temp', conv=float) / 1000
+        cpu_pack_crit_temp = sysfs_get(cpu_pack_info['crit_temp'], cpu_pack_meta['crit_temp'],
+                                       'CPU pack crit temp', conv=float) / 1000
         assert cpu_pack_max_temp <= cpu_pack_crit_temp, "Bad CPU pack max temp or critical temp, {}, {} ".format(
             str(cpu_pack_max_temp),
             str(cpu_pack_crit_temp))
@@ -97,9 +134,13 @@ def check_sysfs(dut, expected_module_temp_fault_value=['0']):
         cpu_crit_temp_list.append(cpu_pack_crit_temp)
 
     for core_id, cpu_info in list(sysfs_facts['cpu_core_info'].items()):
-        cpu_core_temp = float(cpu_info["temp"]) / 1000
-        cpu_core_max_temp = float(cpu_info["max_temp"]) / 1000
-        cpu_core_crit_temp = float(cpu_info["crit_temp"]) / 1000
+        cpu_meta = sysfs_meta['cpu_core_info'][core_id]
+        cpu_core_temp = sysfs_get(cpu_info["temp"], cpu_meta["temp"],
+                                  "CPU core{} temp".format(core_id), conv=float) / 1000
+        cpu_core_max_temp = sysfs_get(cpu_info["max_temp"], cpu_meta["max_temp"],
+                                      "CPU core{} max temp".format(core_id), conv=float) / 1000
+        cpu_core_crit_temp = sysfs_get(cpu_info["crit_temp"], cpu_meta["crit_temp"],
+                                       "CPU core{} crit temp".format(core_id), conv=float) / 1000
         assert cpu_core_max_temp <= cpu_core_crit_temp, "Bad CPU core{} max temp or critical temp, {}, {} ".format(
             core_id,
             str(cpu_core_max_temp),
@@ -118,30 +159,39 @@ def check_sysfs(dut, expected_module_temp_fault_value=['0']):
     logging.info("Check PSU related sysfs")
     if platform_data["psus"].get("hot_swappable"):
         for psu_id, psu_info in list(sysfs_facts['psu_info'].items()):
+            psu_meta = sysfs_meta['psu_info'][psu_id]
             psu_id = int(psu_id)
-            psu_status = int(psu_info["status"])
+            psu_status = sysfs_get(psu_info["status"], psu_meta["status"],
+                                   "PSU{} status".format(psu_id), conv=int)
             if not psu_status:
                 logging.info("PSU {} doesn't exist, skipped".format(psu_id))
                 continue
 
-            psu_pwr_status = int(psu_info["pwr_status"])
+            psu_pwr_status = sysfs_get(psu_info["pwr_status"], psu_meta["pwr_status"],
+                                       "PSU{} pwr_status".format(psu_id), conv=int)
             if not psu_pwr_status:
                 logging.info("PSU {} isn't power on, skipped".format(psu_id))
                 continue
 
-            psu_temp = float(psu_info["temp"]) / 1000
-            psu_max_temp = float(psu_info["max_temp"]) / 1000
+            psu_temp = sysfs_get(psu_info["temp"], psu_meta["temp"],
+                                 "PSU{} temp".format(psu_id), conv=float) / 1000
+            psu_max_temp = sysfs_get(psu_info["max_temp"], psu_meta["max_temp"],
+                                     "PSU{} max temp".format(psu_id), conv=float) / 1000
             assert psu_temp < psu_max_temp, "PSU{} overheated, temp: {}".format(
                 psu_id, str(psu_temp))
-            assert psu_info["max_temp_alarm"] == '0', "PSU{} temp alarm set".format(
+            psu_max_temp_alarm = sysfs_get(psu_info["max_temp_alarm"], psu_meta["max_temp_alarm"],
+                                           "PSU{} temp alarm".format(psu_id))
+            assert psu_max_temp_alarm == '0', "PSU{} temp alarm set".format(
                 psu_id)
+            psu_fan_speed_raw = sysfs_get(psu_info["fan_speed"], psu_meta["fan_speed"],
+                                          "PSU{} fan speed".format(psu_id))
             try:
-                psu_fan_speed = int(psu_info["fan_speed"])
+                psu_fan_speed = int(psu_fan_speed_raw)
                 assert psu_fan_speed > 1000, "Bad fan speed: {}".format(
                     str(psu_fan_speed))
             except Exception as e:
-                assert "Invalid PSU fan speed value {} for PSU {}, exception: {}".format(psu_info["fan_speed"],
-                                                                                         psu_id, e)
+                assert False, "Invalid PSU fan speed value {} for PSU {}, exception: {}".format(
+                    psu_fan_speed_raw, psu_id, e)
 
             if "201911" not in dut.sonic_release and "202012" not in dut.sonic_release:
                 # Check consistency between voltage capability and sysfs
@@ -167,12 +217,20 @@ def check_sysfs(dut, expected_module_temp_fault_value=['0']):
         if not sfp_info["temp_fault"]:
             continue
 
-        assert sfp_info["temp_fault"] in expected_module_temp_fault_value, "SFP%d temp fault" % int(sfp_id)
-        sfp_temp = float(sfp_info['temp']) if sfp_info['temp'] != '0' else 0
-        sfp_temp_crit = float(
-            sfp_info['crit_temp']) if sfp_info['crit_temp'] != '0' else 0
+        sfp_meta = sysfs_meta['sfp_info'][sfp_id]
+        sfp_temp_fault = sysfs_get(sfp_info["temp_fault"], sfp_meta["temp_fault"],
+                                   "SFP{} temp fault".format(sfp_id))
+        assert sfp_temp_fault in expected_module_temp_fault_value, "SFP%d temp fault" % int(sfp_id)
+        sfp_temp_raw = sysfs_get(sfp_info['temp'], sfp_meta['temp'],
+                                 "SFP{} temp".format(sfp_id))
+        sfp_crit_temp_raw = sysfs_get(sfp_info['crit_temp'], sfp_meta['crit_temp'],
+                                      "SFP{} crit temp".format(sfp_id))
+        sfp_emergency_temp_raw = sysfs_get(sfp_info['emergency_temp'], sfp_meta['emergency_temp'],
+                                           "SFP{} emergency temp".format(sfp_id))
+        sfp_temp = float(sfp_temp_raw) if sfp_temp_raw != '0' else 0
+        sfp_temp_crit = float(sfp_crit_temp_raw) if sfp_crit_temp_raw != '0' else 0
         sfp_temp_emergency = float(
-            sfp_info['emergency_temp']) if sfp_info['emergency_temp'] != '0' else 0
+            sfp_emergency_temp_raw) if sfp_emergency_temp_raw != '0' else 0
         if sfp_temp_crit != 0:
             assert sfp_temp < sfp_temp_crit, "SFP{} overheated, temp{}".format(
                 sfp_id, str(sfp_temp))
@@ -219,32 +277,30 @@ def check_psu_sysfs(dut, psu_id, psu_state):
 
 
 def _check_fan_speed_in_range(dut, config):
-    sysfs_facts = dut.sysfs_facts(config=config)['ansible_facts']
+    result = dut.sysfs_facts(config=config)
+    sysfs_facts = result['ansible_facts']
+    sysfs_meta = result['sysfs_metadata']
 
-    return _is_fan_speed_in_range(sysfs_facts)
+    return _is_fan_speed_in_range(sysfs_facts, sysfs_meta)
 
 
-def _is_fan_speed_in_range(sysfs_facts):
+def _is_fan_speed_in_range(sysfs_facts, sysfs_meta):
     for fan_id, fan_info in list(sysfs_facts['fan_info'].items()):
+        fan_meta = sysfs_meta['fan_info'][fan_id]
+        fan_min_speed_raw = sysfs_get(fan_info["min_speed"], fan_meta["min_speed"],
+                                      "Fan {} min speed".format(fan_id))
+        fan_max_speed_raw = sysfs_get(fan_info["max_speed"], fan_meta["max_speed"],
+                                      "Fan {} max speed".format(fan_id))
+        fan_speed_set_raw = sysfs_get(fan_info["speed_set"], fan_meta["speed_set"],
+                                      "Fan {} speed set".format(fan_id))
+        fan_speed_get_raw = sysfs_get(fan_info["speed_get"], fan_meta["speed_get"],
+                                      "Fan {} speed get".format(fan_id))
         try:
-            fan_min_speed = int(fan_info["min_speed"])
+            fan_min_speed = int(fan_min_speed_raw)
             fan_max_speed = int(
-                int(fan_info["max_speed"]) * (1 + MAX_FAN_SPEED_THRESHOLD))
-            fan_speed_set = int(fan_info["speed_set"])
-            fan_speed_get = int(fan_info["speed_get"])
-
-            low_threshold = ((float(fan_speed_set) / 255)
-                             * fan_min_speed) * (1 - 0.5)
-            high_threshold = ((float(fan_speed_set) / 255)
-                              * fan_max_speed) * (1 + 0.5)
-
-            assert fan_min_speed > 0 and fan_max_speed > 10000, 'Invalid fan min/max speed: {}, {}'.format(
-                fan_min_speed,
-                fan_max_speed)
-            assert low_threshold < fan_speed_get < high_threshold, 'Fan speed {} not in range: [{}, {}]'.format(
-                fan_speed_get, low_threshold, high_threshold
-            )
-
+                int(fan_max_speed_raw) * (1 + MAX_FAN_SPEED_THRESHOLD))
+            fan_speed_set = int(fan_speed_set_raw)
+            fan_speed_get = int(fan_speed_get_raw)
         except Exception as e:
             assert False, 'Invalid fan speed: actual speed={}, set speed={}, min={}, max={}, exception={}'.format(
                 fan_info["speed_get"],
@@ -253,6 +309,27 @@ def _is_fan_speed_in_range(sysfs_facts):
                 fan_info["max_speed"],
                 e
             )
+
+        assert fan_min_speed > 0 and fan_max_speed > 10000, \
+            'Invalid fan {} min/max speed: {}, {}'.format(
+                fan_id, fan_min_speed, fan_max_speed)
+
+        low_threshold = ((float(fan_speed_set) / 255) *
+                         fan_min_speed) * (1 - 0.5)
+        high_threshold = ((float(fan_speed_set) / 255) *
+                          fan_max_speed) * (1 + 0.5)
+
+        if not low_threshold < fan_speed_get < high_threshold:
+            logging.warning(
+                'Fan {} speed {} not in range: [{}, {}], '
+                'min_speed={}, max_speed={}, speed_set={}, speed_get={}'.format(
+                    fan_id, fan_speed_get, low_threshold, high_threshold,
+                    fan_info["min_speed"],
+                    fan_info["max_speed"],
+                    fan_info["speed_set"],
+                    fan_info["speed_get"]))
+            return False
+
     return True
 
 


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
`check_sysfs` used to treat a failed or empty sysfs read as a valid value, so later range/content asserts were misleading. Fail the test when a node cannot be read (`rc != 0`) or the value is empty, and include rc/stderr in the failure message.
Depends on:
- https://github.com/sonic-net/sonic-mgmt/pull/27390
- https://github.com/sonic-net/sonic-mgmt/pull/27675

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
Failed cat of `/var/run/hw-management` nodes was not asserted, so the test could pass or fail later with an unclear error.

#### How did you do it?
`sysfs_facts` now returns per-node `rc`/`stderr`. `check_sysfs` asserts each required node was read successfully and is non-empty before checking the value.

#### How did you verify/test it?
Ran `test_check_hw_mgmt_sysfs` / `test_check_sysfs` on Mellanox DUT.

#### Any platform specific information?
NA

### Documentation
NA