### PR TITLE
[snmp]: poll FDB only in test_snmp_fdb_send_tagged on large SKUs

### DIFF
--- a/ansible/library/snmp_facts.py
+++ b/ansible/library/snmp_facts.py
@@ -115,6 +115,11 @@ options:
         description:
             - Encryption key, required if version is authPriv
         required: false
+    collect_only:
+        description:
+            - Restrict collection to the given fact groups, for example ['fdb'].
+              All groups are collected when not set. Requires pysnmp v5+.
+        required: false
 '''
 
 EXAMPLES = '''
@@ -413,6 +418,9 @@ def main_legacy(module):
     m_args = module.params
 
     cmdGen = cmdgen.CommandGenerator()
+
+    if m_args['collect_only']:
+        module.fail_json(msg='collect_only requires pysnmp v5+')
 
     # Verify that we receive a community when using snmp v2
     if m_args['version'] == "v2" or m_args['version'] == "v2c":
@@ -1872,6 +1880,14 @@ class SnmpFactsCollector:
     async def collect_all(self):
         if self.transport is None:
             raise Exception("Transport not initialized. Call setup() first.")
+        collect_only = self.m_args['collect_only']
+        if collect_only:
+            for name in collect_only:
+                if not hasattr(self, f'_collect_{name}'):
+                    self.module.fail_json(msg=f"Unknown collect_only value: {name}")
+            await asyncio.gather(*[getattr(self, f'_collect_{name}')() for name in collect_only])
+            return
+
         await asyncio.gather(
             self._collect_system(),
             self._collect_interfaces(),
@@ -1921,6 +1937,7 @@ if __name__ == "__main__":
             is_dell=dict(required=False, default=False, type='bool'),
             is_eos=dict(required=False, default=False, type='bool'),
             include_swap=dict(required=False, default=False, type='bool'),
+            collect_only=dict(required=False, default=None, type='list'),
             removeplaceholder=dict(required=False)
         ),
         required_together=(

--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -28,21 +28,23 @@ def is_snmp_subagent_running(duthost):
 
 
 def _get_snmp_facts(localhost, host, version, community, is_dell, include_swap, module_ignore_errors,
-                    timeout=SNMP_DEFAULT_TIMEOUT):
+                    timeout=SNMP_DEFAULT_TIMEOUT, collect_only=None):
+    optional_args = {'collect_only': collect_only} if collect_only else {}
     snmp_facts = localhost.snmp_facts(host=host, version=version, community=community, is_dell=is_dell,
                                       module_ignore_errors=module_ignore_errors, include_swap=include_swap,
-                                      timeout=timeout)
+                                      timeout=timeout, **optional_args)
     return snmp_facts
 
 
 def _update_snmp_facts(localhost, host, version, community, is_dell, include_swap, duthost,
-                       timeout=SNMP_DEFAULT_TIMEOUT):
+                       timeout=SNMP_DEFAULT_TIMEOUT, collect_only=None):
     global global_snmp_facts
 
     try:
         snmp_subagent_running = is_snmp_subagent_running(duthost)
         global_snmp_facts = _get_snmp_facts(localhost, host, version, community, is_dell, include_swap,
-                                            module_ignore_errors=False, timeout=timeout)
+                                            module_ignore_errors=False, timeout=timeout,
+                                            collect_only=collect_only)
     except RunAnsibleModuleFail as e:
         logger.info("encountered error when getting snmp facts: {}".format(e))
         global_snmp_facts = {}
@@ -53,15 +55,16 @@ def _update_snmp_facts(localhost, host, version, community, is_dell, include_swa
 
 def get_snmp_facts(duthost, localhost, host, version, community, is_dell=False, module_ignore_errors=False,
                    wait=False, include_swap=False, timeout=DEF_WAIT_TIMEOUT, interval=DEF_CHECK_INTERVAL,
-                   snmp_timeout=SNMP_DEFAULT_TIMEOUT):
+                   snmp_timeout=SNMP_DEFAULT_TIMEOUT, collect_only=None):
     if not wait:
         return _get_snmp_facts(localhost, host, version, community, is_dell, include_swap, module_ignore_errors,
-                               timeout=snmp_timeout)
+                               timeout=snmp_timeout, collect_only=collect_only)
 
     global global_snmp_facts
 
     pytest_assert(wait_until(timeout, interval, 0, _update_snmp_facts, localhost, host, version,
-                             community, is_dell, include_swap, duthost, snmp_timeout), "Timeout waiting for SNMP facts")
+                             community, is_dell, include_swap, duthost, snmp_timeout, collect_only),
+                  "Timeout waiting for SNMP facts")
     return global_snmp_facts
 
 

--- a/tests/snmp/test_snmp_fdb.py
+++ b/tests/snmp/test_snmp_fdb.py
@@ -92,17 +92,17 @@ def is_port_channel_up(duthost, config_portchannels):
     return True
 
 
-def check_snmp_facts(duthost, localhost, hostip, creds_all_duts, config_portchannels, send_cnt, send_portchannels_cnt):
+def check_snmp_facts(duthost, localhost, host_ip, creds_all_duts, snmp_interfaces, config_portchannels,
+                     send_cnt, send_portchannels_cnt):
     dummy_mac_cnt = 0
     recv_portchannels_cnt = 0
+    # Collect the FDB table only.
     snmp_facts = get_snmp_facts(
-        duthost, localhost, host=hostip, version="v2c",
-        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+        duthost, localhost, host=host_ip, version="v2c",
+        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"],
+        collect_only=['fdb'])['ansible_facts']
     if 'snmp_fdb' not in snmp_facts:
         logger.info("'snmp_fdb' not in snmp_facts")
-        return False
-    if 'snmp_interfaces' not in snmp_facts:
-        logger.info("'snmp_interfaces' not in snmp_facts")
         return False
     for key in snmp_facts['snmp_fdb']:
         # key is string: vlan.mac
@@ -112,13 +112,13 @@ def check_snmp_facts(duthost, localhost, hostip, creds_all_duts, config_portchan
         if DUMMY_MAC_PREFIX in items[1]:
             dummy_mac_cnt += 1
             idx = str(snmp_facts['snmp_fdb'][key])
-            if idx not in snmp_facts['snmp_interfaces']:
-                logger.info(f"{idx} not in snmp_facts['snmp_interfaces']")
+            if idx not in snmp_interfaces:
+                logger.info(f"{idx} not in snmp_interfaces")
                 return False
-            if 'name' not in snmp_facts['snmp_interfaces'][idx]:
-                logger.info(f"'name' not in snmp_facts['snmp_interfaces'][{idx}]")
+            if 'name' not in snmp_interfaces[idx]:
+                logger.info(f"'name' not in snmp_interfaces[{idx}]")
                 return False
-            if snmp_facts['snmp_interfaces'][idx]['name'] in config_portchannels:
+            if snmp_interfaces[idx]['name'] in config_portchannels:
                 recv_portchannels_cnt += 1
     if send_cnt != dummy_mac_cnt:
         logger.info("Dummy MAC count does not match")
@@ -144,6 +144,15 @@ def test_snmp_fdb_send_tagged(ptfadapter, duthosts, rand_one_dut_hostname,      
         'ansible_facts']
     config_portchannels = cfg_facts.get('PORTCHANNEL', {})
     assert wait_until(60, 2, 0, is_port_channel_up, duthost, config_portchannels), "Portchannel is not up"
+
+    host_ip = duthost.mgmt_ip
+    # The ifIndex to name mapping does not change while the FDB is polled, so collect it once.
+    snmp_interfaces = get_snmp_facts(
+        duthost, localhost, host=host_ip, version="v2c",
+        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True,
+        collect_only=['interfaces'])['ansible_facts'].get('snmp_interfaces')
+    pytest_assert(snmp_interfaces, "'snmp_interfaces' not in snmp_facts")
+
     send_cnt = 0
     send_portchannels_cnt = 0
     vlan_ports_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
@@ -173,8 +182,5 @@ def test_snmp_fdb_send_tagged(ptfadapter, duthosts, rand_one_dut_hostname,      
         "The dummy MACs are not fully populated."
     )
 
-    hostip = duthost.host.options['inventory_manager'].get_host(
-        duthost.hostname).vars['ansible_host']
-
-    assert wait_until(90, 5, 0, check_snmp_facts, duthost, localhost, hostip, creds_all_duts,
+    assert wait_until(100, 5, 0, check_snmp_facts, duthost, localhost, host_ip, creds_all_duts, snmp_interfaces,
                       config_portchannels, send_cnt, send_portchannels_cnt), "SNMP facts validation failure"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_snmp_fdb_send_tagged fails on large SKUs when a full snmp_facts walk (~85s) uses almost all of the 90s wait_until budget, so SNMP is checked once — often before PortChannel FDB entries appear (CLI already shows them).

Add collect_only to snmp_facts so the test loads interface names once and polls only the FDB on each retry. Legacy pysnmp (<5) fails fast if collect_only is used.
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ X] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ X] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
- master: `test_snmp_fdb_send_tagged` passed on a large SKU (512-port class) po2vlan topology after the change. Previously failed with SNMP FDB validation timeout under the same conditions

### Approach
#### What is the motivation for this PR?
On large SKUs, a full SNMP walk consumes most of the test's retry budget, so `wait_until` cannot effectively wait for SNMP agent lag on PortChannel FDB entries.

#### How did you do it?

- Add `collect_only` to `ansible/library/snmp_facts.py` to collect a subset of fact groups (e.g. `['fdb']`, `['interfaces']`).
- Plumb `collect_only` through `tests/common/helpers/snmp_helpers.py`.
- Update `test_snmp_fdb_send_tagged` to fetch interface names once before sending packets, then poll only the FDB in `check_snmp_facts`.
- Increase SNMP validation timeout from 90s to 100s to account for agent convergence (not walk duration).

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran `pytest snmp/test_snmp_fdb.py -k test_snmp_fdb_send_tagged` on a large SKU testbed with po2vlan topology. Test passed with the fix; without it, SNMP FDB validation failed when PortChannel entries were slow to appear in SNMP.

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
