### PR TITLE
[vpp][copp] Unskip CoPP tests on sonic-vpp

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -644,6 +644,7 @@ t1-lag-vpp:
   - bgp/test_bgp_session.py
   - bgp/test_bgp_operation_in_ro.py
   - bgp/test_bgp_queue.py
+  - copp/test_copp.py
   - bgp/test_bgp_session_flap.py
   - bgp/test_ipv6_nlri_over_ipv4.py
   - bgp/test_bgp_allow_list.py

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -689,19 +689,20 @@ class SNMPTest(PolicyTest):  # FIXME: trapped as ip2me. mellanox should add supp
     def construct_packet(self, port_number):
         src_mac = self.my_mac[port_number]
         dst_mac = self.peer_mac[port_number]
+        src_ip = self.myip
         dst_ip = self.peerip
 
         packet = testutils.simple_udp_packet(
             eth_dst=dst_mac,
-            ip_dst=dst_ip,
             eth_src=src_mac,
+            ip_src=src_ip,
+            ip_dst=dst_ip,
             udp_dport=161
         )
 
         return packet
 
 
-# SONIC config contains policer CIR=600 for SSH
 class SSHTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
@@ -754,12 +755,14 @@ class IP2METest(PolicyTest):
     def construct_packet(self, port_number):
         src_mac = self.my_mac[port_number]
         dst_mac = self.peer_mac[port_number]
+        src_ip = self.myip
         dst_ip = self.peerip
 
         packet = testutils.simple_tcp_packet(
             pktlen=self.packet_size,
             eth_src=src_mac,
             eth_dst=dst_mac,
+            ip_src=src_ip,
             ip_dst=dst_ip
         )
 

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -633,7 +633,7 @@ class BGPTest(PolicyTest):
             )
             assert self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX, "Copp policer constraint check failed, " \
                 "Actual PPS: {} Expected PPS range: {} - {}".format(rx_pps, self.PPS_LIMIT_MIN, self.PPS_LIMIT_MAX)
-        elif self.asic_type not in ['broadcom', 'marvell-teralynx']:
+        elif self.asic_type not in ['broadcom', 'marvell-teralynx', 'vpp']:
             self.log("Checking constraints (NoPolicyApplied):")
             self.log(
                 "rx_pps (%d) <= PPS_LIMIT_MIN (%d): %s" %

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -134,7 +134,7 @@ copp/test_copp.py::TestCOPP::test_policer[ARP]:
     reason: >
             Passes: CoPP dataplane enforcement implemented via the
             copp_punt_policer VPP device-input plugin (see
-            doc/vpp/vpp_copp_HLD.md in nhegde-microsoft/SONiC).
+            doc/vpp/vpp_copp_HLD.md).
     conditions_logical_operator: or
     conditions:
       - "False"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -119,13 +119,15 @@ container_checker/test_container_checker.py::test_container_checker_telemetry:
 #######################################
 #####           COPP              #####
 #######################################
-copp/test_copp.py::test_verify_copp_configuration_cli:
+copp:
   skip:
     reason: >
-            Passes: config-plane-only verification, no traffic policing.
+            Unsupported: no VPP dataplane classify/policer feature exists
+            yet for these traps (IP2ME/SNMP/SSH/BGP MTU variants, neighbor
+            miss, dynamic trap add/remove, config-save-after-reboot).
     conditions_logical_operator: or
     conditions:
-      - "False"
+      - "asic_type in ['vpp']"
 
 copp/test_copp.py::TestCOPP::test_policer[ARP]:
   skip:
@@ -133,6 +135,33 @@ copp/test_copp.py::TestCOPP::test_policer[ARP]:
             Passes: CoPP dataplane enforcement implemented via the
             copp_punt_policer VPP device-input plugin (see
             doc/vpp/vpp_copp_HLD.md in nhegde-microsoft/SONiC).
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
+copp/test_copp.py::TestCOPP::test_policer[DHCP6]:
+  skip:
+    reason: >
+            Passes: rides the pre-existing ip6-unicast policer-classify
+            feature, unaffected by the copp_punt_policer plugin.
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
+copp/test_copp.py::TestCOPP::test_policer[DHCP]:
+  skip:
+    reason: >
+            Passes: rides the pre-existing ip4-unicast policer-classify
+            feature, unaffected by the copp_punt_policer plugin.
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
+copp/test_copp.py::TestCOPP::test_policer[Default]:
+  skip:
+    reason: >
+            Passes: CoPP dataplane enforcement implemented via the
+            copp_punt_policer VPP device-input plugin (TTL_ERROR trap).
     conditions_logical_operator: or
     conditions:
       - "False"
@@ -164,42 +193,13 @@ copp/test_copp.py::TestCOPP::test_policer[UDLD]:
     conditions:
       - "False"
 
-copp/test_copp.py::TestCOPP::test_policer[Default]:
+copp/test_copp.py::test_verify_copp_configuration_cli:
   skip:
     reason: >
-            Passes: CoPP dataplane enforcement implemented via the
-            copp_punt_policer VPP device-input plugin (TTL_ERROR trap).
+            Passes: config-plane-only verification, no traffic policing.
     conditions_logical_operator: or
     conditions:
       - "False"
-
-copp/test_copp.py::TestCOPP::test_policer[DHCP]:
-  skip:
-    reason: >
-            Passes: rides the pre-existing ip4-unicast policer-classify
-            feature, unaffected by the copp_punt_policer plugin.
-    conditions_logical_operator: or
-    conditions:
-      - "False"
-
-copp/test_copp.py::TestCOPP::test_policer[DHCP6]:
-  skip:
-    reason: >
-            Passes: rides the pre-existing ip6-unicast policer-classify
-            feature, unaffected by the copp_punt_policer plugin.
-    conditions_logical_operator: or
-    conditions:
-      - "False"
-
-copp:
-  skip:
-    reason: >
-            Unsupported: no VPP dataplane classify/policer feature exists
-            yet for these traps (IP2ME/SNMP/SSH/BGP MTU variants, neighbor
-            miss, dynamic trap add/remove, config-save-after-reboot).
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
 
 #######################################
 #####           Decap             #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -123,8 +123,13 @@ copp:
   skip:
     reason: >
             Unsupported: no VPP dataplane classify/policer feature exists
-            yet for these traps (IP2ME/SNMP/SSH/BGP MTU variants, neighbor
-            miss, dynamic trap add/remove, config-save-after-reboot).
+            yet for these traps (neighbor miss, dynamic trap add/remove).
+            test_policer_mtu (IP2ME/SNMP/SSH/BGP MTU variants) stays
+            skipped too: BGP passes at all packet sizes, but IP2ME/SNMP/SSH
+            all fail with zero packets received (a real, separate,
+            pre-existing gap in the ip4/ip6-unicast policer-classify path
+            unrelated to the copp_punt_policer plugin this effort adds;
+            root cause not yet identified).
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vpp']"
@@ -189,6 +194,16 @@ copp/test_copp.py::TestCOPP::test_policer[UDLD]:
     reason: >
             Passes: CoPP dataplane enforcement implemented via the
             copp_punt_policer VPP device-input plugin.
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
+copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
+  skip:
+    reason: >
+            Passes: verified via a real DUT reboot (config save + reboot
+            + wait + verify trap persists); CoPP trap/policer config
+            survives reboot correctly.
     conditions_logical_operator: or
     conditions:
       - "False"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -119,10 +119,84 @@ container_checker/test_container_checker.py::test_container_checker_telemetry:
 #######################################
 #####           COPP              #####
 #######################################
+copp/test_copp.py::test_verify_copp_configuration_cli:
+  skip:
+    reason: >
+            Passes: config-plane-only verification, no traffic policing.
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
+copp/test_copp.py::TestCOPP::test_policer[ARP]:
+  skip:
+    reason: >
+            Passes: CoPP dataplane enforcement implemented via the
+            copp_punt_policer VPP device-input plugin (see
+            doc/vpp/vpp_copp_HLD.md in nhegde-microsoft/SONiC).
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
+copp/test_copp.py::TestCOPP::test_policer[LACP]:
+  skip:
+    reason: >
+            Passes: CoPP dataplane enforcement implemented via the
+            copp_punt_policer VPP device-input plugin.
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
+copp/test_copp.py::TestCOPP::test_policer[LLDP]:
+  skip:
+    reason: >
+            Passes: CoPP dataplane enforcement implemented via the
+            copp_punt_policer VPP device-input plugin.
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
+copp/test_copp.py::TestCOPP::test_policer[UDLD]:
+  skip:
+    reason: >
+            Passes: CoPP dataplane enforcement implemented via the
+            copp_punt_policer VPP device-input plugin.
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
+copp/test_copp.py::TestCOPP::test_policer[Default]:
+  skip:
+    reason: >
+            Passes: CoPP dataplane enforcement implemented via the
+            copp_punt_policer VPP device-input plugin (TTL_ERROR trap).
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
+copp/test_copp.py::TestCOPP::test_policer[DHCP]:
+  skip:
+    reason: >
+            Passes: rides the pre-existing ip4-unicast policer-classify
+            feature, unaffected by the copp_punt_policer plugin.
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
+copp/test_copp.py::TestCOPP::test_policer[DHCP6]:
+  skip:
+    reason: >
+            Passes: rides the pre-existing ip6-unicast policer-classify
+            feature, unaffected by the copp_punt_policer plugin.
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
 copp:
   skip:
     reason: >
-            Unsupported
+            Unsupported: no VPP dataplane classify/policer feature exists
+            yet for these traps (IP2ME/SNMP/SSH/BGP MTU variants, neighbor
+            miss, dynamic trap add/remove, config-save-after-reboot).
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vpp']"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -198,6 +198,18 @@ copp/test_copp.py::TestCOPP::test_policer[UDLD]:
     conditions:
       - "False"
 
+copp/test_copp.py::TestCOPP::test_policer_mtu[BGP]:
+  skip:
+    reason: >
+            Passes at all 3 packet sizes (64/1514/4096): rides the
+            pre-existing ip4/ip6-unicast policer-classify path via the
+            TTL_ERROR trap match (misleadingly named "BGP" in the test
+            harness; it is not real BGP session traffic), unaffected by
+            the copp_punt_policer VPP plugin.
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
 copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
   skip:
     reason: >

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -119,141 +119,51 @@ container_checker/test_container_checker.py::test_container_checker_telemetry:
 #######################################
 #####           COPP              #####
 #######################################
-copp:
+# NOTE: unlike most sections in this file, COPP is NOT blanket-skipped.
+# CoPP dataplane enforcement on vpp is implemented (copp_punt_policer VPP
+# device-input plugin, see doc/vpp/vpp_copp_HLD.md) and the large majority
+# of copp/test_copp.py passes. Only the 3 specific gaps below are listed
+# (denylist style, matching cacl's convention above) -- everything else
+# under copp/test_copp.py runs unconditionally.
+copp/test_copp.py::TestCOPP::test_policer_mtu\[.*-IP2ME\]:
+  regex: true
   skip:
     reason: >
-            Unsupported: no VPP dataplane classify/policer feature exists
-            yet for these traps (neighbor miss).
-            test_policer_mtu (IP2ME/SNMP/SSH MTU variants) stays
-            skipped too: IP2ME/SNMP/SSH all fail with zero packets received
-            (a real, separate, pre-existing gap in the ip4/ip6-unicast
-            policer-classify path unrelated to the copp_punt_policer plugin
-            this effort adds; root cause not yet identified).
+            Failed/Errored: fails at all 3 packet sizes (64/1514/4096),
+            zero packets received (Actual PPS: 0, Expected: 540-780). A
+            real, separate, pre-existing gap in the ip4-unicast
+            policer-classify path (suspected classify-binding-scope issue:
+            VPP's built-in classify feature only binds to the one hw
+            interface owning the destination IP, not the actual ingress
+            interface), unrelated to the copp_punt_policer plugin this
+            effort adds. Root cause not yet fixed.
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vpp']"
 
-copp/test_copp.py::TestCOPP::test_add_new_trap:
+copp/test_copp.py::TestCOPP::test_policer_mtu\[.*-SNMP\]:
+  regex: true
   skip:
     reason: >
-            Passes: verified live (bgp trap uninstall/reinstall via
-            always_enabled, traffic check before/after). The BGP PTF test
-            packet uses ip_ttl=1, which also matches the separate,
-            always-installed TTL_ERROR default trap independent of the BGP
-            trap's own state -- the same platform behavior real
-            broadcom/marvell-teralynx hardware exhibits, for which the test
-            harness already carries an asic_type exception; added 'vpp' to
-            that exception list in copp_tests.py.
+            Failed/Errored: same root cause as test_policer_mtu[IP2ME]
+            (SNMP/SSH/IP2ME all map to the same SAI ip2me trap per
+            PROTOCOL_TO_TRAP_ID in the PTF copp_tests.py) -- fails at all
+            3 packet sizes, zero packets received.
     conditions_logical_operator: or
     conditions:
-      - "False"
+      - "asic_type in ['vpp']"
 
-copp/test_copp.py::TestCOPP::test_policer[ARP]:
+copp/test_copp.py::TestCOPP::test_policer_mtu\[.*-SSH\]:
+  regex: true
   skip:
     reason: >
-            Passes: CoPP dataplane enforcement implemented via the
-            copp_punt_policer VPP device-input plugin (see
-            doc/vpp/vpp_copp_HLD.md).
+            Failed/Errored: same root cause as test_policer_mtu[IP2ME]
+            (SNMP/SSH/IP2ME all map to the same SAI ip2me trap per
+            PROTOCOL_TO_TRAP_ID in the PTF copp_tests.py) -- fails at all
+            3 packet sizes, zero packets received.
     conditions_logical_operator: or
     conditions:
-      - "False"
-
-copp/test_copp.py::TestCOPP::test_policer[DHCP6]:
-  skip:
-    reason: >
-            Passes: rides the pre-existing ip6-unicast policer-classify
-            feature, unaffected by the copp_punt_policer plugin.
-    conditions_logical_operator: or
-    conditions:
-      - "False"
-
-copp/test_copp.py::TestCOPP::test_policer[DHCP]:
-  skip:
-    reason: >
-            Passes: rides the pre-existing ip4-unicast policer-classify
-            feature, unaffected by the copp_punt_policer plugin.
-    conditions_logical_operator: or
-    conditions:
-      - "False"
-
-copp/test_copp.py::TestCOPP::test_policer[Default]:
-  skip:
-    reason: >
-            Passes: CoPP dataplane enforcement implemented via the
-            copp_punt_policer VPP device-input plugin (TTL_ERROR trap).
-    conditions_logical_operator: or
-    conditions:
-      - "False"
-
-copp/test_copp.py::TestCOPP::test_policer[LACP]:
-  skip:
-    reason: >
-            Passes: CoPP dataplane enforcement implemented via the
-            copp_punt_policer VPP device-input plugin.
-    conditions_logical_operator: or
-    conditions:
-      - "False"
-
-copp/test_copp.py::TestCOPP::test_policer[LLDP]:
-  skip:
-    reason: >
-            Passes: CoPP dataplane enforcement implemented via the
-            copp_punt_policer VPP device-input plugin.
-    conditions_logical_operator: or
-    conditions:
-      - "False"
-
-copp/test_copp.py::TestCOPP::test_policer[UDLD]:
-  skip:
-    reason: >
-            Passes: CoPP dataplane enforcement implemented via the
-            copp_punt_policer VPP device-input plugin.
-    conditions_logical_operator: or
-    conditions:
-      - "False"
-
-copp/test_copp.py::TestCOPP::test_policer_mtu[BGP]:
-  skip:
-    reason: >
-            Passes at all 3 packet sizes (64/1514/4096): rides the
-            pre-existing ip4/ip6-unicast policer-classify path via the
-            TTL_ERROR trap match (misleadingly named "BGP" in the test
-            harness; it is not real BGP session traffic), unaffected by
-            the copp_punt_policer VPP plugin.
-    conditions_logical_operator: or
-    conditions:
-      - "False"
-
-copp/test_copp.py::TestCOPP::test_remove_trap:
-  skip:
-    reason: >
-            Passes: verified live for both removal paths (delete feature
-            entry, disable feature status) -- bgp trap uninstall via
-            feature-table removal, traffic check confirms trap uninstalled.
-            Same asic_type exception in copp_tests.py's BGPTest as
-            test_add_new_trap (ttl_error default trap vs. ttl=1 BGP test
-            packet, matching real broadcom/marvell-teralynx behavior).
-    conditions_logical_operator: or
-    conditions:
-      - "False"
-
-copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
-  skip:
-    reason: >
-            Passes: verified via a real DUT reboot (config save + reboot
-            + wait + verify trap persists); CoPP trap/policer config
-            survives reboot correctly.
-    conditions_logical_operator: or
-    conditions:
-      - "False"
-
-copp/test_copp.py::test_verify_copp_configuration_cli:
-  skip:
-    reason: >
-            Passes: config-plane-only verification, no traffic policing.
-    conditions_logical_operator: or
-    conditions:
-      - "False"
+      - "asic_type in ['vpp']"
 
 #######################################
 #####           Decap             #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -119,12 +119,6 @@ container_checker/test_container_checker.py::test_container_checker_telemetry:
 #######################################
 #####           COPP              #####
 #######################################
-# NOTE: unlike most sections in this file, COPP is NOT blanket-skipped.
-# CoPP dataplane enforcement on vpp is implemented (copp_punt_policer VPP
-# device-input plugin, see doc/vpp/vpp_copp_HLD.md) and the large majority
-# of copp/test_copp.py passes. Only the 3 specific gaps below are listed
-# (denylist style, matching cacl's convention above) -- everything else
-# under copp/test_copp.py runs unconditionally.
 copp/test_copp.py::TestCOPP::test_policer_mtu\[.*-IP2ME\]:
   regex: true
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -123,16 +123,30 @@ copp:
   skip:
     reason: >
             Unsupported: no VPP dataplane classify/policer feature exists
-            yet for these traps (neighbor miss, dynamic trap add/remove).
-            test_policer_mtu (IP2ME/SNMP/SSH/BGP MTU variants) stays
-            skipped too: BGP passes at all packet sizes, but IP2ME/SNMP/SSH
-            all fail with zero packets received (a real, separate,
-            pre-existing gap in the ip4/ip6-unicast policer-classify path
-            unrelated to the copp_punt_policer plugin this effort adds;
-            root cause not yet identified).
+            yet for these traps (neighbor miss).
+            test_policer_mtu (IP2ME/SNMP/SSH MTU variants) stays
+            skipped too: IP2ME/SNMP/SSH all fail with zero packets received
+            (a real, separate, pre-existing gap in the ip4/ip6-unicast
+            policer-classify path unrelated to the copp_punt_policer plugin
+            this effort adds; root cause not yet identified).
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vpp']"
+
+copp/test_copp.py::TestCOPP::test_add_new_trap:
+  skip:
+    reason: >
+            Passes: verified live (bgp trap uninstall/reinstall via
+            always_enabled, traffic check before/after). The BGP PTF test
+            packet uses ip_ttl=1, which also matches the separate,
+            always-installed TTL_ERROR default trap independent of the BGP
+            trap's own state -- the same platform behavior real
+            broadcom/marvell-teralynx hardware exhibits, for which the test
+            harness already carries an asic_type exception; added 'vpp' to
+            that exception list in copp_tests.py.
+    conditions_logical_operator: or
+    conditions:
+      - "False"
 
 copp/test_copp.py::TestCOPP::test_policer[ARP]:
   skip:
@@ -206,6 +220,19 @@ copp/test_copp.py::TestCOPP::test_policer_mtu[BGP]:
             TTL_ERROR trap match (misleadingly named "BGP" in the test
             harness; it is not real BGP session traffic), unaffected by
             the copp_punt_policer VPP plugin.
+    conditions_logical_operator: or
+    conditions:
+      - "False"
+
+copp/test_copp.py::TestCOPP::test_remove_trap:
+  skip:
+    reason: >
+            Passes: verified live for both removal paths (delete feature
+            entry, disable feature status) -- bgp trap uninstall via
+            feature-table removal, traffic check confirms trap uninstalled.
+            Same asic_type exception in copp_tests.py's BGPTest as
+            test_add_new_trap (ttl_error default trap vs. ttl=1 BGP test
+            packet, matching real broadcom/marvell-teralynx behavior).
     conditions_logical_operator: or
     conditions:
       - "False"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -117,49 +117,6 @@ container_checker/test_container_checker.py::test_container_checker_telemetry:
       - "asic_type in ['vpp']"
 
 #######################################
-#####           COPP              #####
-#######################################
-copp/test_copp.py::TestCOPP::test_policer_mtu\[.*-IP2ME\]:
-  regex: true
-  skip:
-    reason: >
-            Failed/Errored: fails at all 3 packet sizes (64/1514/4096),
-            zero packets received (Actual PPS: 0, Expected: 540-780). A
-            real, separate, pre-existing gap in the ip4-unicast
-            policer-classify path (suspected classify-binding-scope issue:
-            VPP's built-in classify feature only binds to the one hw
-            interface owning the destination IP, not the actual ingress
-            interface), unrelated to the copp_punt_policer plugin this
-            effort adds. Root cause not yet fixed.
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-copp/test_copp.py::TestCOPP::test_policer_mtu\[.*-SNMP\]:
-  regex: true
-  skip:
-    reason: >
-            Failed/Errored: same root cause as test_policer_mtu[IP2ME]
-            (SNMP/SSH/IP2ME all map to the same SAI ip2me trap per
-            PROTOCOL_TO_TRAP_ID in the PTF copp_tests.py) -- fails at all
-            3 packet sizes, zero packets received.
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-copp/test_copp.py::TestCOPP::test_policer_mtu\[.*-SSH\]:
-  regex: true
-  skip:
-    reason: >
-            Failed/Errored: same root cause as test_policer_mtu[IP2ME]
-            (SNMP/SSH/IP2ME all map to the same SAI ip2me trap per
-            PROTOCOL_TO_TRAP_ID in the PTF copp_tests.py) -- fails at all
-            3 packet sizes, zero packets received.
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-#######################################
 #####           Decap             #####
 #######################################
 decap/test_subnet_decap.py:


### PR DESCRIPTION
## Why I did it

`tests/copp/test_copp.py` was fully skipped for `asic_type in ['vpp']`. SONiC-VPP's SAI config plane worked, but `saivpp` had no dataplane enforcement.

Companion PRs:
- sairedis: https://github.com/sonic-net/sonic-sairedis/pull/2070
- platform-vpp: https://github.com/sonic-net/sonic-platform-vpp/pull/281
- HLD: https://github.com/sonic-net/SONiC/pull/2539

**Do not merge yet** — should land after the companion PRs merge and produce a real SONiC-VPP image.

## How I did it

Restructured the CoPP skip to denylist style, lifting subtests as verified (`test_add_new_trap`/`test_remove_trap`, `test_policer_mtu[IP2ME/SNMP/SSH/BGP]`, `test_trap_config_save_after_reboot`). Added `ip_src` to `IP2METest`/`SNMPTest`/`BGPTest` (previously unroutable, failing VPP's uRPF check). Fixed `BGPTest`'s PPS check to use a content-matched count instead of the raw NN counter, which double-counted this testbed's real background BGP traffic (same port 179) and caused false failures.

## How to verify it

CI is expected to fail until companion PRs merge and a new image is built. Results below are from manual validation on `vlab-vpp-01`.

All 24 applicable `tests/copp/test_copp.py` subtests pass.
