### PR TITLE
Retry forced config reload fallback

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -335,13 +335,23 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
     elif config_source == 'config_db':
         cmd = 'config reload -y'
         reloading = False
+        force_reload = False
         if config_force_option_supported(sonic_host):
             if wait_before_force_reload:
-                reloading = wait_until(wait_before_force_reload, 10, 0, _config_reload_cmd_wrapper, cmd, "/bin/bash")
+                reloading = wait_until(
+                    wait_before_force_reload, 10, 0,
+                    _config_reload_cmd_wrapper, cmd, "/bin/bash")
             cmd = 'config reload -y -f'
+            force_reload = True
         if not reloading:
             time.sleep(30)
-            sonic_host.shell(cmd, executable="/bin/bash")
+            if force_reload and wait_before_force_reload:
+                reloading = wait_until(
+                    wait_before_force_reload, 10, 0,
+                    _config_reload_cmd_wrapper, cmd, "/bin/bash")
+                pytest_assert(reloading, "Failed to run forced config reload")
+            else:
+                sonic_host.shell(cmd, executable="/bin/bash")
 
     elif config_source == 'running_golden_config':
         golden_path = '/etc/sonic/running_golden_config.json'


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #27775

`config_reload()` retries normal `config reload -y` when
`wait_before_force_reload` is set. If that retry window expires, it falls
back to `config reload -y -f`.

The forced fallback was previously issued once through `sonic_host.shell()`.
During teardown cleanup, a transient DUT reachability failure can make that
single forced reload fail immediately even though config reload recovery is
still in progress.

This PR retries the forced fallback through the same `wait_until()` wrapper
when `wait_before_force_reload` is requested.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Fixes #27775

Failure type: Day 1 issue

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

Before fix:

- Image: branch.202605-ars.a80989ae-buildimage.be4939271e761c4946afead0d78a18c33d97987a-nightly-2026.09.01.14.41
- Test: `telemetry/test_events.py::test_events_cache_overflow[ldp202-False]`
- Result: failed during teardown
- Log: https://gist.githubusercontent.com/pdam-arista/89c6bdb9b8044a4b7b8a4274dc90a0d1/raw/before_fix_test_events.log
- XML: https://gist.githubusercontent.com/pdam-arista/89c6bdb9b8044a4b7b8a4274dc90a0d1/raw/before_fix_test_events.xml
- Failure:

```text
RuntimeError: Thread worker aborted:
AnsibleConnectionFailure('Host unreachable in the inventory')
```

The traceback shows teardown cleanup entered `config_reload()` and issued the
forced fallback once:

```text
common/config_reload.py:281: in config_reload
cmd = 'config reload -y -f'
```

After fix:

- Image: branch.202605-ars.75fa4b07-buildimage.c02e69d876b983e5923a6f501c56ac6940dba346-nightly-2026.09.03.14.40
- Testbed: `kvm-esx-34-sonictest-16g-004` / `dtAA`
- Test: `telemetry/test_events.py`
- Result: PASS in the completed pass snapshot from the `-R 3` run
  - `tests=4`, `errors=0`, `failures=0`, `skipped=0`
- Log: https://gist.githubusercontent.com/pdam-arista/89c6bdb9b8044a4b7b8a4274dc90a0d1/raw/after_fix_test_events_pass_snapshot.log
- XML: https://gist.githubusercontent.com/pdam-arista/89c6bdb9b8044a4b7b8a4274dc90a0d1/raw/after_fix_test_events_pass_snapshot.xml

The full `-R 3` validation is still running. The completed pass snapshot did
not exercise the forced-reload retry path because normal `config reload -y`
succeeded. After all three runs complete, the logs will be checked for
`config reload -y -f` to confirm whether the new retry path was entered.

### Approach

#### What is the motivation for this PR?

`telemetry/test_events.py::test_events_cache_overflow` hit a retry-only
teardown failure where common cleanup called config reload, the normal reload
path did not complete within the wait window, and the forced fallback failed
on a transient Ansible reachability error.

#### How did you do it?

Added a `force_reload` flag in the `config_db` branch of `config_reload()`.
When the function falls back to `config reload -y -f` and
`wait_before_force_reload` is set, the forced command now uses
`wait_until(wait_before_force_reload, ...)` and fails only after the retry
window expires.

The existing one-shot `sonic_host.shell()` behavior is preserved for callers
that do not request `wait_before_force_reload`.

#### How did you verify/test it?

Runtime validation was run on 202605 `dtAA` with `-R 3`. A completed pass
snapshot is linked in the Test result section.

#### Any platform specific information?

Generic.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.
