### PR TITLE
Cherrypick commit of PR #25385 Smartswitch: DPU: Check DPU Transition State during dpu_module_status

### DIFF
--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -236,17 +236,26 @@ def check_dpu_module_status(duthost, power_status, dpu_name):
         Returns True or False based on status of given DPU module
     """
 
+    # checking state_transition still  in progress for DPU, before checking DPU state
+    cmd = f'sonic-db-cli STATE_DB HGET \"CHASSIS_MODULE_TABLE|{dpu_name}\" transition_in_progress'
+    output_dpu_state = duthost.shell(cmd, module_ignore_errors=True)
+    logging.info("Chassis state for %s: %s", dpu_name, output_dpu_state['stdout'])
+
+    if output_dpu_state['stdout'].strip().lower() == "true":
+        logging.info("{} state transition still in progress".format(dpu_name))
+        return False
+
     output_dpu_status = duthost.shell(
-            'show chassis module status | grep %s' % (dpu_name))
+            'show chassis module status | grep %s' % (dpu_name), module_ignore_errors=True)
 
     if "offline" in output_dpu_status["stdout"].lower():
-        logging.info("'{}' is offline ...".format(dpu_name))
+        logging.info("'{}' state is offline".format(dpu_name))
         if power_status == "off":
             return True
         else:
             return False
     else:
-        logging.info("'{}' is online ...".format(dpu_name))
+        logging.info("'{}' state is online".format(dpu_name))
         if power_status == "on":
             return True
         else:
@@ -369,6 +378,31 @@ def parse_system_health_summary(output_health_summary):
     # Check if all statuses are "OK"
     result = all(status == "OK" for status in status_dict.values())
 
+    return result
+
+
+def check_dpu_system_health_summary(dpuhosts, dpu_id, dpu_name):
+    """
+    Check dpu system health summary
+    Args:
+        dpuhosts: Host handle
+        dpu_id  : DPU ID (numeric)
+        dpu_name: DPU name
+    Return:
+       True : Health summary is ok
+       False: Health summary is not ok
+    """
+    logging.info(f"Check DPU {dpu_name} system health summary")
+    dpuhost = get_dpuhost_for_dpu(dpuhosts, dpu_id)
+    if dpuhost is None:
+        logging.warning("DPU%d not in dpuhosts (len=%d); skipping health summary check", dpu_id, len(dpuhosts))
+        return True
+    output_health_summary = dpuhost.command(
+                                "sudo show system-health summary")['stdout']
+
+    logging.info(output_health_summary)
+
+    result = parse_system_health_summary(output_health_summary)
     return result
 
 

--- a/tests/smartswitch/platform_tests/test_platform_dpu.py
+++ b/tests/smartswitch/platform_tests/test_platform_dpu.py
@@ -10,12 +10,12 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import module
 from tests.common.mellanox_data import is_mellanox_device
-from tests.smartswitch.common.device_utils_dpu import check_dpu_ping_status,\
-    check_dpu_module_status, check_dpu_reboot_cause, check_pmon_status,\
-    parse_dpu_memory_usage, parse_system_health_summary,\
-    pre_test_check, post_test_dpus_check,\
-    dpus_shutdown_and_check, dpus_startup_and_check,check_dpu_system_health_summary,\
-    check_dpu_health_status, check_midplane_status, num_dpu_modules, dpu_setup,\
+from tests.smartswitch.common.device_utils_dpu import check_dpu_ping_status, \
+    check_dpu_module_status, check_dpu_reboot_cause, check_pmon_status, \
+    parse_dpu_memory_usage, parse_system_health_summary, \
+    pre_test_check, post_test_dpus_check, \
+    dpus_shutdown_and_check, dpus_startup_and_check, check_dpu_system_health_summary, \
+    check_dpu_health_status, check_midplane_status, num_dpu_modules, dpu_setup, \
     get_dpuhost_for_dpu  # noqa: F401
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service  # noqa: F401,F403
 
@@ -330,7 +330,7 @@ def test_system_health_summary(duthosts, dpuhosts,
 
     pytest_assert(result, "Switch health status is not ok")
  
-     # Checking system-health summary on DPU
+    # Checking system-health summary on DPU
     for index in range(len(dpu_on_list)):
         dpu_name = dpu_on_list[index]
         dpu_id = int(re.search(r'\d+', dpu_name).group())

--- a/tests/smartswitch/platform_tests/test_platform_dpu.py
+++ b/tests/smartswitch/platform_tests/test_platform_dpu.py
@@ -4,19 +4,17 @@ Tests for the `platform cli ...` commands in DPU
 
 import logging
 import pytest
-import time
 import re
 from datetime import datetime
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import module
 from tests.common.mellanox_data import is_mellanox_device
-from tests.common.cisco_data import is_cisco_device
 from tests.smartswitch.common.device_utils_dpu import check_dpu_ping_status,\
     check_dpu_module_status, check_dpu_reboot_cause, check_pmon_status,\
     parse_dpu_memory_usage, parse_system_health_summary,\
     pre_test_check, post_test_dpus_check,\
-    dpus_shutdown_and_check, dpus_startup_and_check,\
+    dpus_shutdown_and_check, dpus_startup_and_check,check_dpu_system_health_summary,\
     check_dpu_health_status, check_midplane_status, num_dpu_modules, dpu_setup,\
     get_dpuhost_for_dpu  # noqa: F401
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service  # noqa: F401,F403
@@ -28,9 +26,6 @@ pytestmark = [
 # Timeouts, Delays and Time Intervals in secs
 DPU_MAX_TIMEOUT = 360
 DPU_TIME_INT = 30
-
-# Cool off time period after shutting down DPUs
-COOL_OFF_TIME = 300
 
 # DPU Memory Threshold
 DPU_MEMORY_THRESHOLD = 90
@@ -157,15 +152,6 @@ def test_system_health_state(duthosts, dpuhosts,
 
     logging.info("Shutting DOWN the DPUs in parallel")
     dpus_shutdown_and_check(duthost, dpu_on_list, num_dpu_modules)
-
-    """
-    Sleep time of 5 mins is added to get the system health state
-    is reflected in the cli after dpus are shutdown
-    """
-    # Check if it's a Cisco ASIC
-    if is_cisco_device(duthost):
-        logging.info("5 minutes Cool off period after shutdown")
-        time.sleep(COOL_OFF_TIME)
 
     try:
         for index in range(len(dpu_on_list)):
@@ -343,24 +329,15 @@ def test_system_health_summary(duthosts, dpuhosts,
     result = parse_system_health_summary(output_health_summary['stdout'])
 
     pytest_assert(result, "Switch health status is not ok")
-
+ 
+     # Checking system-health summary on DPU
     for index in range(len(dpu_on_list)):
         dpu_name = dpu_on_list[index]
         dpu_id = int(re.search(r'\d+', dpu_name).group())
-        dpuhost = get_dpuhost_for_dpu(dpuhosts, dpu_id)
-        if dpuhost is None:
-            logging.warning("DPU%d not in dpuhosts (len=%d); skipping health summary check", dpu_id, len(dpuhosts))
-            continue
 
-        logging.info("Checking show system-health summary on {}"
-                     .format(dpu_name))
-        output_health_summary = dpuhost.command(
-                                "sudo show system-health summary")['stdout']
-
-        result = parse_system_health_summary(output_health_summary)
-
-        logging.info(output_health_summary)
-        pytest_assert(result,
+        pytest_assert(wait_until(DPU_MAX_TIMEOUT, DPU_TIME_INT, 0,
+                                 check_dpu_system_health_summary, dpuhosts,
+                                 dpu_id, dpu_name),
                       "{} health status is not ok"
                       .format(dpu_name))
 

--- a/tests/smartswitch/platform_tests/test_platform_dpu.py
+++ b/tests/smartswitch/platform_tests/test_platform_dpu.py
@@ -329,7 +329,7 @@ def test_system_health_summary(duthosts, dpuhosts,
     result = parse_system_health_summary(output_health_summary['stdout'])
 
     pytest_assert(result, "Switch health status is not ok")
- 
+
     # Checking system-health summary on DPU
     for index in range(len(dpu_on_list)):
         dpu_name = dpu_on_list[index]


### PR DESCRIPTION
Cherry Pick commit of PR 25385 into 202605 branch.

Please refer PR #25385: Smartswitch: DPU: Check DPU Transition State during dpu_module_status

 https://github.com/sonic-net/sonic-mgmt/pull/25385