### PR TITLE
[dhcp_relay] Fix standby cleanup relay-mode mismatch

### DIFF
--- a/tests/common/unit_tests/README.md
+++ b/tests/common/unit_tests/README.md
@@ -28,6 +28,21 @@ python3 -m pytest --noconftest \
 
 If your environment has the full sonic-mgmt test dependencies installed and you intentionally want global fixtures, you can remove `--noconftest`.
 
+### DHCP relay cleanup regression
+
+`unit_test_dhcp_relay_cleanup.py` exercises both DHCP relay cleanup blocks with
+independent selected/standby relay modes, single/dual-ToR topologies, and config,
+readiness, and socket failures. It extracts the cleanup code via `ast` to avoid
+testbed dependencies; physical packet forwarding still requires a dual-ToR run.
+
+```bash
+python3 -m pytest --noconftest --confcutdir=tests/common/unit_tests \
+  tests/common/unit_tests/unit_test_dhcp_relay_cleanup.py -v
+```
+
+The `--confcutdir` option also prevents collection of parent package setup that
+imports Linux-only testbed utilities.
+
 ## Requirements
 
 - Python 3

--- a/tests/common/unit_tests/unit_test_dhcp_relay_cleanup.py
+++ b/tests/common/unit_tests/unit_test_dhcp_relay_cleanup.py
@@ -1,0 +1,112 @@
+"""Exercise DHCP relay cleanup without importing testbed dependencies.
+
+Run with::
+
+    python3 -m pytest --noconftest --confcutdir=tests/common/unit_tests \
+        tests/common/unit_tests/unit_test_dhcp_relay_cleanup.py -v
+"""
+
+import ast
+from pathlib import Path
+from unittest.mock import Mock, call
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "dhcp_relay" / "test_dhcp_relay.py"
+TEST_NAMES = [
+    "test_dhcp_relay_default",
+    "test_dhcp_relay_with_source_port_ip_in_relay_enabled",
+]
+
+
+def _assert(condition, message="DHCP relay check failed"):
+    assert condition, message
+
+
+@pytest.fixture
+def cleanup_namespace():
+    tree = ast.parse(MODULE_PATH.read_text())
+    functions = {node.name: node for node in tree.body if isinstance(node, ast.FunctionDef)}
+    namespace = {
+        "restart_dhcp_service": Mock(),
+        "check_interface_status": Mock(),
+        "wait_until": Mock(return_value=True),
+        "pytest_assert": _assert,
+        "DUAL_TOR_MODE": "dual",
+    }
+    helper = functions["restart_standby_dhcp_service"]
+    exec(compile(ast.Module(body=[helper], type_ignores=[]), str(MODULE_PATH), "exec"), namespace)
+    return namespace, functions
+
+
+@pytest.mark.parametrize("test_name", TEST_NAMES)
+@pytest.mark.parametrize("testing_mode", ["single", "dual"])
+@pytest.mark.parametrize("relay_agent", ["isc-relay-agent", "sonic-relay-agent"])
+@pytest.mark.parametrize("standby_flag,standby_type", [
+    ("", "isc"),
+    ("False\n", "isc"),
+    ("True\n", "sonic"),
+])
+def test_cleanup_uses_each_tors_relay_mode(
+        cleanup_namespace, test_name, testing_mode, relay_agent, standby_flag, standby_type):
+    """Both cleanup blocks preserve the active mode and inspect the standby's own config."""
+    namespace, functions = cleanup_namespace
+    active = Mock()
+    standby = Mock()
+    standby.shell.return_value = {"stdout": standby_flag}
+    namespace.update(
+        duthost=active, standby_duthost=standby, relay_agent=relay_agent,
+        testing_mode=testing_mode, skip_dhcpmon=False)
+
+    # Execute the real cleanup block, not a copy of its implementation.
+    cleanup = functions[test_name].body[-1]
+    assert isinstance(cleanup, ast.If) and ast.unparse(cleanup.test) == "not skip_dhcpmon"
+    exec(compile(ast.Module(body=[cleanup], type_ignores=[]), str(MODULE_PATH), "exec"), namespace)
+
+    active_type = "sonic" if relay_agent == "sonic-relay-agent" else "isc"
+    expected_restarts = [call(active, [active_type])]
+    expected_checks = []
+    if testing_mode == "dual":
+        standby.shell.assert_called_once_with(
+            'sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "has_sonic_dhcpv4_relay"')
+        expected_restarts.append(call(standby, [standby_type]))
+        expected_checks.append(call(
+            120, 5, 0, namespace["check_interface_status"], standby, "{}-relay-agent".format(standby_type)))
+    else:
+        standby.shell.assert_not_called()
+    expected_checks.append(call(120, 5, 0, namespace["check_interface_status"], active, relay_agent))
+    assert namespace["restart_dhcp_service"].call_args_list == expected_restarts
+    assert namespace["wait_until"].call_args_list == expected_checks
+
+
+def test_standby_config_read_failure_propagates(cleanup_namespace):
+    """A failed CONFIG_DB read must not silently select ISC or restart the service."""
+    namespace, _ = cleanup_namespace
+    standby = Mock()
+    standby.shell.side_effect = RuntimeError("CONFIG_DB unavailable")
+    with pytest.raises(RuntimeError, match="CONFIG_DB unavailable"):
+        namespace["restart_standby_dhcp_service"](standby)
+    namespace["restart_dhcp_service"].assert_not_called()
+    namespace["wait_until"].assert_not_called()
+
+
+def test_standby_readiness_failure_propagates(cleanup_namespace):
+    """Keep the service-readiness gate and do not continue to socket checks after failure."""
+    namespace, _ = cleanup_namespace
+    standby = Mock()
+    standby.shell.return_value = {"stdout": ""}
+    namespace["restart_dhcp_service"].side_effect = AssertionError("dhcp_relay is not ready")
+    with pytest.raises(AssertionError, match="dhcp_relay is not ready"):
+        namespace["restart_standby_dhcp_service"](standby)
+    namespace["wait_until"].assert_not_called()
+
+
+def test_standby_socket_failure_propagates(cleanup_namespace):
+    """A running relay with missing sockets must still fail cleanup."""
+    namespace, _ = cleanup_namespace
+    standby = Mock(hostname="standby")
+    standby.shell.return_value = {"stdout": "True"}
+    namespace["wait_until"].return_value = False
+    with pytest.raises(AssertionError, match="interfaces are not ready on standby ToR standby"):
+        namespace["restart_standby_dhcp_service"](standby)

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -79,6 +79,18 @@ def check_interface_status(duthost, relay_agent="isc-relay-agent"):
     return False
 
 
+def restart_standby_dhcp_service(duthost):
+    """Restore dhcpmon without assuming the selected ToR's relay mode."""
+    sonic_relay_enabled = duthost.shell(
+        'sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "has_sonic_dhcpv4_relay"'
+    )["stdout"].strip() == "True"
+    relay_type = "sonic" if sonic_relay_enabled else "isc"
+    restart_dhcp_service(duthost, [relay_type])
+    pytest_assert(
+        wait_until(120, 5, 0, check_interface_status, duthost, "{}-relay-agent".format(relay_type)),
+        "DHCP relay interfaces are not ready on standby ToR {}".format(duthost.hostname))
+
+
 @pytest.fixture(scope="function")
 def enable_source_port_ip_in_relay(duthosts, rand_one_dut_hostname, tbinfo, request):
     duthost = duthosts[rand_one_dut_hostname]
@@ -315,8 +327,7 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
         relay_types = ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc']
         restart_dhcp_service(duthost, relay_types)
         if testing_mode == DUAL_TOR_MODE:
-            restart_dhcp_service(standby_duthost, relay_types)
-            pytest_assert(wait_until(120, 5, 0, check_interface_status, standby_duthost, relay_agent))
+            restart_standby_dhcp_service(standby_duthost)
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost, relay_agent))
 
 
@@ -437,8 +448,7 @@ def test_dhcp_relay_with_source_port_ip_in_relay_enabled(
         relay_types = ['sonic' if relay_agent == 'sonic-relay-agent' else 'isc']
         restart_dhcp_service(duthost, relay_types)
         if testing_mode == DUAL_TOR_MODE:
-            restart_dhcp_service(standby_duthost, relay_types)
-            pytest_assert(wait_until(120, 5, 0, check_interface_status, standby_duthost, relay_agent))
+            restart_standby_dhcp_service(standby_duthost)
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost, relay_agent))
 
 


### PR DESCRIPTION
### Description of PR

Summary:
Fix standby ToR cleanup in `test_dhcp_relay_default` and
`test_dhcp_relay_with_source_port_ip_in_relay_enabled`. Determine the standby's
relay mode from its own `has_sonic_dhcpv4_relay` configuration, and use that mode
for both service readiness and interface/socket checks.

Fixes #27787

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
https://github.com/sonic-net/sonic-mgmt/issues/27787

Failure type: Regression introduced by #24403, backported to 202605 by #26284.

### Tested branch

Local isolated regression coverage passed on master and 202605.
Physical dual-ToR verification also passed on internal-202605 plus this fix.

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

| Branch | Base revision | Image | Result |
|---|---|---|---|
| master | `db17012d24dfa89ae2da2fe94e96def1e3a771e7` | N/A - isolated unit tests | 27 passed; changed-file pre-commit hooks passed |
| 202605 | `6b8af195e61e044459e47487ed931df9260141a7` | N/A - isolated unit tests | Patch applies cleanly; the same 27 tests passed |
| internal-202605 | `9fae8042611960ce3f35e646f4af2a53ba3a1961` | N/A - isolated unit tests | Adapted insertion context around internal counter helpers; 27 passed; changed-file pre-commit hooks passed |

**Physical verification: FINISHED / SUCCESS, September 7, 2026.**
https://elastictest.org/scheduler/testplan/6a9ece81cecbc372f5d55a96

The successful run used a physical `Arista-7050CX3-32S-C32` classic dual-ToR and
`internal-202605` plus this fix (verification revision
`acb77e225f7e526f56a50f844fefe107b613539f`). The helper and both cleanup blocks
are AST-identical to this PR. Both affected tests ran with both ISC and SONiC
parameters, normal pre/post checks, and no retries.

Both DUTs were confirmed on `SONiC.20260510.13`, matching the original failure.
Preparation logged checkout `acb77e2`, matching the expected verification revision.

| Physical testcase | ISC | SONiC |
|---|---|---|
| `test_dhcp_relay_default` | PASSED | PASSED |
| `test_dhcp_relay_with_source_port_ip_in_relay_enabled` | PASSED | PASSED |

All four outcomes are confirmed by pytest output and JUnit XML. Both SONiC
cases completed the new standby mode read, ISC service readiness, and matching
socket checks successfully. Pre-checks: **14 passed, 3 skipped**.
Post-checks: **7 passed**. Overall plan: **25 passed, 3 skipped, 0 failed/errors**.
The testbed returned to READY and was released normally.

**Nonfatal warning:** the module config audit reported an added
`LOGGER.dhcp4relay` entry on the selected ToR. The same warning is present in
the original failing plan. Framework config reloads succeeded, and all
post-checks passed; this result is not a claim of zero config drift.

The [first physical attempt](https://elastictest.org/scheduler/testplan/6a9eb06b0ba481e905c192a5)
hit the two-hour total `TEST_PLAN_TIMEOUT` after three passes and one interrupted
case. The successful rerun changed only the plan name and total budget (four
hours), not code, test selection, assertions, pre/post checks, or retries.

CI also completed successfully: Azure sonic-mgmt including all impacted-area
KVM jobs, CodeQL, Semgrep, DCO, and EasyCLA.

Original failure:
https://elastictest.org/scheduler/testplan/6a99260a3ff6ad8b9caddf7a?testcase=dhcp_relay%2Ftest_dhcp_relay.py&type=console

### Approach
#### What is the motivation for this PR?

The SONiC-relay fixture configures only the selected ToR. The standby normally
remains on ISC, but both tests passed the selected ToR's `relay_types` to standby
cleanup. For the SONiC parameter this waits for a standby `dhcp4relay` process
that was never configured. The subsequent socket check had the same incorrect
assumption.

#### How did you do it?

Add a small shared standby-cleanup helper within the test module. It reads
`DEVICE_METADATA|localhost.has_sonic_dhcpv4_relay` from the standby CONFIG_DB and
uses the same exact `"True"` check as the DHCP relay supervisor template.
An absent or disabled flag selects ISC; an enabled flag selects SONiC.

Both affected cleanup blocks call this helper. Selected-ToR configuration,
traffic assertions, counter expectations, and selected-ToR cleanup remain
unchanged. Standby mode is not changed, and no readiness or socket assertions
are removed. CONFIG_DB read failures propagate instead of silently selecting
another relay mode.

This does not enable SONiC on an otherwise ISC standby or change the test's
forwarding coverage.

#### How did you verify/test it?

```text
python -m pytest --noconftest --confcutdir=tests/common/unit_tests \
  tests/common/unit_tests/unit_test_dhcp_relay_cleanup.py -q

python -m pre_commit run --files \
  tests/dhcp_relay/test_dhcp_relay.py \
  tests/common/unit_tests/unit_test_dhcp_relay_cleanup.py \
  tests/common/unit_tests/README.md

git diff --check
```

The regression suite executes the actual helper and both actual cleanup blocks
in an isolated namespace, following the repository's existing AST-based unit
test pattern. Coverage includes single/dual-ToR, ISC/SONiC selected mode,
absent/disabled/enabled standby feature flag, and propagation of CONFIG_DB,
service-readiness, and socket failures.

The complete patch was also applied to a separate 202605 worktree and the same
tests rerun there. The physical run above separately verified packet forwarding,
counters, both standby cleanup paths, and normal pre/post checks.

#### Any platform specific information?

The defect is common to dual-ToR platforms, not ASIC-specific. The reported
supervisor-state signature occurs with an ISC-configured standby while the
selected ToR uses SONiC relay.

#### Supported testbed topology if it's a new test case?

No new integration testcase or topology is introduced. Regression coverage
checks single-ToR and dual-ToR cleanup paths.

### Documentation

Updated `tests/common/unit_tests/README.md` with the isolated regression command,
coverage, and the distinction from physical dual-ToR verification.
