### PR TITLE
[platform/test]: Fix BMC power-cycle validation

### DIFF
--- a/tests/common/platform/bmc_utils.py
+++ b/tests/common/platform/bmc_utils.py
@@ -143,7 +143,8 @@ class BmcLogAnalyzer:
     def analyze(self, marker, fail=False, log_target=LOG_TARGET_EVENT_LOG):
         """Scan logs from the start marker forward.
 
-        log_target='event_log' (default): scans /host/bmc/event.log only.
+        log_target='event_log' (default): scans /host/bmc/event.log and its
+        rotated files in chronological order.
         log_target='syslog': delegates to LogAnalyzer.analyze() (/var/log/syslog*).
 
         Returns the same dict shape as LogAnalyzer.analyze():
@@ -156,10 +157,12 @@ class BmcLogAnalyzer:
 
         start_line = "start-LogAnalyzer-{}".format(marker)
         self.duthost.shell("sync {}".format(shlex.quote(BMC_EVENT_LOG)))
+        event_logs = ["{}.{}.gz".format(BMC_EVENT_LOG, index) for index in range(5, 1, -1)]
+        event_logs.extend(["{}.1".format(BMC_EVENT_LOG), BMC_EVENT_LOG])
         result = self.duthost.shell(
-            "sed -n {} {}".format(
+            "zcat -f {} 2>/dev/null | sed -n {}".format(
+                " ".join(shlex.quote(path) for path in event_logs),
                 shlex.quote(r"/{}/,$p".format(start_line)),
-                shlex.quote(BMC_EVENT_LOG)
             ),
             module_ignore_errors=True
         )

--- a/tests/common/unit_tests/unit_test_bmc_utils.py
+++ b/tests/common/unit_tests/unit_test_bmc_utils.py
@@ -1,0 +1,26 @@
+from unittest.mock import Mock
+
+from tests.common.platform.bmc_utils import BmcLogAnalyzer
+
+
+def test_event_log_analyze_scans_rotated_logs_in_chronological_order():
+    duthost = Mock()
+    duthost.shell.side_effect = [
+        {},
+        {
+            'stdout': (
+                'start-LogAnalyzer-power-delay.2026-09-06-23:23:51\n'
+                'NOTICE: STARTUP: Switch-Host already ONLINE\n'
+            )
+        },
+    ]
+    analyzer = BmcLogAnalyzer(duthost, 'power-delay')
+    analyzer.match_regex = [r'.*STARTUP:.*']
+
+    result = analyzer.analyze('power-delay.2026-09-06-23:23:51')
+
+    command = duthost.shell.call_args_list[1].args[0]
+    assert command.index('event.log.5.gz') < command.index('event.log.2.gz')
+    assert command.index('event.log.2.gz') < command.index('event.log.1 ')
+    assert command.endswith("| sed -n '/start-LogAnalyzer-power-delay.2026-09-06-23:23:51/,$p'")
+    assert result['total']['match'] == 1


### PR DESCRIPTION
### Description of PR

Summary:

Make `BmcLogAnalyzer` scan persistent BMC event-log rotations in chronological order. This preserves marker-bounded startup evidence when `/host/bmc/event.log` rotates during a BMC reboot.

Fixes # N/A

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608


### Test result

- Confirmed the marker and post-reboot `STARTUP` records were preserved in `/host/bmc/event.log.2.gz` while the active log was empty. 

### Approach

#### What is the motivation for this PR?

BMC daemon tests write a marker to persistent `/host/bmc/event.log` before reboot and analyze records after that marker when the BMC returns. Log rotation can move both the marker and post-reboot records into a rotated file. The analyzer previously searched only the active log, causing it to report zero matches even though the expected records existed.

#### How did you do it?

Build the persistent event-log input list from the oldest retained compressed rotation through `event.log.1` and the active `event.log`, then concatenate it with `zcat -f` before applying the existing marker-bounded scan. Add focused unit coverage for file ordering and matching a startup record after a marker in the combined stream.

#### How did you verify/test it?

- Reproduced the failure on the Nokia BMC testbed.
- Confirmed the test marker and startup records were in `/host/bmc/event.log.2.gz` after reboot.
- Confirmed the active `/host/bmc/event.log` was empty, explaining the original zero-match result.
- Ran Python compilation and `git diff --check` successfully.

#### Any platform specific information?

Observed on `Nokia-BMC-H6-128`, but the fix applies to all BMC platforms using the persistent rotated event log.

#### Supported testbed topology if it's a new test case?

N/A. Existing integration tests use the `bmc` topology. The added coverage is an isolated unit test.

### Documentation

No documentation update is required; this change corrects test log analysis behavior.
