### PR TITLE
kubesonic: force IPv4 node-ip by default to match IPv4-only minikube master

### DIFF
--- a/tests/kubesonic/test_k8s_join_disjoin.py
+++ b/tests/kubesonic/test_k8s_join_disjoin.py
@@ -186,39 +186,27 @@ def remove_minikube_vip_dns(duthost, vmhost):
     logger.info("Minikube vip dns is removed")
 
 
-def is_the_sku_need_to_remove_node_ip_param(duthost):
-    hwsku = duthost.facts.get("hwsku") if hasattr(duthost, "facts") else None
-    if not hwsku:
-        # Fallback query (ignore errors gracefully)
-        result = duthost.shell("sonic-cfggen -d -v DEVICE_METADATA.localhost.hwsku", module_ignore_errors=True)
-        hwsku = result.get("stdout", "").strip()
-    return hwsku in (
-        "Arista-7060X6-16PE-384C-B-O128S2",
-        "Arista-7060CX-32S-C32",
-        "Arista-7060X6-64PE-B-C512S2",
-        "Mellanox-SN5640-C512S2",
-        "Mellanox-SN5640-C448O16"
-    )
-
-
 def remove_node_ip_param(duthost):
-    """Remove '--node-ip=::' from kubelet config.
+    """Pin kubelet's node IP to the DUT's IPv4 management IP.
+
+    The kubelet default config ships '--node-ip=::' (auto-detect, prefer IPv6). The minikube control
+    plane created by this test is IPv4-only (see setup_k8s_master: --listen-address=0.0.0.0, IPv4
+    apiserver IPs/hosts and 'config kube server ip', MINIKUBE_DEFAULT_IP=192.168.49.2). When the DUT
+    eth0 has a usable global IPv6, kubelet registers an IPv6 InternalIP that the IPv4 master cannot
+    reach, so the join times out. To stay consistent with the IPv4-only master, force the node IP to
+    the DUT IPv4 management address for every SKU.
+
     Creates a backup of the original file once (if not already present) so it can be restored.
-    A series of sed patterns is used to safely eliminate the token with or without surrounding spaces.
     """
-    if not is_the_sku_need_to_remove_node_ip_param(duthost):
-        return
-    logger.info("Detected SKU which requires removal of '--node-ip=::' from kubelet config")
+    logger.info("Forcing kubelet '--node-ip' to the DUT IPv4 management IP to match the IPv4-only minikube master")
     duthost.shell(f"sudo cp {KUBELET_DEFAULT_CONFIG} {KUBELET_DEFAULT_CONFIG_BAK}", module_ignore_errors=True)
     duthost.shell(f"sudo sed -i 's/--node-ip=::/--node-ip={duthost.mgmt_ip}/g' {KUBELET_DEFAULT_CONFIG}")
     duthost.shell("sudo systemctl daemon-reload")
-    logger.info("Kubelet config '--node-ip=::' parameter removed")
+    logger.info("Kubelet config '--node-ip' pinned to IPv4")
 
 
 def restore_node_ip_param(duthost):
-    """Restore kubelet config from backup."""
-    if not is_the_sku_need_to_remove_node_ip_param(duthost):
-        return
+    """Restore kubelet config from backup if one was taken."""
     logger.info("Restoring kubelet config to original state if backup exists")
     restore_cmd = (
         f"if [ -f {KUBELET_DEFAULT_CONFIG_BAK} ]; then "


### PR DESCRIPTION


### Change

- Remove the per-SKU allowlist and **pin kubelet `--node-ip` to the DUT's IPv4 management IP for every SKU**, matching the IPv4-only minikube master.
- Make `restore_node_ip_param` restore unconditionally from the `.bak` file. Previously it re-checked the allowlist helper, but after the `sed` rewrite the `--node-ip=::` token is gone; for non-allowlisted SKUs restore was skipped. Restoring on `.bak` presence is correct and idempotent.

### How to verify

Run `tests/kubesonic/test_k8s_join_disjoin.py::test_kubesonic_join_and_disjoin` on a testbed whose mgmt `eth0` has a global IPv6 (a 202511+ DUT). The node now registers with its IPv4 mgmt IP and the join succeeds.


### Description of PR
Summary: Fixes k8s node joining failure for the `Nokia-BMC-H6-128` SKU in `test_k8s_join_disjoin.py`.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202608

### Approach
#### What is the motivation for this PR?

kubesonic `test_k8s_join_disjoin` sets up an **IPv4-only** minikube control plane (`setup_k8s_master`: `--listen-address=0.0.0.0`, IPv4 `--apiserver-ips`/hosts and `config kube server ip`, `MINIKUBE_DEFAULT_IP=192.168.49.2`). The kubelet default config on the DUT ships `--node-ip=::` (auto-detect, **prefer IPv6**). When a DUT's `eth0` has a usable global IPv6, kubelet registers an **IPv6 InternalIP** that the IPv4 master cannot reach, so `kubeadm join` times out and the test fails with `Failed to join duthost to k8s cluster`.

This surfaced as a broad regression on **202511+ (Debian 13)** trains: the same physical testbeds that passed ~100% on older trains began failing once the base OS started giving `eth0` a routable global IPv6. It was being patched by adding SKUs to a hardcoded allowlist (`is_the_sku_need_to_remove_node_ip_param`), which kept growing (Arista-7060X6-16PE-384C-B-O128S2, Arista-7060CX-32S-C32, Arista-7060X6-64PE-B-C512S2, Mellanox-SN5640-C512S2, Mellanox-SN5640-C448O16).

```
Error from server (NotFound): nodes not found
Failed: Failed to join duthost to k8s cluster
```
The DUT's kubelet config contains `--node-ip=::`, which makes kubelet prefer an IPv6 address. Since the testbed communicates with the k8s (minikube) master over IPv4, the node never registers and the 120s join poll times out.

#### How did you verify/test it?
Validated in nightly tests, extending allow list for k8s worker node ipv4 join

#### Any platform specific information?
Platforms which have eth0 configured as ipv6 and use ipv6 to join k8s cluster

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
