### PR TITLE
Fix drop-check in test_acl_drop and test_acl_egress_drop for test_drop_counters.py

### DIFF
--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -66,7 +66,7 @@ def ensure_no_l3_drops(duthost, packets_count):
     unexpected_drops = {}
     for iface, value in list(intf_l3_counters.items()):
         try:
-            rx_err_value = int(value[RX_ERR])
+            rx_err_value = int(str(value[RX_ERR]).replace(",", ""))
         except ValueError as err:
             logger.info("Unable to verify L3 drops on iface {}, L3 counters may not be supported on this platform\n{}"
                         .format(iface, err))
@@ -83,7 +83,7 @@ def ensure_no_l2_drops(duthost, packets_count):
     unexpected_drops = {}
     for iface, value in list(intf_l2_counters.items()):
         try:
-            rx_drp_value = int(value[RX_DRP])
+            rx_drp_value = int(str(value[RX_DRP]).replace(",", ""))
         except ValueError as err:
             logger.warning("Unable to verify L2 drops on iface {}\n{}".format(iface, err))
             continue

--- a/tests/drop_packets/combined_drop_counters.yml
+++ b/tests/drop_packets/combined_drop_counters.yml
@@ -41,3 +41,4 @@ acl_l2:
     - "x86_64-arista.*"
     - "x86_64-cel_seastone.*"
     - "x86_64-nokia.*"
+    - "x86_64-kvm_x86_64-r0"  # VPP


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

Fixes a latent integer-parsing bug in the drop-counter test helpers that caused ensure_no_l2_drops / ensure_no_l3_drops to silently skip any interface whose RX_DRP / RX_ERR reached the thousands (comma-formatted by portstat -j / intfstat -j). Because PKT_NUMBER = 1000, these checks have effectively been no-ops at the exact packet count they validate. Also declares VPP (x86_64-kvm_x86_64-r0) as an ACL/L2 combined-counter platform, since VPP charges ACL denies to the interface drop counter (RX_DRP).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

Previously, this failure resulted in a warning log:

```
drop_packets/test_drop_counters.py::test_acl_drop[port_channel_members-vlab-vpp-01]
-------------------------------- live log call ---------------------------------
01/09/2026 17:21:40 drop_counters.ensure_no_l2_drops   L0088 WARNING| Unable to verify L2 drops on iface Ethernet28
invalid literal for int() with base 10: '1,000'
PASSED                                                                    [ 83%]

drop_packets/test_drop_counters.py::test_acl_drop[vlan_members-vlab-vpp-01] SKIPPED [ 84%]

drop_packets/test_drop_counters.py::test_acl_drop[rif_members-vlab-vpp-01]
-------------------------------- live log call ---------------------------------
01/09/2026 17:22:48 drop_counters.ensure_no_l2_drops   L0088 WARNING| Unable to verify L2 drops on iface Ethernet84
invalid literal for int() with base 10: '1,000'
PASSED                                                                    [ 85%]

drop_packets/test_drop_counters.py::test_acl_egress_drop[port_channel_members-vlab-vpp-01]
-------------------------------- live log call ---------------------------------
01/09/2026 17:24:39 drop_counters.ensure_no_l2_drops   L0088 WARNING| Unable to verify L2 drops on iface Ethernet28
invalid literal for int() with base 10: '1,000'
PASSED                                                                    [ 86%]

drop_packets/test_drop_counters.py::test_acl_egress_drop[vlan_members-vlab-vpp-01] SKIPPED [ 87%]

drop_packets/test_drop_counters.py::test_acl_egress_drop[rif_members-vlab-vpp-01]
-------------------------------- live log call ---------------------------------
01/09/2026 17:26:31 drop_counters.ensure_no_l2_drops   L0088 WARNING| Unable to verify L2 drops on iface Ethernet112
invalid literal for int() with base 10: '1,000'
PASSED
```

With this change, the check is skipped for sonic-vpp and only the ACL check remains.

### Approach

#### What is the motivation for this PR?
ensure_no_l2_drops / ensure_no_l3_drops parse counters with int(value[RX_DRP]), but portstat -j formats values >= 1000 as "1,000". At PKT_NUMBER=1000 the int() call throws, the interface is skipped, and the check silently passes. On VPP this hid that ACL denies increment RX_DRP.

#### How did you do it?
Strip commas before int() (as verify_drop_counters already does), and add VPP (x86_64-kvm_x86_64-r0) to the acl_l2 list.

#### How did you verify/test it?
On VPP t1-lag: with only the comma fix, test_acl_drop and test_acl_egress_drop flip to FAILED (RX_DRP ~1000); with the acl_l2 entry added, they pass legitimately while the per-ACE counter check still runs.

#### Any platform specific information?
- The acl_l2 entry is VPP-only. 
- The drop_counters.py comma fix is platform-agnostic and corrects a check that was silently no-op at PKT_NUMBER=1000 everywhere. We may need to add other platforms as needed to the list.

#### Supported testbed topology if it's a new test case?
N/A - existing tests, validated on t1-lag.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
