### PR TITLE
improve ansible template compatibility for yaml

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -13,6 +13,11 @@ from datetime import datetime, timedelta
 
 from ansible import constants as ansible_constants
 from ansible.plugins.loader import connection_loader
+try:
+    from ansible.template import trust_as_template
+except ImportError:
+    def trust_as_template(data):
+        return data
 
 from tests.common.devices.base import AnsibleHostBase
 from tests.common.devices.constants import ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC
@@ -109,8 +114,8 @@ class SonicHost(AnsibleHostBase):
 
         if ssh_user and ssh_passwd:
             evars = {
-                'ansible_ssh_user': ssh_user,
-                'ansible_ssh_pass': ssh_passwd,
+                'ansible_ssh_user': trust_as_template(ssh_user),
+                'ansible_ssh_pass': trust_as_template(ssh_passwd),
             }
             self.host.options['variable_manager'].extra_vars.update(evars)
 


### PR DESCRIPTION
### Description of PR
After upgrading to ansible-core 2.19+, Jinja/`lookup()` in host/group vars (e.g. `ansible/group_vars/fanout/secrets.yml`) is no longer rendered when credentials are copied into `variable_manager.extra_vars`.

Ansible 2.19+ only templates strings marked as trusted. Re-assigning `ssh_user`/`ssh_passwd` into extra_vars drops that marker, so values like `{{ lookup('env', '...') }}` are used literally and SSH to fanout fails.

Mark these extra_vars with `ansible.template.trust_as_template` so lookups are evaluated again. Fall back to a no-op on older Ansible that does not provide the API (same pattern as `apswitch.py`). No behavior change for plain-string credentials.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: Others/Improvement

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
tested on master:
<img width="190" height="332" alt="image" src="https://github.com/user-attachments/assets/c2cd9d56-c65d-4580-80ec-dc1f0970e622" />

tested on 202605:
<img width="181" height="308" alt="image" src="https://github.com/user-attachments/assets/c8f6432a-55dd-43a8-9f59-63fef6c94e7b" />

### Approach
#### What is the motivation for this PR?
to fix the compatibility issue introduced by ansible upgrade
#### How did you do it?
import ansible.trust_as_template to allow variable render
#### How did you verify/test it?
fanout is still reachable after this change
#### Any platform specific information?
not related to platform
#### Supported testbed topology if it's a new test case?
no, unrelated to topology
### Documentation