### PR TITLE
[tacacs/test]: Add read-only sudo command coverage

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -99,11 +99,19 @@ def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_ho
         "brctl": ["sudo brctl show"],
         "docker": [
             "sudo docker exec snmp cat /etc/snmp/snmpd.conf",
+            "sudo docker exec swss md5sum /usr/bin/arp_update",
             'sudo docker images --format "table {% raw %}{{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.Size}}{% endraw %}"',
             "sudo docker ps",
             "sudo docker ps -a",
         ],
+        "TSC": ["sudo TSC"],
+        "chage": ["sudo /usr/bin/chage -l admin"],
+        "dmidecode": ["sudo dmidecode -s system-product-name"],
         "lldpctl": ["sudo lldpctl"],
+        "systemctl": [
+            "sudo systemctl status",
+            "sudo systemctl status swss.service",
+        ],
         "vtysh": ['sudo vtysh -c "show version"', 'sudo vtysh -c "show bgp ipv4 summary json"',
                   'sudo vtysh -c "show bgp ipv6 summary json"'],
         "rvtysh": ['sudo rvtysh -c "show ip bgp su"', 'sudo rvtysh -n 0 -c "show ip bgp su"'],
@@ -168,6 +176,26 @@ def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_ho
                                           " 'sudo sonic-installer list' is banned")
 
 
+def test_ro_user_dmesg_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds,
+                               check_tacacs):  # noqa: F811
+    """Verify RO users can disable console messages without leaking test state."""
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+    username = tacacs_creds['tacacs_ro_user']
+    password = tacacs_creds['tacacs_ro_user_passwd']
+
+    if not does_command_exist(localhost, dutip, username, password, "dmesg"):
+        pytest.skip('"dmesg" not found on DUT')
+
+    try:
+        allowed = ssh_remote_allow_run(
+            localhost, dutip, username, password, "sudo dmesg -D"
+        )
+        pytest_assert(allowed, "command 'sudo dmesg -D' not authorized")
+    finally:
+        duthost.shell("sudo dmesg -E")
+
+
 def test_ro_user_banned_by_sudoers_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname,
                                            tacacs_creds, check_tacacs):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -179,7 +207,18 @@ def test_ro_user_banned_by_sudoers_command(localhost, duthosts, enum_rand_one_pe
             "sudo cat /etc/hosts",
             "sudo cat /var/log/syslog /etc/hosts",
             "sudo cat /var/log/syslog.1 /etc/hosts"
-        ]
+        ],
+        "TSC": ["sudo TSC no-stats"],
+        "chage": [
+            "sudo /usr/bin/chage -l admin extra",
+            "sudo /usr/bin/chage -M invalid admin",
+        ],
+        "dmidecode": ["sudo dmidecode -s system-serial-number"],
+        "docker": [
+            "sudo docker exec swss md5sum /usr/bin/other",
+            "sudo docker exec swss md5sum /usr/bin/arp_update extra",
+        ],
+        "systemctl": ["sudo systemctl show swss.service"],
     }
 
     for command in commands:


### PR DESCRIPTION
### Description of PR

Summary:
Add live TACACS coverage for the read-only sudo commands introduced by sonic-net/sonic-buildimage#29320.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or ADO): N/A
Failure type: N/A

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master with candidate image `SONiC-OS-fix_36758854-smartctl-read-only.0-2d35cc42b`: targeted VS tests passed:
  - `test_ro_user_allowed_command`
  - `test_ro_user_dmesg_command`
  - `test_ro_user_banned_by_sudoers_command`

### Approach
#### What is the motivation for this PR?

Validate the read-only sudo policy on a running SONiC DUT through TACACS. This complements the policy update in sonic-net/sonic-buildimage#29320 and prevents future changes from silently weakening or removing the expected authorization behavior.

#### How did you do it?

Extended the existing read-only command table with positive cases for TSC, chage, dmidecode, Docker, and systemctl. Added denied argument variants and a dedicated `dmesg -D` case that restores console logging with `dmesg -E` in a `finally` block.

#### How did you verify/test it?

Deployed the candidate VS image from sonic-net/sonic-buildimage#29320 to `vms-kvm-t0`, confirmed the expected sudoers policy on the DUT, and ran the three targeted tests through the sonic-mgmt test harness. All passed.

#### Any platform specific information?

The module is restricted to VS devices by its existing `device_type('vs')` marker. Individual commands are skipped when the executable is unavailable on the DUT.

#### Supported testbed topology if it's a new test case?

Validated on `vms-kvm-t0`.

### Documentation

No documentation changes are required for test-only coverage.
