### PR TITLE
[iface_namingmode] Gate speed changes by CMIS apps

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -1,3 +1,4 @@
+import ast
 import logging
 import pytest
 import re
@@ -1389,6 +1390,33 @@ class TestConfigInterface():
             pytest.skip("Native speed is not 100G or 40G, it is {}".format(native_speed))
 
         target_speed = speeds_to_test[0] if native_speed == speeds_to_test[1] else speeds_to_test[1]
+
+        db_cli = duthost.asic_instance(asic_index).sonic_db_cli
+        application_advertisement = duthost.shell(
+            f'sudo {db_cli} STATE_DB HGET "TRANSCEIVER_INFO|{interface}" application_advertisement'
+        )['stdout'].strip()
+        if application_advertisement and application_advertisement != 'N/A':
+            try:
+                applications = ast.literal_eval(application_advertisement)
+            except (SyntaxError, ValueError):
+                applications = None
+
+            if isinstance(applications, dict):
+                host_applications = [
+                    application['host_electrical_interface_id'].strip().upper()
+                    for application in applications.values()
+                    if isinstance(application, dict)
+                    and isinstance(application.get('host_electrical_interface_id'), str)
+                    and application['host_electrical_interface_id'].strip()
+                ]
+                target_speed_g = f'{int(target_speed) // 1000}G'
+                if host_applications and not any(
+                        application.startswith(target_speed_g) for application in host_applications):
+                    pytest.skip(
+                        f"Transceiver on {interface} does not advertise a {target_speed_g} "
+                        f"host application: {host_applications}"
+                    )
+
         # Get supported speeds for interface
         supported_speeds_dut = duthost.get_supported_speeds(interface)
         if not supported_speeds_dut:


### PR DESCRIPTION
### Description of PR

Summary:

Prevent the 40G/100G interface speed test from attempting a transition that an inserted CMIS transceiver explicitly does not advertise.

Fixes #27752

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #27752
Failure type: other

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- master: passed
- 202605: passed

### Approach
#### What is the motivation for this PR?

Port and fanout capability lists can include speeds that the currently inserted CMIS transceiver does not advertise. Attempting such a transition causes an avoidable test failure and can leave the link down until cleanup.

#### How did you do it?

Read `application_advertisement` from the selected interface's `TRANSCEIVER_INFO` entry in `STATE_DB`, parse the advertised host applications, and skip only when valid host application data is available and none of it matches the target speed. Missing, malformed, or incomplete advertisement data preserves the existing test path.

#### How did you verify/test it?

Verified Python syntax with `python3 -m py_compile`, checked patch whitespace with `git diff --check`, exercised the parsing and speed-selection logic with representative CMIS application data, and confirmed the public PR CI passed.

#### Any platform specific information?

No. The check applies to any CMIS transceiver that publishes an application advertisement in `STATE_DB`.

#### Supported testbed topology if it's a new test case?

Not a new test case.

### Documentation

No user-facing behavior or test documentation changes are required.