### PR TITLE
Ignore expected BMP memory checker syslog

### DIFF
--- a/tests/bmp/test_frr_bmp_sanity.py
+++ b/tests/bmp/test_frr_bmp_sanity.py
@@ -10,8 +10,14 @@ pytestmark = [
 ]
 
 
-def test_frr_bmp_monit_log(duthosts, enum_frontend_dut_hostname, enum_asic_index):
+def test_frr_bmp_monit_log(duthosts, enum_frontend_dut_hostname, enum_asic_index, loganalyzer):
     duthost = duthosts[enum_frontend_dut_hostname]
+    if loganalyzer and duthost.hostname in loganalyzer:
+        loganalyzer[duthost.hostname].ignore_regex.extend([
+            r".* ERR memory_checker: \[memory_checker\] Failed to get container ID of 'bmp'! Exiting \.\.\.",
+            r".* ERR memory_checker: \[memory_checker\] cgroup memory usage file .* of container 'bmp'.*",
+        ])
+
     disable_bmp_feature(duthost)
 
     pytest_assert(wait_until(180, 60, 0, check_monit_expected_container_logging, duthost),


### PR DESCRIPTION
### Description of PR
Fixes sonic nightly PBI 39626653. `test_frr_bmp_monit_log` intentionally disables the `bmp` feature to validate monit behavior. During that window, `memory_checker` can emit an expected `Failed to get container ID of 'bmp'` syslog line, which loganalyzer currently treats as an unexpected teardown failure.

### Type of change
- [x] Bug fix
- [ ] Test case
- [ ] New feature
- [ ] Breaking change

### Back port request
- [x] 202605

### Approach
#### What is the motivation for this PR?
Avoid false loganalyzer failures from an expected side effect of the BMP monit-log test.

#### How did you do it?
Extend the per-DUT loganalyzer ignore list in `test_frr_bmp_monit_log` for bmp-specific memory_checker messages while keeping loganalyzer enabled for other errors.

#### How did you verify/test it?
Ran `python -m py_compile tests/bmp/test_frr_bmp_sanity.py`.

#### Any platform specific information?
Observed on Arista-7260CX3-C64 dualtor-aa-56, but the expected side effect is test logic specific.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A