### PR TITLE
[uma][lma] Mark the remaining bgp aggregate_address modules for the DMA topologies

### DIFF
--- a/tests/bgp/test_bgp_aggregate_address_bbr_dynamics.py
+++ b/tests/bgp/test_bgp_aggregate_address_bbr_dynamics.py
@@ -41,7 +41,7 @@ from tests.common.gcu_utils import create_checkpoint, rollback_or_reload, delete
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 
 pytestmark = [
-    pytest.mark.topology("m1"),
+    pytest.mark.topology("m1", "uma", "lma"),
 ]
 
 # ---- Test data ----

--- a/tests/bgp/test_bgp_aggregate_address_config_crud.py
+++ b/tests/bgp/test_bgp_aggregate_address_config_crud.py
@@ -34,7 +34,7 @@ from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEI
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("m1"),
+    pytest.mark.topology("m1", "uma", "lma"),
 ]
 
 # ---- Test data ----

--- a/tests/bgp/test_bgp_aggregate_address_dual_stack.py
+++ b/tests/bgp/test_bgp_aggregate_address_dual_stack.py
@@ -37,7 +37,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("m1"),
+    pytest.mark.topology("m1", "uma", "lma"),
     pytest.mark.disable_loganalyzer,
 ]
 

--- a/tests/bgp/test_bgp_aggregate_address_functional_params.py
+++ b/tests/bgp/test_bgp_aggregate_address_functional_params.py
@@ -46,7 +46,7 @@ from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEI
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("m1"),
+    pytest.mark.topology("m1", "uma", "lma"),
 ]
 
 # ---- Test data ----

--- a/tests/bgp/test_bgp_aggregate_address_link_failover.py
+++ b/tests/bgp/test_bgp_aggregate_address_link_failover.py
@@ -35,7 +35,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("m1"),
+    pytest.mark.topology("m1", "uma", "lma"),
     pytest.mark.disable_loganalyzer,
 ]
 

--- a/tests/bgp/test_bgp_aggregate_address_negative.py
+++ b/tests/bgp/test_bgp_aggregate_address_negative.py
@@ -48,7 +48,7 @@ from tests.common.helpers.constants import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology("m1")]
+pytestmark = [pytest.mark.topology("m1", "uma", "lma")]
 
 # ExaBGP base ports
 EXABGP_BASE_PORT = 5000

--- a/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
+++ b/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
@@ -32,7 +32,7 @@ from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEI
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("m1"),
+    pytest.mark.topology("m1", "uma", "lma"),
 ]
 
 # ---- Test data ----

--- a/tests/bgp/test_bgp_aggregate_address_scale_stress.py
+++ b/tests/bgp/test_bgp_aggregate_address_scale_stress.py
@@ -50,7 +50,7 @@ from tests.common.config_reload import config_reload as config_reload_func
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("m1"),
+    pytest.mark.topology("m1", "uma", "lma"),
 ]
 
 # ---- Test data ----


### PR DESCRIPTION
### Description of PR

Summary:
PR #27674 marked ten m1 modules for `uma` and `lma`, but only **two** of the ten `bgp` `aggregate_address` modules were among them. This adds the marker to the remaining eight.

They were left out of that PR for a good reason at the time, and the reason no longer holds. See below.

ADO: 39275309

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Backport is requested to **msft-202603** via the `Request for msft-202603 branch` label, since that branch is not on the list above. That is the branch the DMA testbeds qualify against.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): ADO 39275309

Failure type: other. This is a test coverage gap rather than a failure fix.

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Also tested on **202603**, which is not on the list above and is the branch these testbeds run.

### Test result

- **202603**: from the most recent full qualification run on each DMA testbed.

| Module | uma | lma |
| --- | --- | --- |
| `..._bbr_dynamics` | 5 passed | 5 passed |
| `..._config_crud` | 5 passed | 5 passed |
| `..._dual_stack` | 3 passed | 3 passed |
| `..._functional_params` | 8 passed | 8 passed |
| `..._link_failover` | 4 passed | 4 passed |
| `..._negative` | 13 passed | 13 passed |
| `..._route_withdrawal` | 4 passed | 4 passed |
| `..._scale_stress` | 3 passed | 3 passed |

**43 passing cases per testbed, zero failures, zero errors.**

- **master**: no behaviour change is possible on any existing topology, since the change only adds two entries to a marker and removes none. Covered by this PR's own impacted-area checks. `flake8 --max-line-length=120` clean.

### Approach

#### What is the motivation for this PR?

These eight modules already execute on the DMA testbeds, but only because the qualification passes `--topology m1,uma,any`, which pulls in m1 marked tests. That is incidental rather than intended. If the topology list is ever narrowed, the modules stop being collected and **skip silently**, taking 43 passing cases per testbed with them and reporting green while doing it. That is the same gap #27674 closed for the other ten modules.

#### How did you do it?

Added `uma` and `lma` to `pytest.mark.topology(...)` in eight files, one line each. Nothing removed, no test logic touched.

```
bgp/test_bgp_aggregate_address_bbr_dynamics.py
bgp/test_bgp_aggregate_address_config_crud.py
bgp/test_bgp_aggregate_address_dual_stack.py
bgp/test_bgp_aggregate_address_functional_params.py
bgp/test_bgp_aggregate_address_link_failover.py
bgp/test_bgp_aggregate_address_negative.py
bgp/test_bgp_aggregate_address_route_withdrawal.py
bgp/test_bgp_aggregate_address_scale_stress.py
```

#### How did you verify/test it?

**Why these were not in #27674, and why they are safe now.**

The module list for that PR came from a probe run on the DMA testbeds in mid August. At that time these eight did not pass. Five of them errored with:

```
KeyError: 'uma'
  from DOWNSTREAM_NEIGHBOR_MAP[topo_type]
```

so the probe correctly excluded them.

That was fixed separately by adding `uma` and `lma` to the neighbor maps in `tests/common/helpers/constants.py`. All four maps now carry both entries, so `DOWNSTREAM_NEIGHBOR_MAP["uma"]` resolves and the lookup no longer raises. The modules have passed on both DMA testbeds in every run since, but nobody re-ran the probe, so their markers were never revisited.

This PR is based on those subsequent passing results rather than on a fresh probe. The numbers are in the Test result section above.

#### Any platform specific information?

None. This is topology marker only and not platform specific.

#### Supported testbed topology if it's a new test case?

Not a new test case. The eight modules gain `uma` and `lma` in addition to `m1`, which they already had.

### Documentation

No documentation change needed.
