### PR TITLE
snappi:ensure that exact number of ports are used for single_asic tests

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -2506,14 +2506,13 @@ def tgen_port_info(request: pytest.FixtureRequest, snappi_port_selection, get_sn
                     testbed, testbed_subtype))
 
         snappi_ports = get_snappi_ports
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(
-                get_snappi_ports,
-                rdma_ports,
-                tx_port_count,
-                rx_port_count,
-                testbed
-            )
+        snappi_ports = get_snappi_ports_for_rdma(
+            get_snappi_ports,
+            rdma_ports,
+            tx_port_count,
+            rx_port_count,
+            testbed
+        )
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(
             duthosts, snappi_ports, snappi_api, setup=True)
         yield (testbed_config, port_config_list, snappi_ports)

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -2505,7 +2505,6 @@ def tgen_port_info(request: pytest.FixtureRequest, snappi_port_selection, get_sn
                 "testbed {}, subtype {} in variables.override.yml".format(
                     testbed, testbed_subtype))
 
-        snappi_ports = get_snappi_ports
         snappi_ports = get_snappi_ports_for_rdma(
             get_snappi_ports,
             rdma_ports,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
tgen_port_info in tests/common/snappi_tests/snappi_fixtures.py selects the Tx/Rx ports every Snappi RDMA test runs on. It has two branches: an override branch driven by multidut_port_info in tests/snappi_tests/variables.override.yml, and a dynamic branch driven by snappi_port_selection built from ansible/files/*links.csv.

This PR fixes following defect in that fixture.

Override port selection was gated on is_snappi_multidut. The override branch only called get_snappi_ports_for_rdma() when is_snappi_multidut(duthosts) was True. On a single-DUT (including single-ASIC) testbed that helper never ran, so rdma_ports was used only for the "are enough ports defined?" skip checks and the full get_snappi_ports list from *links.csv was passed straight into snappi_dut_base_config(). Every parametrized subtype therefore configured the same ports, and the test body was re-run identically for each entry in multidut_port_info. The gate is removed so the helper runs whenever an override exists, regardless of DUT type.

Please note that this pull-request is ONLY changes the tgen_port_info function and nothing else.

Summary:
Fixes #27680 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
Removed the if is_snappi_multidut(duthosts): guard around get_snappi_ports_for_rdma() so override-driven Tx/Rx selection applies to single-DUT and single-ASIC testbeds, not just modular chassis and multi-DUT.

File touched: tests/common/snappi_tests/snappi_fixtures.py.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
3. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [X] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
On single-ASIC and single-DUT testbeds, Snappi RDMA tests were not exercising the port combinations their configuration described. Operators define multiple subtypes in variables.override.yml (for example short-to-long and long-to-short) precisely to cover different traffic paths, but the is_snappi_multidut gate discarded those definitions and reused one port set for every iteration. That burns testbed time on duplicate runs and silently loses the intended coverage, while the same testbeds on modular chassis get correct per-subtype selection.

This was also necessary for single-ASIC DUTs in case they used different speed interfaces using breakout_config and had the definitions in both links.csv and variables.override.yml file. 


#### How did you do it?
In tgen_port_info:

Deleted the is_snappi_multidut(duthosts) conditional in the override branch and the now-redundant snappi_ports = get_snappi_ports assignment, calling get_snappi_ports_for_rdma(get_snappi_ports, rdma_ports, tx_port_count, rx_port_count, testbed) unconditionally. The existing pytest_require checks inside that helper still guard against override entries whose hostname/port_name do not match ansible/files/*links.csv.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran the test with single-ASIC DUT with two combinations mentioned in the variables.override.yml file and ensured that each combination is executed for each test.
```
 ------------ curtailed output -----------
ansible@xxxxxxx:/data/tests$ date;python3 -m pytest --inventory ../ansible/ixia-sonic --host-pattern xxxxx --testbed xxxxx --testbed_file ../ansible/testbed.csv --show-capture=stdout --log-cli-level info --showlocals -ra --allow_recover --junit-xml=/tmp/pfc_no_congestion.xml --skip_sanity --disable_memory_utilization --disable_loganalyzer --log-file=/tmp/pfc_no_congestion.log --topology tgen snappi_tests/pfc/test_pfc_no_congestion_throughput.py
Wed Sep  2 17:15:59 UTC 2026

 ------------ curtailed output -----------
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_multiple_prio_diff_dist[tgen_port_info0] âœ“                                                                                            17%
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_multiple_prio_diff_dist[tgen_port_info1] âœ“                                                                                            33%
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_multiple_prio_uni_dist[tgen_port_info0] âœ“                                                                                             50%
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_multiple_prio_uni_dist[tgen_port_info1] âœ“                                                                                             67%
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_single_lossless_prio[tgen_port_info0] âœ“                                                                                               83%
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_single_lossless_prio[tgen_port_info1] âœ“                                                                                              100% 
 ------------ curtailed output -----------
Results (2969.92s (0:49:29)):
       6 passed

```

The same test by deleting the info from variables.override.yml file. In this case, the test should check for metadata/snappi_tests/<dut>.json file to derive the ports and run the test.

```
ansible@xxxxx:/data/tests$ date;python3 -m pytest --inventory ../ansible/ixia-sonic --host-pattern xxxx --testbed xxxx  --testbed_file ../ansible/testbed.csv --show-capture=stdout --log-cli-level info --showlocals -ra --allow_recover --junit-xml=/tmp/pfc_no_congestion.xml --skip_sanity --disable_memory_utilization --disable_loganalyzer --log-file=/tmp/pfc_no_congestion.log --topology tgen snappi_tests/pfc/test_pfc_no_congestion_throughput.py

 ------------ curtailed output -----------
tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_multiple_prio_diff_dist[400.0-single_linecard_single_asic] âœ“                                                                          33%
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_multiple_prio_uni_dist[400.0-single_linecard_single_asic] âœ“                                                                           67%
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_single_lossless_prio[400.0-single_linecard_single_asic] âœ“                                                                            100%
 ------------ curtailed output -----------
Results (1506.49s (0:25:06)):
       3 passed
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
