### PR TITLE
[transceiver] Add test for old to new gold upgrade

### DIFF
--- a/tests/transceiver/cdb_firmware_upgrade/firmware_operations.py
+++ b/tests/transceiver/cdb_firmware_upgrade/firmware_operations.py
@@ -398,6 +398,25 @@ def distinct_version_upgrade_op(duthost, port, port_context, metadata_map):
     )
 
 
+def old_gold_upgrade_op(duthost, port, port_context, metadata_map):
+    """TC15 per-port op: downgrade to old gold, then upgrade to current gold."""
+    cdb_attrs = port_context["cdb_attrs"]
+    old_gold = cdb_attrs["old_gold_firmware_version"]
+    gold = cdb_attrs["gold_firmware_version"]
+
+    logger.info("Port %s: downgrading to old gold firmware %s", port, old_gold)
+    failures = perform_firmware_upgrade(
+        duthost, port, port_context, metadata_map, target_version=old_gold,
+    )
+    if failures:
+        return failures
+
+    logger.info("Port %s: upgrading from old gold %s to gold %s", port, old_gold, gold)
+    return perform_firmware_upgrade(
+        duthost, port, port_context, metadata_map, target_version=gold,
+    )
+
+
 def download_post_reset_op(duthost, port, port_context, metadata_map):
     """TC9 per-port op: download, reset the module, then re-verify the download."""
     cdb_attrs = port_context["cdb_attrs"]

--- a/tests/transceiver/cdb_firmware_upgrade/test_firmware_upgrade.py
+++ b/tests/transceiver/cdb_firmware_upgrade/test_firmware_upgrade.py
@@ -3,6 +3,7 @@
 import logging
 import pytest
 
+from tests.transceiver.attribute_parser.attribute_keys import CDB_FIRMWARE_UPGRADE_ATTRIBUTES_KEY
 from tests.transceiver.cdb_firmware_upgrade import firmware_operations
 
 logger = logging.getLogger(__name__)
@@ -44,3 +45,31 @@ def test_firmware_upgrade_stress(
     logger.info("Firmware upgrade stress exercised %d port(s)", num_ports)
     if all_failures:
         pytest.fail("Firmware upgrade stress failures:\n" + "\n".join(all_failures))
+
+
+def test_firmware_upgrade_from_old_gold(
+    duthost, port_attributes_dict, cdb_firmware_qualifying_ports, get_lport_to_pport_mapping,
+    required_firmware_metadata_for_all_transceivers, lport_to_first_subport_mapping,
+    dom_polling_disabled,
+):
+    """Downgrade to the old gold firmware, then upgrade to the current gold."""
+    old_gold_firmware_ports = [
+        port for port in cdb_firmware_qualifying_ports
+        if port_attributes_dict[port][CDB_FIRMWARE_UPGRADE_ATTRIBUTES_KEY].get(
+            "old_gold_firmware_version"
+        )
+    ]
+    if not old_gold_firmware_ports:
+        pytest.skip("No qualifying ports define old_gold_firmware_version")
+
+    all_failures, num_ports = firmware_operations.execute_on_ports(
+        duthost, port_attributes_dict, old_gold_firmware_ports,
+        get_lport_to_pport_mapping,
+        required_firmware_metadata_for_all_transceivers,
+        firmware_operations.old_gold_upgrade_op,
+        lport_to_first_subport_mapping,
+        verify_post_operation=True,
+    )
+    logger.info("Old-gold to gold firmware upgrade exercised %d port(s)", num_ports)
+    if all_failures:
+        pytest.fail("Old-gold to gold firmware upgrade failures:\n" + "\n".join(all_failures))

--- a/tests/transceiver/cdb_firmware_upgrade/utils/firmware_utils.py
+++ b/tests/transceiver/cdb_firmware_upgrade/utils/firmware_utils.py
@@ -17,7 +17,7 @@ def get_required_firmware_metadata_for_all_transceivers(
     transceiver_firmware_info,
     qualifying_ports,
 ):
-    """Return exact manifest metadata for each qualifying port's firmware_versions."""
+    """Return manifest metadata for each qualifying port's required firmware versions."""
     if not port_attributes_dict:
         pytest.skip("No port attributes available, skipping test.")
     if not qualifying_ports:
@@ -62,6 +62,16 @@ def get_required_firmware_metadata_for_all_transceivers(
                     f"{port}: inactive_firmware_version '{inactive_firmware_version}' must be the "
                     f"second to last entry in firmware_versions {firmware_versions}"
                 )
+
+        required_versions = list(firmware_versions)
+        old_gold_firmware_version = cdb_attrs.get("old_gold_firmware_version")
+        if old_gold_firmware_version:
+            if old_gold_firmware_version == gold_firmware_version:
+                failures.append(
+                    f"{port}: old_gold_firmware_version must differ from gold_firmware_version"
+                )
+            if old_gold_firmware_version not in required_versions:
+                required_versions.append(old_gold_firmware_version)
         if transceiver_key in firmware_metadata_by_transceiver_type:
             continue
 
@@ -77,7 +87,7 @@ def get_required_firmware_metadata_for_all_transceivers(
                 metadata_by_version[version] = firmware_metadata
 
         missing_versions = [
-            version for version in firmware_versions if version not in metadata_by_version
+            version for version in required_versions if version not in metadata_by_version
         ]
         if missing_versions:
             failures.append(
@@ -86,7 +96,7 @@ def get_required_firmware_metadata_for_all_transceivers(
             )
             continue
 
-        selected_firmware = [metadata_by_version[version] for version in firmware_versions]
+        selected_firmware = [metadata_by_version[version] for version in required_versions]
         incomplete_versions = [
             fw.get("version") for fw in selected_firmware
             if not fw.get("binary") or not fw.get("md5sum")


### PR DESCRIPTION
### Description of PR

Summary:
Implements the CDB firmware upgrade test that validates upgrading a module from its previously deployed gold firmware to the current gold firmware.

Follow-up of this PR: https://github.com/sonic-net/sonic-mgmt/pull/27686
### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):

Failure type: Other - new test coverage

### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] N/A

### Approach

#### What is the motivation for this PR?

The existing CDB firmware upgrade tests exercise download and activation using the three images in `firmware_versions`, but they do not reproduce the upgrade performed when a new gold firmware is qualified.

This change adds coverage for downgrading a module to its previously deployed gold firmware and then upgrading it back to the current `gold_firmware_version`.

#### How did you do it?

- Added support for the optional per-transceiver `old_gold_firmware_version` attribute.
- Included `old_gold_firmware_version` in the firmware metadata selected and staged from the per-PN manifest.
- Added validation that `old_gold_firmware_version` differs from `gold_firmware_version`.
- Added an operation that:
  1. Performs a full firmware upgrade to `old_gold_firmware_version`.
  2. Performs a full firmware upgrade back to `gold_firmware_version`.
- Added `test_firmware_upgrade_from_old_gold`.
- The test runs only on qualifying ports that define `old_gold_firmware_version` and skips cleanly when none are configured.

#### How did you verify/test it?
- verified the test passes when the optional attribute is present.
- verified the test is skipped if the attribute is not present.

#### Test logs
```
transceiver/cdb_firmware_upgrade/test_firmware_upgrade.py::test_firmware_upgrade_from_old_gold PASSED                                                [100%]

======================================================= 1 passed, 150 warnings in 2004.56s (0:33:24) =======================================================
```
```
44791:09/09/2026 18:26:25 conftest.presence_verified               L0297 INFO   | presence_verified prerequisite PASSED: 40/40 transceivers present (show CLI)
44796:09/09/2026 18:26:27 conftest.links_verified                  L0331 INFO   | links_verified prerequisite PASSED: 40/40 transceiver ports admin-up and oper-up
44988:09/09/2026 18:27:13 conftest._per_test_health_check          L0367 DEBUG  | Health baseline captured for test_firmware_upgrade_from_old_gold
45036:09/09/2026 18:27:27 firmware_operations.old_gold_upgrade_op  L0407 INFO   | Port EthernetXX: downgrading to old gold firmware 36.229.0
45050:09/09/2026 18:36:14 firmware_operations.perform_firmware_dow L0255 INFO   | Port EthernetXX: firmware download took 520.1s
45077:09/09/2026 18:36:37 firmware_operations.perform_firmware_act L0328 INFO   | Port EthernetXX: firmware run took 11.8s
45082:09/09/2026 18:36:41 firmware_operations.perform_firmware_act L0336 INFO   | Port EthernetXX: firmware commit took 2.1s
45123:09/09/2026 18:37:12 firmware_operations.old_gold_upgrade_op  L0414 INFO   | Port EthernetXX: upgrading from old gold 36.229.0 to gold 36.233.0
45137:09/09/2026 18:46:29 firmware_operations.perform_firmware_dow L0255 INFO   | Port EthernetXX: firmware download took 549.7s
45164:09/09/2026 18:46:52 firmware_operations.perform_firmware_act L0328 INFO   | Port EthernetXX: firmware run took 11.9s
45169:09/09/2026 18:46:56 firmware_operations.perform_firmware_act L0336 INFO   | Port EthernetXX: firmware commit took 2.1s
45390:09/09/2026 18:48:25 test_firmware_upgrade.test_firmware_upgr L0073 INFO   | Old-gold to gold firmware upgrade exercised 1 port(s)
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

MSFT ADO - 39141730