### PR TITLE
ci: enable dualtor-aa-vpp impacted-area PR checks

### DIFF
--- a/.azure-pipelines/impacted_area_testing/constant.py
+++ b/.azure-pipelines/impacted_area_testing/constant.py
@@ -1,6 +1,7 @@
 # Now, we only have below types of PR checker
 # - dpu
 # - dualtor-t0
+# - dualtor-aa-vpp
 # - multi-asic-t1-lag
 # - t0
 # - t0-2vlans
@@ -10,7 +11,7 @@
 # - t1-lag-vpp
 PR_TOPOLOGY_TYPE = ["t0_checker", "t0-2vlans_checker", "t0-sonic_checker", "t0-vpp_checker",
                     "t1_checker", "t1-multi-asic_checker", "t1-lag-vpp_checker", "dpu_checker",
-                    "dualtor_checker", "t2_checker"]
+                    "dualtor_checker", "dualtor-aa-vpp_checker", "t2_checker"]
 
 EXCLUDE_TEST_SCRIPTS = [
     "test_posttest.py",
@@ -28,6 +29,7 @@ PR_CHECKER_TOPOLOGY_NAME = {
     "t1-lag-vpp": ["t1-lag-vpp", "kvmtest-t1-lag-vpp_"],
     "dpu": ["dpu", "kvmtest-dpu_"],
     "dualtor": ["dualtor", "kvmtest-dualtor-t0_"],
+    "dualtor-aa-vpp": ["dualtor-aa-vpp", "kvmtest-dualtor-aa-vpp_"],
     "t2": ["t2", "kvmtest-t2_"]
 }
 

--- a/.azure-pipelines/impacted_area_testing/get_test_scripts.py
+++ b/.azure-pipelines/impacted_area_testing/get_test_scripts.py
@@ -19,6 +19,7 @@ from constant import PR_TOPOLOGY_TYPE, EXCLUDE_TEST_SCRIPTS, CONTROL_PLANE_DEDUP
 VPP_TOPOLOGY_CHECKERS = {
     "t0-vpp": "t0-vpp_checker",
     "t1-lag-vpp": "t1-lag-vpp_checker",
+    "dualtor-aa-vpp": "dualtor-aa-vpp_checker",
 }
 
 

--- a/.azure-pipelines/impacted_area_testing/test_get_test_scripts.py
+++ b/.azure-pipelines/impacted_area_testing/test_get_test_scripts.py
@@ -190,14 +190,15 @@ class TestVppImpactedArea:
     def test_vpp_topologies_use_independent_allowlists(
         self, test_dir, monkeypatch
     ):
-        """Verify t0-vpp and t1-lag-vpp build independent checker lists."""
+        """Verify every VPP topology builds its own independent checker list."""
         tests_dir = os.path.join(test_dir, "tests")
-        _write_file(tests_dir, "bgp/test_t0_vpp.py", "import pytest\n")
-        _write_file(tests_dir, "bgp/test_t1_lag_vpp.py", "import pytest\n")
-        allowlists = {
-            "t0-vpp": ["bgp/test_t0_vpp.py"],
-            "t1-lag-vpp": ["bgp/test_t1_lag_vpp.py"],
-        }
+        # One uniquely-named script per topology, so a checker picking up
+        # another topology's script would be visible rather than masked.
+        allowlists = {}
+        for topology in VPP_TOPOLOGY_CHECKERS:
+            script = "bgp/test_{}.py".format(topology.replace("-", "_"))
+            _write_file(tests_dir, script, "import pytest\n")
+            allowlists[topology] = [script]
         monkeypatch.setattr(
             "get_test_scripts.load_vpp_test_scripts_allowlist",
             lambda topology: allowlists[topology],
@@ -205,10 +206,8 @@ class TestVppImpactedArea:
 
         result = collect_scripts_by_topology_type("bgp", tests_dir)
 
-        assert result["t0-vpp_checker"] == ["bgp/test_t0_vpp.py"]
-        assert result["t1-lag-vpp_checker"] == [
-            "bgp/test_t1_lag_vpp.py"
-        ]
+        for topology, checker in VPP_TOPOLOGY_CHECKERS.items():
+            assert result[checker] == allowlists[topology]
 
     def test_build_vpp_impacted_scripts_preserves_allowlist_order(self):
         result = build_vpp_impacted_scripts(

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -57,7 +57,7 @@ parameters:
   type: string
   default: "sonic-mgmt"
 
-# Keys: "dpu_checker","dualtor_checker","t0-2vlans_checker","t0-sonic_checker","t0_checker","t0-vpp_checker","t1-lag-vpp_checker","t1-multi-asic_checker","t1_checker","t2_checker"
+# Keys: "dpu_checker","dualtor_checker","dualtor-aa-vpp_checker","t0-2vlans_checker","t0-sonic_checker","t0_checker","t0-vpp_checker","t1-lag-vpp_checker","t1-multi-asic_checker","t1_checker","t2_checker"
 # Example: {"t0_checker": ["bgp/test_bgp_command.py", "bgp/test_ping_bgp_neighbor.py"], "t1_checker": ["bgp/test_bgp_fact.py"]}
 - name: IMPACT_AREA_INFO
   type: object
@@ -553,6 +553,52 @@ jobs:
           PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
           EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
           TOPOLOGY: t0-vpp
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
+          KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+          KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
+          MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
+          ASIC_TYPE: "vpp"
+          KVM_IMAGE_BUILD_PIPELINE_ID: "2818"
+          COMMON_EXTRA_PARAMS: "--disable_sai_validation --disable_loganalyzer"
+          ${{ each param in parameters.OVERRIDE_PARAMS }}:
+            ${{ param.key }}: ${{ param.value }}
+
+  - job: dualtor_aa_vpp_elastictest
+    displayName: "impacted-area-kvmtest-dualtor-aa-vpp by Elastictest"
+    dependsOn:
+    - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      RUN_BY_INCLUDE_JOBS: ${{ or(eq(parameters.INCLUDE_JOBS, 'all'), contains(parameters.INCLUDE_JOBS, 'dualtor_aa_vpp_job')) }}
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dualtor-aa-vpp_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+    continueOnError: false
+    pool: ${{ parameters.RUN_TEST_AGENT_POOL }}
+    steps:
+      - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+        - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+          displayName: "Checkout sonic-mgmt repository"
+
+      - template: impacted_area_testing/calculate-instance-numbers.yml
+        parameters:
+          TOPOLOGY: dualtor-aa-vpp
+          BUILD_BRANCH: $(BUILD_BRANCH)
+
+      - template: run-test-elastictest-template.yml
+        parameters:
+          BUILD_REASON: ${{ parameters.BUILD_REASON }}
+          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+          STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+          MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+          PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
+          PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+          EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+          TOPOLOGY: dualtor-aa-vpp
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)

--- a/.azure-pipelines/pre_defined_pr_test.yml
+++ b/.azure-pipelines/pre_defined_pr_test.yml
@@ -28,7 +28,7 @@ parameters:
   type: string
   default: " "
 
-# Keys: "dpu_checker","dualtor_checker","t0-2vlans_checker","t0-sonic_checker","t0_checker","t0-vpp_checker","t1-lag-vpp_checker","t1-multi-asic_checker","t1_checker","t2_checker"
+# Keys: "dpu_checker","dualtor_checker","dualtor-aa-vpp_checker","t0-2vlans_checker","t0-sonic_checker","t0_checker","t0-vpp_checker","t1-lag-vpp_checker","t1-multi-asic_checker","t1_checker","t2_checker"
 # Example: {"t0_checker": ["bgp/test_bgp_command.py", "bgp/test_ping_bgp_neighbor.py"], "t1_checker": ["bgp/test_bgp_fact.py"]}
 - name: IMPACT_AREA_INFO
   type: object

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -303,7 +303,7 @@ class TestPlanManager(object):
                 common_extra_params = common_extra_params + " --topology=t0,any"
             elif topology in ["t1-lag", "t1-8-lag", "t1-vpp", "t1-lag-vpp"]:
                 common_extra_params = common_extra_params + " --topology=t1,any"
-            elif topology == "dualtor":
+            elif topology in ["dualtor", "dualtor-aa-vpp"]:
                 common_extra_params = common_extra_params + " --topology=t0,dualtor,any"
             elif topology == "dpu":
                 common_extra_params = common_extra_params + " --topology=dpu,any"


### PR DESCRIPTION
### Description of PR

Summary:
- Enable impacted-area PR checks on the `dualtor-aa-vpp` topology.
- Register the `dualtor-aa-vpp_checker` and its Kusto topology and test-plan name mapping.
- Add the `dualtor_aa_vpp_elastictest` job using ASIC type `vpp` and KVM image pipeline `2818`.
- Route `dualtor-aa-vpp` test plans through the `--topology=t0,dualtor,any` filter.
- Generalize the one remaining hardcoded VPP unit test so it is driven by `VPP_TOPOLOGY_CHECKERS`.

This follows the same shape as #27024, which enabled `t0-vpp`. The `dualtor-aa-vpp` test-script allowlist already landed in #27663, so this change wires up the checker that consumes it.

39664385

Fixes # (issue) N/A

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 39664385
Failure type:

### Tested branch

- [x] master

### Approach
#### What is the motivation for this PR?

The `dualtor-aa-vpp` topology was onboarded in #27663, which added its test-script allowlist to `pr_test_scripts.yaml`. Nothing consumes that allowlist yet, so dual-ToR VPP changes get no impacted-area PR coverage and rely on manual or nightly runs.

#### How did you do it?

Because #27024 already generalized the VPP selection logic over a dict, most of this is registration:

| File | Change |
|---|---|
| `impacted_area_testing/constant.py` | Register `dualtor-aa-vpp_checker` in `PR_TOPOLOGY_TYPE`; add the `PR_CHECKER_TOPOLOGY_NAME` entry |
| `impacted_area_testing/get_test_scripts.py` | One entry in `VPP_TOPOLOGY_CHECKERS` |
| `test_plan.py` | Route `dualtor-aa-vpp` through the **dualtor** topology filter |
| `pr_test_template.yml` | Add the `dualtor_aa_vpp_elastictest` job |
| `pre_defined_pr_test.yml` | Update the `Keys:` doc comment |
| `impacted_area_testing/test_get_test_scripts.py` | Drive the last hardcoded test off `VPP_TOPOLOGY_CHECKERS` |

Two points worth calling out, since both are places where copying the `t0-vpp` job verbatim would have produced a green-but-useless check:

**1. `dualtor-aa-vpp` takes the `dualtor` topology filter, not the `t0` one.** All six allowlisted scripts are marked `pytest.mark.topology("dualtor")`:

```
test_grpc_server_failure.py   pytest.mark.topology("dualtor")
test_heartbeat_failure.py     pytest.mark.topology("dualtor")
test_link_drop.py             pytest.mark.topology("dualtor")
test_normal_op.py             pytest.mark.topology("dualtor")
test_tor_bgp_failure.py       pytest.mark.topology("dualtor")
test_tor_failure.py           pytest.mark.topology("dualtor")
```

With `--topology=t0,any` every one of them would be deselected and the job would pass without running anything. It uses `--topology=t0,dualtor,any`, matching the existing `dualtor` job.

**2. `PR_CHECKER_TOPOLOGY_NAME` is required, not cosmetic.** `calculate_instance_number.py` indexes it directly to build its Kusto query, so a missing entry raises `KeyError` in the instance-count step before the test plan is ever created. There is no historical data for this topology yet, but that path is already handled — the script falls back to 1800s per script when the query returns nothing.

#### Any platform specific information?

The job uses topology `dualtor-aa-vpp`, ASIC type `vpp`, and the shared SONiC-VPP KVM image pipeline `2818`.

#### Supported testbed topology if it's a new test case?

`dualtor-aa-vpp`

### Verification

**Unit tests** — `65 passed`. The parametrized VPP cases now generate 7 additional cases naming `dualtor-aa-vpp`:

```
test_vpp_allowlist_intersection_includes_raw_script[dualtor-aa-vpp-dualtor-aa-vpp_checker]
test_vpp_checker_omitted_when_no_allowlisted_impacted_scripts[dualtor-aa-vpp-dualtor-aa-vpp_checker]
test_vpp_output_order_follows_allowlist[dualtor-aa-vpp-dualtor-aa-vpp_checker]
...
```

`test_vpp_topologies_use_independent_allowlists` had the two topologies hardcoded and failed on the new entry with `KeyError: 'dualtor-aa-vpp'`. Rather than add a third literal, it now builds its fixture from `VPP_TOPOLOGY_CHECKERS` like its neighbours, so it covers future topologies automatically.

**End-to-end selection** against the real `tests/` tree, confirming the checker fires only when it should:

```
dualtor_io -> dualtor-aa-vpp_checker: 6 scripts   (exactly the allowlist)
bgp        -> dualtor-aa-vpp_checker: 0
snmp       -> dualtor-aa-vpp_checker: 0
acl        -> dualtor-aa-vpp_checker: 0
```

**Consistency check** that all three registries agree for every VPP topology — this is what catches the `KeyError` above:

```
t0-vpp          checker in PR_TOPOLOGY_TYPE=True  topo in PR_CHECKER_TOPOLOGY_NAME=True
t1-lag-vpp      checker in PR_TOPOLOGY_TYPE=True  topo in PR_CHECKER_TOPOLOGY_NAME=True
dualtor-aa-vpp  checker in PR_TOPOLOGY_TYPE=True  topo in PR_CHECKER_TOPOLOGY_NAME=True
```

YAML parses for all three touched files, the new job is structurally well formed with both templates receiving `TOPOLOGY: dualtor-aa-vpp`, and `flake8 --max-line-length=120` is clean on every changed Python file.

### Documentation

N/A
