### PR TITLE
SonicHost: avoid stale basic facts cache

### DIFF
--- a/tests/common/cache/facts_cache.md
+++ b/tests/common/cache/facts_cache.md
@@ -4,7 +4,7 @@ To run test scripts, we frequently need to gather facts from various devices aga
 
 # Cache Design
 
-To simplify the design, we use local (sonic-mgmt container) pickle files to cache information. Although reading from local file is slower than reading from memory, it is still much faster than running commands on remote host through SSH connection and parsing the output. Only the first reading of cached information needs to load from file. Subsequent reading are from a runtime dictionary, the performance is equivalent to reading from memory. A dedicated folder (by default `tests/_cache`) is used to store the cached pickle files. The pickle files are grouped into sub-folders by zone (usually hostname, but the zone name can also be something else that unique, like testbed name). For example, file `tests/_cache/vlab-01/basic_facts.pickle` caches some basic facts of host `vlab-01`.
+To simplify the design, we use local (sonic-mgmt container) pickle files to cache information. Although reading from local file is slower than reading from memory, it is still much faster than running commands on remote host through SSH connection and parsing the output. Only the first reading of cached information needs to load from file. Subsequent reading are from a runtime dictionary, the performance is equivalent to reading from memory. A dedicated folder (by default `tests/_cache`) is used to store the cached pickle files. The pickle files are grouped into sub-folders by zone (usually hostname, but the zone name can also be something else that unique, like testbed name). For example, file `tests/_cache/vlab-01/sonic_basic_facts.pickle` caches some basic facts of host `vlab-01`.
 
 The cache function is mainly implemented in below file:
 ```
@@ -52,7 +52,7 @@ class SonicHost(AnsibleHostBase):
 
     ...
 
-    @cached(name='basic_facts')
+    @cached(name='sonic_basic_facts')
     def _gather_facts(self):
 
     ...
@@ -96,7 +96,7 @@ class SonicHost(AnsibleHostBase):
 
     ...
 
-    @cached(name='basic_facts')
+    @cached(name='sonic_basic_facts')
     def _gather_facts(self):
 ```
 2. have custome zone getter function to retrieve zone from the argument `hostname` defined in the decorated function.
@@ -137,7 +137,7 @@ class SonicHost(AnsibleHostBase):
 
     ...
 
-    @cached(name='basic_facts', after_read=validate_datetime_after_read, before_write=add_datetime_before_write)
+    @cached(name='sonic_basic_facts', after_read=validate_datetime_after_read, before_write=add_datetime_before_write)
     def _gather_facts(self):
 ```
 

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -234,7 +234,7 @@ class SonicHost(AnsibleHostBase):
 
         self.critical_services = service_list
 
-    @cached(name='basic_facts')
+    @cached(name='sonic_basic_facts')
     def _gather_facts(self):
         """
         Gather facts about the platform for this SONiC device.

--- a/tests/common/unit_tests/devices/unit_test_sonic_host_facts_cache.py
+++ b/tests/common/unit_tests/devices/unit_test_sonic_host_facts_cache.py
@@ -1,0 +1,117 @@
+"""Regression test for sonic-mgmt issue #27700.
+
+SonicHost._gather_facts() is decorated with a facts_cache key. Before PR
+#21442, that key ('basic_facts') stored a flat dict. After PR #21442 the
+function returns a nested {"basic_facts": ..., "versions": ...,
+"features": ...} structure, but the decorator kept the same cache key. A
+leftover legacy flat pickle from an older sonic-mgmt checkout was therefore
+loaded as-is by the new code, and SonicHost.__init__ raised
+KeyError('num_asic').
+
+This test avoids importing tests.common.devices.sonic directly, since that
+pulls in the full ansible/pytest_ansible/paramiko stack via
+tests/common/__init__.py. Instead, following the same approach as
+unit_test_dhcp_relay_cleanup.py, it parses the real source with `ast`,
+extracts the real _gather_facts FunctionDef (decorator intact), and executes
+it against the real cached()/FactsCache implementation loaded directly from
+file.
+"""
+
+import ast
+import importlib.util
+import json
+import logging
+import pickle
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FACTS_CACHE_PATH = REPO_ROOT / "tests/common/cache/facts_cache.py"
+SONIC_PATH = REPO_ROOT / "tests/common/devices/sonic.py"
+
+
+def _load_real_cache_module():
+    """Import facts_cache.py by file path, bypassing tests/common/__init__.py."""
+    spec = importlib.util.spec_from_file_location("_facts_cache_under_test", FACTS_CACHE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _extract_gather_facts(cached_decorator):
+    """Compile the real SonicHost._gather_facts FunctionDef, decorator intact."""
+    tree = ast.parse(SONIC_PATH.read_text())
+    sonic_host_cls = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef) and node.name == "SonicHost"
+    )
+    gather_facts_def = next(
+        node for node in sonic_host_cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_gather_facts"
+    )
+    module = ast.Module(body=[gather_facts_def], type_ignores=[])
+    ast.fix_missing_locations(module)
+
+    namespace = {"cached": cached_decorator, "logging": logging, "json": json}
+    exec(compile(module, str(SONIC_PATH), "exec"), namespace)
+    return namespace["_gather_facts"]
+
+
+class FakeSonicHost:
+    """Minimal stand-in exposing only what _gather_facts touches."""
+
+    def __init__(self, hostname):
+        self.hostname = hostname
+        self.sonic_basic_facts_calls = 0
+
+    def sonic_basic_facts(self):
+        self.sonic_basic_facts_calls += 1
+        return {
+            "ansible_facts": {
+                "basic_facts": {"num_asic": 1, "asic_type": "vs", "hwsku": "test-hwsku"},
+                "versions": {"build_version": "master.123-abc"},
+                "features": {"gbsyncd": {"state": "disabled"}},
+            }
+        }
+
+    def get_asics_present_from_inventory(self):
+        return []
+
+
+def test_gather_facts_ignores_legacy_flat_cache(tmp_path):
+    cache_module = _load_real_cache_module()
+
+    # Point the (isolated) FactsCache singleton at tmp_path before the
+    # decorator below is ever invoked.
+    cache_module.FactsCache(cache_location=str(tmp_path))
+
+    # Seed a legacy, pre-PR#21442 style flat pickle under the OLD cache key.
+    hostname = "vlab-01"
+    zone_dir = tmp_path / hostname
+    zone_dir.mkdir()
+    legacy_payload = {
+        "platform": "x86_64-legacy",
+        "hwsku": "legacy-hwsku",
+        "asic_type": "vs",
+        "num_asic": 1,
+        "router_mac": "00:11:22:33:44:55",
+    }
+    legacy_pickle = zone_dir / "basic_facts.pickle"
+    with open(legacy_pickle, "wb") as f:
+        pickle.dump(legacy_payload, f, pickle.HIGHEST_PROTOCOL)
+    legacy_bytes_before = legacy_pickle.read_bytes()
+
+    gather_facts = _extract_gather_facts(cache_module.cached)
+    fake_host = FakeSonicHost(hostname)
+
+    result = gather_facts(fake_host)
+
+    # The legacy flat payload was not returned; a fresh gather happened.
+    assert result != legacy_payload
+    assert fake_host.sonic_basic_facts_calls == 1
+    assert result["basic_facts"]["num_asic"] == 1
+
+    # A new pickle was written under the new key; the legacy one is untouched.
+    new_pickle = zone_dir / "sonic_basic_facts.pickle"
+    assert new_pickle.exists()
+    assert legacy_pickle.exists()
+    assert legacy_pickle.read_bytes() == legacy_bytes_before


### PR DESCRIPTION
### Description of PR

Summary:

Avoid reusing stale `SonicHost` basic-facts cache files created before PR #21442 changed the cached payload schema.

`SonicHost._gather_facts()` previously returned a flat basic-facts dictionary and cached it under the `basic_facts` key. After #21442, it returns a nested structure containing `basic_facts`, `versions`, and `features`, but the persistent cache key remained unchanged.

An existing `basic_facts.pickle` containing the legacy flat structure can therefore be loaded by current code. `SonicHost.__init__()` then cannot find the nested `basic_facts` dictionary and fails when accessing `num_asic`.

This change uses a new `sonic_basic_facts` cache key so incompatible legacy cache files are no longer consumed. It also adds a regression unit test that seeds a legacy cache and verifies that fresh facts are gathered and cached under the new key.

Fixes #27700

### Type of change

* [x] Bug fix
* [x] Testbed and Framework(new/improvement)
* [ ] New Test case

  * [ ] Skipped for non-supported platforms
* [ ] Test case improvement

### Back port request

* [ ] 202311
* [ ] 202405
* [ ] 202411
* [ ] 202505
* [ ] 202511
* [ ] 202512
* [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: regression

### Tested branch

* [x] master
* [ ] 202311
* [ ] 202405
* [ ] 202411
* [ ] 202505
* [ ] 202511
* [ ] 202512
* [ ] 202605
* [ ] N/A

### Test result

Local validation against current master:

```text
python3 -m pytest --noconftest \
    --confcutdir=tests/common/unit_tests \
    tests/common/unit_tests/devices/unit_test_sonic_host_facts_cache.py -v

1 passed
```

Additional validation:

```text
python3 -m py_compile \
    tests/common/devices/sonic.py \
    tests/common/unit_tests/devices/unit_test_sonic_host_facts_cache.py

PASS
```

```text
pre-commit run flake8 --files \
    tests/common/devices/sonic.py \
    tests/common/unit_tests/devices/unit_test_sonic_host_facts_cache.py

flake8 ... Passed
```

```text
git diff --check

PASS
```

No DUT test was performed because the regression is in the local `sonic-mgmt` facts-cache compatibility path. The regression unit test exercises the real `FactsCache`/`cached` implementation and the actual `SonicHost._gather_facts` function from the source file.

### Approach

#### What is the motivation for this PR?

PR #21442 changed the value cached by `SonicHost._gather_facts()` from a flat dictionary to a nested structure without changing the persistent cache key.

A valid cache file generated by older code can therefore be interpreted using the newer schema and cause:

```text
KeyError: 'num_asic'
```

during `SonicHost` initialization, preventing tests using `duthosts` from starting.

#### How did you do it?

Changed the `_gather_facts()` cache key from:

```python
@cached(name='basic_facts')
```

to:

```python
@cached(name='sonic_basic_facts')
```

This causes the current nested facts payload to use a separate persistent cache file. Existing legacy `basic_facts.pickle` files remain harmless and are no longer consumed by `_gather_facts()`.

The facts-cache documentation was updated to reflect the new key.

A regression unit test creates a representative legacy flat `basic_facts.pickle`, executes the real `_gather_facts()` implementation with the real cache decorator, and verifies that:

* the legacy cache is not returned;
* fresh facts are gathered;
* `basic_facts.num_asic` is available;
* a new `sonic_basic_facts.pickle` is created; and
* the legacy cache remains unchanged.

#### How did you verify/test it?

Added and ran a focused local regression unit test requiring no SONiC DUT. Python compilation, repository flake8 checks, and `git diff --check` also pass.

#### Any platform specific information?

No. This is a generic `sonic-mgmt` framework cache compatibility issue.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

Updated `tests/common/cache/facts_cache.md` examples to use the new `sonic_basic_facts` cache key.
