### PR TITLE
[pfcwd]: Suppress LogAnalyzer during config_reload in manage_lag_config teardown

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -1020,12 +1020,17 @@ def shutdown_lag_members(duthost, selected_port, tbinfo, nbrhosts, ports):
     return vm_host, neigh_port_channel, min_links
 
 
-def restore_original_config(duthost, selected_port, vm_host, neigh_port_channel, min_links, ports):
+def restore_original_config(duthost, selected_port, vm_host, neigh_port_channel, min_links, ports,
+                            loganalyzer=None):
     """Revert LAG/min-links edits made by shutdown_lag_members.
 
     Since shutdown_lag_members modifies running CONFIG_DB only (no on-disk
     edits), config_reload from the on-disk config_db is sufficient to bring
     members back up and restore the original min_links.
+
+    Passing the `loganalyzer` fixture suppresses syslog analysis for the duration of the
+    reload, which bounces containers and makes monit's memory_checker probe log benign
+    ERRs for containers that are momentarily gone.
     """
     if ports[selected_port]['test_port_type'] != 'portchannel':
         return
@@ -1035,7 +1040,8 @@ def restore_original_config(duthost, selected_port, vm_host, neigh_port_channel,
                            parents=[f'int {neigh_port_channel}'])
 
     config_reload(duthost, config_source='config_db', safe_reload=True,
-                  check_intf_up_ports=True, wait_for_bgp=True)
+                  check_intf_up_ports=True, wait_for_bgp=True,
+                  ignore_loganalyzer=loganalyzer)
 
 
 def _is_multi_member_lag(duthost, port, ports):

--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -306,7 +306,8 @@ class SendVerifyTraffic():
 
 
 @pytest.fixture(scope='function')
-def manage_lag_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, nbrhosts, setup_pfc_test):
+def manage_lag_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, nbrhosts, setup_pfc_test,
+                      loganalyzer):
     """Complete LAG config resource manager.
 
     Setup (before test): backs up config_db and shuts down extra LAG members so
@@ -322,7 +323,8 @@ def manage_lag_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinf
 
     yield
 
-    restore_original_config(duthost, port, vm_host, neigh_port_channel, min_links, ports)
+    restore_original_config(duthost, port, vm_host, neigh_port_channel, min_links, ports,
+                            loganalyzer=loganalyzer)
 
 
 class TestPfcwdFunc(SetupPfcwdFunc):


### PR DESCRIPTION
### Description of PR

Summary:
Fixes the persistent teardown failure of `pfcwd/test_pfcwd_cli.py::TestPfcwdFunc::test_pfcwd_show_stat`, where LogAnalyzer flags benign `memory_checker` syslog ERRs that are emitted while `config_reload` is bouncing containers.

The `manage_lag_config` fixture calls `config_reload` to restore the LAG/min-links configuration. That reload restarts containers, and monit's periodic `memory_checker` probe (roughly once a minute) lands inside the restart window, logging:

```
ERR memory_checker: [memory_checker] Failed to get container ID of 'telemetry'! Exiting ...
ERR memory_checker: [memory_checker] Failed to get container ID of 'gnmi'! Exiting ...
ERR memory_checker: [memory_checker] cgroup memory usage file '/sys/fs/cgroup/memory/docker/<id>/memory.usage_in_bytes' does not exist!
```

The teardown LogAnalyzer then reports `match: 1, expected_match: 0` and fails the test. This is a test-infrastructure false positive, not a product defect — the ERRs are the expected consequence of an intentional container restart.

`config_reload` is already decorated with `@support_ignore_loganalyzer`, which brackets the call with LogAnalyzer start/end ignore marks when an `ignore_loganalyzer` argument is supplied. That argument is opt-in (`kwargs.pop('ignore_loganalyzer', {})`), and this call site simply never passed it. This PR wires it up rather than adding another per-test `ignore_regex`.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
ADO: 37750801 (https://dev.azure.com/msazure/One/_workitems/edit/37750801)
Failure type: day-one issue (race has existed since the fixture began calling `config_reload`; it surfaces whenever the monit probe interval overlaps the container restart window)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- 202605: SONiC.20260510.13 (the same image as the failing nightly), `Arista-7260CX3-C64` / `t1-64-lag`. A single run passed 2/2, followed by a ×5 repeat run on **both** of the originally failing testbeds: **5/5 repeats green on each**, i.e. **20/20 test instances passed**, 0 failures, 0 errors, 0 skips, with `retry_times = 0` so no failure could be masked by a retry.

Baseline (before the fix), nightly `7260cx3.t1.202605-bjw-only_NightlyTest_20260906.1` on `Arista-7260CX3-C64` / `t1-64-lag`: `test_pfcwd_show_stat` failed on **all three** attempts with an identical signature — `failed on teardown with "Failed: Got matched syslog ... analyze_logs ... exit code 1", match: 1, expected_match: 0`, matching `ERR memory_checker` lines.

### Approach
#### What is the motivation for this PR?

The case fails consistently rather than intermittently on this platform, so retries do not help and the failure masks real regressions.

Measured container downtime during a single `config_reload` in the failing run:

| Container | Down | Up | Outage |
|---|---|---|---|
| telemetry | 13:02:53 | 13:03:48 | ~55s |
| gnmi | 13:02:53 | 13:04:09 | ~76s |

`memory_checker` runs about once per minute, so a 55–78s outage window is almost guaranteed to contain at least one probe. That is why every retry reproduced the failure.

#### How did you do it?

Forward the existing `loganalyzer` fixture into the `config_reload` call so its already-supported `ignore_loganalyzer` argument is populated:

- `tests/common/helpers/pfcwd_helper.py`: `restore_original_config()` takes a new `loganalyzer=None` parameter and passes it as `ignore_loganalyzer=` to `config_reload`.
- `tests/pfcwd/test_pfcwd_cli.py`: the function-scoped `manage_lag_config` fixture requests `loganalyzer` and forwards it.

Notes on the design:

- **Scoped to the reload, not the test.** `restore_original_config` already calls `config_reload(..., safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)`, so the ignore window closes only once critical services are verified up — it covers exactly the container down-to-up period and nothing longer. An `ignore_regex` on the test would suppress those patterns for the entire test duration instead.
- **Uses the existing framework mechanism.** No new regexes are introduced, and `loganalyzer_common_ignore.txt` is left untouched, so genuine `memory_checker` errors outside a reload are still caught.
- **Backward compatible.** `loganalyzer` defaults to `None`, which `support_ignore_loganalyzer` treats as falsy and skips entirely. The module-scoped `manage_lag_config` in `pfcwd_helper.py` is therefore unchanged — it cannot request the function-scoped `loganalyzer` fixture without a `ScopeMismatch`.
- **Exception safe.** The decorator writes the end mark in a `finally`, so a failing reload cannot leave the ignore window open.

#### How did you verify/test it?

Static verification:

- `python -m py_compile` and `flake8 --max-line-length=120` pass on both changed files, with no new warnings against the pre-change baseline.
- Exercised `support_ignore_loganalyzer` directly to confirm the three relevant behaviours: `ignore_loganalyzer=None` is a no-op (preserving existing callers), a populated value writes paired start/end marks around the call, and an exception raised inside the wrapped function still emits the end mark.
- Correlated the reload window against the failing run to confirm the ERR falls inside it: reload started 13:02:16, ERR logged 13:02:52, `critical_services_fully_started` returned 13:04:29, `config_reload` returned 13:04:46. The ERR sits 36s into a window that stays open for a further ~114s.

Device verification ran on `Arista-7260CX3-C64` / `t1-64-lag` testbeds using `SONiC.20260510.13` — the same image the failing nightly used.

**Results**

| Run | Testbed | Outcome |
|---|---|---|
| Single run | a spare 7260CX3 t1-lag testbed | 2 tests, 2 passed |
| Repeat ×5 | originally failing testbed A | 5/5 repeats, 10/10 tests passed |
| Repeat ×5 | originally failing testbed B | 5/5 repeats, 10/10 tests passed |

Both ×5 runs used `retry_times = 0`, so nothing could be hidden by an automatic retry. For contrast, the same test on the same platform failed on **all three** attempts in the nightly before this change.

**The race was actually exercised, not merely avoided.** Across the ten repeats the `memory_checker` ERR fired **14 times** — the exact signature that previously failed the test — and every single occurrence landed inside a LogAnalyzer ignore window:

| Testbed | Ignore windows | `ERR memory_checker` fired | Inside a window | Outside | Test outcome |
|---|---|---|---|---|---|
| A | 20 | 7 | **7** | **0** | all passed |
| B | 20 | 7 | **7** | **0** | all passed |

Sample of the suppressed lines:

```
ERR memory_checker: [memory_checker] Failed to get container ID of 'telemetry'! Exiting ...
ERR memory_checker: [memory_checker] Failed to get container ID of 'gnmi'! Exiting ...
ERR memory_checker: [memory_checker] cgroup memory usage file '.../memory.current' of container '<id>' does not exist on device! Exiting ...
```

Each `config_reload` is bracketed by a window roughly 155–180s wide, which comfortably contains the full container outage (telemetry ~55s, gnmi ~77s) with 40s+ of margin on each side. Note that one repeat recorded zero ERRs, which is consistent with the original intermittency: the failure depends on monit's ~1/min probe landing inside the restart window, so the fix has to be judged over repeated runs rather than a single pass.

Static verification, in addition:

- `python -m py_compile` and `flake8 --max-line-length=120` pass on both changed files, with no new warnings against the pre-change baseline.
- Exercised `support_ignore_loganalyzer` directly to confirm three behaviours: `ignore_loganalyzer=None` is a no-op (so existing callers are unaffected), a populated value writes paired start/end marks around the call, and an exception raised inside the wrapped function still emits the end mark.

One note on branches, for the backport reviewer: verification ran against the 202605 variant of this change. That branch predates the refactor that moved these helpers into `pfcwd_helper.py`, and it reloads in **both** fixture setup and teardown, so it wraps two call sites (hence four windows per repeat above). On `master`, `restore_original_config` is the only `config_reload` in this path — `shutdown_lag_members` edits `config_db.json` without reloading — so the single wrap in this PR covers it. A straight cherry-pick of this commit onto 202605 will therefore conflict, and the resolution must also wrap the setup reload.

#### Any platform specific information?

The failure was observed on `Arista-7260CX3-C64` (broadcom) with the `t1-64-lag` topology, but nothing in the change is platform specific — any platform whose `memory_checker` probe overlaps the container restart window is affected.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case. The affected test keeps its existing `topology("t0", "t1", "lt2", "ft2")` markers.

### Documentation

No documentation change required; this uses an existing, already-documented framework mechanism (`ignore_loganalyzer` / `@support_ignore_loganalyzer`).


