### PR TITLE
Fix gNMI telemetry container recovery check

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -108,7 +108,13 @@ def _check_monit_container_checker(duthost):
     After gNMI cert config recovery, monit needs time to re-evaluate
     container status. This function checks if container_checker has
     returned to a healthy state (OK or Status ok).
+
+    Trigger a focused container_checker refresh before reading the cached
+    monit status. This avoids failing post-test sanity on stale monit state
+    after telemetry was restarted by cert recovery.
     """
+    duthost.shell("sudo /usr/bin/container_checker", module_ignore_errors=True)
+    duthost.shell("sudo monit validate container_checker", module_ignore_errors=True)
     monit_services = duthost.get_monit_services_status()
     if not monit_services:
         return False
@@ -143,8 +149,9 @@ def recover_cert_config(duthost, stopped_programs=None):
     # Restart telemetry container if it was stopped during cert config change
     # apply_cert_config may trigger ctrmgrd to stop the telemetry container
     if not check_container_state(duthost, "telemetry", should_be_running=True):
-        logger.info("Telemetry container is not running after cert config recovery, restarting it")
-        duthost.shell("sudo systemctl restart telemetry", module_ignore_errors=True)
+        logger.info("Telemetry container is not running after cert config recovery, starting it")
+        duthost.shell("sudo systemctl reset-failed telemetry", module_ignore_errors=True)
+        duthost.shell("sudo systemctl start telemetry", module_ignore_errors=True)
 
     # Wait for monit container_checker to report healthy status.
     # After restarting processes/containers, monit needs time to re-evaluate


### PR DESCRIPTION
### Description of PR

Summary:
Fix gNMI certificate recovery so post-test sanity does not fail on stale `container_checker` state after telemetry is stopped/restarted asynchronously.

ADO: https://dev.azure.com/msazure/One/_workitems/edit/39579059

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://dev.azure.com/msazure/One/_workitems/edit/39579059
Failure type: other

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Local validation on master branch:

```text
python -m py_compile tests/gnmi/helper.py
python -m pre_commit run --files tests/gnmi/helper.py
```

The root-cause fix was also validated previously on Arista-720DT in PR #25423 for the same failure shape.

### Approach
#### What is the motivation for this PR?

PBI 39579059 tracks `gnmi/test_gnmi_countersdb.py::test_gnmi_counterdb_streaming_sample_02` on Arista-720DT-G48S4/MX. The test body passes, but module teardown fails because post-test sanity sees monit `container_checker` in `Status failed` with `Expected containers not running: telemetry`.

#### How did you do it?

After gNMI cert recovery, when telemetry is not running, clear any failed systemd state and start telemetry once instead of issuing a restart while it may still be settling. Before reading monit's cached status, trigger a focused `container_checker` refresh and `monit validate container_checker`.

#### How did you verify/test it?

Ran Python syntax validation and repository pre-commit hooks on the changed file. The same code path and failure pattern were validated in the 202511 backport PR #25423 with repeated Arista-720DT runs.

#### Any platform specific information?

Observed on Arista-720DT-G48S4, M0/MX, branch 20260510. Kusto shows Arista-720DT-G48S4 as the dominant affected platform for this failure pattern.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A