### PR TITLE
[202605] snappi/pfc: stop data flows explicitly so paused-traffic tests can finish (#26751)

### DIFF
--- a/tests/common/snappi_tests/read_pcap.py
+++ b/tests/common/snappi_tests/read_pcap.py
@@ -24,6 +24,8 @@ def validate_pfc_frame(pfc_pcap_file, SAMPLE_SIZE=15000, UTIL_THRESHOLD=0.8):
     Returns:
         True if valid PFC frame, False otherwise
     """
+    logger.info("Validating PFC frames in capture file '{}' (sample size {}, util threshold {})"
+                .format(pfc_pcap_file, SAMPLE_SIZE, UTIL_THRESHOLD))
     f = open(pfc_pcap_file, "rb")
     pcap = dpkt.pcapng.Reader(f)
     seen_non_zero_cev = False  # Flag for checking if any PFC frame has non-zero class enable vector
@@ -37,15 +39,29 @@ def validate_pfc_frame(pfc_pcap_file, SAMPLE_SIZE=15000, UTIL_THRESHOLD=0.8):
         if eth.type == PFC_MAC_CONTROL_CODE:
             dest_mac = mac_to_str(eth.dst)
             if dest_mac.lower() != PFC_DEST_MAC:
+                logger.info("PFC frame {} has destination MAC {}, expected {}"
+                            .format(curPktCount, dest_mac, PFC_DEST_MAC))
                 return False, "Destination MAC address is not 01:80:c2:00:00:01"
             pfc_packet = PFCPacket(pfc_frame_bytes=bytes(eth.data))
             if not pfc_packet.is_valid():
                 logger.info("PFC frame {} is not valid. Please check the capture file.".format(curPktCount))
                 return False, "PFC frame is not valid"
             cev = [int(i) for i in pfc_packet.class_enable_vec]
-            seen_non_zero_cev = True if sum(cev) > 0 else seen_non_zero_cev
+            cev_nonzero = sum(cev) > 0
+            # Per-frame detail at debug level so a 15k-packet sample does not flood the log.
+            logger.debug("PFC frame {} valid: dst_mac={}, cbfc_opcode={}, class_enable_vec={}, class_pause_times={}"
+                         .format(curPktCount, dest_mac, hex(pfc_packet.cbfc_opcode),
+                                 pfc_packet.class_enable_vec, pfc_packet.class_pause_times))
+            if cev_nonzero and not seen_non_zero_cev:
+                logger.info("First PFC frame with non-zero class enable vector at packet {}: "
+                            "class_enable_vec={}, class_pause_times={}"
+                            .format(curPktCount, pfc_packet.class_enable_vec, pfc_packet.class_pause_times))
+            seen_non_zero_cev = seen_non_zero_cev or cev_nonzero
             curPFCPktCount += 1
         curPktCount += 1
+
+    logger.info("Scanned {} packets, found {} valid PFC frame(s); non-zero class enable vector seen: {}"
+                .format(curPktCount, curPFCPktCount, seen_non_zero_cev))
 
     if not seen_non_zero_cev:
         logger.info("No PFC frames with non-zero class enable vector found in the capture file.")
@@ -58,9 +74,12 @@ def validate_pfc_frame(pfc_pcap_file, SAMPLE_SIZE=15000, UTIL_THRESHOLD=0.8):
         logger.info("No PFC frames found in the capture file.")
         return False, "No PFC frames found in the capture file"
     elif pfc_util < UTIL_THRESHOLD:
-        logger.info("PFC utilization is too low. Please check the capture file.")
+        logger.info("PFC utilization {:.2f} is below threshold {}. Please check the capture file."
+                    .format(pfc_util, UTIL_THRESHOLD))
         return False, "PFC utilization is too low"
 
+    logger.info("PFC frame validation passed: {} valid PFC frame(s), utilization {:.2f} (threshold {})"
+                .format(curPFCPktCount, pfc_util, UTIL_THRESHOLD))
     return True, None
 
 

--- a/tests/common/snappi_tests/snappi_helpers.py
+++ b/tests/common/snappi_tests/snappi_helpers.py
@@ -368,6 +368,60 @@ def fetch_snappi_flow_metrics(api, flow_names):
     return flow_metrics
 
 
+def set_flow_transmit_state(api, operation, flow_names=None):
+    """
+    Start or stop transmit, optionally scoped to specific flows.
+
+    Scoping matters when some flows must keep running: stopping every flow also
+    stops a PFC pause storm, letting the DUT drain frames it was holding.
+
+    Args:
+    api: snappi api
+    operation (str): 'start' or 'stop'
+    flow_names (list): flows to act on; None acts on all flows. An empty list
+                       is rejected — a scoped call that resolved to no flows
+                       is a caller bug, not a stop-all.
+
+    Returns:
+    None
+    """
+    if flow_names is not None and not flow_names:
+        raise ValueError(
+            "set_flow_transmit_state: flow_names=[] would have been treated as "
+            "'{} ALL flows' (including any PFC pause storm). If you meant all "
+            "flows, pass flow_names=None; otherwise check why the scoped flow "
+            "list resolved to empty.".format(operation)
+        )
+    cs = api.control_state()
+    if flow_names is not None:
+        cs.traffic.flow_transmit.flow_names = flow_names
+    if operation == "start":
+        cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
+    elif operation == "stop":
+        cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
+    else:
+        raise ValueError("operation must be 'start' or 'stop', got {}".format(operation))
+    api.set_control_state(cs)
+
+
+def are_flows_stopped(api, flow_names):
+    """
+    Whether every named flow has reached the 'stopped' transmit state.
+
+    Args:
+    api: snappi api
+    flow_names (list): list of flow names
+
+    Returns:
+    bool: True when a metric was returned for every named flow and all report 'stopped'
+    """
+    flow_metrics = fetch_snappi_flow_metrics(api, flow_names)
+    if len(flow_metrics) != len(flow_names):
+        return False
+
+    return {metric.transmit for metric in flow_metrics} == {'stopped'}
+
+
 def is_traffic_converged(snappi_api, flow_names=[], threshold_perentage=0.01):
     """
     Returns true if traffic has converged within the threshold

--- a/tests/common/snappi_tests/snappi_test_params.py
+++ b/tests/common/snappi_tests/snappi_test_params.py
@@ -78,3 +78,6 @@ class SnappiTestParams():
         self.num_tx_links: Optional[int] = 1
         self.num_rx_links: Optional[int] = 1
         self.tx_dscp_values: Optional[list[int]] = []
+        # Stop the data flows (only) after in-flight stats, so a flow held under a
+        # continuous pause storm reaches 'stopped' instead of timing out the wait loop.
+        self.stop_data_flows_before_final_stats: bool = False

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -21,7 +21,7 @@ from tests.common.snappi_tests.common_helpers import config_capture_settings, ge
     get_pfcwd_stats, get_interface_counters_detailed
 from tests.common.snappi_tests.port import select_ports, select_tx_port
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics, \
-    fetch_flow_metrics_for_macsec    # noqa: F401
+    fetch_flow_metrics_for_macsec, set_flow_transmit_state, are_flows_stopped    # noqa: F401
 from .variables import pfcQueueGroupSize, pfcQueueValueDict
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 from tests.common.cisco_data import is_cisco_device
@@ -757,9 +757,7 @@ def run_traffic(duthost,
 
     if not ptype:
         logger.info("Starting transmit on all flows ...")
-        cs = api.control_state()
-        cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
-        api.set_control_state(cs)
+        set_flow_transmit_state(api, "start")
     else:
         print('Generating Traffic Item')
         trafficItems = ixnet.Traffic.TrafficItem.find()
@@ -845,15 +843,19 @@ def run_traffic(duthost,
             in_flight_flow_metrics = fetch_flow_metrics_for_macsec(api).Rows
         time.sleep(exp_dur_sec*(3/5))
 
+    # A flow held under PFC flow control never transitions to 'stopped' on its own, so stop
+    # transmit here. Only the data flows: the pause storm must keep DUT egress paused.
+    if snappi_extra_params.stop_data_flows_before_final_stats and not ptype:
+        logger.info("Stopping transmit on data flows after in-flight stats collection")
+        set_flow_transmit_state(api, "stop", flow_names=data_flow_names)
+
     attempts = 0
     max_attempts = 20
     while attempts < max_attempts:
         logger.info("Checking if all flows have stopped. Attempt #{}".format(attempts + 1))
         if not ptype:
-            flow_metrics = fetch_snappi_flow_metrics(api, data_flow_names)
             # If all the data flows have stopped
-            transmit_states = [metric.transmit for metric in flow_metrics]
-            if len(flow_metrics) == len(data_flow_names) and list(set(transmit_states)) == ['stopped']:
+            if are_flows_stopped(api, data_flow_names):
                 logger.info("All test and background traffic flows stopped")
                 time.sleep(SNAPPI_POLL_DELAY_SEC)
                 break
@@ -879,6 +881,19 @@ def run_traffic(duthost,
     pytest_assert(attempts < max_attempts,
                   "Flows do not stop in {} seconds".format(max_attempts))
 
+    # Capture stop + retrieval is slow enough to outlast the pause storm, which would let the
+    # DUT drain buffered frames and push a paused flow's rx_frames above 0. Read metrics first.
+    read_stats_before_capture_stop = (
+        snappi_extra_params.stop_data_flows_before_final_stats
+        and not ptype
+        and pcap_type != packet_capture.NO_CAPTURE
+    )
+
+    flow_metrics = None
+    if read_stats_before_capture_stop:
+        logger.info("Dumping per-flow statistics")
+        flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)
+
     if pcap_type != packet_capture.NO_CAPTURE:
         logger.info("Stopping packet capture ...")
         request = api.capture_request()
@@ -891,16 +906,15 @@ def run_traffic(duthost,
         with open(snappi_extra_params.packet_capture_file + ".pcapng", 'wb') as fid:
             fid.write(pcap_bytes.getvalue())
 
-    # Dump per-flow statistics
-    logger.info("Dumping per-flow statistics")
-    if not ptype:
-        flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)
-    else:
-        flow_metrics = fetch_flow_metrics_for_macsec(api).Rows
+    # Dump per-flow statistics (unless already collected above before capture teardown)
+    if flow_metrics is None:
+        logger.info("Dumping per-flow statistics")
+        if not ptype:
+            flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)
+        else:
+            flow_metrics = fetch_flow_metrics_for_macsec(api).Rows
     logger.info("Stopping transmit on all remaining flows")
-    cs = api.control_state()
-    cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
-    api.set_control_state(cs)
+    set_flow_transmit_state(api, "stop")
     check_for_crc_errors(api, snappi_extra_params)
     return flow_metrics, switch_device_results, in_flight_flow_metrics
 

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -3,12 +3,12 @@ import time
 import sys
 from tests.common.cisco_data import is_cisco_device
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts  # noqa: F401
-from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector,\
-    get_lossless_buffer_size, get_pg_dropped_packets,\
-    disable_packet_aging, enable_packet_aging, sec_to_nanosec,\
-    get_pfc_frame_count, packet_capture, config_capture_pkt,\
+from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
+    get_lossless_buffer_size, get_pg_dropped_packets, \
+    disable_packet_aging, enable_packet_aging, sec_to_nanosec, \
+    get_pfc_frame_count, packet_capture, config_capture_pkt, \
     traffic_flow_mode, calc_pfc_pause_flow_rate, get_tx_frame_count      # noqa: F401
 from tests.common.snappi_tests.port import select_ports, select_tx_port  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id, wait_for_arp  # noqa: F401

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -205,11 +205,11 @@ def run_pfc_test(api,
         # PFC pause frame capture is not requested
         valid_pfc_frame_test = False
 
-    if valid_pfc_frame_test and not is_cisco_device(egress_duthost):
-        snappi_extra_params.traffic_flow_config.pause_flow_config["flow_dur_sec"] = DATA_FLOW_DURATION_SEC + \
-            data_flow_delay_sec + SNAPPI_POLL_DELAY_SEC + PAUSE_FLOW_DUR_BASE_SEC
-        snappi_extra_params.traffic_flow_config.pause_flow_config["flow_traffic_type"] = \
-            traffic_flow_mode.FIXED_DURATION
+    # A paused test flow is backpressured by the continuous pause storm and never reaches
+    # 'stopped' on its own, so run_traffic must stop the data flows explicitly. Cisco's
+    # valid-PFC-frame path is excluded to keep its existing behavior unchanged.
+    if test_traffic_pause and not (valid_pfc_frame_test and is_cisco_device(egress_duthost)):
+        snappi_extra_params.stop_data_flows_before_final_stats = True
 
     no_of_streams = 1
     if egress_duthost.facts['asic_type'] == "cisco-8000":


### PR DESCRIPTION
Manual cherry-pick of #26751 (merge commit 088c460250c64ad57879903236127277406c41f9) to **202605**. The automated cherry-pick hit a conflict (`Cherry Pick Conflict_202605`).

**Conflict resolution:** the merge commit's context in `snappi_helpers.py` / `traffic_generation.py` included `fetch_pfc_queue_group_size` / `pfc_queue_group_size` from #26174 (pfcQueueGroupSize autodetect), which is not in 202605. Only the two helpers this PR adds (`set_flow_transmit_state`, `are_flows_stopped`) were kept, and 202605's existing `from .variables import pfcQueueGroupSize, pfcQueueValueDict` import was left as is. The resulting diff is line-for-line identical to the original PR (`diff` of the `+`/`-` lines is empty).

202605 test result (from the original PR): https://elastictest.org/scheduler/testplan/6a9a1726f1937a379ef4fd35 - all PFC test cases passed. MSFT ADO 39059763.

---

### Description of PR

Summary:
Fixes #26748

Two false failures in the snappi PFC pause tests, both caused by a continuous PFC pause storm interacting badly with `run_traffic`'s end-of-run sequencing. Both are test-framework sequencing bugs, not DUT bugs.

**`Flows do not stop in 20 seconds`** — after in-flight stats are collected, `run_traffic` waits for the data flows to reach `stopped` before reading final metrics. In a pause test the lossless test flow is backpressured *at the source* by the DUT's own PFC: the DUT's lossless buffer fills, it pauses the traffic generator, and the fixed-duration flow never finishes transmitting its packet budget — so it never reaches `stopped` and the wait loop exhausts its retries.

**`<flow> should be paused`** — the valid-PFC-frame tests hold DUT egress paused while they capture and validate the PFC frames the DUT emits. `run_pfc_test` reconfigured that pause flow to `FIXED_DURATION`, sized from nominal traffic duration only. Real runtime also includes the DUT poll loop's device round-trips, up to 20 s of wait loop, and the pcap retrieval — none of it in the budget. The pause expired mid-teardown, the DUT drained its buffered frames, and `rx_frames` was no longer 0.

These two are mutually exclusive under *any* fixed pause duration. Short enough for the flow to self-stop means the pause has lapsed and `rx_frames > 0`; long enough to keep `rx_frames == 0` means the flow is still backpressured and never stops. It is not a tuning problem, which is why this changes the sequencing rather than the duration.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

Validated on Broadcom DNX (400G, 4x400G AresOne-M tgen), DUT image `202511.Nexthop.137667`.

**`snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py`** - 11 collected, **7 passed, 0 failed, 4 skipped** (2299s). The 4 skips are the warm/fast reboot variants, which the SKU does not support (`Reboot type warm/fast is not supported on hwsku ...`).

```
PASSED   test_pfc_pause_single_lossless_prio[3]
PASSED   test_pfc_pause_single_lossless_prio[4]
PASSED   test_pfc_pause_counter_check[3]
PASSED   test_pfc_pause_counter_check[4]
PASSED   test_pfc_pause_multi_lossless_prio
PASSED   test_pfc_pause_single_lossless_prio_reboot[cold]
PASSED   test_pfc_pause_multi_lossless_prio_reboot[cold]
SKIPPED  ..._reboot[warm] x2, ..._reboot[fast] x2   (SKU does not support)
```

Across all 7 `run_traffic` cycles the data-flow stop fired and the wait loop broke on the **first check**; previously it ran all 20 attempts and asserted. Zero occurrences of `Flows do not stop in 20 seconds` or `<flow> should be paused`.

**`snappi_tests/pfc/test_valid_pfc_frame_with_snappi.py::test_valid_pfc_frame`** - **PASSED** (584s). This is the test that exercises the continuous pause storm, the metrics-before-capture-teardown reordering, and the resulting capture window together:

```
Validating PFC frames in capture file 'PFC_Capture.pcapng' (sample size 15000, util threshold 0.8)
First PFC frame with non-zero class enable vector at packet 0
Scanned 15000 packets, found 15000 valid PFC frame(s); non-zero class enable vector seen: True
PFC frame validation passed: 15000 valid PFC frame(s), utilization 1.00 (threshold 0.8)
```

The capture filled the entire 15000-packet sample (utilization 1.00 against the 0.8 threshold), so reading the final metrics before capture teardown leaves the capture window comfortably sufficient.

**`snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py`** - 12 collected, **8 passed, 0 failed, 4 skipped** (2573s; the 4 skips are again the warm/fast reboot variants). These tests pass `test_traffic_pause=False`, so they cover the derive's negative branch:

```
run_traffic cycles                                      : 8
"Stopping transmit on data flows after in-flight stats"  : 0    <- flag correctly stayed False
"Stopping transmit on all remaining flows"               : 8    <- unchanged end-of-run path
```

Taken together the derive is confirmed in both directions: the data-flow stop fired on 8/8 cycles where `test_traffic_pause=True` (pause-lossless plus the capture test) and on 0/8 cycles where it is `False`.

### Approach

#### What is the motivation for this PR?

Nine PFC pause tests fail with `Flows do not stop in 20 seconds` on high-speed ports whose lossless buffer fills fast enough to backpressure the traffic generator, and the two valid-PFC-frame capture tests fail with `<flow> should be paused`.

#### How did you do it?

`run_traffic` now stops the data flows explicitly after in-flight collection, so they reach `stopped` without the pause having to expire. The stop is **scoped to `data_flow_names`** — stopping every flow would also stop the pause storm, letting the DUT drain to the receiver and turning the first failure into the second. Gated behind `SnappiTestParams.stop_data_flows_before_final_stats`, default `False`, so ECN, pfcwd and every other `run_traffic` caller is unchanged.

`run_pfc_test` derives the flag from `test_traffic_pause`, a parameter it already receives, rather than each test opting in:

```python
if test_traffic_pause and not (valid_pfc_frame_test and is_cisco_device(egress_duthost)):
    snappi_extra_params.stop_data_flows_before_final_stats = True
```

Every `test_traffic_pause=True` caller needs the stop and no `test_traffic_pause=False` caller does, so this covers pause-lossless, zero-src-MAC, headroom and the two capture tests with nothing to forget. A future paused test gets the behavior by construction instead of hitting the timeout until someone remembers a flag.

The capture path keeps its pause storm continuous and reads the final TGEN metrics **before** the capture is stopped and retrieved, since that teardown is slow enough to outlast the pause window. Non-capture callers still read metrics after the (skipped) capture block, exactly as before.

Transmit control is routed through two new helpers in `snappi_helpers.py`:

```python
set_flow_transmit_state(api, operation, flow_names=None)
are_flows_stopped(api, flow_names)
```

so the scoped stop states its constraint at the call site rather than in an assignment that is easy to miss. Behavior is identical — with `flow_names` empty the helper emits exactly the previous control state, and `are_flows_stopped` keeps both the length guard and the all-`stopped` check. The macsec (`ptype`) branch is untouched, as are the `flow_transmit` sites in `run_basic_traffic` and `run_traffic_and_collect_stats`.

Finally, `validate_pfc_frame` gains diagnostics: the first frame with a non-zero class-enable vector, scan totals, and actual utilization against the threshold, with per-frame detail at `debug` so a 15k-packet sample does not flood the log. No behavior change — this is the instrumentation for the capture-window question noted above.

#### How did you verify/test it?

See **Test result**.

#### Any platform specific information?

Observed on Broadcom DNX at 400G. The root cause is framework sequencing and is not vendor-specific — it affects any platform whose lossless buffer fills fast enough to backpressure the traffic generator. Cisco's valid-PFC-frame path is explicitly excluded from the derive so its behavior is unchanged; that same `valid_pfc_frame_test and not is_cisco_device(...)` guard previously kept Cisco out of the `FIXED_DURATION` reconfiguration.

#### Supported testbed topology if it's a new test case?

N/A — existing tests.

### Documentation

No documentation change. The behavior of these tests is unchanged; only their reliability.

