### PR TITLE
[pfcwd] Restore peer cEOS LAG min-links to configured value

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -1002,7 +1002,19 @@ def shutdown_lag_members(duthost, selected_port, tbinfo, nbrhosts, ports):
             for member in po_config['activePorts']:
                 if member == peer_port:
                     neigh_port_channel = po_name
-                    min_links = len(po_config['activePorts'])
+                    # Save the peer LAG's *configured* min-links threshold so
+                    # teardown can restore the exact original value. Do NOT use
+                    # len(activePorts) here: the active-member count is not the
+                    # configured threshold, and writing it back on cleanup leaves
+                    # the cEOS LAG dirty (e.g. min-links=2 when it was 1). A later
+                    # test that selects the same LAG and removes a member then
+                    # keeps only one active member while the peer still requires
+                    # two, so the LAG never comes up.
+                    min_links = po_config.get('minLinks', 1)
+                    logger.info(
+                        "Peer LAG %s: activePorts=%s, configured minLinks=%s, saved min_links=%s",
+                        neigh_port_channel, po_config['activePorts'],
+                        po_config.get('minLinks'), min_links)
                     break
         vm_host.eos_config(lines=['port-channel min-links 1'],
                            parents=[f'int {neigh_port_channel}'])


### PR DESCRIPTION

### Description of PR
[pfcwd] Restore peer cEOS LAG min-links to len(activePorts) as the original min-links, so teardown wrote the active-member count (e.g. 2) back to the cEOS peer LAG instead of the real configured threshold (1), leaving it dirty. A later test that selected the same LAG and removed a member kept only one active member while the peer still required two, so the LAG never came up and the test timed out.
Save po_config.get('minLinks', 1) instead, and log activePorts / minLinks / saved value for diagnostics.

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/27786

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/sonic-net/sonic-mgmt/issues/27786
Failure type:  regression 

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

For 202605, I have open a new PR https://github.com/sonic-net/sonic-mgmt/pull/27843, because the relevant code are not aligned to 202605, there is conflict

### Test result
- master: Passed

### Approach
#### What is the motivation for this PR?
Fix https://github.com/sonic-net/sonic-mgmt/issues/27786

#### How did you do it?
Restore peer cEOS LAG min-links to configured value,

#### How did you verify/test it?
1. Run pfcwd/test_pfcwd_cli.py first, then run test_encap_with_mirror_session 

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?


### Documentation
N/A
