### PR TITLE
[test_reporting]: Support xUnit2 cases without source fields

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -76,11 +76,13 @@ REQUIRED_METADATA_PROPERTIES = [
 TESTCASE_TAG = "testcase"
 REQUIRED_TESTCASE_ATTRIBUTES = [
     "classname",
-    "file",
-    "line",
     "name",
     "time",
 ]
+OPTIONAL_TESTCASE_ATTRIBUTES = {
+    "file": "",
+    "line": "0",
+}
 
 # Fields found in the testcase/properties section of the JUnit XML file.
 # FIXME: These are specific to pytest, needs to be extended to support spytest.
@@ -228,8 +230,17 @@ def validate_junit_xml_path(path, strict=False):
 
 def _validate_junit_xml(root):
     _validate_test_summary(root)
-    _validate_test_metadata(root)
-    _validate_test_cases(root)
+
+    if root.tag == TESTSUITES_TAG:
+        suites = root.findall(TESTSUITE_TAG)
+        if not suites:
+            raise JUnitXMLValidationError(f"{TESTSUITE_TAG} tag not found")
+        for suite in suites:
+            _validate_test_metadata(suite)
+            _validate_test_cases(suite)
+    else:
+        _validate_test_metadata(root)
+        _validate_test_cases(root)
 
     return root
 
@@ -384,9 +395,18 @@ def _parse_test_summary(root):
 
 
 def _extract_test_summary(test_cases):
-    test_result_summary = defaultdict(int)
+    test_result_summary = {
+        "tests": 0,
+        "failures": 0,
+        "skipped": 0,
+        "errors": 0,
+        "xfails": 0,
+        "time": 0.0,
+    }
+    last_case = None
     for _, cases in test_cases.items():
         for case in cases:
+            last_case = case
             # Error may occur along with other test results, to count error separately.
             # The result field is unique per test case, either error or failure.
             # xfails is the counter for all kinds of xfail results (include success/failure/error/skipped)
@@ -404,9 +424,9 @@ def _extract_test_summary(test_cases):
         + int(test_result_summary["errors"]) + int(test_result_summary["xfails"])
     passed = int(test_result_summary["tests"]) - int(total)
     passed = max(0, passed)
-    if case is None:
+    if last_case is None:
         return test_result_summary
-    name = case['file']
+    name = last_case['file']
     REPORT_LIST.append("{}, {}, {}, {}, {}, {}, {}, {}".
                        format(name, test_result_summary["tests"],
                               passed, test_result_summary["failures"],
@@ -469,6 +489,8 @@ def _parse_test_cases(root):
 
         for attribute in REQUIRED_TESTCASE_ATTRIBUTES:
             result[attribute] = test_case.get(attribute)
+        for attribute, default in OPTIONAL_TESTCASE_ATTRIBUTES.items():
+            result[attribute] = test_case.get(attribute, default)
         for attribute in REQUIRED_TESTCASE_PROPERTIES:
             testcase_properties = _parse_testcase_properties(test_case)
             if attribute in testcase_properties:
@@ -651,7 +673,8 @@ def _validate_json_cases(test_result_json):
         raise TestResultJSONValidationError("test_cases section not found in provided JSON file")
 
     def _validate_test_case(test_case):
-        for attribute in REQUIRED_TESTCASE_ATTRIBUTES + REQUIRED_TESTCASE_JSON_FIELDS:
+        testcase_attributes = REQUIRED_TESTCASE_ATTRIBUTES + list(OPTIONAL_TESTCASE_ATTRIBUTES)
+        for attribute in testcase_attributes + REQUIRED_TESTCASE_JSON_FIELDS:
             if attribute not in test_case:
                 raise TestResultJSONValidationError(
                     f'"{attribute}" not found in test case '

--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -229,18 +229,17 @@ def validate_junit_xml_path(path, strict=False):
 
 
 def _validate_junit_xml(root):
-    _validate_test_summary(root)
-
     if root.tag == TESTSUITES_TAG:
         suites = root.findall(TESTSUITE_TAG)
         if not suites:
             raise JUnitXMLValidationError(f"{TESTSUITE_TAG} tag not found")
-        for suite in suites:
-            _validate_test_metadata(suite)
-            _validate_test_cases(suite)
     else:
-        _validate_test_metadata(root)
-        _validate_test_cases(root)
+        suites = [root]
+
+    for suite in suites:
+        _validate_test_summary(suite)
+        _validate_test_metadata(suite)
+        _validate_test_cases(suite)
 
     return root
 
@@ -369,19 +368,18 @@ def parse_test_result(roots):
         return
 
     for root, document in roots:
-        if root.tag == TESTSUITES_TAG:
-            root = root.find(TESTSUITE_TAG)
-
-        test_result_json["test_metadata"] = _update_test_metadata(test_result_json["test_metadata"],
-                                                                  _parse_test_metadata(root))
-        test_cases = _parse_test_cases(root)
-        test_result_json["test_cases"] = _update_test_cases(test_result_json["test_cases"], test_cases)
-        parsed_summary = _parse_test_summary(root)
-        # xfails is not a testsuite root attribute; derive it from the per-case
-        # results so xfailed/xpassed (native pytest marks) are surfaced instead of 0.
-        parsed_summary["xfails"] = _extract_test_summary(test_cases).get("xfails", "0")
-        test_result_json["test_summary"] = _update_test_summary(test_result_json["test_summary"],
-                                                                parsed_summary)
+        suites = root.findall(TESTSUITE_TAG) if root.tag == TESTSUITES_TAG else [root]
+        for suite in suites:
+            test_result_json["test_metadata"] = _update_test_metadata(test_result_json["test_metadata"],
+                                                                      _parse_test_metadata(suite))
+            test_cases = _parse_test_cases(suite)
+            test_result_json["test_cases"] = _update_test_cases(test_result_json["test_cases"], test_cases)
+            parsed_summary = _parse_test_summary(suite)
+            # xfails is not a testsuite root attribute; derive it from the per-case
+            # results so xfailed/xpassed (native pytest marks) are surfaced instead of 0.
+            parsed_summary["xfails"] = _extract_test_summary(test_cases).get("xfails", "0")
+            test_result_json["test_summary"] = _update_test_summary(test_result_json["test_summary"],
+                                                                    parsed_summary)
     print(f"Parsed {len(roots)} XML document(s) into test result JSON.")
     return test_result_json
 

--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -241,6 +241,17 @@ def _validate_junit_xml(root):
         _validate_test_metadata(suite)
         _validate_test_cases(suite)
 
+    metadata = None
+    for suite in suites:
+        suite_metadata = {k: v for k, v in _parse_test_metadata(suite).items()
+                          if k in REQUIRED_METADATA_PROPERTIES and k != "timestamp"}
+        if not suite_metadata:
+            continue
+        if metadata is None:
+            metadata = suite_metadata
+        elif suite_metadata != metadata:
+            raise JUnitXMLValidationError("testsuite metadata differs between child suites")
+
     return root
 
 

--- a/test_reporting/tests/test_junit_xml_parser.py
+++ b/test_reporting/tests/test_junit_xml_parser.py
@@ -256,6 +256,27 @@ def test_xunit2_testcases_without_file_or_line_are_parsed():
     assert result["test_summary"]["xfails"] == "0"
 
 
+def test_multiple_testsuites_are_aggregated():
+    first_suite = VALID_TEST_RESULT.replace('<?xml version="1.0" encoding="utf-8"?>', "")
+    second_suite = first_suite.replace('classname="bgp.', 'classname="second_bgp.').replace(
+        'classname="acl.', 'classname="second_acl.'
+    )
+    root = validate_junit_xml_stream(f"<testsuites>{first_suite}{second_suite}</testsuites>")
+
+    result = parse_test_result([(root, "multiple-suites.xml")])
+
+    assert set(result["test_cases"]) == {"acl", "bgp", "second_acl", "second_bgp"}
+    assert sum(len(cases) for cases in result["test_cases"].values()) == 8
+    assert result["test_summary"] == {
+        "errors": "2",
+        "failures": "2",
+        "skipped": "2",
+        "tests": "8",
+        "time": "428.108",
+        "xfails": "0",
+    }
+
+
 def test_empty_testsuite_is_parsed():
     root = validate_junit_xml_stream(
         '<testsuite errors="0" failures="0" skipped="0" tests="0" time="0"/>'

--- a/test_reporting/tests/test_junit_xml_parser.py
+++ b/test_reporting/tests/test_junit_xml_parser.py
@@ -238,6 +238,35 @@ def test_json_output_from_file():
     assert ordered(parse_test_result([root])) == ordered(EXPECTED_JSON_OUTPUT)
 
 
+def test_xunit2_testcases_without_file_or_line_are_parsed():
+    xml = "<testsuites>" + VALID_TEST_RESULT.replace(
+        '<?xml version="1.0" encoding="utf-8"?>', ""
+    ).replace(' file="bgp/test_bgp.py"', "").replace(
+        ' file="acl/test_acl.py"', ""
+    ).replace(' line="161"', "").replace(' line="248"', "").replace(
+        ' line="257"', ""
+    ).replace(' line="369"', "") + "</testsuites>"
+
+    root = validate_junit_xml_stream(xml)
+    result = parse_test_result([(root, "xunit2.xml")])
+
+    cases = [case for feature_cases in result["test_cases"].values() for case in feature_cases]
+    assert len(cases) == 4
+    assert all(case["file"] == "" and case["line"] == "0" for case in cases)
+    assert result["test_summary"]["xfails"] == "0"
+
+
+def test_empty_testsuite_is_parsed():
+    root = validate_junit_xml_stream(
+        '<testsuite errors="0" failures="0" skipped="0" tests="0" time="0"/>'
+    )
+
+    result = parse_test_result([(root, "empty.xml")])
+
+    assert result["test_cases"] == {}
+    assert result["test_summary"]["xfails"] == "0"
+
+
 def test_json_output_from_archive():
     roots = validate_junit_xml_archive(VALID_TEST_RESULT_ARCHIVE)
     assert ordered(parse_test_result(roots)) == ordered(EXPECTED_JSON_OUTPUT)

--- a/test_reporting/tests/test_junit_xml_parser.py
+++ b/test_reporting/tests/test_junit_xml_parser.py
@@ -277,6 +277,14 @@ def test_multiple_testsuites_are_aggregated():
     }
 
 
+def test_multiple_testsuites_with_mismatched_metadata_are_rejected():
+    first_suite = VALID_TEST_RESULT.replace('<?xml version="1.0" encoding="utf-8"?>', "")
+    second_suite = first_suite.replace('value="vms-kvm-t0"', 'value="vms-kvm-t1"')
+
+    with pytest.raises(JUnitXMLValidationError, match="testsuite metadata differs between child suites"):
+        validate_junit_xml_stream(f"<testsuites>{first_suite}{second_suite}</testsuites>")
+
+
 def test_empty_testsuite_is_parsed():
     root = validate_junit_xml_stream(
         '<testsuite errors="0" failures="0" skipped="0" tests="0" time="0"/>'


### PR DESCRIPTION
### Description of PR

Fix JUnit XML parsing for pytest xUnit2 reports that omit the optional file and line testcase attributes. Previously, these testcases were discarded, causing _extract_test_summary to raise KeyError: 'failures'.

Summary:
Fixes # (issue)
A vendor JUnit XML report uploaded successfully, but result ingestion failed during parsing with KeyError: 'failures'.

The report uses pytest's xUnit2 format, where testcase file and line attributes may be omitted. The parser treated these fields as mandatory and silently discarded every testcase. Summary extraction then failed because it received an empty testcase collection.

Treated testcase file and line attributes as optional.
Added Kusto-compatible defaults of an empty file path and line 0.
Validated testcase metadata against the inner <testsuite> when the document uses a <testsuites> wrapper.
Initialized all derived summary fields so empty test suites can be handled safely.
Added regression coverage for xUnit2 reports without source fields and empty test suites.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

Fix JUnit XML parsing for pytest xUnit2 reports that omit the optional file and line testcase attributes. Previously, these testcases were discarded, causing _extract_test_summary to raise KeyError: 'failures'.

#### How did you do it?

A vendor JUnit XML report uploaded successfully, but result ingestion failed during parsing with KeyError: 'failures'.

The report uses pytest's xUnit2 format, where testcase file and line attributes may be omitted. The parser treated these fields as mandatory and silently discarded every testcase. Summary extraction then failed because it received an empty testcase collection.

Treated testcase file and line attributes as optional.
Added Kusto-compatible defaults of an empty file path and line 0.
Validated testcase metadata against the inner <testsuite> when the document uses a <testsuites> wrapper.
Initialized all derived summary fields so empty test suites can be handled safely.
Added regression coverage for xUnit2 reports without source fields and empty test suites.

#### How did you verify/test it?

Verified via unit testing.

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA