### PR TITLE
[testbed] Add generic framework latency metrics

### DIFF
--- a/docs/tests/pytest.logging.md
+++ b/docs/tests/pytest.logging.md
@@ -141,8 +141,12 @@ The code for removing these sections is added to hook function tests/conftest.py
 
 ## Structured latency metrics
 
-The framework logs slow and failed operations as single-line `METRIC` JSON records. These records identify latency
-outside simulator processes without including command arguments or credentials:
+The framework writes slow and failed operations as JSON Lines records to
+`logs/framework_latency_metrics_<run-id>.jsonl`. They do not propagate to the standard pytest logger or `test.log`.
+The run ID prevents stale artifacts and concurrent pytest sessions from overwriting each other. When pytest-xdist
+is used, each worker writes a separate file such as `logs/framework_latency_metrics_<run-id>_gw0.jsonl`. Forked
+framework processes write temporary PID-suffixed files that are merged into their pytest worker's file at shutdown.
+These records identify latency outside simulator processes without including command arguments or credentials:
 
 * `ansible_module`: Ansible module duration, target host, caller, return code, and synchronous/asynchronous mode.
 * `framework_wait`, `framework_wait_until`, and `framework_async_wait_until`: explicit waits, convergence conditions,
@@ -152,6 +156,7 @@ outside simulator processes without including command arguments or credentials:
 
 Successful operations are logged when they take at least 5000 milliseconds. Failed operations are always logged.
 Use `--latency-metric-threshold-ms <milliseconds>` to change the threshold, or set it to `0` to log every operation.
+Use `--latency-metric-file <path>` to change the artifact path.
 
 # Logging tips
 

--- a/docs/tests/pytest.logging.md
+++ b/docs/tests/pytest.logging.md
@@ -139,6 +139,20 @@ The "stdout" section mainly contains ansible debug messages for establishing con
 
 The code for removing these sections is added to hook function tests/conftest.py::pytest_runtest_makereport
 
+## Structured latency metrics
+
+The framework logs slow and failed operations as single-line `METRIC` JSON records. These records identify latency
+outside simulator processes without including command arguments or credentials:
+
+* `ansible_module`: Ansible module duration, target host, caller, return code, and synchronous/asynchronous mode.
+* `framework_wait`, `framework_wait_until`, and `framework_async_wait_until`: explicit waits, convergence conditions,
+  attempts, and timeouts.
+* `pytest_fixture`: individual fixture setup duration.
+* `pytest_phase`: total setup, call, and teardown duration for each test.
+
+Successful operations are logged when they take at least 5000 milliseconds. Failed operations are always logged.
+Use `--latency-metric-threshold-ms <milliseconds>` to change the threshold, or set it to `0` to log every operation.
+
 # Logging tips
 
 ## Use logger instead of `print` in scripts

--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -220,7 +220,6 @@ class AnsibleHostBase(object):
 
         def log_module_metric(success, is_async, return_code=None, result_failed=False):
             log_latency_metric(
-                logger,
                 "ansible_module",
                 (time.monotonic() - operation_start) * 1000,
                 success=success,

--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -5,12 +5,15 @@ import collections
 import os
 import signal
 import threading
+import time
 from contextlib import contextmanager
 from multiprocessing.pool import ThreadPool
 import ansible
 from pytest_ansible.results import AdHocResult, ModuleResult
 
 from tests.common.errors import RunAnsibleModuleFail
+from tests.common.latency_metrics import format_caller
+from tests.common.latency_metrics import log_latency_metric
 
 
 # Patch load_extra_vars to return a copy instead of the shared cached dict.
@@ -181,7 +184,10 @@ class AnsibleHostBase(object):
     def _run(self, module_name, *module_args, **complex_args):
 
         previous_frame = inspect.currentframe().f_back
+        if previous_frame.f_code.co_name == "_run_wrapper" and previous_frame.f_back is not None:
+            previous_frame = previous_frame.f_back
         filename, line_number, function_name, lines, index = inspect.getframeinfo(previous_frame)
+        caller = format_caller(filename, function_name, line_number)
 
         verbose = complex_args.pop('verbose', True)
         module = self._get_ansible_module(module_name)
@@ -210,11 +216,43 @@ class AnsibleHostBase(object):
 
         module_ignore_errors = complex_args.pop('module_ignore_errors', False)
         module_async = complex_args.pop('module_async', False)
+        operation_start = time.monotonic()
+
+        def log_module_metric(success, is_async, return_code=None, result_failed=False):
+            log_latency_metric(
+                logger,
+                "ansible_module",
+                (time.monotonic() - operation_start) * 1000,
+                success=success,
+                host=self.hostname,
+                module=module_name,
+                caller=caller,
+                test=os.environ.get("PYTEST_CURRENT_TEST"),
+                is_async=is_async,
+                ignore_errors=module_ignore_errors,
+                return_code=return_code,
+                result_failed=result_failed
+            )
 
         if module_async:
             def run_module(module_args, complex_args):
-                with suppress_signal_registration_for_non_main_thread():
-                    return module(*module_args, **complex_args)[self.hostname]
+                operation_success = False
+                return_code = None
+                result_failed = False
+                try:
+                    with suppress_signal_registration_for_non_main_thread():
+                        result = module(*module_args, **complex_args)[self.hostname]
+                    return_code = result.get('rc', None)
+                    result_failed = getattr(result, "is_failed", False) or 'exception' in result
+                    operation_success = not result_failed
+                    return result
+                finally:
+                    log_module_metric(
+                        operation_success,
+                        True,
+                        return_code,
+                        result_failed=result_failed
+                    )
             pool = ThreadPool()
             result = pool.apply_async(run_module, (module_args, complex_args))
             return pool, result
@@ -222,52 +260,69 @@ class AnsibleHostBase(object):
         module_args = json.loads(json.dumps(module_args, cls=AnsibleHostBase.CustomEncoder))
         complex_args = json.loads(json.dumps(complex_args, cls=AnsibleHostBase.CustomEncoder))
 
-        with suppress_signal_registration_for_non_main_thread():
-            adhoc_res: AdHocResult = module(*module_args, **complex_args)
+        metric_logged = False
+        try:
+            with suppress_signal_registration_for_non_main_thread():
+                adhoc_res: AdHocResult = module(*module_args, **complex_args)
 
-        if module_name == "meta":
-            # The meta module is special in Ansible - it doesn't execute on remote hosts, it controls Ansible's behavior
-            # There are no per-host ModuleResults contained within it
-            return
+            if module_name == "meta":
+                # The meta module controls Ansible itself and has no per-host result.
+                log_module_metric(True, False)
+                metric_logged = True
+                return
 
-        hostname_res: ModuleResult = adhoc_res[self.hostname]
-        hostname_res.encoder = AnsibleHostBase.CustomEncoder
+            hostname_res: ModuleResult = adhoc_res[self.hostname]
+            hostname_res.encoder = AnsibleHostBase.CustomEncoder
+            return_code = hostname_res.get('rc', None)
+            result_failed = hostname_res.is_failed or 'exception' in hostname_res
 
-        if verbose:
-            logger.debug(
-                "{}::{}#{}: [{}] AnsibleModule::{} Result => {}".format(
-                    filename,
-                    function_name,
-                    line_number,
-                    self.hostname,
-                    module_name, json.dumps(hostname_res, cls=AnsibleHostBase.CustomEncoder)
+            if verbose:
+                logger.debug(
+                    "{}::{}#{}: [{}] AnsibleModule::{} Result => {}".format(
+                        filename,
+                        function_name,
+                        line_number,
+                        self.hostname,
+                        module_name, json.dumps(hostname_res, cls=AnsibleHostBase.CustomEncoder)
+                    )
                 )
-            )
-        else:
-            logger.debug(
-                "{}::{}#{}: [{}] AnsibleModule::{} done, is_failed={}, rc={}".format(
-                    filename,
-                    function_name,
-                    line_number,
-                    self.hostname,
-                    module_name,
-                    hostname_res.is_failed,
-                    hostname_res.get('rc', None)
+            else:
+                logger.debug(
+                    "{}::{}#{}: [{}] AnsibleModule::{} done, is_failed={}, rc={}".format(
+                        filename,
+                        function_name,
+                        line_number,
+                        self.hostname,
+                        module_name,
+                        hostname_res.is_failed,
+                        return_code
+                    )
                 )
+
+            if result_failed and not module_ignore_errors:
+                log_module_metric(False, False, return_code, result_failed=True)
+                metric_logged = True
+                raise RunAnsibleModuleFail("run module {} failed".format(module_name), hostname_res)
+
+            # Ensure 'failed' key is always present for backward compatibility with code that
+            # accesses rc['failed'] directly. The _IGNORE hack above is no longer effective in
+            # ansible-core >= 2.21 where the post-processing behavior changed so that 'failed'
+            # is absent from successful command results. Normalizing here is a single robust fix
+            # that covers all call sites without requiring per-file changes.
+            if 'failed' not in hostname_res:
+                hostname_res['failed'] = hostname_res.is_failed
+
+            log_module_metric(
+                not result_failed,
+                False,
+                return_code,
+                result_failed=result_failed
             )
-
-        if (hostname_res.is_failed or 'exception' in hostname_res) and not module_ignore_errors:
-            raise RunAnsibleModuleFail("run module {} failed".format(module_name), hostname_res)
-
-        # Ensure 'failed' key is always present for backward compatibility with code that
-        # accesses rc['failed'] directly. The _IGNORE hack above is no longer effective in
-        # ansible-core >= 2.21 where the post-processing behavior changed so that 'failed'
-        # is absent from successful command results. Normalizing here is a single robust fix
-        # that covers all call sites without requiring per-file changes.
-        if 'failed' not in hostname_res:
-            hostname_res['failed'] = hostname_res.is_failed
-
-        return hostname_res
+            metric_logged = True
+            return hostname_res
+        finally:
+            if not metric_logged:
+                log_module_metric(False, False)
 
 
 class NeighborDevice(dict):

--- a/tests/common/latency_metrics.py
+++ b/tests/common/latency_metrics.py
@@ -1,0 +1,41 @@
+"""Structured latency metrics shared by the pytest test framework."""
+
+import json
+
+
+DEFAULT_LATENCY_METRIC_THRESHOLD_MS = 5000
+_latency_metric_threshold_ms = DEFAULT_LATENCY_METRIC_THRESHOLD_MS
+
+
+def format_caller(filename, function_name, line_number):
+    """Return a stable source location for grouping metrics across runners."""
+    normalized_filename = filename.replace("\\", "/")
+    tests_marker = "/tests/"
+    if tests_marker in normalized_filename:
+        normalized_filename = "tests/" + normalized_filename.split(tests_marker, 1)[1]
+    return "{}::{}#{}".format(normalized_filename, function_name, line_number)
+
+
+def set_latency_metric_threshold(threshold_ms):
+    """Set the minimum successful-operation duration that is logged."""
+    if threshold_ms < 0:
+        raise ValueError("Latency metric threshold must be non-negative")
+
+    global _latency_metric_threshold_ms
+    _latency_metric_threshold_ms = threshold_ms
+
+
+def log_latency_metric(metric_logger, metric, duration_ms, success=True, **fields):
+    """Log a structured metric for slow or failed framework operations."""
+    success = bool(success)
+    if success and duration_ms < _latency_metric_threshold_ms:
+        return False
+
+    record = dict(fields)
+    record.update({
+        "metric": metric,
+        "duration_ms": round(duration_ms, 3),
+        "success": success
+    })
+    metric_logger.info("METRIC %s", json.dumps(record, sort_keys=True))
+    return True

--- a/tests/common/latency_metrics.py
+++ b/tests/common/latency_metrics.py
@@ -1,10 +1,33 @@
 """Structured latency metrics shared by the pytest test framework."""
 
+from datetime import datetime, timezone
+import glob
 import json
+import logging
+import os
+import shutil
+import threading
 
 
 DEFAULT_LATENCY_METRIC_THRESHOLD_MS = 5000
+DEFAULT_LATENCY_METRIC_FILE = os.path.join("logs", "framework_latency_metrics.jsonl")
+logger = logging.getLogger(__name__)
 _latency_metric_threshold_ms = DEFAULT_LATENCY_METRIC_THRESHOLD_MS
+_latency_metric_file = None
+_latency_metric_worker_id = None
+_latency_metric_run_id = None
+_latency_metric_owner_pid = None
+_latency_metric_error_reported = False
+_latency_metric_write_lock = threading.RLock()
+
+
+def _reset_latency_metric_write_lock():
+    global _latency_metric_write_lock
+    _latency_metric_write_lock = threading.RLock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_latency_metric_write_lock)
 
 
 def format_caller(filename, function_name, line_number):
@@ -25,17 +48,110 @@ def set_latency_metric_threshold(threshold_ms):
     _latency_metric_threshold_ms = threshold_ms
 
 
-def log_latency_metric(metric_logger, metric, duration_ms, success=True, **fields):
+def _scoped_metric_file(metric_file, run_id, worker_id):
+    suffixes = [suffix for suffix in (run_id, worker_id) if suffix]
+    if not suffixes:
+        return metric_file
+    file_root, file_extension = os.path.splitext(metric_file)
+    return "{}_{}{}".format(file_root, "_".join(suffixes), file_extension)
+
+
+def _process_metric_file(metric_file, process_id):
+    file_root, file_extension = os.path.splitext(metric_file)
+    return "{}_pid{}{}".format(file_root, process_id, file_extension)
+
+
+def _process_metric_pattern(metric_file):
+    file_root, file_extension = os.path.splitext(metric_file)
+    return "{}_pid*{}".format(file_root, file_extension)
+
+
+def _disable_latency_metrics(error):
+    global _latency_metric_file, _latency_metric_error_reported
+    with _latency_metric_write_lock:
+        if not _latency_metric_error_reported:
+            logger.warning("Disabling framework latency metrics after file I/O error: %s", error)
+            _latency_metric_error_reported = True
+        _latency_metric_file = None
+
+
+def close_latency_metric_file():
+    """Merge child-process records and disable latency metric writes."""
+    global _latency_metric_file, _latency_metric_worker_id, _latency_metric_run_id
+    global _latency_metric_owner_pid, _latency_metric_error_reported
+    with _latency_metric_write_lock:
+        try:
+            if _latency_metric_file is not None and os.getpid() == _latency_metric_owner_pid:
+                process_files = sorted(glob.glob(_process_metric_pattern(_latency_metric_file)))
+                if process_files:
+                    with open(_latency_metric_file, "ab") as metric_stream:
+                        for process_file in process_files:
+                            with open(process_file, "rb") as process_stream:
+                                shutil.copyfileobj(process_stream, metric_stream)
+                            os.remove(process_file)
+        except OSError as error:
+            if not _latency_metric_error_reported:
+                logger.warning("Unable to merge framework latency metric files: %s", error)
+                _latency_metric_error_reported = True
+        finally:
+            _latency_metric_file = None
+            _latency_metric_worker_id = None
+            _latency_metric_run_id = None
+            _latency_metric_owner_pid = None
+
+
+def configure_latency_metric_file(metric_file, run_id=None, worker_id=None):
+    """Configure the JSONL file used for structured latency records."""
+    if not metric_file:
+        raise ValueError("Latency metric file must not be empty")
+
+    close_latency_metric_file()
+    resolved_metric_file = os.path.abspath(_scoped_metric_file(metric_file, run_id, worker_id))
+    metric_directory = os.path.dirname(resolved_metric_file)
+    os.makedirs(metric_directory, exist_ok=True)
+    with open(resolved_metric_file, "x", encoding="utf-8"):
+        pass
+
+    global _latency_metric_file, _latency_metric_worker_id, _latency_metric_run_id
+    global _latency_metric_owner_pid, _latency_metric_error_reported
+    with _latency_metric_write_lock:
+        _latency_metric_file = resolved_metric_file
+        _latency_metric_worker_id = worker_id
+        _latency_metric_run_id = run_id
+        _latency_metric_owner_pid = os.getpid()
+        _latency_metric_error_reported = False
+    return resolved_metric_file
+
+
+def log_latency_metric(metric, duration_ms, success=True, **fields):
     """Log a structured metric for slow or failed framework operations."""
     success = bool(success)
     if success and duration_ms < _latency_metric_threshold_ms:
         return False
 
-    record = dict(fields)
-    record.update({
-        "metric": metric,
-        "duration_ms": round(duration_ms, 3),
-        "success": success
-    })
-    metric_logger.info("METRIC %s", json.dumps(record, sort_keys=True))
+    process_id = os.getpid()
+    try:
+        with _latency_metric_write_lock:
+            if _latency_metric_file is None:
+                return False
+            record = dict(fields)
+            record.update({
+                "metric": metric,
+                "duration_ms": round(duration_ms, 3),
+                "success": success,
+                "timestamp": datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+                "process_id": process_id
+            })
+            if _latency_metric_run_id:
+                record["run_id"] = _latency_metric_run_id
+            if _latency_metric_worker_id:
+                record["worker"] = _latency_metric_worker_id
+            metric_file = _latency_metric_file
+            if process_id != _latency_metric_owner_pid:
+                metric_file = _process_metric_file(metric_file, process_id)
+            with open(metric_file, "a", encoding="utf-8", newline="\n") as metric_stream:
+                metric_stream.write("{}\n".format(json.dumps(record, sort_keys=True)))
+    except OSError as error:
+        _disable_latency_metrics(error)
+        return False
     return True

--- a/tests/common/unit_tests/test_latency_metrics.py
+++ b/tests/common/unit_tests/test_latency_metrics.py
@@ -1,0 +1,72 @@
+import importlib.util
+import json
+import logging
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "latency_metrics.py"
+SPEC = importlib.util.spec_from_file_location("unit_target_latency_metrics", MODULE_PATH)
+latency_metrics = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(latency_metrics)
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestLatencyMetrics(unittest.TestCase):
+    def setUp(self):
+        latency_metrics.set_latency_metric_threshold(1000)
+
+    def tearDown(self):
+        latency_metrics.set_latency_metric_threshold(
+            latency_metrics.DEFAULT_LATENCY_METRIC_THRESHOLD_MS
+        )
+
+    def test_success_below_threshold_is_not_logged(self):
+        with patch.object(LOGGER, "info") as log_info:
+            logged = latency_metrics.log_latency_metric(
+                LOGGER, "operation", 999, success=True
+            )
+
+        self.assertFalse(logged)
+        log_info.assert_not_called()
+
+    def test_failure_below_threshold_is_logged(self):
+        with patch.object(LOGGER, "info") as log_info:
+            logged = latency_metrics.log_latency_metric(
+                LOGGER, "operation", 1.23456, success=False, host="server-1"
+            )
+
+        self.assertTrue(logged)
+        payload = json.loads(log_info.call_args.args[1])
+        self.assertEqual(payload, {
+            "duration_ms": 1.235,
+            "host": "server-1",
+            "metric": "operation",
+            "success": False
+        })
+
+    def test_success_at_threshold_is_logged(self):
+        with patch.object(LOGGER, "info") as log_info:
+            logged = latency_metrics.log_latency_metric(
+                LOGGER, "operation", 1000, success=True, phase="setup"
+            )
+
+        self.assertTrue(logged)
+        self.assertIn('"phase": "setup"', log_info.call_args.args[1])
+
+    def test_negative_threshold_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            latency_metrics.set_latency_metric_threshold(-1)
+
+    def test_format_caller_normalizes_repository_test_path(self):
+        caller = latency_metrics.format_caller(
+            r"C:\repo\tests\common\utilities.py", "wait_until", 123
+        )
+
+        self.assertEqual(caller, "tests/common/utilities.py::wait_until#123")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/common/unit_tests/test_latency_metrics.py
+++ b/tests/common/unit_tests/test_latency_metrics.py
@@ -1,7 +1,9 @@
+from concurrent.futures import ThreadPoolExecutor
 import importlib.util
 import json
-import logging
+import os
 from pathlib import Path
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -11,50 +13,55 @@ SPEC = importlib.util.spec_from_file_location("unit_target_latency_metrics", MOD
 latency_metrics = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(latency_metrics)
 
-LOGGER = logging.getLogger(__name__)
-
 
 class TestLatencyMetrics(unittest.TestCase):
     def setUp(self):
+        self.temp_directory = tempfile.TemporaryDirectory()
+        self.metric_file = os.path.join(self.temp_directory.name, "latency.jsonl")
         latency_metrics.set_latency_metric_threshold(1000)
+        latency_metrics.configure_latency_metric_file(self.metric_file)
 
     def tearDown(self):
+        latency_metrics.close_latency_metric_file()
         latency_metrics.set_latency_metric_threshold(
             latency_metrics.DEFAULT_LATENCY_METRIC_THRESHOLD_MS
         )
+        self.temp_directory.cleanup()
+
+    def read_records(self):
+        latency_metrics.close_latency_metric_file()
+        with open(self.metric_file, encoding="utf-8") as metric_stream:
+            return [json.loads(line) for line in metric_stream]
 
     def test_success_below_threshold_is_not_logged(self):
-        with patch.object(LOGGER, "info") as log_info:
-            logged = latency_metrics.log_latency_metric(
-                LOGGER, "operation", 999, success=True
-            )
+        logged = latency_metrics.log_latency_metric(
+            "operation", 999, success=True
+        )
 
         self.assertFalse(logged)
-        log_info.assert_not_called()
+        self.assertEqual(self.read_records(), [])
 
     def test_failure_below_threshold_is_logged(self):
-        with patch.object(LOGGER, "info") as log_info:
-            logged = latency_metrics.log_latency_metric(
-                LOGGER, "operation", 1.23456, success=False, host="server-1"
-            )
+        logged = latency_metrics.log_latency_metric(
+            "operation", 1.23456, success=False, host="server-1"
+        )
 
         self.assertTrue(logged)
-        payload = json.loads(log_info.call_args.args[1])
-        self.assertEqual(payload, {
-            "duration_ms": 1.235,
-            "host": "server-1",
-            "metric": "operation",
-            "success": False
-        })
+        payload = self.read_records()[0]
+        self.assertEqual(payload["duration_ms"], 1.235)
+        self.assertEqual(payload["host"], "server-1")
+        self.assertEqual(payload["metric"], "operation")
+        self.assertFalse(payload["success"])
+        self.assertEqual(payload["process_id"], os.getpid())
+        self.assertTrue(payload["timestamp"].endswith("Z"))
 
     def test_success_at_threshold_is_logged(self):
-        with patch.object(LOGGER, "info") as log_info:
-            logged = latency_metrics.log_latency_metric(
-                LOGGER, "operation", 1000, success=True, phase="setup"
-            )
+        logged = latency_metrics.log_latency_metric(
+            "operation", 1000, success=True, phase="setup"
+        )
 
         self.assertTrue(logged)
-        self.assertIn('"phase": "setup"', log_info.call_args.args[1])
+        self.assertEqual(self.read_records()[0]["phase"], "setup")
 
     def test_negative_threshold_is_rejected(self):
         with self.assertRaisesRegex(ValueError, "non-negative"):
@@ -66,6 +73,69 @@ class TestLatencyMetrics(unittest.TestCase):
         )
 
         self.assertEqual(caller, "tests/common/utilities.py::wait_until#123")
+
+    def test_worker_uses_separate_metric_file(self):
+        latency_metrics.close_latency_metric_file()
+        worker_metric_file = latency_metrics.configure_latency_metric_file(
+            self.metric_file, run_id="run123", worker_id="gw2"
+        )
+
+        latency_metrics.log_latency_metric("operation", 1000)
+        latency_metrics.close_latency_metric_file()
+
+        self.assertTrue(worker_metric_file.endswith("latency_run123_gw2.jsonl"))
+        with open(worker_metric_file, encoding="utf-8") as metric_stream:
+            payload = json.loads(metric_stream.readline())
+        self.assertEqual(payload["run_id"], "run123")
+        self.assertEqual(payload["worker"], "gw2")
+
+    def test_unconfigured_metrics_do_not_reach_standard_logs(self):
+        latency_metrics.close_latency_metric_file()
+
+        logged = latency_metrics.log_latency_metric(
+            "operation", 1000, success=False
+        )
+
+        self.assertFalse(logged)
+
+    def test_concurrent_records_remain_valid_json_lines(self):
+        latency_metrics.set_latency_metric_threshold(0)
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            list(executor.map(
+                lambda sequence: latency_metrics.log_latency_metric(
+                    "operation", 1, sequence=sequence
+                ),
+                range(100)
+            ))
+
+        records = self.read_records()
+        self.assertEqual(len(records), 100)
+        self.assertEqual({record["sequence"] for record in records}, set(range(100)))
+
+    def test_child_process_file_is_merged_on_close(self):
+        with patch.object(latency_metrics.os, "getpid", return_value=12345):
+            latency_metrics.log_latency_metric("operation", 1000)
+
+        child_metric_file = self.metric_file.replace(".jsonl", "_pid12345.jsonl")
+        self.assertTrue(os.path.isfile(child_metric_file))
+
+        records = self.read_records()
+        self.assertEqual(records[0]["process_id"], 12345)
+        self.assertFalse(os.path.exists(child_metric_file))
+
+    def test_write_error_disables_metrics_without_raising(self):
+        with self.assertLogs(latency_metrics.logger, level="WARNING") as captured_logs:
+            with patch("builtins.open", side_effect=OSError("disk full")):
+                logged = latency_metrics.log_latency_metric(
+                    "operation", 1000, success=False
+                )
+
+        self.assertFalse(logged)
+        self.assertIn("disk full", captured_logs.output[0])
+        self.assertFalse(latency_metrics.log_latency_metric(
+            "operation", 1000, success=False
+        ))
 
 
 if __name__ == "__main__":

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -137,7 +137,6 @@ def wait(seconds, msg=""):
         completed = True
     finally:
         log_latency_metric(
-            logger,
             "framework_wait",
             (time.monotonic() - start_time) * 1000,
             success=completed,
@@ -171,7 +170,6 @@ def wait_until(timeout, interval, delay, condition, *args, **kwargs):
 
     def log_result(success):
         log_latency_metric(
-            logger,
             "framework_wait_until",
             (time.monotonic() - metric_start_time) * 1000,
             success=success,
@@ -278,7 +276,6 @@ async def async_wait_until(timeout, interval, delay, condition, *args, **kwargs)
 
     def log_result(success):
         log_latency_metric(
-            logger,
             "framework_async_wait_until",
             (time.monotonic() - metric_start_time) * 1000,
             success=success,

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -37,6 +37,8 @@ from tests.common.cache import FactsCache
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, UPSTREAM_ALL_NEIGHBOR_MAP
 from tests.common.helpers.constants import DOWNSTREAM_NEIGHBOR_MAP, DOWNSTREAM_ALL_NEIGHBOR_MAP
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.latency_metrics import format_caller
+from tests.common.latency_metrics import log_latency_metric
 from tests.common.portstat_utilities import parse_column_positions
 from netaddr import valid_ipv6
 
@@ -54,6 +56,12 @@ DEFAULT_VRF_NAME = "default"
 MGMT_VRF_NAME = "mgmt"
 
 NON_USER_CONFIG_TABLES = ["FLEX_COUNTER_TABLE", "ASIC_SENSORS", "LOGGER"]
+
+
+def _caller_location():
+    caller_frame = inspect.currentframe().f_back.f_back
+    filename, line_number, function_name, _, _ = inspect.getframeinfo(caller_frame)
+    return format_caller(filename, function_name, line_number)
 
 
 def check_skip_release(duthost, release_list):
@@ -121,7 +129,23 @@ def wait(seconds, msg=""):
     @param msg: Optional extra message for pause reason
     """
     logger.info("Pause %d seconds, reason: %s" % (seconds, msg))
-    time.sleep(seconds)
+    caller = _caller_location()
+    start_time = time.monotonic()
+    completed = False
+    try:
+        time.sleep(seconds)
+        completed = True
+    finally:
+        log_latency_metric(
+            logger,
+            "framework_wait",
+            (time.monotonic() - start_time) * 1000,
+            success=completed,
+            requested_seconds=seconds,
+            reason=str(msg),
+            caller=caller,
+            test=os.environ.get("PYTEST_CURRENT_TEST")
+        )
 
 
 def wait_until(timeout, interval, delay, condition, *args, **kwargs):
@@ -139,6 +163,28 @@ def wait_until(timeout, interval, delay, condition, *args, **kwargs):
     logger.debug("Wait until %s is True, timeout is %s seconds, checking interval is %s, delay is %s seconds" %
                  (condition.__name__, timeout, interval, delay))
 
+    metric_start_time = time.monotonic()
+    caller = _caller_location()
+    condition_name = "{}.{}".format(condition.__module__, condition.__qualname__)
+    attempts = 0
+    exceptions = 0
+
+    def log_result(success):
+        log_latency_metric(
+            logger,
+            "framework_wait_until",
+            (time.monotonic() - metric_start_time) * 1000,
+            success=success,
+            condition=condition_name,
+            caller=caller,
+            test=os.environ.get("PYTEST_CURRENT_TEST"),
+            timeout_seconds=timeout,
+            interval_seconds=interval,
+            delay_seconds=delay,
+            attempts=attempts,
+            exceptions=exceptions
+        )
+
     if delay > 0:
         logger.debug("Delay for %s seconds first" % delay)
         time.sleep(delay)
@@ -147,10 +193,12 @@ def wait_until(timeout, interval, delay, condition, *args, **kwargs):
     elapsed_time = 0
     while elapsed_time < timeout:
         logger.debug("Time elapsed: %f seconds" % elapsed_time)
+        attempts += 1
 
         try:
             check_result = condition(*args, **kwargs)
         except (Exception, pytest.fail.Exception) as e:
+            exceptions += 1
             exc_info = sys.exc_info()
             details = traceback.format_exception(*exc_info)
             logger.error(
@@ -162,6 +210,7 @@ def wait_until(timeout, interval, delay, condition, *args, **kwargs):
 
         if check_result:
             logger.debug("%s is True, exit early with True" % condition.__name__)
+            log_result(True)
             return True
         else:
             logger.debug("%s is False, wait %d seconds and check again" % (condition.__name__, interval))
@@ -170,6 +219,7 @@ def wait_until(timeout, interval, delay, condition, *args, **kwargs):
 
     if elapsed_time >= timeout:
         logger.debug("%s is still False after %d seconds, exit with False" % (condition.__name__, timeout))
+        log_result(False)
         return False
 
 
@@ -220,6 +270,28 @@ async def async_wait_until(timeout, interval, delay, condition, *args, **kwargs)
     logger.debug("Wait until %s is True, timeout is %s seconds, checking interval is %s, delay is %s seconds" %
                  (condition.__name__, timeout, interval, delay))
 
+    metric_start_time = time.monotonic()
+    caller = _caller_location()
+    condition_name = "{}.{}".format(condition.__module__, condition.__qualname__)
+    attempts = 0
+    exceptions = 0
+
+    def log_result(success):
+        log_latency_metric(
+            logger,
+            "framework_async_wait_until",
+            (time.monotonic() - metric_start_time) * 1000,
+            success=success,
+            condition=condition_name,
+            caller=caller,
+            test=os.environ.get("PYTEST_CURRENT_TEST"),
+            timeout_seconds=timeout,
+            interval_seconds=interval,
+            delay_seconds=delay,
+            attempts=attempts,
+            exceptions=exceptions
+        )
+
     if delay > 0:
         logger.debug("Delay for %s seconds first" % delay)
         await asyncio.sleep(delay)
@@ -228,10 +300,12 @@ async def async_wait_until(timeout, interval, delay, condition, *args, **kwargs)
     elapsed_time = 0
     while elapsed_time < timeout:
         logger.debug("Time elapsed: %f seconds" % elapsed_time)
+        attempts += 1
 
         try:
             check_result = condition(*args, **kwargs)
         except Exception as e:
+            exceptions += 1
             exc_info = sys.exc_info()
             details = traceback.format_exception(*exc_info)
             logger.error(
@@ -243,6 +317,7 @@ async def async_wait_until(timeout, interval, delay, condition, *args, **kwargs)
 
         if check_result:
             logger.debug("%s is True, exit early with True" % condition.__name__)
+            log_result(True)
             return True
         else:
             logger.debug("%s is False, wait %d seconds and check again" % (condition.__name__, interval))
@@ -251,6 +326,7 @@ async def async_wait_until(timeout, interval, delay, condition, *args, **kwargs)
 
     if elapsed_time >= timeout:
         logger.debug("%s is still False after %d seconds, exit with False" % (condition.__name__, timeout))
+        log_result(False)
         return False
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ import pathlib
 import importlib
 import inspect
 import concurrent.futures.thread as cft
+import uuid
 
 from datetime import datetime
 from ipaddress import ip_interface, IPv4Interface
@@ -53,6 +54,9 @@ from tests.common.helpers.constants import (
 from tests.common.helpers.custom_msg_utils import add_custom_msg
 from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.helpers.dut_utils import encode_dut_and_container_name
+from tests.common.latency_metrics import close_latency_metric_file
+from tests.common.latency_metrics import configure_latency_metric_file
+from tests.common.latency_metrics import DEFAULT_LATENCY_METRIC_FILE
 from tests.common.latency_metrics import DEFAULT_LATENCY_METRIC_THRESHOLD_MS
 from tests.common.latency_metrics import log_latency_metric
 from tests.common.latency_metrics import set_latency_metric_threshold
@@ -150,6 +154,12 @@ def pytest_addoption(parser):
         default=DEFAULT_LATENCY_METRIC_THRESHOLD_MS,
         type=int,
         help="Log successful framework operations at or above this duration in milliseconds"
+    )
+    parser.addoption(
+        "--latency-metric-file",
+        action="store",
+        default=DEFAULT_LATENCY_METRIC_FILE,
+        help="Write framework latency records to this JSONL file"
     )
     parser.addoption("--ipv6_only_mgmt", action="store_true", default=False,
                      help="Use IPv6-only management network. DUT mgmt_ip will be set to IPv6 address.")
@@ -447,7 +457,19 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     try:
         set_latency_metric_threshold(config.getoption("latency_metric_threshold_ms"))
-    except ValueError as error:
+        worker_input = getattr(config, "workerinput", None)
+        worker_id = worker_input.get("workerid") if worker_input else os.environ.get("PYTEST_XDIST_WORKER")
+        run_id = worker_input.get("latency_metric_run_id") if worker_input else uuid.uuid4().hex[:12]
+        config.latency_metric_run_id = run_id
+        is_xdist_controller = bool(getattr(config.option, "numprocesses", None)) and worker_id is None
+        if not is_xdist_controller:
+            metric_file = configure_latency_metric_file(
+                config.getoption("latency_metric_file"),
+                run_id=run_id,
+                worker_id=worker_id
+            )
+            logger.info("Framework latency metrics will be written to %s", metric_file)
+    except (OSError, ValueError) as error:
         raise pytest.UsageError(str(error))
     if config.getoption("enable_macsec"):
         topo = config.getoption("topology")
@@ -456,6 +478,15 @@ def pytest_configure(config):
         else:
             config.pluginmanager.register(MacsecPluginT0())
     converge_topo_if_needed(config)
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_configure_node(node):
+    node.workerinput["latency_metric_run_id"] = node.config.latency_metric_run_id
+
+
+def pytest_unconfigure(config):
+    close_latency_metric_file()
 
 
 def _load_testbed_config(tbfile, tbname):
@@ -1572,7 +1603,6 @@ def pytest_fixture_setup(fixturedef, request):
     skipped = excinfo is not None and issubclass(excinfo[0], pytest.skip.Exception)
     xfailed = excinfo is not None and issubclass(excinfo[0], pytest.xfail.Exception)
     log_latency_metric(
-        logger,
         "pytest_fixture",
         (time.monotonic() - start_time) * 1000,
         success=excinfo is None or skipped or xfailed,
@@ -1605,7 +1635,6 @@ def pytest_runtest_makereport(item, call):
     outcome = yield
     rep = outcome.get_result()
     log_latency_metric(
-        logger,
         "pytest_phase",
         rep.duration * 1000,
         success=not rep.failed,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,9 @@ from tests.common.helpers.constants import (
 from tests.common.helpers.custom_msg_utils import add_custom_msg
 from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.helpers.dut_utils import encode_dut_and_container_name
+from tests.common.latency_metrics import DEFAULT_LATENCY_METRIC_THRESHOLD_MS
+from tests.common.latency_metrics import log_latency_metric
+from tests.common.latency_metrics import set_latency_metric_threshold
 from tests.common.helpers.parallel_utils import ParallelCoordinator, ParallelStatus, ParallelRunContext
 from tests.common.helpers.pfcwd_helper import TrafficPorts, select_test_ports, set_pfc_timers, \
     is_pfcwd_hw_recovery_enabled
@@ -141,6 +144,13 @@ fix_logging_handler_fork_lock()
 def pytest_addoption(parser):
     parser.addoption("--testbed", action="store", default=None, help="testbed name")
     parser.addoption("--testbed_file", action="store", default=None, help="testbed file name")
+    parser.addoption(
+        "--latency-metric-threshold-ms",
+        action="store",
+        default=DEFAULT_LATENCY_METRIC_THRESHOLD_MS,
+        type=int,
+        help="Log successful framework operations at or above this duration in milliseconds"
+    )
     parser.addoption("--ipv6_only_mgmt", action="store_true", default=False,
                      help="Use IPv6-only management network. DUT mgmt_ip will be set to IPv6 address.")
     parser.addoption("--uhd_config", action="store", help="Enable UHD config mode")
@@ -435,6 +445,10 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    try:
+        set_latency_metric_threshold(config.getoption("latency_metric_threshold_ms"))
+    except ValueError as error:
+        raise pytest.UsageError(str(error))
     if config.getoption("enable_macsec"):
         topo = config.getoption("topology")
         if topo is not None and "t2" in topo:
@@ -1550,6 +1564,26 @@ def log_custom_msg(item):
         item.user_properties.append(('CustomMsg', json.dumps(custom_msg)))
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_fixture_setup(fixturedef, request):
+    start_time = time.monotonic()
+    outcome = yield
+    excinfo = outcome.excinfo
+    skipped = excinfo is not None and issubclass(excinfo[0], pytest.skip.Exception)
+    xfailed = excinfo is not None and issubclass(excinfo[0], pytest.xfail.Exception)
+    log_latency_metric(
+        logger,
+        "pytest_fixture",
+        (time.monotonic() - start_time) * 1000,
+        success=excinfo is None or skipped or xfailed,
+        nodeid=getattr(request.node, "nodeid", repr(request.node)),
+        fixture=fixturedef.argname,
+        scope=fixturedef.scope,
+        outcome="skipped" if skipped else "xfailed" if xfailed else "failed" if excinfo else "passed",
+        testbed=request.config.getoption("testbed")
+    )
+
+
 # This function is a pytest hook implementation that is called to create a test report.
 # By placing the call to log_custom_msg in the 'teardown' phase, we ensure that it is executed
 # at the end of each test, after all other fixture teardowns. This guarantees that any custom
@@ -1570,6 +1604,16 @@ def pytest_runtest_makereport(item, call):
     # execute all other hooks to obtain the report object
     outcome = yield
     rep = outcome.get_result()
+    log_latency_metric(
+        logger,
+        "pytest_phase",
+        rep.duration * 1000,
+        success=not rep.failed,
+        nodeid=item.nodeid,
+        phase=rep.when,
+        outcome=rep.outcome,
+        testbed=item.config.getoption("testbed")
+    )
 
     # set a report attribute for each phase of a call, which can
     # be "setup", "call", "teardown"


### PR DESCRIPTION
### Description of PR

Summary:
Add structured timing metrics for common sonic-mgmt framework paths so long-running tests can distinguish host-command latency, explicit waits/convergence, fixture setup, and pytest setup/call/teardown time. Metrics are stored in dedicated JSONL artifacts rather than `test.log`.

Follow-up to #27365.
ADO: https://msazure.visualstudio.com/One/_workitems/edit/39415272

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A - no backport requested
Failure type: other - test infrastructure latency diagnosis

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master (framework-only; no image required): 10 latency metric unit tests passed.
- master: Python syntax validation passed on all changed Python files.
- master: changed-file pre-commit checks passed on all six changed files.

### Approach
#### What is the motivation for this PR?

PR #27365 identifies latency inside the DualToR mux and NIC simulator request paths, but it cannot show whether time is instead spent in server-side Ansible/SSH execution, generic convergence waits, fixture setup, test execution, or teardown. Those blind spots make server-capacity and testbed bottlenecks difficult to separate from simulator latency.

#### How did you do it?

Add thresholded JSON records for:

- `ansible_module`: duration, target host, module, source caller, current test, return code, async mode, and ignored-error state. Arguments and credentials are not included.
- `framework_wait`, `framework_wait_until`, and `framework_async_wait_until`: duration, caller, condition, attempts, exceptions, delay, interval, and timeout.
- `pytest_fixture`: individual fixture setup duration, scope, outcome, node ID, and testbed.
- `pytest_phase`: aggregate setup, call, and teardown duration for every test.

Records do not propagate to the normal pytest logger or `test.log`. Serial runs write `logs/framework_latency_metrics_<run-id>.jsonl`; pytest-xdist workers write files such as `logs/framework_latency_metrics_<run-id>_gw0.jsonl`. Forked framework processes use temporary PID files that are merged at worker shutdown. Run-scoped names avoid stale-file and concurrent-run collisions. Runtime metric-file I/O errors disable further metrics with one warning instead of affecting test behavior.

Successful operations are logged when they reach the default 5000 ms threshold. Failed operations are always logged. `--latency-metric-threshold-ms` tunes the threshold, while `--latency-metric-file` changes the artifact base path.

No command behavior, timeout, retry, fixture ordering, or test outcome is changed.

#### How did you verify/test it?

Added unit coverage for threshold filtering, failure logging, JSON fields, run/worker naming, thread-safe records, forked-process file merging, I/O failure isolation, threshold validation, and stable caller paths. Ran Python syntax validation and all configured pre-commit hooks on the changed files.

#### Any platform specific information?

Platform and topology independent. Ansible metrics identify whether the target is a DUT, PTF host, VM/server, neighbor, or localhost through the host field.

#### Supported testbed topology if it's a new test case?

No new test case. Metrics apply to existing pytest suites and testbed topologies using the common framework paths.

### Documentation

Updated `docs/tests/pytest.logging.md` with artifact paths, metric names, coverage, concurrency behavior, default threshold, and configuration options.
### Review update (2026-09-17)

Fixed the failing Pre_test Markers Check in 29b8e541464e5cc67906ba216f6ad9efd905f280: renamed the hardware-independent latency suite to unit_test_latency_metrics.py, following the existing unit-test convention, and documented its isolated invocation. All 10 tests pass and the repository marker check reports no missing topology markers. Fresh PR CI is pending.
