### PR TITLE
[dualtor] Generalize mux.service start-limit recovery across shared fixtures

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -39,6 +39,7 @@ from tests.common.dualtor.dual_tor_common import cable_type                     
 from tests.common.dualtor.dual_tor_common import active_standby_ports                                   # noqa: F401
 from tests.common.dualtor.dual_tor_common import active_active_ports                                    # noqa: F401
 from tests.common.dualtor.dual_tor_common import mux_config                                             # noqa: F401
+from tests.common.dualtor.mux_service_utils import recover_mux_service_from_start_limit
 from tests.common.helpers.generators import generate_ip_through_default_route
 from tests.common.utilities import dump_scapy_packet_show_output, get_intf_by_sub_intf, is_ipv4_address, wait_until
 from tests.ptf_runner import ptf_runner
@@ -1753,7 +1754,8 @@ def validate_active_active_dualtor_setup(
                 "config mux mode active all failed on device {}".format(duthost.hostname)
             )
 
-    duthosts.shell("systemctl restart mux.service")
+    for duthost in duthosts:
+        recover_mux_service_from_start_limit(duthost, action="restart")
     # verify both ToRs are active
     for duthost in duthosts:
         pt_assert(

--- a/tests/common/dualtor/mux_service_utils.py
+++ b/tests/common/dualtor/mux_service_utils.py
@@ -1,0 +1,52 @@
+"""Shared helpers for managing `mux.service` on DualToR DUTs.
+
+`mux.service` has a strict systemd start rate-limit
+(``StartLimitBurst=3`` / ``StartLimitIntervalSec=1200``). When several test
+cases start or restart the service in sequence within the same window, the
+budget can be exhausted and systemd rejects the command with
+"start of the service was attempted too often", leaving mux down and causing
+cascading failures in subsequent tests. This module centralizes the proven
+recovery (originally added for the ``shutdown_tor_heartbeat`` teardown in
+sonic-mgmt PR #26956) so every shared restart path can reuse it.
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Known systemd messages emitted when a unit hits its start rate-limit. Keep
+# this list narrow so that only genuine start-limit errors trigger the
+# reset-failed recovery and unrelated mux failures still propagate.
+START_LIMIT_ERROR_SIGNATURES = (
+    "start of the service was attempted too often",
+    "Start request repeated too quickly",
+    "start-limit-hit",
+)
+
+
+def recover_mux_service_from_start_limit(duthost, action="restart"):
+    """Run ``systemctl <action> mux`` and recover from the start rate-limit.
+
+    Detect the systemd start rate-limit error, clear the burst counter with
+    ``systemctl reset-failed mux`` and retry the command once. Any other error
+    is re-raised unchanged so genuine failures still propagate.
+
+    Args:
+        duthost: The DUT host to run the command on.
+        action: The systemctl action, either ``"start"`` or ``"restart"``.
+    """
+    if action not in ("start", "restart"):
+        raise ValueError("Unsupported mux.service action: {}".format(action))
+
+    try:
+        duthost.shell("systemctl {} mux".format(action))
+    except Exception as e:
+        if any(sig in str(e) for sig in START_LIMIT_ERROR_SIGNATURES):
+            logger.warning(
+                "mux.service hit systemd start rate-limit on %s; running "
+                "'systemctl reset-failed mux' and retrying '%s'",
+                duthost.hostname, action,
+            )
+            duthost.shell("systemctl reset-failed mux")
+            duthost.shell("systemctl {} mux".format(action))
+        else:
+            raise

--- a/tests/common/dualtor/tor_failure_utils.py
+++ b/tests/common/dualtor/tor_failure_utils.py
@@ -14,6 +14,7 @@ import logging
 import time
 import contextlib
 from tests.common.utilities import wait_until
+from tests.common.dualtor.mux_service_utils import recover_mux_service_from_start_limit
 
 logger = logging.getLogger(__name__)
 
@@ -58,25 +59,7 @@ def shutdown_tor_heartbeat():
     yield shutdown_tor_heartbeat
 
     for duthost in torhost:
-        # `mux.service` has a strict systemd start rate-limit
-        # (StartLimitBurst=3 / StartLimitIntervalSec=1200). When multiple
-        # test cases in the same module run in sequence, the start budget
-        # can be exhausted and `systemctl start mux` fails with
-        # "start of the service was attempted too often". Detect that and
-        # recover with `systemctl reset-failed mux` followed by a retry.
-        try:
-            duthost.shell("systemctl start mux")
-        except Exception as e:
-            if "start of the service was attempted too often" in str(e):
-                logger.warning(
-                    "mux.service hit systemd start rate-limit on %s; "
-                    "running 'systemctl reset-failed mux' and retrying start",
-                    duthost.hostname,
-                )
-                duthost.shell("systemctl reset-failed mux")
-                duthost.shell("systemctl start mux")
-            else:
-                raise
+        recover_mux_service_from_start_limit(duthost, action="start")
         duthost.shell("systemctl enable mux")
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Generalize the `mux.service` systemd start rate-limit recovery (originally added for the `shutdown_tor_heartbeat` teardown in #26956) into a shared helper and reuse it across the other shared DualToR paths that start/restart `mux.service`.

ADO: 39415268

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): ADO 39415268
Failure type: regression (shared fixtures hit the same systemd StartLimit as #26956)

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

Framework-only refactor validated with static checks (`flake8` and the repo `pre-commit` suite pass on all changed files). Behavior mirrors the already-merged, testbed-verified recovery in #26956; no logic change beyond centralizing and reusing it.

### Approach
#### What is the motivation for this PR?

`mux.service` has a strict systemd start rate-limit (`StartLimitBurst=3` / `StartLimitIntervalSec=1200`). In the 20260510 seven-day nightly window, 24 `RunAnsibleModuleFail` cases across 4 builds failed because `systemctl start/restart mux` was rejected with *"start of the service was attempted too often"*, leaving mux down and cascading into subsequent test failures. #26956 fixed this for one fixture teardown; the same rate-limit affects the other shared restart paths.

#### How did you do it?

- Added `tests/common/dualtor/mux_service_utils.py` with `recover_mux_service_from_start_limit(duthost, action)` — runs `systemctl <action> mux`, and on the systemd start-limit signature runs `systemctl reset-failed mux` and retries once. Any other error is re-raised unchanged so genuine failures still propagate.
- `validate_active_active_dualtor_setup` (`dual_tor_utils.py`): replaced `duthosts.shell("systemctl restart mux.service")` with a per-host call to the helper (per-host so the recovery can catch each host's error).
- `shutdown_tor_heartbeat` teardown (`tor_failure_utils.py`): replaced the inline try/except (added in #26956) with a call to the shared helper.

#### How did you verify/test it?

`flake8` and the repository `pre-commit` hooks pass on all three changed files. The recovery logic is unchanged from the testbed-verified #26956.

#### Any platform specific information?

None. DualToR topologies only.

#### Supported testbed topology if it's a new test case?

N/A — shared fixture/utility change, not a new test case.

### Documentation

N/A