### PR TITLE
[pathlib]: Serialize pathlib.Path in AnsibleHostBase.CustomEncoder

### DIFF
--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -3,6 +3,7 @@ import json
 import logging
 import collections
 import os
+import pathlib
 import signal
 import threading
 from contextlib import contextmanager
@@ -130,6 +131,8 @@ class AnsibleHostBase(object):
         def default(self, obj):
             if isinstance(obj, bytes):
                 return obj.decode('utf-8')
+            elif isinstance(obj, pathlib.PurePath):
+                return str(obj)
             elif isinstance(obj, collections.UserDict):
                 return obj.data
             return super().default(obj)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
PR #26868 (Make Ansible Dir Configurable) turned several hardcoded path
constants into pathlib.Path objects, but CustomEncoder only handled
bytes/UserDict, so any Path reaching Ansible module args now raises
TypeError. Add a pathlib.PurePath branch (and the missing import) to
serialize paths as strings.

Traceback **without** the fix:
```
    @pytest.fixture
    def fanouthost(duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, conn_graph_facts, localhost):
        """
        Fixture that allows to update Fanout configuration if there is a need to send incorrect packets.
        Added possibility to create vendor specific logic to handle fanout configuration.
        If vendor need to update Fanout configuration, 'fanouthost' fixture should load and return appropriate instance.
        This instance can be used inside test case to handle fanout configuration in vendor specific section.
        By default 'fanouthost' fixture will not instantiate any instance so it will return None, and in such case
        'fanouthost' instance should not be used in test case logic.
        """
        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
        fanout = None
        # Check that class to handle fanout config is implemented
        if "mellanox" == duthost.facts["asic_type"]:
            fanout = get_fanout_obj(conn_graph_facts, duthost, fanouthosts)
            # if the leaf fanout switch is Mellanox, but running SONiC OS
            # then we have to skip some test cases because some operation (like the openflow)
            # is only supported on the Mellanox onyx
>           if not is_mellanox_fanout(duthost, localhost) or fanout.os == "sonic":
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

conn_graph_facts = {'device_bmc_info': {'testbed_MSN4700': {}}, 'device_bmc_link': {'testbed_MSN4700': {}}, 'device_conn': {'testbed_MSN4700': {'Hostname': 'rcon-....', 'HwSku': '', 'ManagementIp': '10....', 'ManagementRoutes': [], ...}}, ...}
duthost    = 
duthosts   = []
enum_rand_one_per_hwsku_frontend_hostname = 'testbed_MSN4700'
fanout     = { os: 'sonic', hostname: 'testbed_MSN4700', device_type: 'FanoutLeaf' }
fanouthosts = {'testbed_MSN4700_f': { os: 'sonic', hostname: 'testbed_MSN4700_f', device_type: 'FanoutLeaf' }}
localhost  = 

drop_packets/drop_packets.py:90: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
common/helpers/dut_utils.py:545: in is_mellanox_fanout
    localhost.conn_graph_facts(host=duthost.hostname, filepath=LAB_CONNECTION_GRAPH_PATH)["ansible_facts"]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        duthost    = 
        localhost  = 
common/devices/base.py:171: in _run_wrapper
    return self._run(module_name, *module_args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        kwargs     = {'filepath': PosixPath('/root/mars/workspace/sonic-mgmt/ansible/files'), 'host': 'testbed_MSN4700'}
        module_args = ()
        module_name = 'conn_graph_facts'
        self       = 
common/devices/base.py:197: in _run
    json.dumps(complex_args, cls=AnsibleHostBase.CustomEncoder)
        complex_args = {'filepath': PosixPath('/root/mars/workspace/sonic-mgmt/ansible/files'), 'host': 'testbed_MSN4700'}
        filename   = '/root/mars/workspace/sonic-mgmt/tests/common/devices/base.py'
        function_name = '_run_wrapper'
        index      = 0
        line_number = 171
        lines      = ['                return self._run(module_name, *module_args, **kwargs)\n']
        module     = >
        module_args = ()
        module_name = 'conn_graph_facts'
        previous_frame = 
        self       = 
        verbose    = True
/usr/lib/python3.12/json/__init__.py:238: in dumps
    **kw).encode(obj)
          ^^^^^^^^^^^
        allow_nan  = True
        check_circular = True
        cls        = 
        default    = None
        ensure_ascii = True
        indent     = None
        kw         = {}
        obj        = {'filepath': PosixPath('/root/mars/workspace/sonic-mgmt/ansible/files'), 'host': 'testbed_MSN4700'}
        separators = None
        skipkeys   = False
        sort_keys  = False
/usr/lib/python3.12/json/encoder.py:200: in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        o          = {'filepath': PosixPath('/root/mars/workspace/sonic-mgmt/ansible/files'), 'host': 'testbed_MSN4700'}
        self       = 
/usr/lib/python3.12/json/encoder.py:258: in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
        _encoder   = 
        _iterencode = <_json.Encoder object at 0x7d2b804f7e80>
        _one_shot  = True
        floatstr   = .floatstr at 0x7d2b85a22ac0>
        markers    = {137626012473664: {'filepath': PosixPath('/root/mars/workspace/sonic-mgmt/ansible/files'), 'host': 'testbed_MSN4700'}, 137626310536976: PosixPath('/root/mars/workspace/sonic-mgmt/ansible/files')}
        o          = {'filepath': PosixPath('/root/mars/workspace/sonic-mgmt/ansible/files'), 'host': 'testbed_MSN4700'}
        self       = 
common/devices/base.py:135: in default
    return super().default(obj)
           ^^^^^^^^^^^^^^^^^^^^
        __class__  = 
        obj        = PosixPath('/root/mars/workspace/sonic-mgmt/ansible/files')
        self       = 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = 
o = PosixPath('/root/mars/workspace/sonic-mgmt/ansible/files')

    def default(self, o):
        """Implement this method in a subclass such that it returns
        a serializable object for ``o``, or calls the base implementation
        (to raise a ``TypeError``).
    
        For example, to support arbitrary iterators, you could
        implement default like this::
    
            def default(self, o):
                try:
                    iterable = iter(o)
                except TypeError:
                    pass
                else:
                    return list(iterable)
                # Let the base class default method raise the TypeError
                return super().default(o)
    
        """
>       raise TypeError(f'Object of type {o.__class__.__name__} '
                        f'is not JSON serializable')
E       TypeError: Object of type PosixPath is not JSON serializable

o          = PosixPath('/root/mars/workspace/sonic-mgmt/ansible/files')
self       = 

/usr/lib/python3.12/json/encoder.py:180: TypeError
```
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [X] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
- master: related tests running without failures in fixtures (for example, drop_packets/test_drop_counters.py - using fanouthost fixture)

### Approach
#### What is the motivation for this PR?
  Fix introduced issue


#### How did you do it?
   Serialize pathlib.Path


#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
   Executed test, which previously failed in pre-test fixtures

