### PR TITLE
Fix dwrr test on TH6 platform

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1709,7 +1709,8 @@ class TestQosSai(QosSaiBase):
             "pkts_num_leak_out": qosConfig[portSpeedCableLength]["pkts_num_leak_out"],
             "hwsku": dutTestParams['hwsku'],
             "topo": dutTestParams["topo"],
-            "qos_remap_enable": qos_remap_enable
+            "qos_remap_enable": qos_remap_enable,
+            "dut_asic": dutConfig.get("dutAsic", "")
         })
 
         if "platform_asic" in dutTestParams["basicParams"]:

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4857,8 +4857,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                                                port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
                                                xmit_counters_base, self, src_port_id, pkt, 10)
 
-            if 'hwsku' in self.test_params and 'Arista-7060X6' in self.test_params['hwsku']:
-
+            if 'dut_asic' in self.test_params and self.test_params['dut_asic'] in ('th5', 'th6'):
                 n_prio = [int(n / sum(q_pkt_cnt) * pkts_num_egr_mem) for n in q_pkt_cnt]
                 for i in range(pkts_num_egr_mem - sum(n_prio)):
                     n_prio[i] += 1


### PR DESCRIPTION
### Description of PR
Summary:
Fix DWRR test failure on TH6 platform.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [x] 202605

### Approach
#### What is the motivation for this PR?
The DWRR (WRRtest) special-case packet distribution logic in `sai_qos_tests.py` only triggered
for hwsku `Arista-7060X6` (a TH5-based platform). This caused the test to fail on TH6 platforms,
which need the same egress-membership packet-count compensation logic but weren't matched by the
hwsku string check.

#### How did you do it?
Replaced the hwsku string match with a check against the DUT ASIC type (`dut_asic in ('th5', 'th6')`),
which generalizes the existing TH5 special case to also cover TH6. Added `dut_asic` (sourced from
`dutConfig["dutAsic"]`) to the `testParams` passed to `WRRtest` in `testQosSaiDwrr` so the PTF test
can read it.

#### How did you verify/test it?
Verified the modified files compile cleanly (`python3 -m py_compile`) and reviewed that `dutAsic`
is always populated in `dutConfig` (see `qos_sai_base.py`) before being consumed here.

Ran `testQosSaiDwrr` locally on a TH6 testbed:
```
collected 5 items

qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[single_asic] PASSED                                                                                                              [ 20%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[single_dut_multi_asic] SKIPPED (Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests)      [ 40%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[multi_dut_longlink_to_shortlink] SKIPPED (Don't have 2 frontend nodes - so can't run multi_dut tests)                             [ 60%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[multi_dut_shortlink_to_shortlink] SKIPPED (Don't have 2 frontend nodes - so can't run multi_dut tests)                            [ 80%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[multi_dut_shortlink_to_longlink] SKIPPED (Don't have 2 frontend nodes - so can't run multi_dut tests)                             [100%]
```
(Remaining cases skipped due to lack of multi-asic/multi-dut nodes in the local testbed, not related to this change.)

#### Any platform specific information?
Affects TH5/TH6 Broadcom ASIC platforms (e.g. Arista-7060X6 and other TH6 platforms) running the QoS DWRR test.

#### Supported testbed topology if it's a new test case?
N/A - existing test case, no topology change.

### Documentation
N/A
