### PR TITLE
[fdb]: Make bulk learn validation independent of SAI batching

### DIFF
--- a/tests/fdb/test_fdb_churn.py
+++ b/tests/fdb/test_fdb_churn.py
@@ -276,6 +276,22 @@ def fdb_table_has_mac_on_port(duthost, vlan_id, mac, port):
     return "port" in text and port in text
 
 
+def get_fdb_table_macs(duthost, vlan_id):
+    """Return MAC addresses currently present in STATE_DB for `vlan_id`."""
+    prefix = "FDB_TABLE|Vlan{}:".format(vlan_id)
+    out = duthost.command(
+        "redis-cli -n 6 --scan --pattern '{}*'".format(prefix),
+        module_ignore_errors=True,
+    )
+    if out.get("rc") != 0:
+        return set()
+    return {
+        key[len(prefix):].lower()
+        for key in out.get("stdout_lines", [])
+        if key.startswith(prefix)
+    }
+
+
 def inject_learn_frames(ptfadapter, port, src_mac, vlan_id, count=1):
     """Inject `count` ARP requests with given src_mac on PTF `port`."""
     for _ in range(count):
@@ -590,8 +606,24 @@ def test_fdb_distinct_macs_bulk_learn(
                 ptfadapter, topo["ptf_port_a"], mac, topo["inject_vlan_a"]
             )
 
-    # Sample a handful of the MACs we injected and verify their
-    # presence -- checking all 1000 individually would be slow.
+    # Query all VLAN FDB keys in one scan so the exact bulk-learning
+    # result, rather than a vendor-specific envelope count, is the
+    # primary correctness gate.
+    expected_macs = set(macs)
+    pytest_assert(
+        wait_until(
+            STATS_PUBLISH_SEC + 60, 1, 0,
+            lambda: expected_macs.issubset(
+                get_fdb_table_macs(duthost, topo["vlan_id"])
+            ),
+        ),
+        "Not all {} injected MACs are present in STATE_DB; {} missing".format(
+            count,
+            len(expected_macs - get_fdb_table_macs(duthost, topo["vlan_id"])),
+        ),
+    )
+
+    # Verify representative entries also point to the expected port.
     sample = [macs[0], macs[count // 2], macs[-1]]
     for mac in sample:
         pytest_assert(
@@ -610,12 +642,11 @@ def test_fdb_distinct_macs_bulk_learn(
     logger.info("bulk-distinct: pushed=%d, hits=%d, injected=%d", pushed, hits, count)
     # `lru_pushed` counts envelopes, not events; on batching SAI adapters
     # one envelope carries N sub-events, so ``pushed`` can be far below
-    # `count`. Use a proportional lower bound while still catching total
-    # pipeline outages.  The STATE_DB sample check above is the strict correctness gate.
-    min_pushed = max(1, count // 10)
+    # `count`. The complete STATE_DB check above is the strict correctness
+    # gate; requiring one envelope still catches total pipeline outages.
     pytest_assert(
-        pushed >= min_pushed,
-        "Expected at least {} pushes; got {}".format(min_pushed, pushed),
+        pushed >= 1,
+        "Expected at least one push; got {}".format(pushed),
     )
     # Within one pass every MAC's LEARN is a distinct payload; the test
     # does two passes over the same MAC list (workaround for KVM/libsaivs


### PR DESCRIPTION
Validate all injected MACs in STATE_DB and require only one notification envelope, avoiding vendor-specific assumptions about SAI event batching.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/26295 https://github.com/sonic-net/sonic-mgmt/issues/28049
Fix  `test_fdb_distinct_macs_bulk_learn`  false failures on SAI implementations that batch many FDB events into a small number of notification envelopes.

This is a follow-up to sonic-net/sonic-mgmt#26559, backported to 202605 through #27059.

Failure: https://elastictest.org/scheduler/testplan/6a9a37a8f1937a379ef4fd6c

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?
PR #26559 fixed a race between the test and orchagent’s periodic publication of notification-consumer statistics. It introduced  wait_for_stat_stable()  and recognized that  lru_pushed  counts Redis notification envelopes rather than individual FDB events.

However, the merged implementation retained a proportional lower bound:

`min_pushed = max(1, count // 10)`

For 1,000 injected MAC addresses, the test therefore required at least 100 notification envelopes.

On a `Mellanox SN4700` testbed, the test failed with:

Expected at least 100 pushes; got 15

The first, middle, and last sampled MAC addresses were all present in `STATE_DB`,  `lru_dedup_hits`  was zero, and the other FDB churn tests passed. This indicates that FDB learning worked, but the SAI implementation batched the 1,000 FDB events into only 15 notification envelopes.

The 10% envelope threshold is not portable because SONiC does not define how many FDB events a vendor SAI implementation may place in one notification envelope.

Simply changing the threshold to  pushed >= 1  would address the batching issue, but it would weaken the existing test because only three of the 1,000 injected MAC addresses were previously checked in STATE_DB. This PR therefore strengthens the functional validation while removing the vendor-specific batching assumption.

#### How did you do it?
Added a helper that retrieves all FDB MAC addresses for the test VLAN from STATE_DB using a single Redis  SCAN  operation.

The bulk-learning test now:

1. Injects 1,000 distinct MAC addresses as before.
2. Waits until all 1,000 injected MAC addresses are present in STATE_DB.
3. Checks representative entries to confirm they are associated with the expected port.
4. Requires at least one  lru_pushed  notification envelope to confirm that the notification pipeline was active.
5. Retains the existing dedup and orchagent health checks.

The new validation separates two different concerns:

• FDB correctness: All injected MAC addresses must be present in STATE_DB.
• Notification pipeline health: At least one notification envelope must have been processed.

This avoids assuming a fixed relationship between the number of learned MAC addresses and the number of vendor-generated notification envelopes.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
The original failing run on a `Mellanox SN4700` reported:

Injected MACs: 1000
lru_pushed: 15
lru_dedup_hits: 0

The run successfully found all three previously sampled MAC addresses in `STATE_DB` but failed only because the test required at least 100 envelopes. With this change, 15 envelopes satisfy the platform-independent pipeline-health requirement, while the test now additionally requires all 1,000 injected MAC addresses to be present in `STATE_DB`.

https://elastictest.org/scheduler/testplan/6a9a3e8e0f7c07c20a9b5113

#### Any platform specific information?
The failure was observed on:

Platform: `Mellanox SN4700`
HWSKU: `Mellanox-SN4700-O8V48`
Topology: `t0`

The implementation is not limited to Mellanox or SN4700. It removes a vendor-specific assumption and supports SAI implementations that batch multiple FDB events into a single notification envelope.

#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
