### PR TITLE
[gnmi] Fix create_revoked_cert_and_crl() missing duthost in cert rotation helpers

### DIFF
--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -102,7 +102,7 @@ def rotate_gnmi_certs(duthost, localhost, ptfhost):
     prepare_server_cert(duthost, localhost)
     prepare_client_cert(localhost)
     copy_certificate_to_ptf(ptfhost)
-    create_revoked_cert_and_crl(localhost, ptfhost)
+    create_revoked_cert_and_crl(localhost, ptfhost, duthost)
     copy_certificate_to_dut(duthost)
 
 

--- a/tests/gnmi/test_mimic_hwproxy_cert_rotation.py
+++ b/tests/gnmi/test_mimic_hwproxy_cert_rotation.py
@@ -15,7 +15,7 @@ def _rotate_gnmi_certs(duthost, localhost, ptfhost):
     prepare_server_cert(duthost, localhost)
     prepare_client_cert(localhost)
     copy_certificate_to_ptf(ptfhost)
-    create_revoked_cert_and_crl(localhost, ptfhost)
+    create_revoked_cert_and_crl(localhost, ptfhost, duthost)
     copy_certificate_to_dut(duthost)
 
 


### PR DESCRIPTION
### Description of PR
Summary:
Fix a TypeError in gNMI cert rotation setup after GitHub PR #26486 added a required `duthost` argument to `create_revoked_cert_and_crl()`. Two rotation helpers were left on the old two-arg call, so `rotate_gnmi_certs` / `setup_gnmi_rotated_server` and `test_mimic_hwproxy_cert_rotation` fail at fixture/setup time.

`create_gnmi_certs` already passes `duthost`; this change does the same in:
- `tests/gnmi/conftest.py` (`rotate_gnmi_certs` / `setup_gnmi_rotated_server`)
- `tests/gnmi/test_mimic_hwproxy_cert_rotation.py` (`_rotate_gnmi_certs`)

Follow-up of #26486. Internal NVIDIA change: https://git-nbu-sw.nvidia.com/r/c/switchx/sonic/sonic-mgmt/+/348035

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression (call sites missed when #26486 added required `duthost`)

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

### Approach
#### What is the motivation for this PR?
PR #26486 changed `create_revoked_cert_and_crl(localhost, ptfhost, duthost)` so the CRL URL follows the DUT management IP family (`get_ptf_crl_server_ip`). `create_gnmi_certs` was updated, but cert-rotation helpers still called the helper with two arguments, which raises:

`TypeError: create_revoked_cert_and_crl() missing 1 required positional argument: 'duthost'`

That breaks gNMI cert rotation (including `test_mimic_hwproxy_cert_rotation`) before the test body runs.

#### How did you do it?
Pass `duthost` into `create_revoked_cert_and_crl()` at the two remaining call sites, matching `create_gnmi_certs`.

#### How did you verify/test it?
- Inspected `tests/common/helpers/gnmi_utils.py`: helper requires `duthost`; `create_gnmi_certs` already passes it.
- Confirmed the two leftover two-arg calls.
- ran the test on Nvidia platforms and it passed

#### Any platform specific information?
No. Affects any platform that runs gNMI cert rotation / CRL setup.

#### Supported testbed topology if it's a new test case?
N/A (bug fix, not a new test).

### Documentation
N/A