### PR TITLE
[redfish] Expect the base-MAC suffix on the service root Product field

### DIFF
--- a/tests/redfish/test_redfish_service_root.py
+++ b/tests/redfish/test_redfish_service_root.py
@@ -40,7 +40,7 @@ class TestRedfishServiceRoot:
             "Expected Content-Type to contain 'application/json', got: {!r}".format(content_type)
         )
 
-    def test_service_root_fields(self, redfish_client):
+    def test_service_root_fields(self, redfish_client, bmc_exec):
         """
         Service root contains required fields.
 
@@ -61,7 +61,10 @@ class TestRedfishServiceRoot:
         assert_field_contains(body, "@odata.type", "ServiceRoot")
         assert_field_nonempty(body, "RedfishVersion")
         assert_field_nonempty(body, "UUID")
-        assert_field_equals(body, "Product", "SONiCBMC")
+        stdout, _, _ = bmc_exec("sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' mac")
+        mac = stdout.strip().lower()
+        expected = "SONiCBMC-{}".format(mac) if mac else "SONiCBMC"
+        assert_field_equals(body, "Product", expected)
 
         # Navigation links
         update_service_link = body.get("UpdateService", {}).get("@odata.id", "")


### PR DESCRIPTION
### Description of PR

Summary:

`test_service_root_fields` asserted the service root `Product` field equals exactly `SONiCBMC`. bmcweb reports `SONiCBMC-<base MAC>` when the base MAC is set, so this case failed on every such BMC.

The test now reads the base MAC from the BMC's CONFIG_DB (`DEVICE_METADATA|localhost` `mac`), which is the same source bmcweb reads through the dbus bridge, and expects `SONiCBMC-<mac>` when it is set or the bare `SONiCBMC` when it is not. A BMC that has a MAC configured but reports the bare name fails the case, so the suffix is verified rather than merely tolerated.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Back port request

None, master only.

### Approach

#### What is the motivation for this PR?

The exact-match assertion made the service root case fail on any BMC whose `Product` carries the base-MAC suffix, even though the endpoint behaves as designed.

#### How did you do it?

The test fetches the configured base MAC over the existing `bmc_exec` fixture and derives the expected `Product` value from it, keeping the assertion strict in both directions.

#### How did you verify/test it?

Verified on a SONiC BMC testbed: the case passes with `Product` reporting `SONiCBMC-<base MAC>`, and the derived expectation keeps the bare `SONiCBMC` valid for a BMC with no MAC configured.
