### PR TITLE
snappi: single-asic support for test_pfc_port_congestion and test_pfc_no_congestion tests

### DIFF
--- a/tests/snappi_tests/pfc/files/pfc_congestion_helper.py
+++ b/tests/snappi_tests/pfc/files/pfc_congestion_helper.py
@@ -204,6 +204,9 @@ def run_pfc_test(api,
 
     pytest_assert(testbed_config is not None, 'Fail to get L2/3 testbed config')
 
+    rx_port_asic_value = rx_port['asic_value'] if egress_duthost.is_multi_asic else None
+    tx_port_asic_value = tx_port['asic_value'] if ingress_duthost.is_multi_asic else None
+
     if (test_def['enable_pfcwd']):
         start_pfcwd(egress_duthost)
         start_pfcwd(ingress_duthost)
@@ -212,11 +215,11 @@ def run_pfc_test(api,
         stop_pfcwd(ingress_duthost)
 
     if (test_def['enable_credit_wd']):
-        enable_packet_aging(egress_duthost, rx_port['asic_value'])
-        enable_packet_aging(ingress_duthost, tx_port['asic_value'])
+        enable_packet_aging(egress_duthost, rx_port_asic_value)
+        enable_packet_aging(ingress_duthost, tx_port_asic_value)
     else:
-        disable_packet_aging(egress_duthost, rx_port['asic_value'])
-        disable_packet_aging(ingress_duthost, tx_port['asic_value'])
+        disable_packet_aging(egress_duthost, rx_port_asic_value)
+        disable_packet_aging(ingress_duthost, tx_port_asic_value)
 
     # Port id of Rx port for traffic config
     # rx_port_id and tx_port_id belong to IXIA chassis.

--- a/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
+++ b/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
@@ -18,7 +18,7 @@ from tests.snappi_tests.cisco.helper import disable_voq_watchdog                
 import logging
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen')]
+pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
 @pytest.fixture(autouse=True, scope='module')

--- a/tests/snappi_tests/pfc/test_pfc_port_congestion.py
+++ b/tests/snappi_tests/pfc/test_pfc_port_congestion.py
@@ -16,7 +16,7 @@ from tests.snappi_tests.cisco.helper import disable_voq_watchdog                
 import logging
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen')]
+pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
 @pytest.fixture(autouse=True, scope='module')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Following testcases needed to be supported on single-asic DUTs as well:
snappi_tests/pfc/test_pfc_no_congestion_throughput.py
snappi_tests/pfc/test_pfc_port_congestion.py

Summary:
Fixes #27727 
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

Added single-asic support for the above two testcases.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [X] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
Test is based on sonic-mgmt master whereas the DUT is running local 2025xx image.

PFC_NO_CONGESTION:
```
 ------------ curtailed output -----------
ansible@xxxxxxx:/data/tests$ date;python3 -m pytest --inventory ../ansible/ixia-sonic --host-pattern xxxxx --testbed xxxxx --testbed_file ../ansible/testbed.csv --show-capture=stdout --log-cli-level info --showlocals -ra --allow_recover --junit-xml=/tmp/pfc_no_congestion.xml --skip_sanity --disable_memory_utilization --disable_loganalyzer --log-file=/tmp/pfc_no_congestion.log --topology tgen snappi_tests/pfc/test_pfc_no_congestion_throughput.py
Wed Sep  2 17:15:59 UTC 2026

 ------------ curtailed output -----------
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_multiple_prio_diff_dist[tgen_port_info0] âœ“                                                                                            17%
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_multiple_prio_diff_dist[tgen_port_info1] âœ“                                                                                            33%
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_multiple_prio_uni_dist[tgen_port_info0] âœ“                                                                                             50%
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_multiple_prio_uni_dist[tgen_port_info1] âœ“                                                                                             67%
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_single_lossless_prio[tgen_port_info0] âœ“                                                                                               83%
 tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_single_lossless_prio[tgen_port_info1] âœ“                                                                                              100% 
 ------------ curtailed output -----------
Results (2969.92s (0:49:29)):
       6 passed
```

PFC_PORT_CONGESTION:
```
 ------------ curtailed output ----------
ansible@XXXXXX:/data/tests$ date;python3 -m pytest --inventory ../ansible/ixia-sonic --host-pattern xxxxxx --testbed xxxxxx --testbed_file ../ansible/testbed.csv --show-capture=stdout --log-cli-level info --showlocals -ra --allow_recover --junit-xml=/tmp/pfc_congestion.xml --skip_sanity --disable_memory_utilization --disable_loganalyzer --log-file=/tmp/pfc_congestion.log --topology tgen snappi_tests/pfc/test_pfc_port_congestion.py 
 ------------ curtailed output ----------
tests/snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_diff_dist[tgen_port_info0]            12%
tests/snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_diff_dist[tgen_port_info1] s          25% 
 tests/snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_uni_dist[tgen_port_info0]            38%
tests/snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_uni_dist[tgen_port_info1] s           50%
 tests/snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_equal_dist[tgen_port_info0]         62%
 tests/snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_equal_dist[tgen_port_info1] s      75%
tests/snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_non_cngtn[tgen_port_info0]          88%
 tests/snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_non_cngtn[tgen_port_info1] s      100%
 ------------ curtailed output ----------
Results (2125.48s (0:35:25)):
       4 passed
       4 skipped
 ------------ curtailed output ----------
```
Note - 4 testcases were skipped because it did not enough Tx ports for multiple-ingresses.

### Approach
#### What is the motivation for this PR?
Following two testcases check for the behavior of DUT at line-rate in case of single-ingress-egress and two-ingress-one-egress setup. However, these testcases were ONLY support for multi-asic DUT. 
snappi_tests/pfc/test_pfc_no_congestion_throughput.py
snappi_tests/pfc/test_pfc_port_congestion.py

These testcases also need to be supported for single-ASIC DUTs as well. 

#### How did you do it?
- Added tgen keyword in topology for the both the testcases.
- Resolved the ASIC_VALUE in the helper file to ensure that for single-ASIC DUTs, asic_value is passed as None.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran the test with variables.override.yml file containing tx and rx ports. Results posted above.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
