### PR TITLE
[redfish] Enable the redfish feature before the suite runs

### DIFF
--- a/tests/redfish/conftest.py
+++ b/tests/redfish/conftest.py
@@ -253,7 +253,51 @@ def bmc_clock_in_sync(bmc_duthost):
 
 
 @pytest.fixture(scope="session")
-def bmc_tls_certs(bmc_duthost, bmc_ip, bmc_clock_in_sync, tmp_path_factory):
+def redfish_feature_enabled(bmc_duthost):
+    """Make sure the redfish feature is enabled and its container is running.
+
+    The image ships the redfish FEATURE row as "disabled" and expects it to be
+    turned on at runtime, so the suite cannot assume the container is already
+    up. Without this the first "docker exec redfish" in bmc_tls_certs fails with
+    "No such container: redfish", and because that fixture is session scoped the
+    whole suite errors instead of skipping.
+
+    Restores the original feature state at session end so the DUT is left as the
+    image shipped it.
+    """
+    features, ok = bmc_duthost.get_feature_status()
+    pyrequire(
+        ok and BMCWEB_CONTAINER in features,
+        "redfish FEATURE row not present on this DUT; the image was likely built "
+        "without the redfish docker (INCLUDE_REDFISH=n)",
+    )
+
+    was_enabled = features[BMCWEB_CONTAINER] == "enabled"
+    if not was_enabled:
+        logger.info("redfish feature is disabled, enabling it for this session")
+        bmc_duthost.shell(
+            "sudo config feature state {} enabled".format(BMCWEB_CONTAINER),
+            module_ignore_errors=False,
+        )
+
+    pyrequire(
+        wait_until(BMCWEB_READY_TIMEOUT, BMCWEB_READY_POLL, 0,
+                   bmc_duthost.is_service_fully_started, BMCWEB_CONTAINER),
+        "redfish container did not start within {}s of enabling the feature".format(
+            BMCWEB_READY_TIMEOUT),
+    )
+
+    yield
+
+    if not was_enabled:
+        logger.info("Restoring redfish feature to its shipped disabled state")
+        _safe(bmc_duthost.shell,
+              "sudo config feature state {} disabled".format(BMCWEB_CONTAINER),
+              module_ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def bmc_tls_certs(bmc_duthost, bmc_ip, bmc_clock_in_sync, redfish_feature_enabled, tmp_path_factory):
     """Generate TLS certificates, install them on the BMC, and clean up at session end.
 
     What this fixture does:


### PR DESCRIPTION
### Description of PR

Summary:

The redfish suite assumed the `redfish` feature was already enabled on the BMC DUT, but the image ships the FEATURE row disabled and expects it to be turned on at runtime. On such a DUT the first `docker exec redfish` in the session-scoped `bmc_tls_certs` fixture failed with `No such container: redfish`, and because that fixture is session scoped the whole suite errored during setup instead of running or skipping cleanly.

This PR adds a session-scoped `redfish_feature_enabled` fixture that enables the feature when it is off, waits for the container to come up, and restores the shipped state at session end so the DUT is left as the image shipped it. `bmc_tls_certs` now depends on it, so every test in the suite runs against a live redfish container.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Back port request

None, master only.

### Approach

#### What is the motivation for this PR?

Make the redfish suite runnable on a freshly imaged BMC DUT. Without this change, every test in `tests/redfish/` errors during session setup on an image that ships the feature disabled, which is the default.

#### How did you do it?

A session-scoped `redfish_feature_enabled` fixture in `tests/redfish/conftest.py` reads the FEATURE table, enables `redfish` when it is disabled, waits until the container is fully started, and restores the original state at session end. If the FEATURE row is absent the suite is skipped with a clear message, since the image was built without the redfish container.

#### How did you verify/test it?

Verified on a SONiC BMC testbed with the feature shipped disabled: the fixture enables it, the full suite runs against the live container, and the disabled state is restored at session end.
