### PR TITLE
everflow: pace policer test traffic

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -9,7 +9,6 @@ Usage:          Examples of how to use:
 
 import sys
 import time
-import datetime
 import logging
 
 import ptf
@@ -22,13 +21,14 @@ from ptf.mask import Mask
 logger = logging.getLogger('EverflowPolicerTest')
 
 
-def _send_original_flow_paced(send_batch, total_packets, batch_size, batch_interval, sleep=time.sleep):
+def _send_packets_paced(send_batch, total_packets, batch_size, batch_interval, sleep=time.sleep):
     """
     @summary: Send total_packets by calling send_batch(count) repeatedly, capping
-    each call at batch_size and pacing calls by batch_interval. This avoids
-    handing PTF a single unpaced send of total_packets, which can generate an
-    unpaced microburst and intermittently cause the PTF-side capture to lose
-    some packets (see sonic-net/sonic-mgmt#27708).
+    each call at batch_size and pacing calls by batch_interval. This avoids handing
+    PTF a single unpaced burst, which can create sustained bursts on the PTF/kernel
+    transmit path and intermittently lose packets (see sonic-net/sonic-mgmt#27708).
+    Used both for the original (non-mirrored) flow send and the CBS-absorption
+    burst in checkMirroredFlow().
     """
     remaining = total_packets
     while remaining > 0:
@@ -39,17 +39,38 @@ def _send_original_flow_paced(send_batch, total_packets, batch_size, batch_inter
             sleep(batch_interval)
 
 
+def _send_packets_paced_for_duration(
+        send_batch, duration, batch_size, batch_interval, sleep=time.sleep, monotonic=time.monotonic):
+    """
+    @summary: Call send_batch(batch_size) repeatedly for approximately duration
+    seconds, pacing batches by batch_interval, instead of a tight single-packet
+    send loop. Pacing gives the PTF/kernel transmit path time to drain between
+    batches. Returns the exact number of packets requested through send_batch()
+    so callers can compute an accurate tx rate (see sonic-net/sonic-mgmt#27708).
+    """
+    end_time = monotonic() + duration
+    tx_pkts = 0
+    while monotonic() < end_time:
+        send_batch(batch_size)
+        tx_pkts += batch_size
+        remaining = end_time - monotonic()
+        if remaining > 0:
+            sleep(min(batch_interval, remaining))
+    return tx_pkts
+
+
 class EverflowPolicerTest(BaseTest):
 
     GRE_PROTOCOL_NUMBER = 47
     NUM_OF_TOTAL_PACKETS = 10000
     METER_TYPES = ['packets', 'bytes']
-    # Cap on packets sent per pacing batch, and the delay between batches, when
-    # sending the original (non-mirrored) flow. This keeps PTF from generating
-    # an unpaced send microburst, which can intermittently cause the PTF-side
-    # capture to lose some original-flow packets (see sonic-net/sonic-mgmt#27708).
-    ORIGINAL_FLOW_BATCH_SIZE = 60
-    ORIGINAL_FLOW_BATCH_INTERVAL = 0.01
+    # Cap on packets sent per pacing batch, and the delay between batches, used to
+    # pace the original-flow send and both checkMirroredFlow() traffic-generation
+    # paths (CBS absorption and sustained transmission). This keeps offered traffic
+    # from bursting unpaced, while remaining far above the policer's configured
+    # rate limit (see sonic-net/sonic-mgmt#27708).
+    PACED_SEND_BATCH_SIZE = 60
+    PACED_SEND_BATCH_INTERVAL = 0.01
 
     def __init__(self):
         '''
@@ -203,11 +224,11 @@ class EverflowPolicerTest(BaseTest):
         self.dataplane.flush()
 
         count = 0
-        _send_original_flow_paced(
+        _send_packets_paced(
             lambda n: testutils.send_packet(self, self.src_port, self.base_pkt, count=n),
             self.NUM_OF_TOTAL_PACKETS,
-            self.ORIGINAL_FLOW_BATCH_SIZE,
-            self.ORIGINAL_FLOW_BATCH_INTERVAL,
+            self.PACED_SEND_BATCH_SIZE,
+            self.PACED_SEND_BATCH_INTERVAL,
         )
         for i in range(0, self.NUM_OF_TOTAL_PACKETS):
             (rcv_device, rcv_port, rcv_pkt, pkt_time) = testutils.dp_poll(self, timeout=0.1, exp_pkt=masked_exp_pkt)
@@ -330,15 +351,17 @@ class EverflowPolicerTest(BaseTest):
 
             return dataplane.match_exp_pkt(payload_mask, pkt)
 
+        def send_batch(count):
+            testutils.send_packet(self, self.src_port, self.base_pkt, count=count)
+
         # send some amount to absorb CBS capacity
-        testutils.send_packet(self, self.src_port, self.base_pkt, count=self.NUM_OF_TOTAL_PACKETS)
+        _send_packets_paced(
+            send_batch, self.NUM_OF_TOTAL_PACKETS,
+            self.PACED_SEND_BATCH_SIZE, self.PACED_SEND_BATCH_INTERVAL)
         self.dataplane.flush()
 
-        end_time = datetime.datetime.now() + datetime.timedelta(seconds=self.send_time)
-        tx_pkts = 0
-        while datetime.datetime.now() < end_time:
-            testutils.send_packet(self, self.src_port, self.base_pkt)
-            tx_pkts += 1
+        tx_pkts = _send_packets_paced_for_duration(
+            send_batch, self.send_time, self.PACED_SEND_BATCH_SIZE, self.PACED_SEND_BATCH_INTERVAL)
 
         rx_pkts = 0
         while True:

--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -22,11 +22,34 @@ from ptf.mask import Mask
 logger = logging.getLogger('EverflowPolicerTest')
 
 
+def _send_original_flow_paced(send_batch, total_packets, batch_size, batch_interval, sleep=time.sleep):
+    """
+    @summary: Send total_packets by calling send_batch(count) repeatedly, capping
+    each call at batch_size and pacing calls by batch_interval. This avoids
+    handing PTF a single unpaced send of total_packets, which can generate an
+    unpaced microburst and intermittently cause the PTF-side capture to lose
+    some packets (see sonic-net/sonic-mgmt#27708).
+    """
+    remaining = total_packets
+    while remaining > 0:
+        count = min(batch_size, remaining)
+        send_batch(count)
+        remaining -= count
+        if remaining > 0:
+            sleep(batch_interval)
+
+
 class EverflowPolicerTest(BaseTest):
 
     GRE_PROTOCOL_NUMBER = 47
     NUM_OF_TOTAL_PACKETS = 10000
     METER_TYPES = ['packets', 'bytes']
+    # Cap on packets sent per pacing batch, and the delay between batches, when
+    # sending the original (non-mirrored) flow. This keeps PTF from generating
+    # an unpaced send microburst, which can intermittently cause the PTF-side
+    # capture to lose some original-flow packets (see sonic-net/sonic-mgmt#27708).
+    ORIGINAL_FLOW_BATCH_SIZE = 60
+    ORIGINAL_FLOW_BATCH_INTERVAL = 0.01
 
     def __init__(self):
         '''
@@ -180,7 +203,12 @@ class EverflowPolicerTest(BaseTest):
         self.dataplane.flush()
 
         count = 0
-        testutils.send_packet(self, self.src_port, self.base_pkt, count=self.NUM_OF_TOTAL_PACKETS)
+        _send_original_flow_paced(
+            lambda n: testutils.send_packet(self, self.src_port, self.base_pkt, count=n),
+            self.NUM_OF_TOTAL_PACKETS,
+            self.ORIGINAL_FLOW_BATCH_SIZE,
+            self.ORIGINAL_FLOW_BATCH_INTERVAL,
+        )
         for i in range(0, self.NUM_OF_TOTAL_PACKETS):
             (rcv_device, rcv_port, rcv_pkt, pkt_time) = testutils.dp_poll(self, timeout=0.1, exp_pkt=masked_exp_pkt)
             if rcv_pkt is not None:

--- a/tests/common/unit_tests/unit_test_everflow_policer_pacing.py
+++ b/tests/common/unit_tests/unit_test_everflow_policer_pacing.py
@@ -1,0 +1,66 @@
+"""Exercise the EverflowPolicerTest original-flow send pacing without PTF.
+
+ansible/roles/test/files/acstests/everflow_policer_test.py imports ptf, which
+is not available in this unit-test environment. The module-level
+_send_original_flow_paced() helper has no ptf dependency, so it is extracted
+via ast and exec'd in isolation to test it directly.
+
+Run with::
+
+    python3 -m pytest --noconftest --confcutdir=tests/common/unit_tests \
+        tests/common/unit_tests/unit_test_everflow_policer_pacing.py -v
+"""
+
+import ast
+import time
+from pathlib import Path
+from unittest.mock import Mock, call
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "ansible" / "roles" / "test" / "files" / "acstests" / "everflow_policer_test.py"
+)
+
+
+def _load_send_original_flow_paced():
+    tree = ast.parse(MODULE_PATH.read_text())
+    func = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_send_original_flow_paced"
+    )
+    # The helper's "sleep=time.sleep" default argument is evaluated when the
+    # def statement executes, so "time" must be present in the namespace.
+    namespace = {"time": time}
+    exec(compile(ast.Module(body=[func], type_ignores=[]), str(MODULE_PATH), "exec"), namespace)
+    return namespace["_send_original_flow_paced"]
+
+
+@pytest.fixture
+def send_original_flow_paced():
+    return _load_send_original_flow_paced()
+
+
+def test_paced_send_batches_10000_in_60s_with_40_final_batch(send_original_flow_paced):
+    send_batch = Mock()
+    sleep = Mock()
+
+    send_original_flow_paced(
+        send_batch, total_packets=10000, batch_size=60, batch_interval=0.01, sleep=sleep)
+
+    counts = [c.args[0] for c in send_batch.call_args_list]
+    assert counts == [60] * 166 + [40]
+    assert sum(counts) == 10000
+    assert sleep.call_args_list == [call(0.01)] * 166
+
+
+def test_paced_send_exact_multiple_has_no_short_final_batch(send_original_flow_paced):
+    send_batch = Mock()
+
+    send_original_flow_paced(
+        send_batch, total_packets=120, batch_size=60, batch_interval=0.01, sleep=Mock())
+
+    counts = [c.args[0] for c in send_batch.call_args_list]
+    assert counts == [60, 60]

--- a/tests/common/unit_tests/unit_test_everflow_policer_pacing.py
+++ b/tests/common/unit_tests/unit_test_everflow_policer_pacing.py
@@ -1,9 +1,9 @@
-"""Exercise the EverflowPolicerTest original-flow send pacing without PTF.
+"""Exercise the EverflowPolicerTest send-pacing helpers without PTF.
 
 ansible/roles/test/files/acstests/everflow_policer_test.py imports ptf, which
-is not available in this unit-test environment. The module-level
-_send_original_flow_paced() helper has no ptf dependency, so it is extracted
-via ast and exec'd in isolation to test it directly.
+is not available in this unit-test environment. The pacing helpers have no
+ptf dependency, so each is extracted via ast and exec'd in isolation to test
+it directly.
 
 Run with::
 
@@ -25,29 +25,55 @@ MODULE_PATH = (
 )
 
 
-def _load_send_original_flow_paced():
+def _load_function(name):
     tree = ast.parse(MODULE_PATH.read_text())
     func = next(
         node for node in tree.body
-        if isinstance(node, ast.FunctionDef) and node.name == "_send_original_flow_paced"
+        if isinstance(node, ast.FunctionDef) and node.name == name
     )
-    # The helper's "sleep=time.sleep" default argument is evaluated when the
-    # def statement executes, so "time" must be present in the namespace.
+    # Both helpers' "sleep=time.sleep" / "monotonic=time.monotonic" default
+    # arguments are evaluated when the def statement executes, so "time" must
+    # be present in the namespace.
     namespace = {"time": time}
     exec(compile(ast.Module(body=[func], type_ignores=[]), str(MODULE_PATH), "exec"), namespace)
-    return namespace["_send_original_flow_paced"]
+    return namespace[name]
+
+
+def _get_method_ast(class_name, method_name):
+    tree = ast.parse(MODULE_PATH.read_text())
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name)
+    return next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == method_name)
 
 
 @pytest.fixture
-def send_original_flow_paced():
-    return _load_send_original_flow_paced()
+def send_packets_paced():
+    return _load_function("_send_packets_paced")
 
 
-def test_paced_send_batches_10000_in_60s_with_40_final_batch(send_original_flow_paced):
+@pytest.fixture
+def send_packets_paced_for_duration():
+    return _load_function("_send_packets_paced_for_duration")
+
+
+class FakeClock:
+    """Deterministic monotonic()/sleep() pair: sleep() advances the fake clock,
+    monotonic() never advances on its own. No real delay occurs."""
+
+    def __init__(self):
+        self.now = 0.0
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
+
+
+def test_paced_send_batches_10000_in_batches_of_60_with_40_final(send_packets_paced):
     send_batch = Mock()
     sleep = Mock()
 
-    send_original_flow_paced(
+    send_packets_paced(
         send_batch, total_packets=10000, batch_size=60, batch_interval=0.01, sleep=sleep)
 
     counts = [c.args[0] for c in send_batch.call_args_list]
@@ -56,11 +82,53 @@ def test_paced_send_batches_10000_in_60s_with_40_final_batch(send_original_flow_
     assert sleep.call_args_list == [call(0.01)] * 166
 
 
-def test_paced_send_exact_multiple_has_no_short_final_batch(send_original_flow_paced):
+def test_paced_send_exact_multiple_has_no_short_final_batch(send_packets_paced):
     send_batch = Mock()
 
-    send_original_flow_paced(
+    send_packets_paced(
         send_batch, total_packets=120, batch_size=60, batch_interval=0.01, sleep=Mock())
 
     counts = [c.args[0] for c in send_batch.call_args_list]
     assert counts == [60, 60]
+
+
+def test_paced_duration_send_caps_final_sleep_to_remaining_duration(send_packets_paced_for_duration):
+    clock = FakeClock()
+    send_batch = Mock()
+    sleep = Mock(side_effect=clock.sleep)
+
+    tx_pkts = send_packets_paced_for_duration(
+        send_batch, duration=0.025, batch_size=60, batch_interval=0.01,
+        sleep=sleep, monotonic=clock.monotonic)
+
+    counts = [c.args[0] for c in send_batch.call_args_list]
+    assert counts == [60, 60, 60]                  # exact batch size, every call
+    assert tx_pkts == 180                           # returned count matches what was sent
+
+    sleep_values = [c.args[0] for c in sleep.call_args_list]
+    # Final sleep is capped to what's left of duration, not a full batch_interval.
+    assert sleep_values == pytest.approx([0.01, 0.01, 0.005])
+    assert clock.now == pytest.approx(0.025)
+
+
+def test_check_mirrored_flow_uses_both_pacing_helpers_and_no_direct_send():
+    method = _get_method_ast("EverflowPolicerTest", "checkMirroredFlow")
+
+    # Only walk top-level statements, skipping nested defs (match_payload,
+    # send_batch) so their calls -- including the one legitimate direct
+    # testutils.send_packet() inside send_batch() -- aren't counted here.
+    calls = []
+    for statement in method.body:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        calls.extend(node for node in ast.walk(statement) if isinstance(node, ast.Call))
+
+    helper_names = {call.func.id for call in calls if isinstance(call.func, ast.Name)}
+    assert "_send_packets_paced" in helper_names
+    assert "_send_packets_paced_for_duration" in helper_names
+
+    direct_send_packet_calls = [
+        call for call in calls
+        if isinstance(call.func, ast.Attribute) and call.func.attr == "send_packet"
+    ]
+    assert direct_send_packet_calls == []


### PR DESCRIPTION
### Description of PR

Summary:

Pace PTF traffic generation in `EverflowPolicerTest` to avoid unpaced bursts and sustained tight send loops that can cause packet loss or exhaust the PTF transmit path for reasons unrelated to DUT policer behavior.

`checkOriginalFlow()` previously sent all 10,000 packets in one unpaced `send_packet(..., count=10000)` call. This can produce short microbursts and intermittent packet loss before policer validation starts.

`checkMirroredFlow()` also had two unpaced traffic paths: the 10,000-packet CBS-absorption burst and the sustained send loop. The sustained tight loop can exhaust the PTF transmit path and raise `OSError: [Errno 105] No buffer space available` before TX/RX PPS validation completes.

This change:

- sends count-based traffic in batches of at most 60 packets with a 10 ms interval;
- uses the same pacing for the CBS-absorption burst;
- paces the duration-based mirrored traffic using `time.monotonic()`;
- preserves the exact transmitted packet count used for TX PPS calculation; and
- keeps the offered traffic rate safely above the configured policer upper bound.

The existing packet receive checks and policer assertions are unchanged.

Fixes #27708

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A  
Failure type: test reliability issue

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Local validation against master:

```text
python3 -m pytest --noconftest \
    --confcutdir=tests/common/unit_tests \
    tests/common/unit_tests/unit_test_everflow_policer_pacing.py -v

4 passed
```

Additional validation:

```text
python3 -m py_compile \
    ansible/roles/test/files/acstests/everflow_policer_test.py \
    tests/common/unit_tests/unit_test_everflow_policer_pacing.py

PASS
```

```text
pre-commit run --files \
    ansible/roles/test/files/acstests/everflow_policer_test.py \
    tests/common/unit_tests/unit_test_everflow_policer_pacing.py

All hooks passed
```

```text
git diff --check

PASS
```

No DUT test was performed. The local regression tests validate the pacing helpers and verify that `checkMirroredFlow()` uses both paced traffic-generation paths.

### Approach

#### What is the motivation for this PR?

Unpaced traffic generation in `EverflowPolicerTest` can make the test fail because of the PTF traffic-generation path rather than DUT policer behavior.

For the original flow, a single 10,000-packet send can create a short burst large enough to cause intermittent packet loss.

For the mirrored flow, both the CBS-absorption burst and sustained tight send loop were unpaced. The sustained loop can exhaust the transmit path and raise `ENOBUFS` before the test reaches its TX/RX PPS assertions.

#### How did you do it?

Added shared pacing helpers for count-based and duration-based traffic generation.

Count-based sends:

- send at most 60 packets per batch;
- wait 10 ms between batches;
- preserve the exact requested total packet count.

Duration-based sends:

- send traffic in 60-packet batches;
- pace batches at 10 ms intervals;
- use `time.monotonic()` for duration measurement;
- cap the final sleep to the remaining duration; and
- return the exact transmitted packet count for the existing TX PPS calculation.

The same pacing is used for:

- `checkOriginalFlow()`;
- the `checkMirroredFlow()` CBS-absorption send; and
- the sustained `checkMirroredFlow()` traffic.

The nominal pacing target is approximately 6,000 pps before send overhead, which remains many times above the policer rates exercised by the current test.

The following behavior is unchanged:

- `NUM_OF_TOTAL_PACKETS`;
- original-flow 99% receive assertion;
- policer min/max calculations;
- `tx_pps > max_rx_pps` validation;
- `min_rx_pps <= rx_pps <= max_rx_pps` validation;
- receive polling and packet matching; and
- platform-specific packet handling.

#### How did you verify/test it?

The unit tests use AST extraction so the standalone pacing logic can be tested without importing the PTF-dependent module.

Coverage verifies:

- 10,000 packets are split into 166 batches of 60 plus a final batch of 40;
- the exact packet total is preserved;
- 10 ms delays occur between count-based batches;
- no unnecessary delay occurs after the final count-based batch;
- exact-multiple packet counts are handled correctly;
- duration-based pacing terminates at the configured deadline using a deterministic fake clock;
- the final sleep is capped to the remaining duration;
- the returned TX packet count matches the generated traffic; and
- `checkMirroredFlow()` calls both pacing helpers and contains no direct unpaced `send_packet()` call in its outer traffic-generation path.

#### Any platform specific information?

No. This is a generic PTF traffic-generation reliability issue.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.