### PR TITLE
[lldp] Wait for BGP to reconverge after batched flap to avoid swss memory false alarm

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -587,6 +587,17 @@ def test_lldp_entry_table_after_all_batched_flap(
     # Single wait_until call checking all interfaces together
     _verify_interface_lldp_recovery(db_instance, testable_interfaces, lldpctl_lookup_map, delay=10)
 
+    # Bulk flapping every port tears down and re-establishes BGP on all of them at
+    # once, which makes orchagent/swss churn heavily while routes are reprogrammed.
+    # Wait for the BGP sessions to reconverge so that swss reclaims the transient
+    # memory before the memory_utilization fixture takes its teardown snapshot,
+    # avoiding a docker:swss memory-alarm false positive from an unsettled reading.
+    bgp_neighbors = list(duthost.get_bgp_neighbors().keys())
+    pytest_assert(
+        wait_until(300, 10, 30, duthost.check_bgp_session_state, bgp_neighbors),
+        "BGP sessions did not re-establish after batched interface flap",
+    )
+
 
 # Test case 5: Verify LLDP_ENTRY_TABLE after system reboot
 def test_lldp_entry_table_after_lldp_restart(


### PR DESCRIPTION
### Description of PR

Summary:
`test_lldp_entry_table_after_all_batched_flap` flaps every port in a single batch, which drives heavy `orchagent`/`swss` churn as BGP tears down and re-establishes on all ports and routes are reprogrammed. The `memory_utilization` fixture's teardown `docker stats` snapshot could be taken before `swss` reclaimed this transient memory, tripping a `docker:swss` memory-usage alarm (e.g. ~4.8% -> ~10.2%) that is **not** a real memory leak.

This adds a `wait_until` on `check_bgp_session_state` after LLDP recovery so the BGP sessions reconverge and `swss` settles before the teardown memory snapshot is taken — mirroring the existing pattern already used in `test_lldp_entry_table_after_syncd_orchagent`.

Fixes the intermittent `docker:swss` memory false alarm on `lldp/test_lldp_syncd.py::test_lldp_entry_table_after_all_batched_flap`.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/39560635

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39560635
Failure type: day-one issue (transient false alarm — the batched-flap case never waited for BGP reconvergence before the teardown memory snapshot)

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

Validated on `internal-202605` (the branch the nightly failure was reported on) across two hwskus and three testbeds; the master PR carries the identical fix commit. `lldp/test_lldp_syncd.py` was run with `memory_utilization` **enabled** (`--disable_memory_utilization` stripped). Thresholds: `docker:swss` high 10% / increase 5%.

| Testbed | hwsku | Job | Result | `docker:swss` at teardown |
|---------|-------|-----|--------|---------------------------|
| testbed-bjw3-can-t1-7060-1 | Arista-7060CX-32S-C32 | [`6a9e17b7`](https://elastictest.org/scheduler/testplan/6a9e17b7bf4e21a161e5a23c) | PASS — 25 tests (23 pass, 0 fail, 2 skip) | ~2.5–3.0%, ~0% increase |
| tbtk5a-t1-7260-14 | Arista-7260CX3 | [`6a9e0dc8`](https://elastictest.org/scheduler/testplan/6a9e0dc8b0c89efe75bfddec) | PASS — 6 tests (6 pass, 0 fail) | 2.7%, 0% increase |
| testbed-bjw-can-t1-7060-2 | Arista-7060CX-32S-C32 | [`6a9e0d8d`](https://elastictest.org/scheduler/testplan/6a9e0d8d8674732a12b87415) | PASS — 25 tests (23 pass, 0 fail, 2 skip) | flat, below threshold |
| testbed-bjw3-can-t1-7060-1 | Arista-7060CX-32S-C32 | [`6a9e3bd8`](https://elastictest.org/scheduler/testplan/6a9e3bd8d47d7ec0360c73e4) (re-verify on fresh backport) | PASS — 25 tests (23 pass, 0 fail, 2 skip) | 2.54% (201.3 MiB / 7.74 GiB), ~0% increase |

`test_lldp_entry_table_after_all_batched_flap` passed on every run with `swss` memory sitting flat and well below the alarm thresholds and no growth across setup->teardown. Prior to the fix the same case intermittently crossed the `docker:swss` high threshold at teardown (~10.2%).

### Approach
#### What is the motivation for this PR?

The batched-flap case intermittently raised a `docker:swss` memory-utilization alarm during teardown. Investigation showed this is a transient spike from `swss`/`orchagent` reprogramming while BGP re-establishes across all ports at once — not a real leak. The `memory_utilization` fixture snapshots `docker stats` at teardown, and could sample `swss` before it reclaimed the churn memory.

#### How did you do it?

Added a `wait_until(300, 10, 30, duthost.check_bgp_session_state, bgp_neighbors)` after `_verify_interface_lldp_recovery(...)` so BGP sessions reconverge and `swss` settles before the teardown memory snapshot. This mirrors the existing wait already present in `test_lldp_entry_table_after_syncd_orchagent`.

#### How did you verify/test it?

Ran `lldp/test_lldp_syncd.py` on two hwskus (7060, 7260) across three testbeds with `memory_utilization` enabled — see the Test result section. All runs passed with `docker:swss` flat and well under the 10% high / 5% increase thresholds; the batched-flap case that previously false-alarmed is now stable.

#### Any platform specific information?

None — the change is platform-agnostic and only affects the batched-flap LLDP test flow.

#### Supported testbed topology if it's a new test case?

N/A — existing test case.

### Documentation

N/A