### PR TITLE
[route] Fix route consistency snapshot flake

### DIFF
--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -2,7 +2,6 @@ import pytest
 import logging
 import re
 import math
-import time
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.dut_utils import get_program_info
 from tests.common.config_reload import config_reload

--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -1,7 +1,5 @@
 import pytest
 import logging
-import threading
-import queue
 import re
 import math
 import time
@@ -71,33 +69,17 @@ class TestRouteConsistency():
         prefix_snapshot = {}
         max_prefix_cnt = 0
 
-        def retrieve_route_snapshot(asic, prefix_snapshot, dut_instance_name, signal_queue):
-            prefix_snapshot[dut_instance_name] = \
-                set(self.extract_dest_ips(asic.run_sonic_db_cli_cmd('ASIC_DB KEYS *ROUTE_ENTRY*')['stdout_lines']))
-            logger.debug("snapshot of route table from {}: {}".format(dut_instance_name,
-                                                                      len(prefix_snapshot[dut_instance_name])))
-            signal_queue.put(1)
-
-        thread_count = 0
-        signal_queue = queue.Queue()
         for idx, dut in enumerate(duthosts.frontend_nodes):
             for asic in dut.asics:
                 dut_instance_name = dut.hostname + '-' + str(asic.asic_index)
                 if dut.facts['switch_type'] in ["voq", "chassis-packet"] and idx == 0:
                     dut_instance_name = dut_instance_name + "UpstreamLc"
-                    threading.Thread(target=retrieve_route_snapshot, args=(asic, prefix_snapshot,
-                                                                           dut_instance_name, signal_queue)).start()
-                    thread_count += 1
-
-        ts1 = time.time()
-        while signal_queue.qsize() < thread_count:
-            ts2 = time.time()
-            if (ts2 - ts1) > 60:
-                raise TimeoutError("Get route prefix snapshot from asicdb Timeout!")
-            continue
-
-        for dut_instance_name in prefix_snapshot.keys():
-            max_prefix_cnt = max(max_prefix_cnt, len(prefix_snapshot[dut_instance_name]))
+                    # pytest-ansible dispatchers share mutable state and cannot be reused concurrently.
+                    prefix_snapshot[dut_instance_name] = set(self.extract_dest_ips(
+                        asic.run_sonic_db_cli_cmd('ASIC_DB KEYS *ROUTE_ENTRY*')['stdout_lines']))
+                    logger.debug("snapshot of route table from {}: {}".format(
+                        dut_instance_name, len(prefix_snapshot[dut_instance_name])))
+                    max_prefix_cnt = max(max_prefix_cnt, len(prefix_snapshot[dut_instance_name]))
         return prefix_snapshot, max_prefix_cnt
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Description of PR

Summary:
Serialize ASIC_DB route snapshot collection on the controller to avoid flaky failures from concurrent pytest-ansible calls.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38896300/?view=edit
Failure type: other - test infrastructure race condition

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- Reproduction before fix: SONiC.20251110.42 - Attempts 0 and 3 failed with route snapshot timeouts: https://elastictest.org/scheduler/testplan/6a7d796279a16f6b66031ae6
- Validation after fix: _SONiC.20251110.48 - All 4 test cases passed: https://elastictest.org/scheduler/testplan/6a9f9f2eef719d7dfd657106

### Approach
#### What is the motivation for this PR?

`get_route_prefix_snapshot_from_asicdb` launches concurrent controller threads that reuse the same pytest-ansible/SonicHost dispatcher. In the observed failures, one Ansible transaction raised `AnsibleConnectionFailure` and did not post its completion signal, causing the main thread to report a route snapshot timeout.

#### How did you do it?

Removed the controller-side threading and queue logic and collected each ASIC snapshot serially.

#### How did you verify/test it?

Ran `route/test_route_consistency.py` on 202511; all [4 test cases passed](https://elastictest.org/scheduler/testplan/6a9f9f2eef719d7dfd657106).

#### Any platform specific information?

The failure was observed on an Arista-7280DR3AM-36 multi-ASIC HWSKU. The change is not platform-specific.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A