### PR TITLE
[ssh] Revert enabling test_ssh_stress on vpp

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -727,7 +727,6 @@ t1-lag-vpp:
   - ssh/test_ssh_ciphers.py
   - ssh/test_ssh_default_password.py
   - ssh/test_ssh_limit.py
-  - ssh/test_ssh_stress.py
   - srv6/test_srv6_dataplane.py
   - srv6/test_srv6_static_config.py
   - sub_port_interfaces/test_show_subinterface.py

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5439,10 +5439,11 @@ ssh/test_ssh_default_password:
       - "asic_type not in ['vpp']"
 
 ssh/test_ssh_stress.py::test_ssh_stress:
+  # This test is not stable, skip it for now.
+  # known issue: https://github.com/paramiko/paramiko/issues/1508
   skip:
     reason: "This test failed intermittent due to known issue of paramiko, skip for now"
-    conditions:
-      - "asic_type not in ['vpp']"
+    conditions: https://github.com/paramiko/paramiko/issues/1508
 
 #######################################
 #####             stress          #####


### PR DESCRIPTION
### Description of PR

Summary:
Revert the two `test_ssh_stress` changes made by #25279, so the test goes back to being skipped on vpp as it is on every other platform. The rest of #25279 stays in place.

`ssh/test_ssh_stress.py::test_ssh_stress` has been skipped everywhere since 2021 (#4348) for being intermittent. #25279 enabled it on vpp and added it to the `t1-lag-vpp` PR gate. Since then it has failed roughly **4.6% of runs** — **85 failures out of 1,854 over the last 30 days** — all on `t1-lag-vpp`, which is the only topology where the test executes at all.

Agreed with @aaronber0614, who enabled it in #25279. Discussion: https://github.com/sonic-net/sonic-mgmt/pull/25279#issuecomment-5525873524

The other three ssh tests from #25279 are untouched and keep running on vpp — over the same 30 days `test_ssh_ciphers` (81,060 runs), `test_ssh_limit` (1,915) and `test_ssh_default_password` (1,911) each had **zero** failures.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
N/A — no backport requested. #25279 was never backported, so the vpp enablement exists only on master. I checked `tests_mark_conditions.yaml` on 202311, 202405, 202411, 202505, 202511, 202512 and 202605: all still carry the original issue-linked rule and already skip this test, so a cherry-pick would be a no-op and would not apply cleanly.

Failure type: regression (introduced on master by #25279 on 2026-06-28; failures began that same week)

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: the conditional-mark block is now byte-identical to its pre-#25279 form, and `paramiko/paramiko#1508` is still open, so `update_issue_status()` resolves the condition to `True` and the test skips. Both YAML files parse cleanly. The `t1-lag-vpp` section retains the other three ssh tests and no other section was touched.
- The underlying failure was measured on a live `vms-kvm-vpp-t1-lag` testbed running `master.0-dirty-20260824` — details below.

### Approach
#### What is the motivation for this PR?

The failures are a measurement artifact in the test, not a product problem, and the test provides very little signal even when it passes.

**Why it fails on vpp.** `vpp_main` busy-polls ~2.1 of the 10 vCPUs continuously even at idle (measured: `vpp_main` at 210% with `vmstat` showing `us=21 sy=1 id=78`). That puts the CPU baseline near 0.27 and leaves little headroom to drain the backlog the test creates for itself — five unpaced ssh sessions issuing ~137 bgp flaps, ~139 acl-loader updates and ~96 route add/deletes in 300 seconds. `run_post_test_system_check` samples while that drain is still in progress, so the verdict depends on where the samples land. All 85 failures sit in a narrow band just past the threshold (delta 0.200–0.336, p50 0.24); none are leak-shaped, which a real leak would be since the in-test peak is ~0.96.

Ruled out with data: steal time (max `st` was 7 across 117 raw `vmstat` samples from a failing run, worth at most 0.022 on the metric), an actual resource leak, and bgp flap parity (a passing run also ended on `config bgp startup all`).

**Why it is low-value even when green.** The one assertion that would catch real ssh-induced slowdown — `pytest_assert(duration < 3*baselines[command_ind])` — runs inside a worker thread, so `pytest.fail` there kills only that thread while `join()` returns normally and the test still passes. The post-test check measures the test's own `config`/`acl-loader` churn rather than anything about ssh, and the 20-connection phase logs a count but asserts nothing.

Fixing it properly means redesigning what the test asserts (measuring ssh-attributable resources rather than whole-box CPU), which is a larger piece of work. Since it currently costs PR-gate reruns for everyone touching sonic-mgmt and sonic-buildimage, reverting the enablement is the better immediate trade.

#### How did you do it?

Reverted exactly the two `test_ssh_stress` pieces of #25279:

1. Removed `ssh/test_ssh_stress.py` from the `t1-lag-vpp` section of `.azure-pipelines/pr_test_scripts.yaml` (the only section #25279 added it to). The `t0`, `t1-lag` and `onboarding_t1_multi_asic` listings pre-date #25279 and are left alone.
2. Restored the conditional-mark entry in `tests_mark_conditions.yaml` to its pre-#25279 form, which ties the skip to `paramiko/paramiko#1508` via `update_issue_status()`. That is the same rule every release branch still carries, so master matches them again.

Note the `reason` string goes back to citing the paramiko issue. That is deliberate for a clean revert, though the failure documented above is a different mechanism; the vpp-specific findings live in the #25279 discussion linked at the top.

#### How did you verify/test it?

Revert correctness: the conditional-mark block now matches `5fdc15256^` byte for byte, `paramiko/paramiko#1508` is confirmed still open (so the condition resolves to skip), both YAML files parse, and the `t1-lag-vpp` section still lists the other three ssh tests and nothing else changed.

Root cause, measured on a live `vms-kvm-vpp-t1-lag` testbed (DUT `vlab-vpp-01`, 10 vCPU):
- Idle: `vpp_main` 210–213%, `vmstat` `us=21 sy=1 id=78 wa=0 st=0`, metric 0.22.
- 24 back-to-back runs: all passed, delta mean 0.076 / sd 0.059 / max 0.180, baseline mean 0.265 (production p50 is 0.27).
- Post-stress profile: peak ~0.98, then a plateau at 0.37–0.44 for ~15s, reaching baseline only after ~100s — while the test allows ~30–45s. During that plateau the hot processes are `zebra`, `bgpd`, `syncd` and `redis-server`, i.e. control-plane backlog, with `vpp_main` flat at 211%.
- Variants that also passed: 6 vCPU (baseline 0.37, stress saturated at 0.99) and a cold page cache after `drop_caches` (memory delta 0.073, versus 0.080 measured from a production run's raw `vmstat`).

Worth stating plainly: I could not reproduce a failing run outside CI, which is part of why I am not proposing a fix here. At a 4.6% rate, 0 failures in 24 runs is a ~32% likely outcome, so that is consistent rather than contradictory.

#### Any platform specific information?

vpp only. `t1-lag-vpp` is the sole topology where this test executes — over the last 30 days it was 100% skipped on t2 (2,864 runs), t1-lag (2,817), t0 (2,558) and t1-8-lag (2,465). It provides no physical-hardware coverage.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case.

### Documentation

No documentation changes required.
