### PR TITLE
[recover_testbed]: Convert IP variables to strings

### DIFF
--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -78,9 +78,9 @@ def recover_testbed(sonichosts, conn_graph_facts, localhost, image_url, hwsku):
                 extra_vars = {
                     'addr': mgmt_ip.split('/')[0],
                     'mask': ipaddress.ip_interface(mgmt_ip).with_netmask.split('/')[1],
-                    'gwaddr': list(ipaddress.ip_interface(mgmt_ip).network.hosts())[0],
+                    'gwaddr': str(list(ipaddress.ip_interface(mgmt_ip).network.hosts())[0]),
                     'mgmt_ip': mgmt_ip,
-                    'brd_ip': ipaddress.ip_interface(mgmt_ip).network.broadcast_address,
+                    'brd_ip': str(ipaddress.ip_interface(mgmt_ip).network.broadcast_address),
                     'network': str(ipaddress.ip_interface(mgmt_ip).network).split('/')[0]
                 }
                 sonichost.vm.extra_vars.update(extra_vars)


### PR DESCRIPTION
### Description of PR

Summary:

Convert the recovery script's gateway and broadcast addresses to strings before adding them to Ansible `extra_vars`.

Ansible Core 2.19 and newer applies strict data tagging to play variables and rejects Python `ipaddress.IPv4Address` objects with:

```text
ansible.module_utils._internal._datatag.NotTaggableError:
<class 'ipaddress.IPv4Address'> is not taggable
```

This causes recover-by-console plans to fail after SSH access succeeds, while rendering `interfaces.j2`.

Fixes # (not applicable)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: regression

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: `pre-commit` passed for `.azure-pipelines/recover_testbed/recover_testbed.py`.
- master: reproduced with Ansible Core 2.20.5 that `IPv4Address` values raise `NotTaggableError`, while the converted string values pass the same data-tagging path.
- Production evidence:
  - [STaR lab, Mellanox, internal-202605-dev-mlnx](https://elastictest.org/scheduler/testplan/6a9a3e07b9406622d7a43acf?testcase=testbed_q_star_lab_vms7-t1-4700-5_prepare.log&type=prepare)
  - [Beijing lab, Celestica, internal](https://elastictest.org/scheduler/testplan/6a9a26e4b9406622d7a43aa5?testcase=testbed_q_beijing_lab_testbed-bjw2-can-e1031-1_prepare.log&type=prepare)
  - [TK5 lab, Mellanox, internal](https://elastictest.org/scheduler/testplan/6a9a1362b9406622d7a43a84?testcase=testbed_q_tk5_lab_tbtk5-t0-4600c-2_prepare.log&type=prepare)

Kusto shows `RECOVER_BY_CONSOLE_FAILED` increased to approximately 30-38% of weekly recovery plans from July 20 onward. Since June 26, 2,298 of 8,936 recovery plans ended with this error code. The error code also covers unrelated console failures, so the linked prepare logs provide the direct signature evidence for this fix.

### Approach
#### What is the motivation for this PR?

`recover_testbed.py` adds gateway and broadcast addresses returned by Python's `ipaddress` module directly to Ansible `extra_vars`. These values are `IPv4Address` objects. Ansible Core 2.19 and newer no longer accepts this type during variable data tagging, causing deterministic recovery failures before the network interface template is rendered.

#### How did you do it?

Convert `gwaddr` and `brd_ip` to strings before adding them to `extra_vars`. All values consumed by `interfaces.j2` are now primitive string values.

#### How did you verify/test it?

Ran the repository pre-commit checks for the modified file and reproduced the data-tagging behavior with Ansible Core 2.20.5. Raw `IPv4Address` values fail with `NotTaggableError`; their string forms are accepted.

#### Any platform specific information?

No. The failure has been observed on Mellanox and Celestica DUTs across multiple physical labs.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
