### PR TITLE
Fix IPv6 neighbor cleanup in downstream active test

### DIFF
--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -80,7 +80,7 @@ def test_active_tor_remove_neighbor_downstream_active(
     @contextlib.contextmanager
     def remove_neighbor(ptfhost, duthost, server_ip, ip_version, neighbor_details):
         # restore ipv4 neighbor since it is statically configured
-        flush_neighbor_ct = flush_neighbor(duthost, server_ip, restore=ip_version in ("ipv4", "ipv6"))
+        flush_neighbor_ct = flush_neighbor(duthost, server_ip, restore=ip_version == "ipv4")
         try:
             ptfhost.shell("supervisorctl stop arp_responder", module_ignore_errors=True)
             # stop garp_service since there is no equivalent in production
@@ -132,7 +132,7 @@ def test_active_tor_remove_neighbor_downstream_active(
             testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), pkt, count=10)
     finally:
         # try to recover the removed neighbor so test_downstream_ecmp_nexthops could have a healthy mocked device
-        if removed_neighbor:
+        if removed_neighbor and removed_neighbor.get("lladdr"):
             if ip_version == "ipv4":
                 cmd = 'ip -4 neigh replace {} lladdr {} dev {}'\
                       .format(server_ip, removed_neighbor['lladdr'], removed_neighbor['dev'])


### PR DESCRIPTION
### Description of PR
Summary:
Fixes IPv6 cleanup failure in `dualtor/test_orchagent_active_tor_downstream.py::test_active_tor_remove_neighbor_downstream_active` where the selected IPv6 neighbor may not include `lladdr` in `ip neighbor show` output. The test was attempting to restore that neighbor through `flush_neighbor(..., restore=True)` and again in final cleanup, causing `KeyError: 'lladdr'`.

Fixes ADO PBI 39540650.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

### Approach
#### What is the motivation for this PR?
The master baseline run fails the IPv6 parameter of the downstream-active dualtor test during cleanup with `KeyError: 'lladdr'`. The log shows `flush_neighbor` captured only `{'dev': 'Vlan1000'}` for the IPv6 neighbor, so cleanup must not assume a link-layer address is always present.

#### How did you do it?
Keep `flush_neighbor` self-restore limited to IPv4, where this neighbor is statically configured, and guard the test's final explicit restore so it only builds an `lladdr` command when the captured neighbor data actually contains `lladdr`.

#### How did you verify/test it?
Ran `python -m py_compile tests/dualtor/test_orchagent_active_tor_downstream.py`.

#### Any platform specific information?
N/A. Observed in virtual baseline `vms-kvm-t0`.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
N/A.