### PR TITLE
[lldp] Restore true batch flap on single-ASIC DUTs

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -581,9 +581,12 @@ def test_lldp_entry_table_after_all_batched_flap(
     lldpctl_lookup_map = _build_lldpctl_lookup_map(lldpctl_interfaces)
     for asic_str, asic_interfaces in asic_interface_map.items():
         logger.info("Flapping interfaces: {}".format(asic_interfaces))
-        # Interface range shutdown/startup is not supported in multi-asic platforms.
-        for interface in asic_interfaces:
-            _shutdown_startup_interface(duthost, interface, asic_str)
+        if duthost.is_multi_asic:
+            # Interface range shutdown/startup is not supported in multi-asic platforms.
+            for interface in asic_interfaces:
+                _shutdown_startup_interface(duthost, interface, asic_str)
+        else:
+            _shutdown_startup_interface(duthost, ",".join(asic_interfaces), asic_str)
     # Single wait_until call checking all interfaces together
     _verify_interface_lldp_recovery(db_instance, testable_interfaces, lldpctl_lookup_map, delay=10)
 


### PR DESCRIPTION
### Description of PR
Fixes `lldp/test_lldp_syncd.py::test_lldp_entry_table_after_all_batched_flap` using per-interface shutdown/startup even on single-ASIC platforms.

The test is intended to validate a batched flap, but after multi-ASIC compatibility handling it toggled each interface sequentially. On T1 Broadcom/Arista single-ASIC testbeds this causes repeated route/BGP churn and SWSS memory/log pressure, producing teardown memory alarms such as `docker:swss Current memory usage exceeds high threshold 10%`.

This PR keeps the existing per-interface fallback for multi-ASIC platforms, where interface ranges are not supported, and restores a single ranged `config interface shutdown/startup` command for single-ASIC platforms.

### Type of change
- [x] Bug fix
- [ ] Test new feature
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Approach
#### What is the motivation for this PR?
Nightly PBI 39560635 tracks a consistent teardown failure in the LLDP batch-flap test: SWSS memory rises above the memory-utilization high threshold after sequentially flapping all T1 ports.

#### How did you do it?
For non-multi-ASIC DUTs, join the selected interfaces with commas and call the existing shutdown/startup helper once per ASIC group. Multi-ASIC DUTs keep the previous individual-interface path because interface ranges are not supported there.

#### How did you verify/test it?
Ran Python syntax validation:
`python -m py_compile tests/lldp/test_lldp_syncd.py`

#### Any platform specific information?
Observed on 202605 T1 Broadcom/Arista single-ASIC nightly runs. Multi-ASIC behavior is unchanged.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A

### Merge order / conflict note

#27888 rewrites the same test module and conflicts with this PR in `test_lldp_entry_table_after_all_batched_flap` (verified locally: merging the two heads produces a content conflict in `tests/lldp/test_lldp_syncd.py`). This PR is the small one, so merging it first and rebasing #27888 on top - keeping the `if duthost.is_multi_asic` guard - avoids re-opening ADO 39560635.

### Test result

master: PR CI (Azure.sonic-mgmt build 1211575) ran `lldp/test_lldp_syncd.py` on the Elastictest KVM plans at head `de82766`: t0 5 passed / 1 skipped, t0-vpp 6 passed, t1-lag 5 passed / 1 skipped, t1-lag-vpp 6 passed; the multi-asic-t1 and t2 jobs skip the module on virtual chassis, so the unchanged multi-ASIC branch is not re-executed there.
No 202605 branch run and no physical single-ASIC T1 run were performed for this change, so the backport request still lacks 202605 evidence.