### PR TITLE
[arp] Fix flaky test_unknown_mac: pin the ARP entry to a synthetic MAC

### DIFF
--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -14,7 +14,6 @@ import ptf.packet as packet
 from tests.common import constants
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py   # noqa: F401
-from tests.common.fixtures.ptfhost_utils import iptables_drop_ipv6_tx   # noqa: F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa: F401
@@ -25,6 +24,10 @@ logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology("t0")]
 
 TEST_PKT_CNT = 10
+
+# Locally administered unicast MAC. Nothing on the testbed ever sources it, so once the FDB is
+# flushed the DUT can never re-learn it while the test is running.
+UNKNOWN_DST_MAC = "02:00:00:11:22:33"
 
 
 def initClassVars(func):
@@ -96,6 +99,7 @@ def unknownMacSetup(duthosts, rand_one_dut_hostname, tbinfo):
     vlan = dict()
     vlan['addr'] = mg_facts['minigraph_vlan_interfaces'][0]['addr']
     vlan['pfx'] = mg_facts['minigraph_vlan_interfaces'][0]['prefixlen']
+    vlan['intf'] = mg_facts['minigraph_vlan_interfaces'][0]['attachto']
     vlan['ips'] = duthost.get_ip_in_range(num=1, prefix="{}/{}".format(vlan['addr'], vlan['pfx']),
                                           exclude_ips=[vlan['addr']] + server_ips)['ansible_facts']['generated_ips']
     vlan['hostip'] = vlan['ips'][0].split('/')[0]
@@ -175,32 +179,37 @@ def flushArpFdb(duthosts, rand_one_dut_hostname, dut_disable_arp_update):
 
 
 @pytest.fixture(autouse=True)
-def populateArp(unknownMacSetup, flushArpFdb, ptfhost, duthosts, rand_one_dut_hostname,
+def populateArp(unknownMacSetup, flushArpFdb, duthosts, rand_one_dut_hostname,
                 toggle_all_simulator_ports_to_rand_selected_tor_m,              # noqa: F811
-                setup_standby_ports_on_rand_unselected_tor_unconditionally,     # noqa: F811
-                iptables_drop_ipv6_tx):                                         # noqa: F811
+                setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa: F811
     """
-    Fixture to populate ARP entry on the DUT for the traffic destination
+    Fixture to populate a static ARP entry on the DUT for the traffic destination
+
+    The neighbor is pinned to a synthetic MAC instead of being resolved against a PTF
+    interface. On dualtor the PTF interface that owns the destination IP is also the live
+    server NIC, so its MAC is re-learned into the FDB within seconds of `sonic-clear fdb all`
+    and the traffic gets forwarded instead of dropped.
 
     Args:
         unknownMacSetup(fixture) : module scope autouse fixture for test setup
         flushArpFdb(fixture) : func scope fixture
-        ptfhost(AnsibleHost) : ptf host instance
         duthosts(AnsibleHost) : multi dut instance
         rand_one_dut_hostname(string) : one of the dut instances from the multi dut
     """
     # Wait 5 seconds for mux to toggle
     time.sleep(5)
     setup = unknownMacSetup
-    ptfhost.script("./scripts/remove_ip.sh")
-    logger.info("Populate ARP entry for dest port")
-    ptfhost.command("ifconfig eth{} {}".format(setup['ptf_dst_port'], setup['vlan']['ips'][0]))
-    ptfhost.command("ping {} -c 3".format(setup['vlan']['addr']))
-    # Wait 5 seconds for secondary ARP before proceeding to clear FDB
-    time.sleep(5)
+    duthost = duthosts[rand_one_dut_hostname]
+    dst_ip = setup['vlan']['hostip']
+    vlan_intf = setup['vlan']['intf']
 
-    logger.info("Clean up all ips on the PTF")
-    ptfhost.script("./scripts/remove_ip.sh")
+    logger.info("Populate ARP entry {} -> {} on {}".format(dst_ip, UNKNOWN_DST_MAC, vlan_intf))
+    duthost.shell("sudo ip neigh replace {} lladdr {} nud permanent dev {}"
+                  .format(dst_ip, UNKNOWN_DST_MAC, vlan_intf))
+
+    yield
+
+    duthost.shell("sudo ip neigh del {} dev {}".format(dst_ip, vlan_intf), module_ignore_errors=True)
 
 
 class PreTestVerify(object):


### PR DESCRIPTION




Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 39373323
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result


- 202605: 20260531.13

dualtor:
```
arp/test_unknown_mac.py::TestUnknownMac::test_unknown_mac[dscp-3] PASSED                                                                                                                                                                                                                                                                     [ 33%]
arp/test_unknown_mac.py::TestUnknownMac::test_unknown_mac[dscp-4] PASSED                                                                                                                                                                                                                                                                     [ 66%]
arp/test_unknown_mac.py::TestUnknownMac::test_unknown_mac[dscp-8] PASSED                                                                                                                                                                                                                                                                     [100%]

=================================================================================================================================================== 3 passed, 178 warnings in 607.58s (0:10:07) ====================================================================================================================================================
```

t0:
```
arp/test_unknown_mac.py::TestUnknownMac::test_unknown_mac[dscp-3] PASSED                                                                                                                                                                                                                                                                                                                                    [ 33%]
arp/test_unknown_mac.py::TestUnknownMac::test_unknown_mac[dscp-4] PASSED                                                                                                                                                                                                                                                                                                                                    [ 66%]
arp/test_unknown_mac.py::TestUnknownMac::test_unknown_mac[dscp-8] PASSED                                                                                                                                                                                                                                                                                                                                    [100%]

=================================================================================================================================================================================== 3 passed, 98 warnings in 771.56s (0:12:51) ====================================================================================================================================================================================
```

### Approach
#### What is the motivation for this PR?

`arp/test_unknown_mac.py` is flaky. It fails intermittently with:

```
E   Failed: Drop counters failed to increment
arp/test_unknown_mac.py:361
```

Kusto shows this signature recurring for months across multiple branches and
HWSKUs, hitting a *random* `dscp` parameter each time (dscp-3 / dscp-4 / dscp-8),
which is the hallmark of a race rather than a code- or platform-specific defect.
Example: 7050cx3.dualtor-aa.202605 nightly, testplan `6a8697e0a4d1c39d04745e57`,
DUT Arista-7050CX3-32S-C32 (broadcom) — the automatic retry of the same module
passed 3/3.

The test requires the destination MAC to be **resolved in ARP but absent from the
FDB**, so traffic towards it is dropped and counted as `RX_DRP` on the ingress
ports. The failure is that the precondition silently stops holding before traffic
is sent — the packets get *forwarded* instead of dropped:

| Port | TX_OK delta over the traffic window |
|---|---|
| 23 other VLAN ports | +29 (background) |
| **Ethernet8** (the destination port) | **+69 → +40 excess** |

+40 = 4 ingress ports × `TEST_PKT_CNT` (10). `RX_DRP` stayed 0 on every port.

Root cause, from syncd syslog:

```
19:02:42.388  fdb_table_delete MAC:72-95-88-8C-D0-02      (sonic-clear fdb all)
19:02:50      test: '72:95:88:8c:d0:02' not present in fdb as expected
19:02:50.097  fdb_table_add    MAC:72-95-88-8C-D0-02 vlan:1000
19:02:54..19:03:02  traffic sent   -> forwarded, not dropped
```

The precondition was built by assigning an unused VLAN IP to a PTF port and
pinging the VLAN gateway. On dualtor that PTF port is **also the live server NIC
of a mux port** — `72:95:88:8c:d0:02` owns both the test IP `192.168.0.50` and the
real `server_ipv4` `192.168.0.4`. So the resolved MAC belongs to a host that keeps
transmitting: `sonic-clear fdb all` only removes it until the server's next frame,
and there is a ~12 s unguarded window between `_checkFdbEntryMiss()` and the last
send (`sonic-clear counters`, counter-baseline poll, four send/verify iterations).
Measured re-learn delay across three flushes in a single run: +5.5 s, +56.8 s,
+62.6 s — whether it lands inside the window is a coin flip.

Excluding the mux server IPs from the generated address (already done via
`mux_cable_server_ip`) does not help: the collision is on the **MAC**, not the IP.
`random.choice(vlan['ports'])` always lands on a mux port on dualtor, so the
synthetic IP always inherits a live server MAC.

This also supersedes the mitigation in #18638, which suppressed IPv6 RA/RS from
the PTF for the same reason. That only silenced one of many frame sources for the
resolved MAC, so the race survived it.

Note the existing `verify_no_packet_any(ports=ptf_vlan_ports)` did **not** catch
the mis-forwarding — all 24 VLAN ports were negative-checked and passed even
though the destination port egressed the packets. Only the `RX_DRP` check exposed
it.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

Program the neighbour directly on the DUT with a locally administered MAC that no
device on the testbed sources, so the FDB entry can never be (re)learned while
traffic is running:

```python
UNKNOWN_DST_MAC = "02:00:00:11:22:33"
...
duthost.shell("sudo ip neigh replace {} lladdr {} nud permanent dev {}"
              .format(dst_ip, UNKNOWN_DST_MAC, vlan_intf))
yield
duthost.shell("sudo ip neigh del {} dev {}".format(dst_ip, vlan_intf),
              module_ignore_errors=True)
```

This removes the premise of the race instead of trying to shrink the window.

Supporting changes:

- Added `vlan['intf']` (from `minigraph_vlan_interfaces[0]['attachto']`) to the
  setup dict.
- `populateArp` no longer touches the PTF, so the two `remove_ip.sh` calls, the
  second `time.sleep(5)`, and the `ptfhost` / `iptables_drop_ipv6_tx` fixture
  dependencies are dropped.

`PreTestVerify` is unchanged — `show arp` / `ip neigh show` still report the entry
(state `PERMANENT` matches the existing `[A-Z]+` regex), and `_checkFdbEntryMiss`
now stays true through the whole traffic phase.

Prior art for the pinned-neighbour pattern:
`tests/everflow/test_everflow_testbed.py` and
`tests/iface_loopback_action/iface_loopback_action_helper.py`.

#### How did you verify/test it?

check the test result section.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
