### PR TITLE
[docs]: Add optional backport metadata to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -56,6 +56,17 @@ If you request a backport/cherry-pick, provide both:
 Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
 Failure type: <!-- day-one issue / regression / other -->
 
+### Backport metadata (optional)
+<!--
+Fill these fields only for a release backport PR; leave them blank for ordinary
+PRs targeting master. Replace the inline comments with the original same-repo
+PR URL and target release branch. Repeat Backport-of for multiple originals.
+Keep each field on its own plain line, outside quotes and code fences.
+GitHub's actual PR base branch is authoritative; Target-branch should match it.
+-->
+Backport-of: <!-- https://github.com/sonic-net/sonic-mgmt/pull/NUMBER -->
+Target-branch: <!-- release branch -->
+
 ### Tested branch
 <!--
 Select each branch where the change was tested. If you request a


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add optional, machine-readable Backport-of and Target-branch fields for release backport PRs, while preserving all existing issue, change-type, backport-request, tested-branch, and test-result sections.
Issue: N/A (contribution-template enhancement; no associated issue).
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

Documentation-only contribution-template improvement; no test or framework runtime changes.

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A - no release backport is requested.
Failure type: N/A - documentation-only enhancement.

### Backport metadata (optional)
<!--
Fill these fields only for a release backport PR; leave them blank for ordinary
PRs targeting master. Replace the inline comments with the original same-repo
PR URL and target release branch. Repeat Backport-of for multiple originals.
Keep each field on its own plain line, outside quotes and code fences.
GitHub's actual PR base branch is authoritative; Target-branch should match it.
-->
Backport-of: <!-- https://github.com/sonic-net/sonic-mgmt/pull/NUMBER -->
Target-branch: <!-- release branch -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Test result

N/A for SONiC images and testbeds: this changes only the PR template. Local checks on the master-based branch passed:
- Repository pre-commit checks for .github/PULL_REQUEST_TEMPLATE.md: trailing whitespace, end of file, and added-large-file checks passed; non-applicable hooks skipped.
- git diff --check passed.
- In-memory template-contract checks passed: existing sections are byte-for-byte unchanged after removing the new section; blank placeholders yield no metadata; filled release fields and repeated originals match anchored field patterns; quoted, fenced, and cross-repository examples are ignored.

Hosted CI will report separately after PR creation; no hosted result is claimed here.
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

Backport relationships recorded only in free-form comments can be missed during release tracking. Optional, consistently named PR-body fields make original PRs and intended release branches easier for reviewers and lightweight tooling to identify, without replacing existing issue and test-evidence requirements.

#### How did you do it?

Added an optional metadata section with separate, unquoted and unfenced field lines. HTML-comment placeholders avoid assigning a real source PR or release to every new PR. The instructions restrict the fields to release backports, permit repeated Backport-of lines for multiple same-repository originals, leave ordinary master PRs blank, and state that GitHub's actual base branch is authoritative. No workflow, parser, hardware configuration, or test code is changed.

#### How did you verify/test it?

Ran the targeted repository pre-commit command, whitespace validation, and in-memory raw-body contract checks listed under Test result. Confirmed that the diff adds only 11 lines to the official template and preserves every existing section. Searched open PRs for a comparable template/metadata enhancement before filing; none was found. Hardware and broad test suites are not applicable to this documentation-only change.
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

#### Any platform specific information?

N/A - repository contribution guidance only; no platform behavior changes.

#### Supported testbed topology if it's a new test case?

N/A - no new test case.

### Documentation

The official PR template is the documentation updated by this change. No separate wiki update is needed.
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
