### PR TITLE
[nic_simulator]: Add IPv6 only active-active gRPC support

### DIFF
--- a/ansible/dualtor/nic_simulator/README.md
+++ b/ansible/dualtor/nic_simulator/README.md
@@ -1,0 +1,70 @@
+# NIC simulator IPv4/IPv6 listeners
+
+Each active NIC interface gets one `NiCServer` and one `OVSBridge`. Its IPv4
+address and all stable global-scope IPv6 addresses bind to the **same** gRPC
+server and share forwarding, drop/recovery and flap-counter state. The
+management interface also supports both families, or IPv6 alone. No wildcard
+listeners are used.
+
+IPv4 discovery retains the existing ioctl path. IPv6 discovery uses shell-free
+`ip -j -6 addr show dev INTERFACE`; ULA addresses are supported. Link-local,
+tentative, DAD-failed, deprecated and temporary addresses are excluded. Addresses
+are discovered at startup; restart after changing interface addresses. Missing
+IPv6 tooling does not prevent IPv4-only startup. Interfaces without either a
+usable IPv4 or IPv6 address are skipped; management must have a usable address.
+
+## CLI
+
+Run inside the existing simulator network namespace, with its `mgmt` and `ethN`
+addresses and OVS bridges already provisioned. For example, from the repository
+root (replace the example namespace, VM set and addresses with your configuration):
+
+```bash
+ip netns exec ns-example .venv-nic-simulator/bin/python \
+  ansible/dualtor/nic_simulator/nic_simulator.py \
+  -p 50075 -v example -l info \
+  -d 10.1.0.36,10.1.0.38,10.1.0.39 \
+  --ipv6-loopback-ips fc00::36,fc00::38,fc00::39
+```
+
+Both triplets are ordered **Loopback2, upper-ToR Loopback3, lower-ToR Loopback3**.
+Each must contain three bare literals of the correct family (no prefixes or zone
+IDs). The optional `--ipv6-loopback-ips` adds IPv6 counterparts to the existing
+loopback and per-ToR TCP return flows; it does not assign addresses or enable
+IPv6 in the namespace. Listener discovery is independent of this option. Omit
+it to retain the default flow configuration; IPv4 defaults are unchanged.
+
+`-n` / `--duplicate_nic_upstream` duplicates NIC upstream traffic for both
+families, omitting both families' per-ToR TCP return overrides. Normal mode
+routes TCP return traffic to the corresponding ToR. Drop/recovery applies to
+both families, using the existing shared ECMP group.
+
+Management RPC `nic_addresses` can contain either family. IPv6 aliases refer to
+the same NIC server as its IPv4 address, including for server start/stop. Channel
+targets use `IPv4:port` or `[IPv6]:port`; protobufs are unchanged. Every requested
+bind must succeed or startup fails rather than leaving a partial listener set.
+
+## Standalone unit tests
+
+No testbed, OVS daemon, root privileges, proto regeneration, or integration
+conftest is needed. From the repository root, use a dedicated virtual environment:
+
+```bash
+python3 -m venv .venv-nic-simulator
+.venv-nic-simulator/bin/python -m pip install \
+  -r ansible/dualtor/nic_simulator/unit_tests/requirements.txt
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv-nic-simulator/bin/python -m pytest \
+  -c ansible/dualtor/nic_simulator/unit_tests/pytest.ini \
+  --confcutdir=ansible/dualtor/nic_simulator/unit_tests \
+  ansible/dualtor/nic_simulator/unit_tests -q
+```
+
+If the OS lacks `ensurepip`, an already-installed `virtualenv` can create the
+environment instead. Tests mock the OVS command boundary and also run real
+loopback gRPC RPCs for dual-bind and IPv6-only operation. Only those real IPv6
+tests skip when the host cannot bind `::1`.
+
+Not covered by these local tests: actual OVS flow acceptance/packet forwarding,
+namespace provisioning, routing/firewall policy, deployment templates, external
+client IPv6 configuration, or ycabled end-to-end validation. This change does not
+configure or deploy to a testbed.

--- a/ansible/dualtor/nic_simulator/nic_simulator.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator.py
@@ -13,6 +13,7 @@ import argparse
 import contextlib
 import fcntl
 import grpc
+import ipaddress
 import json
 import logging
 import os
@@ -73,6 +74,87 @@ def get_ip_address(ifname):
     except OSError:
         addr = None
     return addr
+
+
+def get_ipv6_addresses(ifname):
+    """Return stable, usable global-scope IPv6 addresses (including ULA)."""
+    try:
+        result = subprocess.run(
+            ["ip", "-j", "-6", "addr", "show", "dev", ifname],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True,
+            text=True, shell=False
+        )
+        interfaces = json.loads(result.stdout)
+    except (OSError, subprocess.CalledProcessError, ValueError) as error:
+        # Missing IPv6 tooling must not break an existing IPv4 deployment.
+        logging.warning("Cannot discover IPv6 addresses on %s: %s", ifname, error)
+        return []
+
+    addresses = set()
+    excluded_flags = {"tentative", "dadfailed", "deprecated", "temporary"}
+    for interface in interfaces:
+        for info in interface.get("addr_info", []):
+            if info.get("family") != "inet6" or info.get("scope") != "global":
+                continue
+            if excluded_flags.intersection(info.get("flags", [])):
+                continue
+            if any(info.get(flag, False) for flag in excluded_flags):
+                continue
+            if str(info.get("preferred_life_time")) == "0" or str(info.get("valid_life_time")) == "0":
+                continue
+            try:
+                address = ipaddress.IPv6Address(info["local"])
+            except (KeyError, ValueError):
+                continue
+            if (address.is_link_local or address.is_loopback or address.is_multicast
+                    or address.is_unspecified or address.is_site_local or address.ipv4_mapped):
+                continue
+            addresses.add(address)
+    return [str(address) for address in sorted(addresses)]
+
+
+def validate_loopback_ips(addresses, version):
+    """Validate and normalize a Loopback2/upper Loopback3/lower Loopback3 triplet."""
+    if isinstance(addresses, str):
+        addresses = addresses.split(",")
+    if len(addresses) != 3:
+        raise ValueError("Expected exactly three IPv%s loopback addresses" % version)
+    result = []
+    for value in addresses:
+        address = ipaddress.ip_address(value.strip())
+        if address.version != version or "%" in value:
+            raise ValueError("Expected an IPv%s loopback address, got %s" % (version, value))
+        result.append(str(address))
+    return tuple(result)
+
+
+def grpc_target(address, port):
+    """Format an IP literal for a gRPC listener or channel."""
+    address = ipaddress.ip_address(address)
+    if address.version == 6:
+        return "[%s]:%s" % (address, port)
+    return "%s:%s" % (address, port)
+
+
+def bind_grpc_addresses(server, addresses, port):
+    """Bind every specific address to one server, failing on partial setup."""
+    try:
+        if not addresses:
+            raise ValueError("At least one specific gRPC binding address is required")
+        for address in dict.fromkeys(addresses):
+            if ipaddress.ip_address(address).is_unspecified:
+                raise ValueError("Wildcard gRPC listeners are not allowed: %s" % address)
+            target = grpc_target(address, port)
+            bound_port = server.add_insecure_port(target)
+            if not bound_port:
+                raise RuntimeError("Failed to bind gRPC listener %s" % target)
+            # Keep a single port across listeners even when requesting an ephemeral port.
+            if port == 0:
+                port = bound_port
+    except Exception:
+        server.stop(grace=None)
+        raise
+    return port
 
 
 def run_command(cmd, check=True):
@@ -408,6 +490,7 @@ class OVSBridge(object):
         "loopback2_ip",
         "upper_tor_loopback3_ip",
         "lower_tor_loopback3_ip",
+        "ipv6_loopback_ips",
         "ports",
         "lower_tor_port",
         "upper_tor_port",
@@ -434,7 +517,10 @@ class OVSBridge(object):
         "flap_counter"
     )
 
-    def __init__(self, bridge_name, loopback_ips, duplicate_nic_upstream=False):
+    def __init__(self, bridge_name, loopback_ips, duplicate_nic_upstream=False, ipv6_loopback_ips=None):
+        loopback_ips = validate_loopback_ips(loopback_ips, 4)
+        self.ipv6_loopback_ips = (validate_loopback_ips(ipv6_loopback_ips, 6)
+                                  if ipv6_loopback_ips is not None else None)
         self.bridge_name = bridge_name
         self.loopback2_ip = loopback_ips[0]
         self.upper_tor_loopback3_ip = loopback_ips[1]
@@ -560,6 +646,22 @@ class OVSBridge(object):
             priority=7,
             upstream=True
         )
+        if self.ipv6_loopback_ips is not None:
+            loopback2, upper_loopback3, lower_loopback3 = self.ipv6_loopback_ips
+            if not duplicate_nic_upstream:
+                for address, enabled in ((upper_loopback3, [False, True]),
+                                         (lower_loopback3, [True, False])):
+                    self._add_flow(
+                        self.server_nic, packet_filter="tcp6,ipv6_dst=%s" % address,
+                        output_ports=[self.lower_tor_port, self.upper_tor_port],
+                        priority=10, upstream=True, enable_output_ports=enabled
+                    )
+            for address, priority in ((loopback2, 8), (upper_loopback3, 7), (lower_loopback3, 7)):
+                self._add_flow(
+                    self.ptf_port, packet_filter="ipv6,ipv6_dst=%s" % address,
+                    output_ports=[self.lower_tor_port, self.upper_tor_port],
+                    priority=priority, upstream=True
+                )
         # upstream arp packet from ptf port should be duplicated to both ToRs
         self.upstream_arp_flow = self._add_flow(
             self.ptf_port, packet_filter="arp",
@@ -648,6 +750,15 @@ class OVSBridge(object):
                          self.bridge_name, portids, tuple(ForwardingState.STATE_LABELS[_] for _ in states))
             return states
 
+    def _set_upstream_drop(self, portid, recover):
+        """Apply link drop/recovery to both IP families and all duplicated traffic."""
+        for flow in self.flows:
+            if not isinstance(flow, OVSUpstreamFlow) or not flow.get_port_enable(portid):
+                continue
+            if flow.get_drop(portid) == recover:
+                flow.set_drop(portid=portid, recover=recover)
+                OVSCommand.ovs_ofctl_mod_flow(self.bridge_name, flow)
+
     def set_drop(self, portids, directions, recover):
         """Set drop on a link."""
         logging.info("Set drop on bridge %s: portids=%s, directions=%s, recover=%s"
@@ -666,55 +777,7 @@ class OVSBridge(object):
                         OVSCommand.ovs_ofctl_mod_flow(
                             self.bridge_name, downstream_flow)
 
-                    # recover upstream
-                    # recover upstream traffic from server NiC
-                    if self.upstream_upper_tor_nic_flow.get_port_enable(portid):
-                        if self.upstream_upper_tor_nic_flow.get_drop(portid):
-                            self.upstream_upper_tor_nic_flow.set_drop(
-                                portid=portid, recover=recover)
-                            OVSCommand.ovs_ofctl_mod_flow(
-                                self.bridge_name, self.upstream_upper_tor_nic_flow)
-                    if self.upstream_lower_tor_nic_flow.get_port_enable(portid):
-                        if self.upstream_lower_tor_nic_flow.get_drop(portid):
-                            self.upstream_lower_tor_nic_flow.set_drop(
-                                portid=portid, recover=recover)
-                            OVSCommand.ovs_ofctl_mod_flow(
-                                self.bridge_name, self.upstream_lower_tor_nic_flow)
-                    if self.upstream_nic_flow.get_drop(portid):
-                        self.upstream_nic_flow.set_drop(
-                            portid=portid, recover=recover)
-                        OVSCommand.ovs_ofctl_mod_flow(
-                            self.bridge_name, self.upstream_nic_flow)
-                    # recover upstream loopback2 traffic from ptf
-                    if self.upstream_loopback2_flow.get_drop(portid):
-                        self.upstream_loopback2_flow.set_drop(
-                            portid=portid, recover=recover)
-                        OVSCommand.ovs_ofctl_mod_flow(
-                            self.bridge_name, self.upstream_loopback2_flow)
-                    # recover upstream upper ToR loopback3 traffic from ptf
-                    if self.upstream_upper_tor_loopback3_flow.get_drop(portid):
-                        self.upstream_upper_tor_loopback3_flow.set_drop(
-                            portid=portid, recover=recover)
-                        OVSCommand.ovs_ofctl_mod_flow(
-                            self.bridge_name, self.upstream_upper_tor_loopback3_flow)
-                    # recover upstream lower ToR loopback3 traffic from ptf
-                    if self.upstream_lower_tor_loopback3_flow.get_drop(portid):
-                        self.upstream_lower_tor_loopback3_flow.set_drop(
-                            portid=portid, recover=recover)
-                        OVSCommand.ovs_ofctl_mod_flow(
-                            self.bridge_name, self.upstream_lower_tor_loopback3_flow)
-                    # recover upstream arp traffic from ptf
-                    if self.upstream_arp_flow.get_drop(portid):
-                        self.upstream_arp_flow.set_drop(
-                            portid=portid, recover=recover)
-                        OVSCommand.ovs_ofctl_mod_flow(
-                            self.bridge_name, self.upstream_arp_flow)
-                    # recover upstream icmpv6 traffic from ptf
-                    if self.upstream_icmpv6_flow.get_drop(portid):
-                        self.upstream_icmpv6_flow.set_drop(
-                            portid=portid, recover=recover)
-                        OVSCommand.ovs_ofctl_mod_flow(
-                            self.bridge_name, self.upstream_icmpv6_flow)
+                    self._set_upstream_drop(portid, recover=True)
 
                     forwarding_state = forwarding_state_getter()
                     if forwarding_state == ForwardingState.STANDBY:
@@ -730,46 +793,7 @@ class OVSBridge(object):
                                 self.bridge_name, downstream_flow)
                     elif direction == 1:
                         # upstream
-                        # drop upstream traffic from server NiC
-                        if self.upstream_upper_tor_nic_flow.get_port_enable(portid):
-                            if not self.upstream_upper_tor_nic_flow.get_drop(portid):
-                                self.upstream_upper_tor_nic_flow.set_drop(portid)
-                                OVSCommand.ovs_ofctl_mod_flow(
-                                    self.bridge_name, self.upstream_upper_tor_nic_flow)
-                        if self.upstream_lower_tor_nic_flow.get_port_enable(portid):
-                            if not self.upstream_lower_tor_nic_flow.get_drop(portid):
-                                self.upstream_lower_tor_nic_flow.set_drop(portid)
-                                OVSCommand.ovs_ofctl_mod_flow(
-                                    self.bridge_name, self.upstream_lower_tor_nic_flow)
-                        if not self.upstream_nic_flow.get_drop(portid):
-                            self.upstream_nic_flow.set_drop(portid)
-                            OVSCommand.ovs_ofctl_mod_flow(
-                                self.bridge_name, self.upstream_nic_flow)
-                        # drop upstream loopback2 traffic from ptf
-                        if not self.upstream_loopback2_flow.get_drop(portid):
-                            self.upstream_loopback2_flow.set_drop(portid)
-                            OVSCommand.ovs_ofctl_mod_flow(
-                                self.bridge_name, self.upstream_loopback2_flow)
-                        # drop upstream upper ToR loopback3 traffic from ptf
-                        if not self.upstream_upper_tor_loopback3_flow.get_drop(portid):
-                            self.upstream_upper_tor_loopback3_flow.set_drop(portid)
-                            OVSCommand.ovs_ofctl_mod_flow(
-                                self.bridge_name, self.upstream_upper_tor_loopback3_flow)
-                        # drop upstream lower ToR loopback3 traffic from ptf
-                        if not self.upstream_lower_tor_loopback3_flow.get_drop(portid):
-                            self.upstream_lower_tor_loopback3_flow.set_drop(portid)
-                            OVSCommand.ovs_ofctl_mod_flow(
-                                self.bridge_name, self.upstream_lower_tor_loopback3_flow)
-                        # drop upstream arp traffic from ptf
-                        if not self.upstream_arp_flow.get_drop(portid):
-                            self.upstream_arp_flow.set_drop(portid)
-                            OVSCommand.ovs_ofctl_mod_flow(
-                                self.bridge_name, self.upstream_arp_flow)
-                        # drop upstream icmpv6 traffic from ptf
-                        if not self.upstream_icmpv6_flow.get_drop(portid):
-                            self.upstream_icmpv6_flow.set_drop(portid)
-                            OVSCommand.ovs_ofctl_mod_flow(
-                                self.bridge_name, self.upstream_icmpv6_flow)
+                        self._set_upstream_drop(portid, recover=False)
 
                         forwarding_state = forwarding_state_getter()
                         # use set forwarding state to standby to simulator link drop
@@ -845,8 +869,9 @@ class InterruptableThread(threading.Thread):
 class NiCServer(nic_simulator_grpc_service_pb2_grpc.DualToRActiveServicer):
     """gRPC for a NiC."""
 
-    def __init__(self, nic_addr, ovs_bridge, binding_port):
+    def __init__(self, nic_addr, ovs_bridge, binding_port, nic_addresses=None):
         self.nic_addr = nic_addr
+        self.nic_addresses = tuple(dict.fromkeys([nic_addr] + list(nic_addresses or [])))
         self.ovs_bridge = ovs_bridge
         self.binding_port = binding_port
         self.server = None
@@ -925,8 +950,8 @@ class NiCServer(nic_simulator_grpc_service_pb2_grpc.DualToRActiveServicer):
                       context.peer(), self.nic_addr, response)
         return response
 
-    def _run_server(self, binding_port):
-        """Run the gRPC server."""
+    def _start_server(self, binding_port):
+        """Bind and start synchronously so startup failures reach the caller."""
         self.server = grpc.server(
             futures.ThreadPoolExecutor(
                 max_workers=THREAD_CONCURRENCY_PER_SERVER),
@@ -936,45 +961,51 @@ class NiCServer(nic_simulator_grpc_service_pb2_grpc.DualToRActiveServicer):
             self,
             self.server
         )
-        self.server.add_insecure_port("%s:%s" % (self.nic_addr, binding_port))
+        self.binding_port = bind_grpc_addresses(self.server, self.nic_addresses, binding_port)
         self.server.start()
-        self.server.wait_for_termination()
 
     def start(self):
         """Start the gRPC server thread."""
-        self.thread = InterruptableThread(
-            target=self._run_server, args=(self.binding_port,))
+        if self.started:
+            return
+        self._start_server(self.binding_port)
+        self.thread = InterruptableThread(target=self.server.wait_for_termination)
         self.thread.start()
         self.started = True
 
     def stop(self):
         """Stop the gRPC server thread."""
-        self.server.stop(grace=None)
+        if self.server is not None:
+            self.server.stop(grace=None)
         self.started = False
 
     def join(self, timeout=None, suppress_exception=False):
         """Wait the gRPC server thread termination."""
-        self.thread.join(
-            timeout=timeout, suppress_exception=suppress_exception)
+        if self.thread is not None:
+            self.thread.join(
+                timeout=timeout, suppress_exception=suppress_exception)
 
 
 class MgmtServer(nic_simulator_grpc_mgmt_service_pb2_grpc.DualTorMgmtServiceServicer):
     """Management gRPC server to interact with sonic-mgmt."""
 
-    def __init__(self, binding_address, binding_port, nic_servers):
+    def __init__(self, binding_address, binding_port, nic_servers, binding_addresses=None):
         self.binding_address = binding_address
+        self.binding_addresses = tuple(dict.fromkeys([binding_address] + list(binding_addresses or [])))
         self.binding_port = binding_port
         self.nic_servers = nic_servers
         self.client_stubs = {}
+        self.admin_lock = threading.Lock()
         self.server = None
 
     def _get_client_stub(self, nic_address):
+        nic_address = str(ipaddress.ip_address(nic_address))
         if nic_address in self.client_stubs:
             client_stub = self.client_stubs[nic_address]
         else:
             client_stub = nic_simulator_grpc_service_pb2_grpc.DualToRActiveStub(
                 grpc.insecure_channel(
-                    "%s:%s" % (nic_address, self.binding_port),
+                    grpc_target(nic_address, self.binding_port),
                     options=GRPC_CLIENT_OPTIONS
                 )
             )
@@ -1064,6 +1095,11 @@ class MgmtServer(nic_simulator_grpc_mgmt_service_pb2_grpc.DualTorMgmtServiceServ
         return response
 
     def SetNicServerAdminState(self, request, context):
+        # IPv4 and IPv6 callers may administer the same object concurrently.
+        with self.admin_lock:
+            return self._set_nic_server_admin_state(request, context)
+
+    def _set_nic_server_admin_state(self, request, context):
         nic_addresses = request.nic_addresses
         admin_states = request.admin_states
         logging.debug(
@@ -1071,7 +1107,7 @@ class MgmtServer(nic_simulator_grpc_mgmt_service_pb2_grpc.DualTorMgmtServiceServ
 
         successes = []
         for nic_address, admin_state in zip(nic_addresses, admin_states):
-            nic_server = self.nic_servers[nic_address]
+            nic_server = self.nic_servers[str(ipaddress.ip_address(nic_address))]
             success = True
             if admin_state:
                 if not nic_server.started:
@@ -1170,8 +1206,7 @@ class MgmtServer(nic_simulator_grpc_mgmt_service_pb2_grpc.DualTorMgmtServiceServ
         )
         nic_simulator_grpc_mgmt_service_pb2_grpc.add_DualTorMgmtServiceServicer_to_server(
             self, self.server)
-        self.server.add_insecure_port("%s:%s" % (
-            self.binding_address, self.binding_port))
+        self.binding_port = bind_grpc_addresses(self.server, self.binding_addresses, self.binding_port)
         self.server.start()
         self.server.wait_for_termination()
 
@@ -1179,14 +1214,26 @@ class MgmtServer(nic_simulator_grpc_mgmt_service_pb2_grpc.DualTorMgmtServiceServ
 class NiCSimulator(nic_simulator_grpc_service_pb2_grpc.DualToRActiveServicer):
     """NiC simulator class, define all the gRPC calls."""
 
-    def __init__(self, vm_set, mgmt_port, binding_port, loopback_ips, duplicate_nic_upstream=False):
+    def __init__(self, vm_set, mgmt_port, binding_port, loopback_ips, duplicate_nic_upstream=False,
+                 ipv6_loopback_ips=None):
+        loopback_ips = validate_loopback_ips(loopback_ips, 4)
+        if ipv6_loopback_ips is not None:
+            ipv6_loopback_ips = validate_loopback_ips(ipv6_loopback_ips, 6)
         self.vm_set = vm_set
         self.server_nics = self._find_all_server_nics()
         self.server_nic_addresses = {
             nic: get_ip_address(nic) for nic in self.server_nics}
+        self.server_nic_ipv6_addresses = {
+            nic: get_ipv6_addresses(nic) for nic in self.server_nics}
         self.mgmt_port = mgmt_port
         self.mgmt_port_address = get_ip_address(mgmt_port)
+        self.mgmt_port_addresses = ([self.mgmt_port_address] if self.mgmt_port_address else [])
+        self.mgmt_port_addresses.extend(get_ipv6_addresses(mgmt_port))
+        if not self.mgmt_port_addresses:
+            raise ValueError("No usable IPv4 or global IPv6 address on management interface %s" % mgmt_port)
+        self.mgmt_port_address = self.mgmt_port_addresses[0]
         self.ovs_bridges = {}
+        self.servers = {}
         self.binding_port = binding_port
         for bridge_name in self._find_all_bridges():
             index = bridge_name.split("-")[-1]
@@ -1194,17 +1241,20 @@ class NiCSimulator(nic_simulator_grpc_service_pb2_grpc.DualToRActiveServicer):
             # only manipulate active server nics
             if server_nic in self.server_nic_addresses:
                 server_nic_addr = self.server_nic_addresses[server_nic]
-                if server_nic_addr is not None:
-                    self.ovs_bridges[server_nic_addr] = OVSBridge(bridge_name, loopback_ips, duplicate_nic_upstream)
+                addresses = ([server_nic_addr] if server_nic_addr else [])
+                addresses.extend(self.server_nic_ipv6_addresses[server_nic])
+                if addresses:
+                    ovs_bridge = OVSBridge(bridge_name, loopback_ips, duplicate_nic_upstream, ipv6_loopback_ips)
+                    server = NiCServer(addresses[0], ovs_bridge, binding_port, addresses)
+                    for address in addresses:
+                        self.ovs_bridges[address] = ovs_bridge
+                        self.servers[address] = server
 
         logging.info("Starting NiC simulator to manipulate OVS bridges: %s",
                      json.dumps(list(self.ovs_bridges.keys()), indent=4))
 
-        self.servers = {}
-        self.servers = {nic_addr: NiCServer(nic_addr, ovs_bridge, binding_port)
-                        for nic_addr, ovs_bridge in self.ovs_bridges.items()}
         self.mgmt_server = MgmtServer(
-            self.mgmt_port_address, binding_port, self.servers)
+            self.mgmt_port_address, binding_port, self.servers, self.mgmt_port_addresses)
 
     def _find_all_server_nics(self):
         return [_ for _ in os.listdir('/sys/class/net') if re.search(NETNS_IFACE_PATTERN, _)]
@@ -1216,13 +1266,13 @@ class NiCSimulator(nic_simulator_grpc_service_pb2_grpc.DualToRActiveServicer):
         return bridges
 
     def start_nic_servers(self):
-        for nic_addr, server in self.servers.items():
-            logging.debug("Starting gRPC server on NiC %s", nic_addr)
+        for server in dict.fromkeys(self.servers.values()):
+            logging.debug("Starting gRPC server on NiC %s", server.nic_addr)
             server.start()
 
     def stop_nic_servers(self):
-        for nic_addr, server in self.servers.items():
-            logging.debug("Stopping gRPC server on NiC %s", nic_addr)
+        for server in dict.fromkeys(self.servers.values()):
+            logging.debug("Stopping gRPC server on NiC %s", server.nic_addr)
             server.stop()
             server.join()
 
@@ -1271,6 +1321,10 @@ def parse_args():
         dest="loopback_ips"
     )
     parser.add_argument(
+        "--ipv6-loopback-ips",
+        help="Optional IPv6 triplet: <Loopback2>,<upper ToR Loopback3>,<lower ToR Loopback3>"
+    )
+    parser.add_argument(
         "-n",
         "--duplicate_nic_upstream",
         default=False,
@@ -1278,6 +1332,12 @@ def parse_args():
         help="Duplicate NIC upstream traffic to both ToRs (default: False)",
     )
     args = parser.parse_args()
+    try:
+        validate_loopback_ips(args.loopback_ips, 4)
+        if args.ipv6_loopback_ips is not None:
+            validate_loopback_ips(args.ipv6_loopback_ips, 6)
+    except ValueError as error:
+        parser.error(str(error))
     return args
 
 
@@ -1326,14 +1386,17 @@ def main():
     config_env()
     config_logging(args.vm_set, args.log_level.upper(), args.stdout_log)
     OVSCommand.setup_openflow_version()
-    loopback_ips = args.loopback_ips.split(",")
-    if len(loopback_ips) != 3:
-        raise ValueError("Invalid loopback ips: {loopback_ips}".format(loopback_ips=loopback_ips))
-    nic_simulator = NiCSimulator(args.vm_set, "mgmt", args.port, loopback_ips, args.duplicate_nic_upstream)
-    nic_simulator.start_nic_servers()
+    loopback_ips = validate_loopback_ips(args.loopback_ips, 4)
+    nic_simulator = NiCSimulator(args.vm_set, "mgmt", args.port, loopback_ips, args.duplicate_nic_upstream,
+                                 args.ipv6_loopback_ips)
     try:
+        nic_simulator.start_nic_servers()
         nic_simulator.start_mgmt_server()
     except KeyboardInterrupt:
+        pass
+    finally:
+        if nic_simulator.mgmt_server.server is not None:
+            nic_simulator.mgmt_server.server.stop(grace=None)
         nic_simulator.stop_nic_servers()
 
 

--- a/ansible/dualtor/nic_simulator/unit_tests/pytest.ini
+++ b/ansible/dualtor/nic_simulator/unit_tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = .
+addopts = -ra

--- a/ansible/dualtor/nic_simulator/unit_tests/requirements.txt
+++ b/ansible/dualtor/nic_simulator/unit_tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest>=7,<9
+grpcio>=1.51,<2
+protobuf>=3.20,<8

--- a/ansible/dualtor/nic_simulator/unit_tests/test_ipv6.py
+++ b/ansible/dualtor/nic_simulator/unit_tests/test_ipv6.py
@@ -1,0 +1,471 @@
+"""Standalone NIC simulator tests; no SONiC integration fixtures or OVS access."""
+import json
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import threading
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+import grpc
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import nic_simulator as simulator  # noqa: E402
+
+
+V4 = ("10.1.0.36", "10.1.0.38", "10.1.0.39")
+V6 = ("fc00::36", "fc00::38", "fc00::39")
+PORT = 50075
+PB = simulator.nic_simulator_grpc_service_pb2
+MGMT_PB = simulator.nic_simulator_grpc_mgmt_service_pb2
+
+
+@pytest.fixture(autouse=True)
+def no_ovs_commands(monkeypatch):
+    """Never execute an OVS/shell command, even if a test forgets a mock."""
+    monkeypatch.setattr(simulator, "run_command", Mock(side_effect=AssertionError("Unexpected OVS command")))
+
+
+@pytest.fixture
+def ovs(monkeypatch):
+    """Mock only the OVS boundary, retaining actual flow and state logic."""
+    commands = {}
+    for name in vars(simulator.OVSCommand):
+        if name.startswith("ovs_"):
+            commands[name] = Mock()
+            monkeypatch.setattr(simulator.OVSCommand, name, commands[name])
+    commands["ovs_vsctl_list_ports"].return_value = SimpleNamespace(
+        stdout="iaa-test-1 nic-test-1 tor-a tor-b"
+    )
+    return commands
+
+
+def address_info(address="fc00::1", **kwargs):
+    """Construct the relevant iproute2 JSON address fields."""
+    info = {"family": "inet6", "scope": "global", "local": address,
+            "preferred_life_time": 4294967295, "valid_life_time": 4294967295}
+    info.update(kwargs)
+    return info
+
+
+def test_ipv6_discovery_stable_and_shell_free(monkeypatch):
+    """Sort/deduplicate global IPv6 and pass the interface as a literal argv item."""
+    entries = [address_info("2001:db8::2"), address_info("fc00::2"),
+               address_info("fc00:0:0:0:0:0:0:2"), address_info("2001:db8::1")]
+    run = Mock(return_value=SimpleNamespace(stdout=json.dumps([{"addr_info": entries}])))
+    monkeypatch.setattr(simulator.subprocess, "run", run)
+    interface = "eth1; touch /do-not-create"
+    assert simulator.get_ipv6_addresses(interface) == ["2001:db8::1", "2001:db8::2", "fc00::2"]
+    run.assert_called_once_with(
+        ["ip", "-j", "-6", "addr", "show", "dev", interface],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, text=True, shell=False
+    )
+
+
+@pytest.mark.parametrize("info", [
+    address_info("fe80::1"), address_info("::"), address_info("::1"),
+    address_info("ff02::1"), address_info("fec0::1"), address_info("::ffff:192.0.2.1"),
+    address_info(scope="link"), address_info(scope="host"), address_info(family="inet"),
+    address_info("not-an-ip"), address_info("192.0.2.1"),
+    address_info(preferred_life_time=0), address_info(preferred_life_time="0"),
+    address_info(valid_life_time=0),
+] + [address_info(**{flag: True}) for flag in ("tentative", "dadfailed", "deprecated", "temporary")]
+  + [address_info(flags=[flag]) for flag in ("tentative", "dadfailed", "deprecated", "temporary")])
+def test_ipv6_discovery_excludes_unusable_addresses(monkeypatch, info):
+    """Reject non-global, transient, failed-DAD, deprecated and invalid addresses."""
+    monkeypatch.setattr(simulator.subprocess, "run", Mock(
+        return_value=SimpleNamespace(stdout=json.dumps([{"addr_info": [info]}]))
+    ))
+    assert simulator.get_ipv6_addresses("eth1") == []
+
+
+@pytest.mark.parametrize("failure", [FileNotFoundError(), subprocess.CalledProcessError(1, "ip")])
+def test_ipv6_discovery_failure_preserves_ipv4(monkeypatch, failure):
+    """Unavailable iproute2/IPv6 discovery is not fatal to IPv4-only deployments."""
+    monkeypatch.setattr(simulator.subprocess, "run", Mock(side_effect=failure))
+    assert simulator.get_ipv6_addresses("eth1") == []
+
+
+@pytest.mark.parametrize("output", ["not-json", "[]", '[{"addr_info": []}]'])
+def test_ipv6_discovery_empty_or_invalid_json(monkeypatch, output):
+    """Return no IPv6 addresses when there is no usable JSON address record."""
+    monkeypatch.setattr(simulator.subprocess, "run", Mock(return_value=SimpleNamespace(stdout=output)))
+    assert simulator.get_ipv6_addresses("eth1") == []
+
+
+@pytest.mark.parametrize("has_address", [True, False])
+def test_existing_ipv4_ioctl_path(monkeypatch, has_address):
+    """Preserve SIOCGIFADDR IPv4 discovery and its missing-address return value."""
+    sock = Mock()
+    sock.fileno.return_value = 7
+    socket_factory = Mock(return_value=sock)
+    monkeypatch.setattr(simulator.socket, "socket", socket_factory)
+    ioctl = Mock(return_value=b"\0" * 20 + socket.inet_aton("192.0.2.1"))
+    if not has_address:
+        ioctl.side_effect = OSError()
+    monkeypatch.setattr(simulator.fcntl, "ioctl", ioctl)
+    assert simulator.get_ip_address("eth1") == ("192.0.2.1" if has_address else None)
+    socket_factory.assert_called_once_with(socket.AF_INET, socket.SOCK_DGRAM)
+    assert ioctl.call_args.args[:2] == (7, 0x8915)
+
+
+@pytest.mark.parametrize("option,value", [
+    ("--ipv6-loopback-ips", "fc00::1,fc00::2"),
+    ("--ipv6-loopback-ips", "fc00::1,fc00::2,fc00::3,fc00::4"),
+    ("--ipv6-loopback-ips", "fc00::1,192.0.2.1,fc00::3"),
+    ("--ipv6-loopback-ips", "fc00::1,,fc00::3"),
+    ("--ipv6-loopback-ips", "fc00::1/64,fc00::2,fc00::3"),
+    ("--ipv6-loopback-ips", "fc00::1%eth0,fc00::2,fc00::3"),
+    ("--ipv6-loopback-ips", "fc00::1,fc00::2,fc00::3;echo bad"),
+    ("-d", "fc00::1,fc00::2,fc00::3"),
+    ("-d", "192.0.2.1,192.0.2.2"),
+])
+def test_cli_rejects_invalid_triplets(monkeypatch, option, value):
+    """Validate triplet length, literals and family before touching OVS."""
+    monkeypatch.setattr(sys, "argv", ["nic_simulator", "-p", str(PORT), "-v", "test", option, value])
+    with pytest.raises(SystemExit) as error:
+        simulator.parse_args()
+    assert error.value.code == 2
+
+
+def test_cli_defaults_and_optional_ipv6(monkeypatch):
+    """Keep IPv4 defaults and accept the optional IPv6 loopback triplet."""
+    argv = ["nic_simulator", "-p", str(PORT), "-v", "test"]
+    monkeypatch.setattr(sys, "argv", argv)
+    args = simulator.parse_args()
+    assert args.loopback_ips == ",".join(V4)
+    assert args.ipv6_loopback_ips is None
+    monkeypatch.setattr(sys, "argv", argv + ["--ipv6-loopback-ips", ",".join(V6), "-n"])
+    args = simulator.parse_args()
+    assert simulator.validate_loopback_ips(args.ipv6_loopback_ips, 6) == V6
+    assert args.duplicate_nic_upstream
+
+
+def test_constructor_validates_before_ovs(ovs):
+    """Direct callers cannot inject malformed loopback filters into shell commands."""
+    with pytest.raises(ValueError):
+        simulator.OVSBridge("baa-test-1", V4, False, ["fc00::1;echo bad"] * 3)
+    ovs["ovs_vsctl_list_ports"].assert_not_called()
+
+
+@pytest.mark.parametrize("duplicate", [False, True])
+def test_ipv6_flows_mirror_ipv4(ovs, duplicate):
+    """Match the IPv4 priorities, ports, per-ToR enables and duplication policy."""
+    bridge = simulator.OVSBridge("baa-test-1", V4, duplicate, V6)
+    filters = {flow.packet_filter: flow for flow in bridge.flows}
+    for index, address in enumerate(V6):
+        v6 = filters["ipv6,ipv6_dst=%s" % address]
+        v4 = filters["ip,ip_dst=%s" % V4[index]]
+        assert (v6.in_port, v6.output_ports, v6.priority) == (v4.in_port, v4.output_ports, v4.priority)
+        assert v6.enable_output_ports == [True, True]
+    for index, enables in ((1, [False, True]), (2, [True, False])):
+        key = "tcp6,ipv6_dst=%s" % V6[index]
+        if duplicate:
+            assert key not in filters
+        else:
+            flow = filters[key]
+            assert flow.priority == 10
+            assert flow.in_port == bridge.server_nic
+            assert flow.enable_output_ports == enables
+            expected_port = bridge.upper_tor_port if index == 1 else bridge.lower_tor_port
+            assert str(flow).endswith("actions=output:%s" % expected_port)
+    assert "ipv6,nw_proto=58" in filters
+    assert len(bridge.groups) == 1
+
+
+def test_default_flows_remain_ipv4_compatible(ovs):
+    """No opt-in means no new IPv6 loopback flows and the existing ICMPv6 flow remains."""
+    bridge = simulator.OVSBridge("baa-test-1", V4)
+    assert len(bridge.flows) == 11
+    assert not any("ipv6_dst" in (flow.packet_filter or "") for flow in bridge.flows)
+    assert bridge.upstream_icmpv6_flow.packet_filter == "ipv6,nw_proto=58"
+
+
+@pytest.mark.parametrize("duplicate", [False, True])
+@pytest.mark.parametrize("ipv6", [None, V6])
+@pytest.mark.parametrize("portid", [0, 1])
+def test_drop_recovery_covers_both_families(ovs, duplicate, ipv6, portid):
+    """All enabled upstream flows drop/recover together, without affecting the other ToR."""
+    bridge = simulator.OVSBridge("baa-test-1", V4, duplicate, ipv6)
+    upstream = [flow for flow in bridge.flows if isinstance(flow, simulator.OVSUpstreamFlow)]
+    original = [str(flow) for flow in upstream]
+    bridge.set_drop([portid], [1], False)
+    assert bridge.query_forwarding_state([portid, 1 - portid]) == [False, True]
+    for flow in upstream:
+        assert flow.get_drop(portid) == flow.get_port_enable(portid)
+        assert not flow.get_drop(1 - portid)
+        if flow.get_port_enable(portid):
+            assert "output:%s" % flow.output_ports[portid] not in str(flow)
+    before = ovs["ovs_ofctl_mod_flow"].call_count
+    bridge.set_drop([portid], [1], False)
+    assert ovs["ovs_ofctl_mod_flow"].call_count == before
+    bridge.set_drop([portid], [0], False)
+    assert bridge.downstream_flows[portid].drop
+    bridge.set_drop([portid], [1], True)
+    assert not bridge.downstream_flows[portid].drop
+    assert [str(flow) for flow in upstream] == original
+    assert bridge.query_forwarding_state([0, 1]) == [True, True]
+
+
+@pytest.mark.parametrize("ipv4,ipv6", [
+    ("192.0.2.1", []), (None, ["fc00::1"]), ("192.0.2.1", ["fc00::1", "fc00::2"]), (None, [])
+])
+def test_simulator_aliases_and_unique_lifecycle(monkeypatch, ipv4, ipv6):
+    """One interface has one bridge/server, even with multiple IPv4/IPv6 aliases."""
+    monkeypatch.setattr(simulator.NiCSimulator, "_find_all_server_nics", lambda self: ["eth1"])
+    monkeypatch.setattr(simulator.NiCSimulator, "_find_all_bridges", lambda self: ["baa-test-1"])
+    monkeypatch.setattr(simulator, "get_ip_address", lambda interface: ipv4 if interface == "eth1" else None)
+    monkeypatch.setattr(simulator, "get_ipv6_addresses",
+                        lambda interface: ipv6 if interface == "eth1" else ["fc00::100"])
+    bridge_factory = Mock()
+    server_factory = Mock()
+    monkeypatch.setattr(simulator, "OVSBridge", bridge_factory)
+    monkeypatch.setattr(simulator, "NiCServer", server_factory)
+    instance = simulator.NiCSimulator("test", "mgmt", PORT, V4, False, V6)
+    addresses = ([ipv4] if ipv4 else []) + ipv6
+    assert list(instance.servers) == addresses
+    assert instance.mgmt_server.binding_addresses == ("fc00::100",)
+    assert instance.mgmt_server.nic_servers is instance.servers
+    if not addresses:
+        bridge_factory.assert_not_called()
+        server_factory.assert_not_called()
+        return
+    bridge_factory.assert_called_once_with("baa-test-1", V4, False, V6)
+    server_factory.assert_called_once_with(addresses[0], bridge_factory.return_value, PORT, addresses)
+    assert all(server is server_factory.return_value for server in instance.servers.values())
+    assert all(bridge is bridge_factory.return_value for bridge in instance.ovs_bridges.values())
+    instance.start_nic_servers()
+    instance.stop_nic_servers()
+    server_factory.return_value.start.assert_called_once()
+    server_factory.return_value.stop.assert_called_once()
+    server_factory.return_value.join.assert_called_once()
+
+
+def test_no_management_address_fails_before_ovs(monkeypatch):
+    """Do not create listeners on None/wildcards or alter bridges without a management address."""
+    monkeypatch.setattr(simulator.NiCSimulator, "_find_all_server_nics", lambda self: [])
+    monkeypatch.setattr(simulator, "get_ip_address", lambda interface: None)
+    monkeypatch.setattr(simulator, "get_ipv6_addresses", lambda interface: [])
+    with pytest.raises(ValueError, match="management interface"):
+        simulator.NiCSimulator("test", "mgmt", PORT, V4)
+
+
+@pytest.mark.parametrize("addresses", [("192.0.2.1",), ("fc00::1",), ("192.0.2.1", "fc00::1")])
+def test_nic_binds_specific_addresses_to_one_grpc_server(monkeypatch, addresses):
+    """Each NIC binds only its explicit addresses, registering a single servicer."""
+    transport = Mock()
+    transport.add_insecure_port.return_value = PORT
+    factory = Mock(return_value=transport)
+    monkeypatch.setattr(simulator.grpc, "server", factory)
+    register = Mock()
+    monkeypatch.setattr(simulator.nic_simulator_grpc_service_pb2_grpc,
+                        "add_DualToRActiveServicer_to_server", register)
+    server = simulator.NiCServer(addresses[0], Mock(), PORT, addresses)
+    server.start()
+    server.start()
+    server.join(timeout=2)
+    server.stop()
+    factory.assert_called_once()
+    register.assert_called_once_with(server, transport)
+    assert transport.add_insecure_port.call_args_list == [
+        call(simulator.grpc_target(address, PORT)) for address in addresses
+    ]
+    transport.start.assert_called_once()
+
+
+@pytest.mark.parametrize("kind", ["nic", "mgmt"])
+@pytest.mark.parametrize("failure", [0, RuntimeError("bind failed")])
+def test_bind_failure_is_synchronous_and_cleans_up(monkeypatch, kind, failure):
+    """An unsuccessful second bind cannot leave a partly active dual-stack service."""
+    transport = Mock()
+    transport.add_insecure_port.side_effect = [PORT, failure]
+    monkeypatch.setattr(simulator.grpc, "server", Mock(return_value=transport))
+    if kind == "nic":
+        server = simulator.NiCServer("192.0.2.1", Mock(), PORT, ["fc00::1"])
+    else:
+        server = simulator.MgmtServer("192.0.2.1", PORT, {}, ["fc00::1"])
+    with pytest.raises(RuntimeError):
+        server.start()
+    transport.start.assert_not_called()
+    transport.stop.assert_called_once_with(grace=None)
+    if kind == "nic":
+        assert not server.started
+        assert server.thread is None
+
+
+@pytest.mark.parametrize("addresses", [[], ["::"], ["0.0.0.0"]])
+def test_no_wildcard_or_empty_listener_set(addresses):
+    """Reject configurations that could cross NIC boundaries or listen nowhere."""
+    transport = Mock()
+    with pytest.raises(ValueError):
+        simulator.bind_grpc_addresses(transport, addresses, PORT)
+    transport.add_insecure_port.assert_not_called()
+    transport.stop.assert_called_once_with(grace=None)
+
+
+def test_multiple_nics_keep_separate_state(monkeypatch, ovs):
+    """IPv6 aliases share their own NIC's bridge, never another NIC's state."""
+    monkeypatch.setattr(simulator.NiCSimulator, "_find_all_server_nics", lambda self: ["eth1", "eth2"])
+    monkeypatch.setattr(simulator.NiCSimulator, "_find_all_bridges", lambda self: ["baa-test-1", "baa-test-2"])
+    monkeypatch.setattr(simulator, "get_ip_address", lambda interface: {
+        "eth1": "192.0.2.1", "eth2": "192.0.2.2", "mgmt": "192.0.2.100"
+    }[interface])
+    monkeypatch.setattr(simulator, "get_ipv6_addresses", lambda interface: {
+        "eth1": ["fc00::1"], "eth2": ["fc00::2"], "mgmt": ["fc00::100"]
+    }[interface])
+    instance = simulator.NiCSimulator("test", "mgmt", PORT, V4, False, V6)
+    assert instance.servers["192.0.2.1"] is instance.servers["fc00::1"]
+    assert instance.servers["192.0.2.2"] is instance.servers["fc00::2"]
+    assert instance.servers["fc00::1"] is not instance.servers["fc00::2"]
+    instance.ovs_bridges["fc00::1"].set_forwarding_state([0], [False])
+    assert instance.ovs_bridges["192.0.2.1"].query_forwarding_state([0]) == [False]
+    assert instance.ovs_bridges["fc00::2"].query_forwarding_state([0]) == [True]
+    assert instance.mgmt_server.binding_addresses == ("192.0.2.100", "fc00::100")
+
+
+@pytest.mark.parametrize("stage", ["nic", "mgmt"])
+def test_main_cleans_up_on_startup_failure(monkeypatch, stage):
+    """Clean up previously started NICs if a later NIC or management bind fails."""
+    monkeypatch.setattr(sys, "argv", ["nic_simulator", "-p", str(PORT), "-v", "test"])
+    monkeypatch.setattr(simulator, "config_env", Mock())
+    monkeypatch.setattr(simulator, "config_logging", Mock())
+    monkeypatch.setattr(simulator.OVSCommand, "setup_openflow_version", Mock())
+    instance = Mock()
+    if stage == "nic":
+        instance.start_nic_servers.side_effect = RuntimeError("bind failed")
+    else:
+        instance.start_mgmt_server.side_effect = RuntimeError("bind failed")
+    factory = Mock(return_value=instance)
+    monkeypatch.setattr(simulator, "NiCSimulator", factory)
+    with pytest.raises(RuntimeError, match="bind failed"):
+        simulator.main()
+    factory.assert_called_once_with("test", "mgmt", PORT, V4, False, None)
+    instance.stop_nic_servers.assert_called_once()
+    instance.mgmt_server.server.stop.assert_called_once_with(grace=None)
+
+
+def test_management_dual_bind_and_ipv6_client(monkeypatch):
+    """Management listeners and internal client channels bracket IPv6 literals."""
+    transport = Mock()
+    transport.add_insecure_port.return_value = PORT
+    monkeypatch.setattr(simulator.grpc, "server", Mock(return_value=transport))
+    channel = Mock()
+    monkeypatch.setattr(simulator.grpc, "insecure_channel", channel)
+    stub_factory = Mock()
+    monkeypatch.setattr(simulator.nic_simulator_grpc_service_pb2_grpc, "DualToRActiveStub", stub_factory)
+    server = simulator.MgmtServer("192.0.2.100", PORT, {}, ["fc00::100"])
+    server.start()
+    assert transport.add_insecure_port.call_args_list == [call("192.0.2.100:50075"), call("[fc00::100]:50075")]
+    stub = server._get_client_stub("fc00:0:0:0:0:0:0:1")
+    assert stub is server._get_client_stub("fc00::1")
+    channel.assert_called_once_with("[fc00::1]:50075", options=simulator.GRPC_CLIENT_OPTIONS)
+
+
+def test_management_alias_admin_operations(monkeypatch):
+    """IPv4 and expanded IPv6 aliases start/stop the same NIC only once per state change."""
+    nic = simulator.NiCServer("192.0.2.1", Mock(), PORT, ["fc00::1"])
+    transport = Mock()
+    transport.add_insecure_port.return_value = PORT
+    factory = Mock(return_value=transport)
+    monkeypatch.setattr(simulator.grpc, "server", factory)
+    mgmt = simulator.MgmtServer("192.0.2.100", PORT, {"192.0.2.1": nic, "fc00::1": nic})
+    for state in (True, False):
+        response = mgmt.SetNicServerAdminState(MGMT_PB.ListOfNiCServerAdminStateRequest(
+            nic_addresses=["192.0.2.1", "fc00:0:0:0:0:0:0:1"], admin_states=[state, state]
+        ), Mock())
+        assert list(response.successes) == [True, True]
+        assert nic.started == state
+    factory.assert_called_once()
+    transport.stop.assert_called_once()
+
+
+@pytest.fixture
+def ipv6_loopback():
+    """Skip real IPv6 tests only when the host cannot bind its IPv6 loopback."""
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as sock:
+            sock.bind(("::1", 0))
+    except OSError as error:
+        pytest.skip("IPv6 loopback unavailable: %s" % error)
+
+
+@pytest.mark.parametrize("dual_stack", [False, True])
+def test_real_grpc_shared_state_and_ipv6_only(ovs, ipv6_loopback, dual_stack):
+    """Real IPv4/IPv6 RPCs and management clients share one bridge and flap/drop state."""
+    bridge = simulator.OVSBridge("baa-test-1", V4, False, V6)
+    addresses = ["127.0.0.1", "::1"] if dual_stack else ["::1"]
+    server = simulator.NiCServer(addresses[0], bridge, 0, addresses)
+    channels = []
+    try:
+        server.start()
+        stubs = []
+        for address in addresses:
+            channel = grpc.insecure_channel(simulator.grpc_target(address, server.binding_port))
+            channels.append(channel)
+            grpc.channel_ready_future(channel).result(timeout=5)
+            stubs.append(simulator.nic_simulator_grpc_service_pb2_grpc.DualToRActiveStub(channel))
+        response = stubs[0].SetAdminForwardingPortState(PB.AdminRequest(portid=[0, 1], state=[False, True]), timeout=5)
+        assert list(response.state) == [False, True]
+        query = PB.AdminRequest(portid=[0, 1])
+        assert list(stubs[-1].QueryAdminForwardingPortState(query, timeout=5).state) == [False, True]
+        assert list(stubs[-1].QueryFlapCounter(PB.FlapCounterRequest(portid=[0, 1]), timeout=5).flaps) == [1, 0]
+        stubs[-1].SetDrop(PB.DropRequest(portid=[1], direction=[1], recover=False), timeout=5)
+        assert list(stubs[0].QueryAdminForwardingPortState(query, timeout=5).state) == [False, False]
+        stubs[-1].SetDrop(PB.DropRequest(portid=[1], direction=[1], recover=True), timeout=5)
+        assert bridge.query_forwarding_state([0, 1]) == [False, True]
+        mgmt = simulator.MgmtServer("::1", server.binding_port, {address: server for address in addresses})
+        # Exercise the actual management internal IPv6 client without replacing it with a mock.
+        context = Mock()
+        reply = mgmt.QueryAdminForwardingPortState(MGMT_PB.ListOfAdminRequest(
+            nic_addresses=["::1"], admin_requests=[PB.AdminRequest(portid=[0, 1])]
+        ), context)
+        context.set_code.assert_not_called()
+        assert list(reply.admin_replies[0].state) == [False, True]
+        server.stop()
+        server.join(timeout=5)
+        server.start()
+        # Restarting the transport must not recreate the bridge or reset its state.
+        with grpc.insecure_channel(simulator.grpc_target("::1", server.binding_port)) as channel:
+            grpc.channel_ready_future(channel).result(timeout=5)
+            stub = simulator.nic_simulator_grpc_service_pb2_grpc.DualToRActiveStub(channel)
+            assert list(stub.QueryFlapCounter(PB.FlapCounterRequest(portid=[0, 1]), timeout=5).flaps) == [1, 0]
+            assert list(stub.QueryAdminForwardingPortState(query, timeout=5).state) == [False, True]
+    finally:
+        for channel in channels:
+            channel.close()
+        server.stop()
+        server.join(timeout=5)
+    assert not server.thread.is_alive()
+
+
+@pytest.mark.parametrize("dual_stack", [False, True])
+def test_real_management_listeners(monkeypatch, ipv6_loopback, dual_stack):
+    """Serve management RPCs on real IPv6-only or IPv4+IPv6 loopback listeners."""
+    addresses = ["127.0.0.1", "::1"] if dual_stack else ["::1"]
+    transport = grpc.server(simulator.futures.ThreadPoolExecutor(max_workers=2))
+    monkeypatch.setattr(simulator.grpc, "server", Mock(return_value=transport))
+    ready = threading.Event()
+    original_wait = transport.wait_for_termination
+
+    def wait_for_termination():
+        ready.set()
+        original_wait()
+
+    monkeypatch.setattr(transport, "wait_for_termination", wait_for_termination)
+    mgmt = simulator.MgmtServer(addresses[0], 0, {}, addresses)
+    thread = simulator.InterruptableThread(target=mgmt.start)
+    try:
+        thread.start()
+        assert ready.wait(timeout=5), "Management server did not start"
+        for address in addresses:
+            with grpc.insecure_channel(simulator.grpc_target(address, mgmt.binding_port)) as channel:
+                grpc.channel_ready_future(channel).result(timeout=5)
+                stub = simulator.nic_simulator_grpc_mgmt_service_pb2_grpc.DualTorMgmtServiceStub(channel)
+                reply = stub.QueryAdminForwardingPortState(MGMT_PB.ListOfAdminRequest(), timeout=5)
+                assert list(reply.admin_replies) == []
+    finally:
+        transport.stop(grace=None)
+        thread.join(timeout=5)
+    assert not thread.is_alive()


### PR DESCRIPTION
### Description of PR

Summary: Add native IPv6 support to the active-active NIC simulator so clients can use an IPv6-only SoC endpoint, while preserving IPv4 behavior and sharing forwarding state between both address families.

Related client change: https://github.com/sonic-net/sonic-platform-daemons/pull/836

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

None requested.

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The simulator currently discovers only IPv4 NIC addresses and constructs unbracketed gRPC endpoints. This prevents direct validation of clients using IPv6-only SoC configuration. IPv6 connections also need equivalents of the existing per-ToR TCP return-path and loopback duplication flows.

#### How did you do it?

- Discover stable global-scope IPv6 interface addresses, including ULA, using shell-free iproute2 JSON queries. Exclude link-local, tentative, DAD-failed, deprecated, and temporary addresses; retain existing IPv4 discovery.
- Bind each NIC's IPv4 and IPv6 addresses to one gRPC server and one OVS bridge/state object. Support IPv6-only interfaces without introducing wildcard listeners.
- Format IPv6 listener/client targets as `[address]:port` and validate every bind.
- Support management IPv6 aliases for the same NIC, including server start/stop, without duplicating lifecycle operations.
- Add optional `--ipv6-loopback-ips` with validated Loopback2/upper Loopback3/lower Loopback3 addresses. Generate IPv6 counterparts of the existing loopback and per-ToR TCP return flows, preserving duplication policy and shared drop/recovery behavior.
- Add standalone unit tests and generic usage documentation. No protobuf changes or runtime dependencies beyond the existing Python standard library, gRPC, and iproute2 are introduced.

#### How did you verify/test it?

- **76 standalone unit tests passed, with no skips**, rerun after rebasing onto current public master. Coverage includes IPv4 compatibility, IPv6 discovery/filtering, target formatting, invalid CLI input, binding failures, shared address aliases, OVS flow/drop/recovery logic, and real dual-bind/IPv6-only loopback gRPC RPCs.
- `git diff --check` passed.
- **Running-daemon end-to-end validation passed from both ToRs** for one active-active port, using the modified native simulator directly: no IPv6 proxy, synthetic replies, or substituted daemon connectivity callbacks.
- Confirmed IPv4 preference with both SoC address fields configured and native IPv6 established sockets/Redis `READY` when `soc_ipv4` was absent.
- Verified successful `QueryAdminForwardingPortState` and `SetAdminForwardingPortState` RPCs and actual OVS forwarding-state updates over IPv6.
- Verified the IPv6 OVS flows were accepted and their packet counters increased.
- Stopped and started only the NIC listeners via the management IPv6 alias. Both running daemons detected failure and automatically reconnected to `READY` without daemon restarts; real IPv6 RPCs resumed.
- Restored original client configuration/code after validation and verified IPv4 connectivity and active forwarding state.

Scope: This is simulator support, not complete IPv6-only system provisioning. Interface addresses, routing, and any required per-ToR source translation must be provisioned separately. Full integration/HA traffic-loss tests, all-port IPv6 scale, TLS/mTLS, and long-duration stability were not run. Existing operation/link/version RPC stubs are not used as success evidence.

Elastictest plan 6aa0849ac6c96c8b4c4567fb
<img width="427" height="691" alt="image" src="https://github.com/user-attachments/assets/d87fa409-007a-4347-a314-0a4ed2dcec78" />


#### Any platform specific information?

No ASIC-specific changes. Runtime use requires Linux network interfaces and the existing OVS-based NIC simulator environment. Standalone tests mock OVS; real IPv6 loopback tests skip only when the host cannot bind IPv6 loopback.

#### Supported testbed topology if it's a new test case?

Not a new topology-specific integration test. The change supports the existing active-active DualToR NIC simulator. Unit tests run independently of integration fixtures.

### Documentation

Added `ansible/dualtor/nic_simulator/README.md` with generic CLI examples, shared listener/state semantics, provisioning boundaries, and standalone test instructions. No deployment-specific configuration or validation artifacts are included.