### PR TITLE
Fix SNMP queue test failures when queue indexes in CONFIG_DB are represented as ranges.

### DIFF
--- a/tests/snmp/test_snmp_queue.py
+++ b/tests/snmp/test_snmp_queue.py
@@ -82,14 +82,29 @@ def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
 
             # Check if queue index in QUEUE table in config_db
             # is present in SNMP result
-            if intf in q_interfaces:
+            """if intf in q_interfaces:
                 for queue_idx in q_interfaces[intf]:
                     # queue_idx starts with 0, queue_idx in OID starts with 1
                     # Increment queue_idx by 1 to form the right OID.
                     snmp_q_idx = int(queue_idx) + 1
                     if str(snmp_q_idx) not in v['queues'][direction_type]:
                         pytest.fail("Expected queue index %d not present in \
-                                     SNMP result for interface %s" % (snmp_q_idx, v['name']))
+                                     SNMP result for interface %s" % (snmp_q_idx, v['name']))"""
+            if intf in q_interfaces:
+                for queue_idx in q_interfaces[intf]:
+                    if '-' in str(queue_idx):
+                        start, end = map(int, queue_idx.split('-'))
+                        queue_list = range(start, end + 1)
+                    else:
+                        queue_list = [int(queue_idx)]
+
+                    for q in queue_list:
+                        snmp_q_idx = q + 1
+                        if str(snmp_q_idx) not in v['queues'][direction_type]:
+                            pytest.fail("Expected queue index %d not present in SNMP result for interface %s"
+                                        % (snmp_q_idx, v['name']))
+
+
             # compare number of unicast queues in CLI to the number of queue indexes in
             # SNMP result
             if port_name_to_ns[intf]:


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #27747
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
202605: Tested test_snmp_queues with queue indexes represented both as individual indexes and ranges.
SNMP queue indexes are correctly validated against the corresponding CONFIG_DB queue entries.

### Approach
#### What is the motivation for this PR?
The SNMP queue test fails when queue indexes in CONFIG_DB are represented as a range, such as 0-7. The existing test logic treats the range as a single queue index and therefore fails to match the individual queue indexes reported through SNMP.

#### How did you do it?
Updated tests/snmp/test_snmp_queue.py to:

Support queue indexes represented as individual values as well as ranges.
Expand queue ranges into individual queue indexes before performing validation.
Compare each expected queue index against the queue indexes returned by SNMP.
Preserve the existing queue index offset handling between CONFIG_DB and SNMP OIDs.

#### How did you verify/test it?
Executed the SNMP queue test on the 202605 branch and verified that queue indexes represented both individually and as ranges are correctly processed and matched against the SNMP results. ( t0 and t1)

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
NA
