### PR TITLE
[dualtor] Require ICMP responder for mux setup test

### DIFF
--- a/tests/dualtor_mgmt/test_dualtor_setup_mux_ports.py
+++ b/tests/dualtor_mgmt/test_dualtor_setup_mux_ports.py
@@ -10,6 +10,7 @@ from tests.common.dualtor.dual_tor_utils import upper_tor_host                  
 from tests.common.dualtor.dual_tor_utils import lower_tor_host                                              # noqa: F401
 from tests.common.dualtor.dual_tor_utils import show_muxcable_status
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor      # noqa: F401
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder                             # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 
 


### PR DESCRIPTION
### Description of PR
Summary:
Fixes dualtor mux setup test failures where `toggle_all_simulator_ports_to_rand_selected_tor` can time out with `Failed to toggle all ports ... from mux simulator` because the test module does not request the `run_icmp_responder` autouse fixture required by the deprecated toggle utility.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Approach
#### What is the motivation for this PR?
The failing test uses `toggle_all_simulator_ports_to_rand_selected_tor`. That fixture documents that ICMP responder must be running so linkmgrd can converge mux state quickly, but `test_dualtor_setup_mux_ports.py` did not import/request the fixture.

#### How did you do it?
Import `run_icmp_responder` in the test module so its module-scoped autouse setup runs before the custom mux toggle fixture.

#### How did you verify/test it?
Ran Python syntax compilation for `tests/dualtor_mgmt/test_dualtor_setup_mux_ports.py`.

#### Any platform specific information?
Observed on Arista-7260CX3-D108C8 dualtor.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A