### PR TITLE
[snappi/ecn]: Reliably stop capture before download in test_dequeue_ecn

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -977,8 +977,10 @@ def run_traffic(duthost,
         request = api.capture_request()
         request.port_name = snappi_extra_params.packet_capture_ports[0]
         cs = api.control_state()
+        cs.port.capture.port_names = snappi_extra_params.packet_capture_ports
         cs.port.capture.state = cs.port.capture.STOP
         api.set_control_state(cs)
+        time.sleep(SNAPPI_POLL_DELAY_SEC)
         logger.info("Retrieving and saving packet capture to {}.pcapng".format(snappi_extra_params.packet_capture_file))
         pcap_bytes = api.get_capture(request)
         with open(snappi_extra_params.packet_capture_file + ".pcapng", 'wb') as fid:

--- a/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
@@ -112,6 +112,7 @@ def test_dequeue_ecn(request,
             "flow_pkt_count": data_flow_pkt_count
         }
 
+    request.addfinalizer(lambda: cleanup_config(duthosts, snappi_ports))
     ip_pkts = run_ecn_test(api=snappi_api,
                            testbed_config=testbed_config,
                            port_config_list=port_config_list,
@@ -134,4 +135,3 @@ def test_dequeue_ecn(request,
     # Check if the last packet is not ECN marked
     pytest_assert(not is_ecn_marked(ip_pkts[-1]),
                   "The last packet should not be marked")
-    cleanup_config(duthosts, snappi_ports)


### PR DESCRIPTION
### Description of PR
Summary:
Fixes #27709

`tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py::test_dequeue_ecn` intermittently fails on the Mellanox SN4700 because the downloaded IxNetwork capture contains 100 UDP/IP packets while the fixed-packet flow is configured to transmit 101. IxNetwork emits `Capture was not stopped for this port Port 0`, indicating capture finalization was not complete when the PCAP was retrieved.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?
The capture STOP control state in `run_traffic()` did not set `cs.port.capture.port_names` (unlike the START operation), and the PCAP was downloaded immediately after STOP without allowing IxNetwork to finish stopping and flushing the hardware capture buffer. This produced an incomplete PCAP and an intermittent, exact packet-count assertion failure before ECN marking was evaluated. Additionally, `cleanup_config()` ran only after the assertions, so it was skipped on failure, leaving modified `BUFFER_PROFILE`/`WRED_PROFILE` entries and a secondary `CONFIG_DB` consistency warning.

#### How did you do it?
- In `tests/common/snappi_tests/traffic_generation.py` (`run_traffic`), target the configured capture ports explicitly on STOP (`cs.port.capture.port_names = snappi_extra_params.packet_capture_ports`) and sleep `SNAPPI_POLL_DELAY_SEC` before `api.get_capture()` so the capture buffer is flushed.
- In `tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py`, register `cleanup_config()` as a pytest finalizer via `request.addfinalizer(...)` so DUT config is restored even when a packet assertion fails. The exact packet-count assertion is left unchanged.

#### How did you verify/test it?
flake8 passes on both changed files (`--max-line-length=120`). To be validated on the `vms20-rdma-t0-sn4700` testbed per the issue reproduction steps.

#### Any platform specific information?
Observed on Mellanox SN4700, but the fix is generic to the snappi capture teardown path.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A