### PR TITLE
kubesonic: resolve pause image from DUT + poll for daemonset readiness (PBI 38770822)

### DIFF
--- a/tests/kubesonic/test_k8s_join_disjoin.py
+++ b/tests/kubesonic/test_k8s_join_disjoin.py
@@ -35,7 +35,13 @@ VMHOST_PARAM_DEFAULT = None
 DUT_CERT_DIR = "/etc/sonic/credentials"
 DUT_CERT_BAK = f"{DUT_CERT_DIR}.bak"
 DUT_HOSTS_FILE = "/etc/hosts"
+# Fallback only. Prefer resolving the pause image actually present on the DUT
+# via get_dut_pause_image(): on internal builds the image is preloaded under
+# the DEFAULT_CONTAINER_REGISTRY name (e.g. publicmirror.azurecr.io/pause:3.5),
+# not under this deprecated k8s.gcr.io name, so hardcoding this would force a
+# runtime pull from the frozen k8s.gcr.io registry and fail (ImagePullBackOff).
 DUT_PAUSE_IMAGE = "k8s.gcr.io/pause:3.5"
+DUT_KUBEADM_FLAGS_FILE = "/var/lib/kubelet/kubeadm-flags.env"
 
 
 def check_dut_k8s_version_supported(duthost):
@@ -233,7 +239,34 @@ def restore_node_ip_param(duthost):
     logger.info("Kubelet config node ip param restore completed")
 
 
-def deploy_test_daemonset(vmhost):
+def get_dut_pause_image(duthost):
+    """Resolve the pause/sandbox image that is actually present on the DUT.
+
+    kubelet's configured --pod-infra-container-image reflects the image name
+    that was preloaded into the SONiC image. On internal builds this is the
+    DEFAULT_CONTAINER_REGISTRY name (e.g. publicmirror.azurecr.io/pause:3.5);
+    on community builds it is k8s.gcr.io/pause:3.5. Using this value keeps the
+    test daemonset from requesting an image name that cannot be resolved
+    locally (which would trigger a doomed pull from the frozen k8s.gcr.io).
+    Falls back to DUT_PAUSE_IMAGE if the flag cannot be read.
+    """
+    result = duthost.shell(
+        "grep -o -- '--pod-infra-container-image=[^ \"]*' "
+        f"{DUT_KUBEADM_FLAGS_FILE} | head -n1 | cut -d= -f2",
+        module_ignore_errors=True,
+    )
+    pause_image = result["stdout"].strip() if result["rc"] == 0 else ""
+    if not pause_image:
+        logger.warning(
+            f"Could not resolve pause image from {DUT_KUBEADM_FLAGS_FILE}, "
+            f"falling back to {DUT_PAUSE_IMAGE}"
+        )
+        pause_image = DUT_PAUSE_IMAGE
+    logger.info(f"Using pause image for test daemonset: {pause_image}")
+    return pause_image
+
+
+def deploy_test_daemonset(vmhost, pause_image):
     logger.info("Start to deploy daemonset and check the status")
     daemonset_yaml = "/tmp/daemonset.yaml"
     daemonset_content = f'''
@@ -254,8 +287,9 @@ spec:
         {DAEMONSET_NODE_LABEL}: "true"
       hostNetwork: true
       containers:
-      - image: {DUT_PAUSE_IMAGE}
+      - image: {pause_image}
         name: {DAEMONSET_CONTAINER_NAME}
+        imagePullPolicy: IfNotPresent
     '''
 
     vmhost.shell(f"echo -n '{daemonset_content}' > {daemonset_yaml}")
@@ -368,7 +402,8 @@ def setup_and_teardown(duthost, vmhost, creds):
     update_kubelet_config(vmhost, creds)
 
     # Deploy test daemonset
-    deploy_test_daemonset(vmhost)
+    pause_image = get_dut_pause_image(duthost)
+    deploy_test_daemonset(vmhost, pause_image)
 
     # Check k8s state db
     check_k8s_state_db(duthost)

--- a/tests/kubesonic/test_k8s_join_disjoin.py
+++ b/tests/kubesonic/test_k8s_join_disjoin.py
@@ -5,6 +5,7 @@ import time
 from datetime import datetime
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import get_image_type
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,8 @@ KUBELET_DEFAULT_CONFIG_BAK = f"{KUBELET_DEFAULT_CONFIG}.bak"
 DAEMONSET_NODE_LABEL = "deployDaemonset"
 DAEMONSET_POD_LABEL = "test-ds-pod"
 DAEMONSET_CONTAINER_NAME = "mock-ds-container"
+DAEMONSET_POD_TIMEOUT_SECOND = 120
+DAEMONSET_POD_CHECK_INTERVAL = 5
 VMHOST_PARAM_DEFAULT = None
 DUT_CERT_DIR = "/etc/sonic/credentials"
 DUT_CERT_BAK = f"{DUT_CERT_DIR}.bak"
@@ -440,28 +443,58 @@ def trigger_disjoin_and_check(duthost, vmhost):
     logger.info(f"Successfully disjoined duthost {duthost.hostname} from k8s cluster")
 
 
+def _get_daemonset_pod_status(duthost, vmhost):
+    return vmhost.shell(
+        f"{NO_PROXY} minikube kubectl -- get pods -l group={DAEMONSET_POD_LABEL} "
+        f"--field-selector spec.nodeName={duthost.hostname}",
+        module_ignore_errors=True)
+
+
+def _is_daemonset_pod_running(duthost, vmhost):
+    status = _get_daemonset_pod_status(duthost, vmhost)
+    return "1/1" in status["stdout"] and "Running" in status["stdout"]
+
+
+def _is_daemonset_container_present(duthost):
+    result = duthost.shell(f"docker ps | grep {DAEMONSET_CONTAINER_NAME}", module_ignore_errors=True)
+    return result["stdout"].strip() != ""
+
+
+def _is_daemonset_pod_deleted(duthost, vmhost):
+    status = _get_daemonset_pod_status(duthost, vmhost)
+    return "No resources found" in status["stderr"]
+
+
+def _is_daemonset_container_absent(duthost):
+    result = duthost.shell(f"docker ps | grep {DAEMONSET_CONTAINER_NAME}", module_ignore_errors=True)
+    return result["stdout"].strip() == ""
+
+
 def deploy_daemonset_pod_and_check(duthost, vmhost):
     logger.info("Start to label node and check if the daemonset pod is deployed")
     vmhost.shell(f"{NO_PROXY} minikube kubectl -- label node {duthost.hostname} {DAEMONSET_NODE_LABEL}=true")
-    time.sleep(15)
-    ds_pod_status = vmhost.shell(f"{NO_PROXY} minikube kubectl -- get pods -l group={DAEMONSET_POD_LABEL} \
-                                    --field-selector spec.nodeName={duthost.hostname}")
-    pytest_assert("1/1" in ds_pod_status["stdout"], "Failed to find daemonset pod from k8s")
-    pytest_assert("Running" in ds_pod_status["stdout"], "Failed to find daemonset pod from k8s")
-    container_status = duthost.shell(f"docker ps |grep {DAEMONSET_CONTAINER_NAME}", module_ignore_errors=True)
-    pytest_assert(container_status["stdout"] != "", "Failed to find daemonset pod from duthost")
+    pytest_assert(
+        wait_until(DAEMONSET_POD_TIMEOUT_SECOND, DAEMONSET_POD_CHECK_INTERVAL, 0,
+                   _is_daemonset_pod_running, duthost, vmhost),
+        "Failed to find daemonset pod from k8s")
+    pytest_assert(
+        wait_until(DAEMONSET_POD_TIMEOUT_SECOND, DAEMONSET_POD_CHECK_INTERVAL, 0,
+                   _is_daemonset_container_present, duthost),
+        "Failed to find daemonset pod from duthost")
     logger.info("Successfully deployed daemonset pod")
 
 
 def delete_daemonset_pod_and_check(duthost, vmhost):
     logger.info("Start to unlabel node and check if the daemonset pod is deleted")
     vmhost.shell(f"{NO_PROXY} minikube kubectl -- label node {duthost.hostname} {DAEMONSET_NODE_LABEL}-")
-    time.sleep(15)
-    ds_pod_status = vmhost.shell(f"{NO_PROXY} minikube kubectl -- get pods -l group={DAEMONSET_POD_LABEL} \
-                                    --field-selector spec.nodeName={duthost.hostname}")
-    pytest_assert("No resources found" in ds_pod_status["stderr"], "Failed to delete daemonset")
-    container_status = duthost.shell("docker ps |grep {DAEMONSET_CONTAINER_NAME}", module_ignore_errors=True)
-    pytest_assert(container_status["stdout"] == "", "Failed to delete daemonset pod")
+    pytest_assert(
+        wait_until(DAEMONSET_POD_TIMEOUT_SECOND, DAEMONSET_POD_CHECK_INTERVAL, 0,
+                   _is_daemonset_pod_deleted, duthost, vmhost),
+        "Failed to delete daemonset")
+    pytest_assert(
+        wait_until(DAEMONSET_POD_TIMEOUT_SECOND, DAEMONSET_POD_CHECK_INTERVAL, 0,
+                   _is_daemonset_container_absent, duthost),
+        "Failed to delete daemonset pod")
     logger.info("Successfully deleted daemonset pod")
 
 


### PR DESCRIPTION
### Description of PR

`tests/kubesonic/test_k8s_join_disjoin.py::test_kubesonic_join_and_disjoin` intermittently and, on some testbeds, deterministically failed with **`Failed to find daemonset pod from k8s`** (tracked by **PBI 38770822**, IcM 832945741). This PR makes the test both **tolerant of slow readiness** and **correct about the image it deploys**.

### Root cause (confirmed)

The test daemonset hardcoded its container image as `k8s.gcr.io/pause:3.5`. On internal builds the k8s images are preloaded through `DEFAULT_CONTAINER_REGISTRY` (e.g. `publicmirror.azurecr.io/pause:3.5`) and — prior to **sonic-buildimage#29402** — were **not retagged** to the upstream `k8s.gcr.io` runtime names. kubelet therefore could not resolve `k8s.gcr.io/pause:3.5` locally and attempted a pull from the **frozen `k8s.gcr.io`** registry, which fails (`ImagePullBackOff`), so the pod never reached `Running`.

- **Regression introduced by** sonic-buildimage#25341 (merged 2026-02-12), which routed the k8s pulls through `DEFAULT_CONTAINER_REGISTRY` without a retag.
- **Product fix** is sonic-buildimage#29402 (retag to upstream names; backported to 202605/202608). Confirmed on-device in the related incident: the pause image was present only as `publicmirror.azurecr.io/pause:3.5`, and repointing kubelet's `--pod-infra-container-image` to that tag brought all pods up.
- Wall-clock onset (Kusto `RunDate`): ~0 before Apr 2026, ramping Jul–Sep 2026 — consistent with the #25341 → #29402 window.

### Changes

1. **Resolve the pause image from the DUT** instead of hardcoding it. `get_dut_pause_image()` reads kubelet's configured `--pod-infra-container-image` from `/var/lib/kubelet/kubeadm-flags.env`, so the daemonset requests the image name actually present on the DUT (works on both internal and community builds). Falls back to the previous hardcoded value if the flag cannot be read. Also sets `imagePullPolicy: IfNotPresent` so kubelet never contacts the dead registry.
2. **Bounded readiness polling** replaces the fixed `time.sleep(15)` + immediate hard-assert in both the deploy and delete paths (`wait_until`, 120s/5s), with helper predicates and diagnostics on timeout. Fixes a latent vacuous-assert (f-string) bug in the delete-path container check.

### Relationship to the build fix

Change (1) makes the test robust regardless of whether #29402 has landed in the branch under test. Change (2) absorbs genuine slow-start latency and fixes the vacuous assert. Neither is a substitute for the build-side fix (#29402) on builds where the image is genuinely missing under the requested name — but with (1) the test no longer requests an unresolvable name in the first place.

### How to verify

Run `test_kubesonic_join_and_disjoin` on an affected T0 testbed (e.g. Arista-7050/7060/7260) on a `20260510.*` build. The daemonset pod should reach `Running` using the locally-present pause image; the poll-based checks report status on timeout instead of asserting after a fixed sleep.
