### PR TITLE
[conditional_mark]: Skip saitests folder for BMC as they are unit tests

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5000,9 +5000,9 @@ sai_qualify:
 #######################################
 #####              saitests         #####
 #######################################
-saitests:
+saitests/:
   skip:
-    reason: "It is not tested for now"
+    reason: "saitests are PTF/unit test scripts, not collected as pytest test cases for BMC"
     conditions:
       - "True"
 


### PR DESCRIPTION
### Description of PR
Summary:
`tests/saitests/` contains PTF/thrift test scripts and `mock/ut` + `mock/it` unit-test scripts, not pytest test cases meant to run on BMC testbeds. This PR updates the `conditional_mark` entry so the skip strictly matches the `saitests/` folder path and clarifies the reason.

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202608

### Approach
#### What is the motivation for this PR?
`tests/saitests/` holds PTF/thrift scripts and mock unit tests, not pytest test cases intended to run on BMC. They should be skipped so BMC does not attempt to collect/run them.

#### How did you do it?
In `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`, changed the condition key from `saitests` to `saitests/` so the prefix match (`nodeid.startswith(condition_entry)`) is scoped strictly to the `saitests/` folder, and updated the `reason` to explain these are unit/PTF scripts.

#### How did you verify/test it?
Matching in `conditional_mark/__init__.py` uses `nodeid.startswith(condition_entry)` against the `tests/`-relative nodeid; `saitests/` matches every nodeid under the folder (e.g. `saitests/mock/ut/test_probing_observer.py::...`) while avoiding accidental matches on unrelated sibling paths that merely start with `saitests`.

#### Any platform specific information?
Applies to BMC where saitests would otherwise be collected/run.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A