### PR TITLE
[202605][backport] [pfcwd]: Suppress LogAnalyzer during config_reload in manage_lag_config

### DIFF
--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -252,7 +252,7 @@ class SendVerifyTraffic():
         on the number of ports. Send extra in case of imperfect hashing.
         """
         factor = 1
-        num_dst_ports = 1 if type(self.pfc_wd_test_port_ids) != list else len(self.pfc_wd_test_port_ids)
+        num_dst_ports = 1 if not isinstance(self.pfc_wd_test_port_ids, list) else len(self.pfc_wd_test_port_ids)
         if num_dst_ports > 1:
             factor = 1.25 * num_dst_ports
         return factor
@@ -267,7 +267,7 @@ class SendVerifyTraffic():
         """
         logger.info("Check for egress {} on Tx port {}".format(action, self.pfc_wd_test_port))
         dst_port = "[" + str(self.pfc_wd_test_port_id) + "]"
-        if action == "forward" and type(self.pfc_wd_test_port_ids) == list:
+        if action == "forward" and isinstance(self.pfc_wd_test_port_ids, list):
             dst_port = "".join(str(self.pfc_wd_test_port_ids)).replace(',', '')
         ptf_params = {'router_mac': self.router_mac,
                       'vlan_mac': self.vlan_mac,
@@ -297,7 +297,7 @@ class SendVerifyTraffic():
             action(string) : PTF test action
         """
         logger.info("Check for ingress {} on Rx port {}".format(action, self.pfc_wd_test_port))
-        if type(self.pfc_wd_rx_port_id) == list:
+        if isinstance(self.pfc_wd_rx_port_id, list):
             dst_port = "".join(str(self.pfc_wd_rx_port_id)).replace(',', '')
         else:
             dst_port = "[ " + str(self.pfc_wd_rx_port_id) + " ]"

--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -321,7 +321,7 @@ class SendVerifyTraffic():
                    log_file=log_file, is_python3=True)
 
 
-def _shutdown_lag_members(duthost, port, tbinfo, nbrhosts, port_type):
+def _shutdown_lag_members(duthost, port, tbinfo, nbrhosts, port_type, loganalyzer=None):
     """Backs up config_db and modifies LAG members to isolate the selected port for PFCwd testing."""
     if port_type != 'portchannel':
         return None, None, None
@@ -367,7 +367,8 @@ def _shutdown_lag_members(duthost, port, tbinfo, nbrhosts, port_type):
     _backup_original_config(duthost)
     duthost.command(cmd, _uses_shell=True)
     duthost.command("sudo cp /tmp/config_db.json /etc/sonic/config_db.json", _uses_shell=True)
-    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True,
+                  ignore_loganalyzer=loganalyzer)
     return vm_host, neigh_port_channel, min_links
 
 
@@ -376,7 +377,7 @@ def _backup_original_config(duthost):
     duthost.command("cp /etc/sonic/config_db.json /tmp/config_db_backup.json", _uses_shell=True)
 
 
-def _restore_original_config(duthost, port, vm_host, neigh_port_channel, min_links, port_type):
+def _restore_original_config(duthost, port, vm_host, neigh_port_channel, min_links, port_type, loganalyzer=None):
     """Restores config_db and original LAG config after PFCwd testing."""
     if port_type != 'portchannel':
         return
@@ -385,16 +386,22 @@ def _restore_original_config(duthost, port, vm_host, neigh_port_channel, min_lin
         vm_host.eos_config(lines=[f'port-channel min-links {min_links}'], parents=[f'int {neigh_port_channel}'])
 
     duthost.command("sudo mv /tmp/config_db_backup.json /etc/sonic/config_db.json", _uses_shell=True)
-    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True,
+                  ignore_loganalyzer=loganalyzer)
 
 
 @pytest.fixture(scope='function')
-def manage_lag_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, nbrhosts, setup_pfc_test):
+def manage_lag_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, nbrhosts, setup_pfc_test,
+                      loganalyzer):
     """Complete LAG config resource manager.
 
     Setup (before test): backs up config_db and shuts down extra LAG members so
     only the selected port remains active.
     Teardown (after test): restores the original config_db, always runs even on failure.
+
+    The loganalyzer fixture is forwarded so syslog analysis is suppressed for the duration of
+    each config_reload, which bounces containers and makes monit's memory_checker probe log
+    benign ERRs for containers that are momentarily gone.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     ports = setup_pfc_test['selected_test_ports']
@@ -402,11 +409,12 @@ def manage_lag_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinf
     port_type = ports[port]['test_port_type']
 
     vm_host, neigh_port_channel, min_links = _shutdown_lag_members(
-        duthost, port, tbinfo, nbrhosts, port_type)
+        duthost, port, tbinfo, nbrhosts, port_type, loganalyzer=loganalyzer)
 
     yield
 
-    _restore_original_config(duthost, port, vm_host, neigh_port_channel, min_links, port_type)
+    _restore_original_config(duthost, port, vm_host, neigh_port_channel, min_links, port_type,
+                             loganalyzer=loganalyzer)
 
 
 class TestPfcwdFunc(SetupPfcwdFunc):


### PR DESCRIPTION
### Description of PR

Summary:
Backport of #27798 to **202605**. Created manually because the automatic cherry-pick reported a conflict (label `Cherry Pick Conflict_202605`).

`manage_lag_config` calls `config_reload` to set up and restore the LAG/min-links configuration. That reload restarts containers, and monit's periodic `memory_checker` probe (roughly once a minute) lands inside the restart window, logging:

```
ERR memory_checker: [memory_checker] Failed to get container ID of 'telemetry'! Exiting ...
ERR memory_checker: [memory_checker] Failed to get container ID of 'gnmi'! Exiting ...
ERR memory_checker: [memory_checker] cgroup memory usage file '/sys/fs/cgroup/memory/docker/<id>/memory.usage_in_bytes' does not exist!
```

The teardown LogAnalyzer then reports `match: 1, expected_match: 0` and fails the test. This is a test-infrastructure false positive, not a product defect — the ERRs are the expected consequence of an intentional container restart.

`config_reload` is already decorated with `@support_ignore_loganalyzer`, which brackets the call with LogAnalyzer start/end ignore marks when an `ignore_loganalyzer` argument is supplied. That argument is opt-in (`kwargs.pop('ignore_loganalyzer', {})`), and this call site simply never passed it. This change wires it up rather than adding another per-test `ignore_regex`.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
ADO: 37750801 (https://dev.azure.com/msazure/One/_workitems/edit/37750801)

### Why this is not a straight cherry-pick

`master` carries a refactor that moved the LAG helpers out of `test_pfcwd_cli.py` and into `tests/common/helpers/pfcwd_helper.py`. That refactor was never backported, so on `202605` the helpers are still private functions inside the test module:

| | `master` | `202605` |
|---|---|---|
| `tests/common/helpers/pfcwd_helper.py` | 1078 lines — defines `shutdown_lag_members`, `restore_original_config`, `manage_lag_config`; imports `config_reload` | 908 lines — defines **none** of them; does not import `config_reload` |
| LAG helper call | `pfcwd_helper.restore_original_config(...)` | `test_pfcwd_cli._restore_original_config(...)` — private, different signature |
| `config_reload` calls in this path | 1 (teardown only) | **2** (fixture setup **and** teardown) |

Cherry-picking `86e0d2b09d` consequently conflicts in **both** files (`UU` on each):

- **`pfcwd_helper.py`** — relative to the merge base, `202605` looks as though that entire helper region was deleted, while the commit modifies inside it. Git reports a delete/modify conflict: an empty `HEAD` side against the whole incoming helper block (`send_tx_egress`, `shutdown_lag_members`, … `restore_original_config`).
- **`test_pfcwd_cli.py`** — the call site differs in both name and signature:

  ```
  <<<<<<< HEAD
      _restore_original_config(duthost, port, vm_host, neigh_port_channel, min_links, port_type)
  =======
      restore_original_config(duthost, port, vm_host, neigh_port_channel, min_links, ports,
                              loganalyzer=loganalyzer)
  >>>>>>> 86e0d2b09d
  ```

Taking the incoming side would call helpers that do not exist on this branch, so the change is re-implemented against the `202605` layout rather than textually merged, and `pfcwd_helper.py` is deliberately left untouched.

Separately, on `master` `shutdown_lag_members` only edits `config_db.json` without reloading, so one wrap sufficed there. On `202605` the setup path performs its own `config_reload` (which bounces `gnmi` for ~77s), so **both** call sites are wrapped here. Resolving the conflict by mechanically matching master's diff would have left that setup reload exposed.

### A second, required commit: pre-existing `E721` cleanup

The pre-commit `flake8` hook lints **whole touched files**, so merely modifying `test_pfcwd_cli.py` surfaces three pre-existing `E721` findings and fails `Pre_test Static Analysis`:

```
tests/pfcwd/test_pfcwd_cli.py:255:30: E721 do not compare types, for exact checks use `is` / `is not` ...
tests/pfcwd/test_pfcwd_cli.py:270:36: E721 ...
tests/pfcwd/test_pfcwd_cli.py:300:12: E721 ...
```

These exist only on `202605`. Master cleaned them up tree-wide in #26073 (`cafdb1588c`), which was never backported — and that commit anticipated precisely this situation:

> The newer pycodestyle lints whole touched files, so these pre-existing legitimate findings would otherwise block unrelated future PRs that touch these files with errors they did not introduce.

The second commit therefore applies the identical `type(x) == T` → `isinstance(x, T)` conversion that master already uses, keeping the two branches textually aligned. No behaviour change.

This adaptation was flagged in advance in the `#27798` description.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512

N/A — this **is** the 202605 backport.

### Tested branch

- [ ] master
- [x] 202605

### Approach
#### What is the motivation for this PR?

The case fails consistently rather than intermittently on this platform, so retries do not help and the failure masks real regressions. In the originating nightly, `test_pfcwd_show_stat` failed on **all three** attempts with an identical signature.

Measured container downtime during a single `config_reload`:

| Container | Down | Up | Outage |
|---|---|---|---|
| telemetry | 13:02:53 | 13:03:48 | ~55s |
| gnmi | 13:02:53 | 13:04:09 | ~76s |

`memory_checker` runs about once per minute, so a 55–78s outage window is almost guaranteed to contain at least one probe.

#### How did you do it?

Forward the existing `loganalyzer` fixture into both `config_reload` calls so the already-supported `ignore_loganalyzer` argument is populated:

- `_shutdown_lag_members()` takes a new `loganalyzer=None` parameter and passes it as `ignore_loganalyzer=` to its `config_reload`.
- `_restore_original_config()` does the same for the teardown reload.
- The function-scoped `manage_lag_config` fixture requests `loganalyzer` and forwards it to both.

Notes on the design:

- **Scoped to the reload, not the test.** Both calls already use `safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True`, so each ignore window closes only once critical services are verified up — covering exactly the container down-to-up period and nothing longer. An `ignore_regex` on the test would suppress those patterns for the entire test duration instead.
- **Uses the existing framework mechanism.** No new regexes are introduced, and `loganalyzer_common_ignore.txt` is left untouched, so genuine `memory_checker` errors outside a reload are still caught.
- **Backward compatible.** `loganalyzer` defaults to `None`, which `support_ignore_loganalyzer` treats as falsy and skips entirely, so the existing `TestPfcwdFunc` wrappers that call these helpers without the argument are unaffected.
- **Exception safe.** The decorator writes the end mark in a `finally`, so a failing reload cannot leave the ignore window open.

#### How did you verify/test it?

**This exact code shape is what was verified on hardware.** The device runs reported in #27798 were executed against the 202605 variant of the change — i.e. the two-reload version in this PR — so this backport is directly verified rather than extrapolated from master.

Image `SONiC.20260510.13` (the same image as the failing nightly), `Arista-7260CX3-C64` / `t1-64-lag`.

| Run | Testbed | Outcome |
|---|---|---|
| Single run | a spare 7260CX3 t1-lag testbed | 2 tests, 2 passed |
| Repeat ×5 | originally failing testbed A | 5/5 repeats, 10/10 tests passed |
| Repeat ×5 | originally failing testbed B | 5/5 repeats, 10/10 tests passed |

Both ×5 runs used `retry_times = 0`, so nothing could be hidden by an automatic retry.

**The race was actually exercised, not merely avoided.** Across the ten repeats the `memory_checker` ERR fired **14 times** — the exact signature that previously failed the test — and every occurrence landed inside a LogAnalyzer ignore window:

| Testbed | Ignore windows | `ERR memory_checker` fired | Inside a window | Outside | Test outcome |
|---|---|---|---|---|---|
| A | 20 | 7 | **7** | **0** | all passed |
| B | 20 | 7 | **7** | **0** | all passed |

Twenty windows across five repeats is four per repeat, i.e. two reloads × (start, end) — confirming both wrapped call sites are active on this branch. Each window is roughly 155–180s wide and comfortably contains the full container outage (telemetry ~55s, gnmi ~77s) with 40s+ of margin on each side.

Note that one repeat recorded zero ERRs, which is consistent with the original intermittency: the failure depends on monit's ~1/min probe landing inside the restart window, so the fix has to be judged over repeated runs rather than a single pass.

Static verification:

- `python -m py_compile` and `flake8 --max-line-length=120` pass on the changed file, with no new warnings against the pre-change baseline (the three pre-existing `E721` warnings at lines 255/270/300 are untouched).
- Exercised `support_ignore_loganalyzer` directly to confirm three behaviours: `ignore_loganalyzer=None` is a no-op (so existing callers are unaffected), a populated value writes paired start/end marks around the call, and an exception raised inside the wrapped function still emits the end mark.

#### Any platform specific information?

The failure was observed on `Arista-7260CX3-C64` (broadcom) with the `t1-64-lag` topology, but nothing in the change is platform specific — any platform whose `memory_checker` probe overlaps the container restart window is affected.

#### Supported testbed topology if it's a new test case?

N/A — not a new test case. The affected test keeps its existing `topology("t0", "t1", "lt2", "ft2")` markers.

### Documentation

No documentation change required; this uses an existing, already-documented framework mechanism (`ignore_loganalyzer` / `@support_ignore_loganalyzer`).
