### PR TITLE
Skip fib test on topology t1-isolated-d32u1s2

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2000,9 +2000,9 @@ fdb/test_fdb_mac_learning.py::TestFdbMacLearning::testFdbMacLearning:
 #######################################
 fib/test_fib.py:
   skip:
-    reason: 'Skip on t1-isolated-d32/128 topos'
+    reason: 'Skip on t1-isolated-d32/128/u1s2 topos'
     conditions:
-      - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
+      - "topo_name in ['t1-isolated-d128', 't1-isolated-d32', 't1-isolated-d32u1s2']"
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
     conditions:


### PR DESCRIPTION

### Description of PR
Due to there is only one nexthop in topology t1-isolated-d32u1s2 
which could not meet the hash requirement
Add the PR for branch 202511 only, related with the original PR:
https://github.com/sonic-net/sonic-mgmt/pull/24917

Summary:
Fixes # (issue)


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
- 202511: 202511 latest image  - <script skipped on the topology t1-isolated-d32u1s2 >

### Approach
#### What is the motivation for this PR?
Fib test not supported on topology t1-isolated-d32u1s2
#### How did you do it?
Skip fib test on topology t1-isolated-d32u1s2
#### How did you verify/test it?
Validated in regression

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
