### PR TITLE
`bgp/test_prefix_list_suppress.py` add `wait_until` for syslog

### DIFF
--- a/tests/bgp/test_prefix_list_suppress.py
+++ b/tests/bgp/test_prefix_list_suppress.py
@@ -721,15 +721,13 @@ class TestAnchorPrefixRegression:
             # On spine devices the new "AsPath Manager is enabled for <TYPE>"
             # line must appear. On non-spine devices it must not.
             if spine:
-                new_line = collect_syslog_since_marker(
-                    duthost, marker,
-                    "AsPath Manager is enabled for",
-                )
                 pytest_assert(
-                    new_line.strip(),
+                    wait_until(30, 5, 0,
+                               lambda d=duthost, m=marker: collect_syslog_since_marker(
+                                   d, m, "AsPath Manager is enabled for").strip()),
                     "Expected 'AsPath Manager is enabled for <DEVICE_TYPE>'"
                     " log line on spine device {} after bgpcfgd restart in"
-                    " {}".format(duthost.hostname, container),
+                    " {}".format(duthost.hostname, container)
                 )
 
             # bgpcfgd must not have logged a traceback since the restart.


### PR DESCRIPTION


https://github.com/sonic-net/sonic-mgmt/issues/27837

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The test `bgp/test_prefix_list_suppress.py::TestAnchorPrefixRegression::test_prefix_list_mgr_running_on_every_device` expects bgpcfgd to emit syslog 'AsPath Manager is enabled for'
But sometimes the assertion is seen before the syslog shows up (see https://github.com/sonic-net/sonic-mgmt/issues/27837)
Add a wait_until to give bgpcfgd a chance to emit the syslog

Summary:
Fixes #27837 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- 202605: Ran with latest built 202605 and stressed test 20 times, all pass

### Approach
#### What is the motivation for this PR?
If bgpcfgd is slower to emit the syslog we shouldn't cause the test to fail

#### How did you do it?
Convert syslog read and assert into a `wait_until`

#### How did you verify/test it?
Ran the `bgp/test_prefix_list_suppress.py::TestAnchorPrefixRegression::test_prefix_list_mgr_running_on_every_device` against a UT2 20 times without failure

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A