### PR TITLE
Fix intermittent standalone tunnel route test failure by pausing arp_update

### DIFF
--- a/tests/dualtor/test_standalone_tunnel_route.py
+++ b/tests/dualtor/test_standalone_tunnel_route.py
@@ -30,10 +30,17 @@ pytestmark = [
 
 @pytest.fixture(autouse=True)
 def cleanup_neighbors(duthosts):
-    """Cleanup neighbors."""
-    duthosts.shell("sonic-clear arp")
-    duthosts.shell("sonic-clear ndp")
-    return
+    """Cleanup neighbors while preventing background neighbor updates."""
+    arp_update_stop_cmd = "docker exec swss supervisorctl stop arp_update"
+    arp_update_start_cmd = "docker exec swss supervisorctl start arp_update"
+
+    try:
+        duthosts.shell(arp_update_stop_cmd)
+        duthosts.shell("sonic-clear arp")
+        duthosts.shell("sonic-clear ndp")
+        yield
+    finally:
+        duthosts.shell(arp_update_start_cmd)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Description of PR
The `test_standalone_tunnel_route` test can fail when the background
`arp_update` process runs while the test is creating an unresolved IPv6
neighbor.
In failed runs, the required tunnel route is removed while the test packets
are being sent. PTF then fails because it does not receive the expected
tunneled packet.
This change pauses `arp_update` for the whole test and starts it again during
cleanup.

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/27701

### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605


### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605
- [ ] N/A

### Approach
#### What is the motivation for this PR?
The test needs full control of the neighbor state while it checks standalone
tunnel routing.
The background `arp_update` process can interfere with this state and cause
the tunnel route to be removed while packets are being sent.


#### How did you do it?
The `cleanup_neighbors` fixture now:
1. Stops `arp_update`.
2. Clears the ARP entries.
3. Clears the NDP entries.
4. Runs the test.
5. Starts `arp_update` again in a `finally` block.
Using `finally` makes sure that `arp_update` is restarted even if the test
fails.
No route-state waiting or synchronization was added.

#### How did you verify/test it?
The test was run 30 times before and after the change.
- Before the fix: 28 passed and 2 failed
- After the fix: 30 passed and 0 failed
The two failures before the fix showed the same tunnel-route
create, remove, and create-again sequence.

#### Any platform specific information?
The failure was observed on a Broadcom Dual-ToR testbed. Other platforms were
not tested.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
No documentation change is needed. This change only updates the test fixture.
