### PR TITLE
[dhcp_relay] Keep VRF recovery ignores through LogAnalyzer teardown

### DIFF
--- a/tests/common/unit_tests/unit_test_dhcpv4_vrf_recovery.py
+++ b/tests/common/unit_tests/unit_test_dhcpv4_vrf_recovery.py
@@ -1,0 +1,101 @@
+"""Exercise the VRF recovery fixture without importing testbed dependencies.
+
+Run with::
+
+    python3 -m pytest --noconftest --confcutdir=tests/common/unit_tests \
+        tests/common/unit_tests/unit_test_dhcpv4_vrf_recovery.py -v
+"""
+
+import ast
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "dhcp_relay" / "test_dhcpv4_relay.py"
+TRANSIENT_ERRORS = [
+    "ERR monit[883]: 'routeCheck' status failed (255)",
+    "ERR route_check.py: Some routes have failed state in FRR",
+    "ERR route_check.py: Some routes are not set offloaded in FRR",
+]
+
+
+@pytest.fixture
+def recovery_context():
+    tree = ast.parse(MODULE_PATH.read_text())
+    function = next(node for node in tree.body
+                    if isinstance(node, ast.FunctionDef) and node.name == "frr_recovery_after_vrf_unbind")
+    function.decorator_list = []
+    namespace = {"logger": Mock(), "wait_until": Mock()}
+    # Execute the real fixture generator, without SONiC integration imports.
+    exec(compile(ast.Module(body=[function], type_ignores=[]), str(MODULE_PATH), "exec"), namespace)
+    namespace["wait_until"].side_effect = lambda timeout, interval, delay, predicate: predicate()
+    dut = Mock(hostname="dut")
+    dut.shell.return_value = {"rc": 0}
+    return namespace, dut
+
+
+@pytest.mark.parametrize("route_check_rc", [0, 1])
+def test_transient_ignores_survive_recovery_teardown(recovery_context, route_check_rc):
+    namespace, dut = recovery_context
+    dut.shell.return_value = {"rc": route_check_rc}
+    analyzer = SimpleNamespace(ignore_regex=[r"existing unrelated ignore"])
+    other_analyzer = SimpleNamespace(ignore_regex=[r"other DUT ignore"])
+    original_list = analyzer.ignore_regex
+    fixture = namespace["frr_recovery_after_vrf_unbind"](
+        {"dut": dut}, "dut", {"dut": analyzer, "other": other_analyzer})
+
+    next(fixture)
+    dut.shell.assert_not_called()
+    analyzer.ignore_regex.append(r"ignore added during test")
+    with pytest.raises(StopIteration):
+        next(fixture)
+
+    # Model the later LogAnalyzer scan with no global routeCheck suppression.
+    for message in TRANSIENT_ERRORS:
+        assert any(re.search(pattern, message) for pattern in analyzer.ignore_regex)
+    assert not any(re.search(pattern, "ERR unexpected failure") for pattern in analyzer.ignore_regex)
+    assert analyzer.ignore_regex is original_list
+    assert analyzer.ignore_regex[0] == r"existing unrelated ignore"
+    assert analyzer.ignore_regex[-1] == r"ignore added during test"
+    assert other_analyzer.ignore_regex == [r"other DUT ignore"]
+    assert dut.shell.call_args_list == [
+        call("sudo config bgp shutdown all", module_ignore_errors=True),
+        call("sudo config bgp startup all", module_ignore_errors=True),
+        call("sudo /usr/local/bin/route_check.py", module_ignore_errors=True),
+    ]
+    assert namespace["wait_until"].call_count == 1
+    assert namespace["wait_until"].call_args.args[:3] == (180, 5, 0)
+    assert namespace["logger"].warning.call_count == (1 if route_check_rc else 0)
+
+
+@pytest.mark.parametrize("analyzers", [None, {}, {"other": SimpleNamespace(ignore_regex=[])}])
+def test_recovery_without_selected_loganalyzer(recovery_context, analyzers):
+    namespace, dut = recovery_context
+    fixture = namespace["frr_recovery_after_vrf_unbind"]({"dut": dut}, "dut", analyzers)
+    next(fixture)
+    with pytest.raises(StopIteration):
+        next(fixture)
+    assert dut.shell.call_args_list == [
+        call("sudo config bgp shutdown all", module_ignore_errors=True),
+        call("sudo config bgp startup all", module_ignore_errors=True),
+        call("sudo /usr/local/bin/route_check.py", module_ignore_errors=True),
+    ]
+    if analyzers:
+        assert analyzers["other"].ignore_regex == []
+
+
+def test_recovery_exception_propagates_without_removing_ignores(recovery_context):
+    namespace, dut = recovery_context
+    analyzer = SimpleNamespace(ignore_regex=[])
+    fixture = namespace["frr_recovery_after_vrf_unbind"]({"dut": dut}, "dut", {"dut": analyzer})
+    next(fixture)
+    dut.shell.side_effect = RuntimeError("DUT connection failed")
+    with pytest.raises(RuntimeError, match="DUT connection failed"):
+        next(fixture)
+    for message in TRANSIENT_ERRORS:
+        assert any(re.search(pattern, message) for pattern in analyzer.ignore_regex)
+    namespace["wait_until"].assert_not_called()

--- a/tests/dhcp_relay/test_dhcpv4_relay.py
+++ b/tests/dhcp_relay/test_dhcpv4_relay.py
@@ -145,29 +145,25 @@ def frr_recovery_after_vrf_unbind(duthosts, rand_one_dut_hostname, loganalyzer):
         r".*ERR route_check.*Some routes are not set offloaded in FRR.*",
     ]
 
-    saved_ignore = None
     if la is not None:
-        saved_ignore = list(la.ignore_regex)
+        # LogAnalyzer is function-scoped and scans after this dependent fixture
+        # tears down, so keep the ignores on its per-test instance until then.
         la.ignore_regex.extend(transient_ignores)
 
     yield
 
-    try:
-        duthost.shell("sudo config bgp shutdown all", module_ignore_errors=True)
-        duthost.shell("sudo config bgp startup all", module_ignore_errors=True)
+    duthost.shell("sudo config bgp shutdown all", module_ignore_errors=True)
+    duthost.shell("sudo config bgp startup all", module_ignore_errors=True)
 
-        def _route_check_ok():
-            return duthost.shell(
-                "sudo /usr/local/bin/route_check.py",
-                module_ignore_errors=True)["rc"] == 0
+    def _route_check_ok():
+        return duthost.shell(
+            "sudo /usr/local/bin/route_check.py",
+            module_ignore_errors=True)["rc"] == 0
 
-        if not wait_until(180, 5, 0, _route_check_ok):
-            logger.warning(
-                "route_check did not converge within 180s after VRF unbind "
-                "BGP shutdown/startup; continuing teardown anyway")
-    finally:
-        if la is not None and saved_ignore is not None:
-            la.ignore_regex[:] = saved_ignore
+    if not wait_until(180, 5, 0, _route_check_ok):
+        logger.warning(
+            "route_check did not converge within 180s after VRF unbind "
+            "BGP shutdown/startup; continuing teardown anyway")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Description of PR

Summary: Keep the existing VRF-recovery LogAnalyzer ignores active until the per-test log scan completes.

`frr_recovery_after_vrf_unbind` depends on `loganalyzer`, so its teardown runs first. Previously it restored `ignore_regex` after BGP recovery, removing the transient-error patterns before LogAnalyzer scanned the log. LogAnalyzer is function-scoped and creates fresh analyzer instances for each test, so these patterns should remain on that instance through its scan.

Affected scope: one module, `tests/dhcp_relay/test_dhcpv4_relay.py`, and two test functions:

- `test_dhcp_relay_with_non_default_vrf`
- `test_dhcp_relay_with_different_non_default_vrf`

No unmerged PR dependencies. Related product work: https://github.com/sonic-net/sonic-swss/pull/4746 and https://github.com/sonic-net/sonic-swss/pull/4764.

##### Work item tracking
- Microsoft ADO (number only): 39619101
- Task: https://msazure.visualstudio.com/One/_workitems/edit/39619101
- Shared VRF PBI: https://msazure.visualstudio.com/One/_workitems/edit/38514061

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

None; this PR targets master only.

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): Not applicable; no backport requested.
Failure type: Pre-existing fixture teardown-lifetime defect; not a new product regression.

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Current-head PR CI is pending. The isolated regression has been added but not executed; no new hardware validation has been performed. No branch is claimed tested.

Historical context only: the earlier combined SWSS candidate, build 1167872 from https://github.com/sonic-net/sonic-swss/pull/4747 at head `d219d1c994b10f419e96a4cd35dd0c8b4e6e3edb`, produced `10 passed` and `2 errors` on the 202605 t0 testbed `testbed-bjw3-can-t0-7060-6`. The errors were LogAnalyzer teardown failures at iterations 9 and 10, both matching `ERR monit[883]: 'routeCheck' status failed (255)`. This was not a fully green run and is not validation of this PR.

### Approach
#### What is the motivation for this PR?

There are two distinct protections against those historical false-positive teardown errors:

1. **Already suppressed globally:** https://github.com/sonic-net/sonic-mgmt/pull/24642 added a common ignore for the recorded monit `routeCheck` message; https://github.com/sonic-net/sonic-mgmt/pull/26997 delivered that suppression to 202605.
2. **Fixture correction independent of that suppression:** this PR retains the fixture's existing transient-error patterns until LogAnalyzer finishes. Even without the global ignore, the intended per-test ignores would then cover the recovery messages during the scan.

The common ignore mitigates the recorded symptom but does not fix the fixture lifetime. This PR fixes that lifetime; it does not repair the underlying FRR routing defect, change the recovery policy, or retroactively make the historical run green.

#### How did you do it?

Remove the saved-ignore snapshot and premature restoration. Keep the existing BGP shutdown/startup, route-check polling, timeout warning, and exception propagation unchanged. Do not broaden any regex or change the common ignore file.

Add an isolated regression using the repository's existing AST-based unit-test pattern. It executes the real fixture generator and checks the ignore list after teardown without loading the global routeCheck suppression. It also covers successful/unsuccessful route checks, a disabled or missing selected analyzer, preservation of unrelated ignores, and recovery exceptions.

#### How did you verify/test it?

Validation remains pending. The regression's targeted invocation is documented in its module. Existing CI configuration is unchanged; adding the regression does not imply that the current pipeline executes it.

#### Any platform specific information?

No platform-specific implementation. Historical evidence is from the Arista-7060CX-32S t0 testbed noted above.

#### Supported testbed topology if it's a new test case?

No new hardware test case or topology. The isolated regression needs no DUT.

### Documentation

The fixture comment explains the required lifetime, and the regression module documents its standalone invocation.
