### PR TITLE
[platform_tests] Flap LPMODE-skipped transceivers after SFP reset

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -364,6 +364,13 @@ class TestSfpApi(PlatformApiTestBase):
             return 0.3
         return 0
 
+    def should_skip_lpmode_check(self, xcvr_info_dict):
+        return any(
+            xcvr_info_dict.get("manufacturer", "").strip() == xcvr_to_skip["manufacturer"] and
+            xcvr_info_dict.get("model", "").strip() == xcvr_to_skip["model"]
+            for xcvr_to_skip in self.LPMODE_SKIP_LIST
+        )
+
     def is_xcvr_support_lpmode(self, xcvr_info_dict, port_index=None):
         """Returns True if transceiver is support low power mode, False if not supported"""
         xcvr_type = xcvr_info_dict["type"]
@@ -379,12 +386,10 @@ class TestSfpApi(PlatformApiTestBase):
             return False
 
         # Temporarily add this logic to skip lpmode test for some transceivers with known issue
-        for xcvr_to_skip in self.LPMODE_SKIP_LIST:
-            if (xcvr_info_dict["manufacturer"].strip() == xcvr_to_skip["manufacturer"] and
-                    xcvr_info_dict["model"].strip() == xcvr_to_skip["model"]):
-                logger.info("Temporarily skipping {} - {} due to known issue".format(
-                    xcvr_info_dict["manufacturer"], xcvr_info_dict["model"]))
-                return False
+        if self.should_skip_lpmode_check(xcvr_info_dict):
+            logger.info("Temporarily skipping {} - {} due to known issue".format(
+                xcvr_info_dict["manufacturer"], xcvr_info_dict["model"]))
+            return False
 
         return True
 
@@ -413,7 +418,10 @@ class TestSfpApi(PlatformApiTestBase):
                 continue
 
             info_dict = port_index_to_info_dict[sfp_port_idx]
-            if self.is_xcvr_support_lpmode(info_dict, sfp_port_idx):
+            if (
+                self.is_xcvr_support_lpmode(info_dict, sfp_port_idx)
+                or self.should_skip_lpmode_check(info_dict)
+            ):
                 logger.info("Flapping interface {} - xcvr supports lpmode and needs to be flapped".format(intf))
                 interfaces_to_flap.append(intf)
         return interfaces_to_flap


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Ensure transceivers intentionally skipped by the LPMODE validation are still flapped after `sfp.reset()`.

`is_xcvr_support_lpmode()` returns `False` for entries in `LPMODE_SKIP_LIST`. The reset test previously reused that result to select interfaces for recovery, so those transceivers were reset but omitted from the shutdown/startup flap. On affected Arista 7280DR3 systems with Cloud Light 7123-G37 modules, the transceiver remained in low-power mode and the interface stayed operationally down.

<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38573079
Failure type: day-one issue

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

- 202511: `20251110.48` - [Elastictest](https://elastictest.org/scheduler/testplan/6aa022fbc20a0bf64dd45862)

### Approach
#### What is the motivation for this PR?

Known-problem transceivers must skip direct LPMODE API validation, but they still require interface recovery after SFP reset. Treating both decisions as the same condition leaves the interfaces operationally down and causes the reset test and its BGP teardown to fail.

#### How did you do it?

Extracted the existing LPMODE skip-list match into `should_skip_lpmode_check()` and reused it when selecting interfaces to flap after reset. This keeps LPMODE API checks skipped for known-problem modules while still restoring their interfaces. The existing flat-memory handling on master remains unchanged.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

Ran [the tests on DT2 testbed](https://elastictest.org/scheduler/testplan/6aa022fbc20a0bf64dd45862) and made sure all the respective tests are passing.

#### Any platform specific information?

Observed on Arista-7280DR3AM-36 with Cloud Light 7123-G37-01 transceivers. The change relies on the existing generic `LPMODE_SKIP_LIST` rather than hard-coding a platform.

#### Supported testbed topology if it's a new test case?

Not a new test case. The failure was reproduced on `t2_single_node_max`.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

N/A