### PR TITLE
[elastictest] Fix dump collection with Ansible 2.20

### DIFF
--- a/.azure-pipelines/collect_dump.py
+++ b/.azure-pipelines/collect_dump.py
@@ -5,6 +5,7 @@ import datetime
 import gzip
 import logging
 import os
+import subprocess
 import sys
 import tarfile
 import traceback
@@ -18,7 +19,10 @@ ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
 if ansible_path not in sys.path:
     sys.path.append(ansible_path)
 
-from devutil.devices.factory import init_testbed_sonichosts  # noqa: E402
+from devutil.devices.factory import (  # noqa: E402
+    init_sonichosts,
+    init_testbed_sonichosts,
+)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -50,8 +54,10 @@ def get_techsupport(sonichost, time_since, dump_dir):
         return None
 
     except Exception as e:
-        logger.info(f"[{sonichost.hostname}] Failed to get techsupport: {e}")
-        sys.exit(RC_GET_TECHSUPPORT_FAILED)
+        logger.error(
+            f"[{sonichost.hostname}] Failed to get techsupport: {e}"
+        )
+        raise
 
 
 def extract_dump_tar_gz(tar_file_path, extract_path):
@@ -124,26 +130,84 @@ def collect_dump_and_extract(sonichost, time_since, testbed_name_with_idx, dump_
         logger.warning(f"[{sonichost.hostname}] No dump file collected.")
 
 
-def main(args):
+def collect_dump_in_subprocess(args: argparse.Namespace, hostname: str) -> int:
+    """Run each Ansible collection from a child process's main thread."""
+    command = [
+        sys.executable,
+        os.path.abspath(__file__),
+        "--inventory",
+        *args.inventory,
+        "--testbed-name",
+        args.testbed_name,
+        "--testbed-name-with-idx",
+        args.testbed_name_with_idx,
+        "-f",
+        args.tbfile,
+        "-s",
+        args.time_since,
+        "--verbosity",
+        str(args.verbosity),
+        "--dump-dir",
+        args.dump_dir,
+        "--dut",
+        hostname,
+    ]
+    logger.info(
+        f"[{hostname}] Starting isolated dump collection process"
+    )
+    return subprocess.run(command, check=False).returncode
+
+
+def collect_single_dut(args: argparse.Namespace) -> int:
+    logger.info(f"Initializing host {args.dut}")
+    sonichosts = init_sonichosts(
+        args.inventory, args.dut, options={"verbosity": args.verbosity}
+    )
+    if not sonichosts:
+        return RC_INIT_FAILED
+
+    os.makedirs(args.dump_dir, exist_ok=True)
+    collect_dump_and_extract(
+        sonichosts[0],
+        args.time_since,
+        args.testbed_name_with_idx,
+        args.dump_dir,
+    )
+    return 0
+
+
+def main(args: argparse.Namespace) -> int:
+    if args.dut:
+        return collect_single_dut(args)
+
     logger.info("Initializing hosts")
     sonichosts = init_testbed_sonichosts(
         args.inventory, args.testbed_name, testbed_file=args.tbfile, options={"verbosity": args.verbosity}
     )
 
     if not sonichosts:
-        sys.exit(RC_INIT_FAILED)
+        return RC_INIT_FAILED
 
-    if not os.path.exists(args.dump_dir):
-        os.makedirs(args.dump_dir)
+    os.makedirs(args.dump_dir, exist_ok=True)
 
     with ThreadPoolExecutor(max_workers=len(sonichosts)) as executor:
-        futures = [
-            executor.submit(collect_dump_and_extract,
-                            sonichost, args.time_since, args.testbed_name_with_idx, args.dump_dir)
+        futures = {
+            executor.submit(
+                collect_dump_in_subprocess, args, sonichost.hostname
+            ): sonichost.hostname
             for sonichost in sonichosts
+        }
+        failed_hosts = [
+            hostname
+            for future, hostname in futures.items()
+            if future.result() != 0
         ]
-        for future in futures:
-            future.result()
+
+    if failed_hosts:
+        logger.error(f"Dump collection failed on hosts: {failed_hosts}")
+        return RC_GET_TECHSUPPORT_FAILED
+
+    return 0
 
 
 if __name__ == "__main__":
@@ -207,5 +271,12 @@ if __name__ == "__main__":
         help="Directory to store collected dumps."
     )
 
+    parser.add_argument(
+        "--dut",
+        type=str,
+        default=None,
+        help=argparse.SUPPRESS
+    )
+
     args = parser.parse_args()
-    main(args)
+    sys.exit(main(args))


### PR DESCRIPTION
### Description of PR

Summary:
Elastictest collects each DUT's techsupport dump concurrently. The current implementation invokes Ansible from `ThreadPoolExecutor` worker threads, which fails with Ansible Core 2.20.8 because `TaskQueueManager` installs signal handlers that Python only permits in the main thread.

Keep the existing per-DUT thread-pool concurrency, but have each thread supervise an isolated Python subprocess. Each child initializes one DUT and executes Ansible from that process's main thread.

Fixes # N/A

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?

After upgrading `docker-sonic-mgmt:latest` to Ansible Core 2.20.8, nightly dump collection exits immediately with `signal only works in main thread of the main interpreter`. The resulting techsupport archive and extracted syslog files are not uploaded to Elastictest artifacts.

Older Ansible versions could also fail in this path with `A worker was found in a dead state`, because Ansible process management was still being invoked from Python worker threads.

#### How did you do it?

The parent process still uses `ThreadPoolExecutor` for concurrent per-DUT collection. Each worker launches the same collector script with an internal single-DUT argument. The child process initializes its own Ansible host and runs the collection from its main thread. Child return codes are aggregated and propagated by the parent.

#### How did you verify/test it?

- Compiled `collect_dump.py` with `py_compile`.
- Exercised the parent-to-child command construction and failure propagation.
- Confirmed a subprocess launched from a thread can initialize signal handlers from its own main thread.
- Compared Flake8 output with the baseline and introduced no new violations.

#### Any platform specific information?

The issue affects physical Elastictest testbeds using the upgraded Python 3 sonic-mgmt container with Ansible Core 2.20.8.

#### Supported testbed topology if it's a new test case?

N/A. No new test case.

### Documentation

N/A. Internal execution behavior only.
