### PR TITLE
[test] Revert Skip process_monitoring tests on BMC topology (#26984)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4253,12 +4253,6 @@ portstat/test_portstat.py:
 #######################################
 #####     process_monitoring      #####
 #######################################
-process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes:
-  skip:
-    reason: "BMC platforms have no swss/orchagent/syncd containers. This test kills critical processes and relies on auto-restart to recover, which fails on BMC due to reduced container set and lack of PDU controller."
-    conditions:
-      - "'bmc' in topo_type"
-
 process_monitoring/test_critical_process_monitoring.py::test_orchagent_heartbeat:
   skip:
     reason: "This test is intended for Orchagent freeze scenario during warm-reboot. It is not required for T1 devices, and not supported on 202412 release. Also not applicable on BMC platforms which have no orchagent."


### PR DESCRIPTION


### Description of PR
  This reverts commit 84876cbc2caeabbd9f19af8ccab073a0d41237c0.

  The BMC skip added in #26984 worked around two problems that are now
  fixed:
  - Database-container recovery on BMC now power-cycles via PDU (test_critical_process_monitoring.py), instead of leaving the board in an unrecoverable boot loop.
  - #27355 fixed the false "not running" alert for autorestart processes (bmcweb/sonic-dbus-bridge) that caused BMC failures.

Summary:
Fixes #27723

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result


### Approach
#### What is the motivation for this PR?
Reenable process_monitoring_tests on BMC

#### How did you do it?

#### How did you verify/test it?
Check change reverts #26984

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

