### PR TITLE
[dualtor]: Add IPv6 tunnel memory leak coverage

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -1312,6 +1312,8 @@ class VMTopology(object):
                         (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             bind_helper("ovs-ofctl add-flow %s table=0,priority=10,ip,in_port=%s,nw_proto=4,action=output:%s,%s" %
                         (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=10,ip,in_port=%s,nw_proto=41,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             bind_helper("ovs-ofctl add-flow %s table=0,priority=8,ip,in_port=%s,nw_frag=yes,action=output:%s,%s" %
                         (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             bind_helper("ovs-ofctl add-flow %s table=0,priority=8,ipv6,in_port=%s,nw_frag=yes,action=output:%s,%s" %

--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -30,9 +30,23 @@ pytestmark = [
 ]
 
 PACKET_COUNT = 1000
+NEIGHBOR_RESOLUTION_TIMEOUT = 30
 # It's normal to see the mem usage increased a little bit
 # set threshold buffer to 5%
 MEM_THRESHOLD_BUFFER = 0.05
+
+
+@pytest.fixture(params=["ipv4", "ipv6"])
+def ip_version(request):
+    """Traffic IP version to test."""
+    return request.param
+
+
+@pytest.fixture
+def setup_arp_responder(ip_version, request):
+    """Configure the PTF responder for the selected server IP version."""
+    fixture_name = "run_arp_responder_ipv6" if ip_version == "ipv6" else "run_arp_responder"
+    request.getfixturevalue(fixture_name)
 
 
 def validate_neighbor_entry_exist(duthost, neighbor_addr):
@@ -117,7 +131,8 @@ def check_memory_leak(duthost, target_mem_usage, delay=10, timeout=15, interval=
 
 
 def test_tunnel_memory_leak(toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa: F811
-                            ptfhost, ptfadapter, conn_graph_facts, tbinfo, vmhost, run_arp_responder):  # noqa: F811
+                            ptfhost, ptfadapter, conn_graph_facts, tbinfo, vmhost, ip_version,
+                            setup_arp_responder):  # noqa: F811
     """
     Test if there is memory leak for service tunnel_packet_handler.
     Send ip packets from standby TOR T1 to Server, standby TOR will
@@ -151,6 +166,7 @@ def test_tunnel_memory_leak(toggle_all_simulator_ports_to_upper_tor, upper_tor_h
     ptf_t1_intf = random.choice(get_t1_ptf_ports(lower_tor_host, tbinfo))
 
     all_servers_ips = mux_cable_server_ip(upper_tor_host)
+    server_ip_key = "server_{}".format(ip_version)
     unexpected_count = 0
     expected_count = 0
     asic_type = upper_tor_host.facts["asic_type"]
@@ -158,19 +174,19 @@ def test_tunnel_memory_leak(toggle_all_simulator_ports_to_upper_tor, upper_tor_h
     with prepare_services(ptfhost):
         # Delete the neighbors
         for iface, server_ips in list(all_servers_ips.items()):
-            server_ipv4 = server_ips["server_ipv4"].split("/")[0]
-            pytest_assert(wait_until(10, 1, 0, delete_neighbor, upper_tor_host, server_ipv4),
-                          "server ip {} hasn't been deleted from neighbor table.".format(server_ipv4))
+            server_ip = server_ips[server_ip_key].split("/")[0]
+            pytest_assert(wait_until(10, 1, 0, delete_neighbor, upper_tor_host, server_ip),
+                          "server ip {} hasn't been deleted from neighbor table.".format(server_ip))
         # sleep 10s to wait memory usage stable
         time.sleep(10)
         # Get the original memory usage before test
         origin_mem_usage = get_tunnel_packet_handler_memory_usage(upper_tor_host)
         logging.info("tunnel_packet_handler.py original MEM USAGE:{}".format(origin_mem_usage))
         for iface, server_ips in list(all_servers_ips.items()):
-            server_ipv4 = server_ips["server_ipv4"].split("/")[0]
-            logging.info("Select DUT interface {} and server IP {} to test.".format(iface, server_ipv4))
+            server_ip = server_ips[server_ip_key].split("/")[0]
+            logging.info("Select DUT interface {} and server IP {} to test.".format(iface, server_ip))
 
-            pkt, exp_pkt = build_packet_to_server(lower_tor_host, ptfadapter, server_ipv4)
+            pkt, exp_pkt = build_packet_to_server(lower_tor_host, ptfadapter, server_ip)
 
             if asic_type == "vs":
                 logging.info("ServerTrafficMonitor do not support on KVM dualtor, skip following steps.")
@@ -189,18 +205,24 @@ def test_tunnel_memory_leak(toggle_all_simulator_ports_to_upper_tor, upper_tor_h
                     mem_usage = get_tunnel_packet_handler_memory_usage(upper_tor_host)
                     logging.info(
                         "tunnel_packet_handler MEM USAGE:{}".format(mem_usage))
-                    pytest_assert(validate_neighbor_entry_exist(upper_tor_host, server_ipv4),
+                    pytest_assert(wait_until(NEIGHBOR_RESOLUTION_TIMEOUT, 1, 0,
+                                             validate_neighbor_entry_exist, upper_tor_host, server_ip),
                                   "The server ip {} doesn't exist in neighbor table on dut {}. \
-                                  tunnel_packet_handler isn't triggered.".format(server_ipv4, upper_tor_host.hostname))
+                                  tunnel_packet_handler isn't triggered.".format(server_ip, upper_tor_host.hostname))
+                    # The initial burst triggers neighbor resolution. Send additional packets
+                    # after resolution so the downstream traffic monitor can validate forwarding.
+                    testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), pkt, count=10)
             except Exception as e:
                 logging.error("Capture exception {}, continue the process.".format(repr(e)))
             if len(server_traffic_monitor.matched_packets) == 0:
-                logging.error("Didn't receive any expected packets for server {}.".format(server_ipv4))
+                logging.error("Didn't receive any expected packets for server {}.".format(server_ip))
                 unexpected_count += 1
             else:
                 expected_count += 1
         logging.info("The amount of expected scenarios: {}, the amount of unexpected scenarios: {}."
                      .format(expected_count, unexpected_count))
+        pytest_assert(expected_count > 0,
+                      "Didn't receive any expected {} packets for any server.".format(ip_version))
         # sleep 10s to wait memory usage stable, check if there is memory leak
         time.sleep(10)
         check_result = check_memory_leak(upper_tor_host, float(origin_mem_usage) * (1 + MEM_THRESHOLD_BUFFER))


### PR DESCRIPTION
### Description of PR

Summary:
Extend `test_tunnel_memory_leak` to cover IPv6 traffic and allow IPv6-in-IPv4 packets through VM topology OVS bridges to cEOS neighbors.

Fixes # (issue): N/A

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: day-one issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- master: SONiC.20260510.13 - `vms24-dual-t0-7050-1`: 2 passed, 2 expected active-active skips. Both IPv4 and IPv6 active-standby cases completed 24/24 server scenarios, and tunnel packet handler memory remained within the 5% threshold.

### Approach
#### What is the motivation for this PR?

`test_tunnel_memory_leak` only exercised IPv4 server traffic. When extended to IPv6, the standby ToR generated IPv6-in-IPv4 tunnel packets with outer IP protocol 41, but the VM topology OVS rules only forwarded protocol 4 IP-in-IP packets to cEOS. Protocol 41 matched the generic IPv4 rule and was mirrored only to PTF, so it never reached the T1 neighbor or active ToR to trigger neighbor discovery.

#### How did you do it?

Added an OVS rule that forwards outer IP protocol 41 packets to both the neighbor VM and PTF. Parameterized the memory leak test for IPv4 and IPv6, selected the existing IPv6 NDP responder configuration, waited for neighbor resolution, sent follow-up packets to validate downstream forwarding, and required at least one successful server scenario so datapath failures cannot pass only on the memory check.

The existing `arp_responder.py` already supports IPv6 Neighbor Solicitation and Advertisement, so no responder implementation change was required.

#### How did you verify/test it?

```text
./run_tests.sh -n vms24-dual-t0-7050-1 \
  -d str2-7050cx3-acs-06,str2-7050cx3-acs-07 \
  -u -r -c dualtor/test_tunnel_memory_leak.py \
  -f ../ansible/testbed.yaml \
  -i ../ansible/str2,../ansible/veos \
  -t dualtor -m individual \
  -e "--skip_sanity --disable_loganalyzer"
```

Result: 2 passed and 2 expected active-active skips. IPv4 and IPv6 each completed all 24 server traffic scenarios without misses.

#### Any platform specific information?

Validated on Arista-7050CX3-32S-C32 (Broadcom TD3) with cEOS T1 neighbors. The OVS change applies to neighbor VM bridges created by `vm_topology.py`.

#### Supported testbed topology if it's a new test case?

Dual ToR.

### Documentation

N/A.
