### PR TITLE
[dualtor-io] find the target ToR port on a KVM testbed

### DIFF
--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -425,22 +425,35 @@ class DualTorIO:
 
             # get the dut ports that is connected to the bridge
             list_ports_res = self.vmhost.shell("ovs-vsctl list-ports %s" % active_active_vmhost_bridge)
-            active_active_vmhost_dut_ports = [port for port in list_ports_res["stdout_lines"] if "." in port]
+            bridge_ports = list_ports_res["stdout_lines"]
 
-            # NOTE: Let's assume that the upper ToR's port is always ending with
-            # smaller vlan suffix, so active_active_vmhost_dut_ports[0] is connected
-            # to the upper ToR and active_active_vmhost_dut_ports[1] is connected
-            # to the lower ToR.
-            active_active_vmhost_dut_ports.sort()
-            for dut, vmhost_dut_port in zip(self.tbinfo["duts"], active_active_vmhost_dut_ports):
-                if self.duthost.hostname == dut:
-                    vmhost_target_dut_port = vmhost_dut_port
+            # On a KVM testbed each ToR port is a tap named after the DUT itself
+            # (sonic.xml.j2 names them <dut_name>-<port number>), so the port of the
+            # target ToR can be picked directly and no ordering assumption is needed.
+            for port in bridge_ports:
+                if port.startswith("%s-" % self.duthost.hostname):
+                    vmhost_target_dut_port = port
                     break
             else:
-                raise ValueError(
-                    "Failed to find the port connected to DUT %s in bridge %s" %
-                    (self.duthost.hostname, active_active_vmhost_bridge)
-                )
+                # On a physical testbed the ToR ports are VLAN subinterfaces of the
+                # server NIC (<port>.<vlan id>) and carry no DUT name, so fall back to
+                # picking them by order.
+                active_active_vmhost_dut_ports = [port for port in bridge_ports if "." in port]
+
+                # NOTE: Let's assume that the upper ToR's port is always ending with
+                # smaller vlan suffix, so active_active_vmhost_dut_ports[0] is connected
+                # to the upper ToR and active_active_vmhost_dut_ports[1] is connected
+                # to the lower ToR.
+                active_active_vmhost_dut_ports.sort()
+                for dut, vmhost_dut_port in zip(self.tbinfo["duts"], active_active_vmhost_dut_ports):
+                    if self.duthost.hostname == dut:
+                        vmhost_target_dut_port = vmhost_dut_port
+                        break
+                else:
+                    raise ValueError(
+                        "Failed to find the port connected to DUT %s in bridge %s, ports are %s" %
+                        (self.duthost.hostname, active_active_vmhost_bridge, bridge_ports)
+                    )
 
             get_ovs_port_no_res = self.vmhost.shell("ovs-vsctl get Interface %s ofport" % vmhost_target_dut_port)
             vmhost_target_dut_port_no = get_ovs_port_no_res["stdout"].strip()


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 39664424
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

Fix the following failure on `dualtor-aa-vpp` testbed:

```
dualtor_io/test_normal_op.py::test_normal_op_active_server_to_active_server[active-active] 

...

  File "/var/src/sonic-mgmt/tests/common/dualtor/dual_tor_io.py", line 440, in _generate_upstream_packet_to_target_duthost
    raise ValueError(
ValueError: Failed to find the port connected to DUT vlab-vpp-05 in bridge baa-vms6-10-9
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

The current port selection follows the physical testbed front-panel port naming convention: there the ToR ports are
VLAN subinterfaces of the server NIC, created by vlan_port.py as
`"%s.%d" % (port, vlan_id)`.

On a KVM testbed the ToR ports are the DUT VM taps, which sonic.xml.j2
names `"{{ dut_name }}-{{ i + 1 }}"` and so contain no dot:

```
  $ ovs-vsctl list-ports baa-vms6-10-13
  iaa-vms6-10-13
  nic-vms6-10-13
  vlab-vpp-05-14
  vlab-vpp-06-14
```
Let's support kvm testbed port name mode.

#### How did you verify/test it?
on dualtor-aa-vpp:

```
dualtor_io/test_normal_op.py::test_normal_op_upstream[active-active] PASSED [  5%]
dualtor_io/test_normal_op.py::test_normal_op_downstream_upper_tor[active-active] PASSED [ 11%]
dualtor_io/test_normal_op.py::test_normal_op_downstream_lower_tor[active-active] PASSED [ 16%]
dualtor_io/test_normal_op.py::test_normal_op_active_server_to_active_server[active-active] PASSED [ 22%]
dualtor_io/test_normal_op.py::test_normal_op_active_server_to_standby_server[active-active] PASSED [ 27%]
dualtor_io/test_normal_op.py::test_upper_tor_config_reload_upstream[active-active] XPASS.com/sonic-net/sonic-mgmt/issues/21139) [ 33%]
dualtor_io/test_normal_op.py::test_lower_tor_config_reload_upstream[active-active] SKIPPED [ 38%]
dualtor_io/test_normal_op.py::test_lower_tor_config_reload_downstream_upper_tor[active-active] PASSED [ 44%]
dualtor_io/test_normal_op.py::test_upper_tor_config_reload_downstream_lower_tor[active-active] SKIPPED [ 50%]
dualtor_io/test_normal_op.py::test_tor_switch_upstream[active-active] PASSED [ 55%]
dualtor_io/test_normal_op.py::test_tor_switch_downstream_active[active-active] PASSED [ 61%]
dualtor_io/test_normal_op.py::test_tor_switch_downstream_standby[active-active] PASSED [ 66%]
dualtor_io/test_normal_op.py::test_mux_port_switch_active_server_to_active_server[active-active] PASSED [ 72%]
dualtor_io/test_normal_op.py::test_mux_port_switch_active_server_to_standby_server[active-active] PASSED [ 77%]
dualtor_io/test_normal_op.py::test_normal_op_upstream_soc[active-active] PASSED [ 83%]
dualtor_io/test_normal_op.py::test_normal_op_downstream_upper_tor_soc[active-active] PASSED [ 88%]
dualtor_io/test_normal_op.py::test_normal_op_downstream_lower_tor_soc[active-active] PASSED [ 94%]
dualtor_io/test_normal_op.py::test_upstream_standby_rx_drop_check[active-active] SKIPPED
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
