### PR TITLE
[clock] Fix test_config_clock_date skip on ntpsec/chrony images and stale Click error strings

### DIFF
--- a/tests/clock/conftest.py
+++ b/tests/clock/conftest.py
@@ -1,35 +1,12 @@
-import re
-import time
 import pytest
 import logging
 
 from tests.clock.test_clock import ClockConsts, ClockUtils
+from tests.common.helpers.ntp_helper import get_ntp_daemon_in_use, run_ntp, stop_ntp
 
 
 def pytest_addoption(parser):
     parser.addoption("--ntp_server", action="store", default=None, required=False, help="IP of NTP server to use")
-
-
-@pytest.fixture(scope='module', autouse=True)
-def ntp_server(request, duthosts, rand_one_dut_hostname):
-    """
-    @summary: Return NTP server's ip if given, otherwise skip the test
-    """
-    ntp_server_ip = request.config.getoption("ntp_server")
-    logging.info(f'NTP server ip from execution parameter: {ntp_server_ip}')
-
-    duthost = duthosts[rand_one_dut_hostname]
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-    ntp_servers = config_facts.get('NTP_SERVER', {})
-
-    if ntp_server_ip is None:
-        # if ntp_server_ip is not given, try to get it from DUT config
-        if ntp_servers:
-            ntp_server_ip = list(ntp_servers.keys())[0]
-            logging.info(f'NTP server ip from DUT: {ntp_server_ip}')
-        else:
-            pytest.skip("IP of NTP server was not given")
-    return ntp_server_ip
 
 
 @pytest.fixture(scope="function")
@@ -56,71 +33,28 @@ def init_timezone(duthosts):
 
 
 @pytest.fixture(scope="function")
-def restore_time(duthosts, ntp_server):
+def restore_time(duthosts):
     """
-    @summary: fixture to restore time after test (using ntp)
+    @summary:
+        Fixture that restores the DUT system time after a test that deliberately
+        changes the clock.
+
+        Before the test the NTP daemon is stopped so it does not correct the clock
+        mid-test. After the test the DUT is re-synchronised with its configured NTP
+        server(s) via run_ntp(), which restarts the daemon and asserts that the DUT
+        becomes synchronised again. Any failure to re-sync is surfaced as a real
+        test error instead of being skipped or hidden.
+
+        Supports ntpsec, chrony and classic ntp based images.
     """
-    logging.info('Check NTP server reachability')
-    try:
-        ClockUtils.run_cmd(duthosts, f'{ClockConsts.CMD_NTPDATE} -q {ntp_server}', raise_err=True)
-    except Exception as e:
-        pytest.skip(f'Unreachable NTP server {ntp_server}: {str(e)}')
+    duthost = duthosts[0]
+    ntp_daemon = get_ntp_daemon_in_use(duthost)
+    logging.info(f'NTP daemon in use on DUT: {ntp_daemon.name}')
 
-    logging.info('Check if there is ntp configured before test')
-    show_ntp_output = ClockUtils.run_cmd(duthosts, ClockConsts.CMD_SHOW_NTP)
-    if 'unsynchronised' in show_ntp_output:
-        logging.info('There is no NTP server configured before test')
-        orig_ntp_server = None
-    else:
-        synchronized_str = 'synchronised to'
-        logging.info('There is NTP server configured before test')
-        assert synchronized_str in show_ntp_output, f'There is NTP configured but output do not contain ' \
-                                                    f'"{synchronized_str}"'
-        # primary ntp server is the one with astrix (*) in front of it
-        orig_ntp_server = re.findall(r'\d+.\d+.\d+.\d+',
-                                     re.findall(r'\*\d+.\d+.\d+.\d+',
-                                                show_ntp_output)[0])[0]
-        logging.info(f'Original NTP: {orig_ntp_server}')
-
-    if orig_ntp_server:
-        logging.info('Disable original NTP before test')
-        output = ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_NTP_DEL, orig_ntp_server)
-        assert ClockConsts.OUTPUT_CMD_NTP_DEL_SUCCESS.format(orig_ntp_server) in output, \
-            f'Error: The given string does not contain the expected substring.\n' \
-            f'Expected substring: "{ClockConsts.OUTPUT_CMD_NTP_DEL_SUCCESS.format(orig_ntp_server)}"\n' \
-            f'Given (whole) string: "{output}"'
+    logging.info('Stopping NTP daemon so it does not correct the clock during the test')
+    stop_ntp(duthost, ntp_daemon)
 
     yield
 
-    logging.info(f'Reset time after test. Sync with NTP server: {ntp_server}')
-
-    logging.info('Stopping NTP service')
-    ClockUtils.run_cmd(duthosts, ClockConsts.CMD_NTP_STOP)
-
-    logging.info(f'Syncing datetime with NTP server {ntp_server}')
-    ClockUtils.run_cmd(duthosts, ClockConsts.CMD_NTPDATE, f'-s {ntp_server}')
-
-    logging.info('Starting NTP service')
-    ClockUtils.run_cmd(duthosts, ClockConsts.CMD_NTP_START)
-
-    if orig_ntp_server:
-        logging.info('Restore original NTP server after test')
-        output = ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_NTP_ADD, orig_ntp_server)
-        assert ClockConsts.OUTPUT_CMD_NTP_ADD_SUCCESS.format(orig_ntp_server) in output, \
-            f'Error: The given string does not contain the expected substring.\n' \
-            f'Expected substring: "{ClockConsts.OUTPUT_CMD_NTP_ADD_SUCCESS.format(orig_ntp_server)}"\n' \
-            f'Given (whole) string: "{output}"'
-
-        logging.info('Check polling time')
-        show_ntp_output = ClockUtils.run_cmd(duthosts, ClockConsts.CMD_SHOW_NTP)
-        match = re.search(ClockConsts.REGEX_NTP_POLLING_TIME, show_ntp_output)
-        if match:
-            polling_time_seconds = int(match.group(1))
-        else:
-            logging.info('Could not match the regex.\nPattern: "{}"\nShow ntp output string: "{}"'
-                         .format(ClockConsts.REGEX_NTP_POLLING_TIME, show_ntp_output))
-            polling_time_seconds = ClockConsts.RANDOM_NUM
-        logging.info(f'Polling time (in seconds): {polling_time_seconds + 1}')
-
-        logging.info('Wait for the sync')
-        time.sleep(polling_time_seconds)
+    logging.info(f'Restore DUT time by re-syncing with NTP ({ntp_daemon.name})')
+    run_ntp(duthost, ntp_daemon)

--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -33,17 +33,14 @@ class ClockConsts:
     CMD_SHOW_CLOCK_TIMEZONES = "show clock timezones"
     CMD_CONFIG_CLOCK_TIMEZONE = "config clock timezone"
     CMD_CONFIG_CLOCK_DATE = "config clock date"
-    CMD_NTP_STOP = 'service ntp stop'
-    CMD_NTP_START = 'service ntp start'
-    CMD_NTPDATE = 'ntpdate'
 
     # expected outputs
     OUTPUT_CMD_SUCCESS = ''
 
     # expected errors
     ERR_BAD_TIMEZONE = 'Timezone {} does not conform format'
-    ERR_MISSING_DATE = 'Error: Missing argument "<YYYY-MM-DD>"'
-    ERR_MISSING_TIME = 'Error: Missing argument "<HH:MM:SS>"'
+    ERR_MISSING_DATE = "Error: Missing argument '<YYYY-MM-DD>'"
+    ERR_MISSING_TIME = "Error: Missing argument '<HH:MM:SS>'"
     ERR_BAD_DATE = 'Date {} does not conform format YYYY-MM-DD'
     ERR_BAD_TIME = 'Time {} does not conform format HH:MM:SS'
 
@@ -54,18 +51,10 @@ class ClockConsts:
     MIN_SYSTEM_DATE = "1970-01-01"
     MAX_SYSTEM_DATE = "2106-02-06"
 
-    # ntp
-    CMD_SHOW_NTP = "show ntp"
-    CMD_CONFIG_NTP_ADD = "config ntp add"
-    CMD_CONFIG_NTP_DEL = "config ntp del"
-    OUTPUT_CMD_NTP_ADD_SUCCESS = 'NTP server {} added to configuration\nRestarting ntp-config service...'
-    OUTPUT_CMD_NTP_DEL_SUCCESS = 'NTP server {} removed from configuration\nRestarting ntp-config service...'
-    REGEX_NTP_POLLING_TIME = r'polling server every (\d+)'
-
 
 class ClockUtils:
     @staticmethod
-    def run_cmd(duthosts, cmd, param='', raise_err=False):
+    def run_cmd(duthosts, cmd, param=''):
         """
         @summary:
             Run a given command and return its output.
@@ -82,12 +71,12 @@ class ClockUtils:
             try:
                 cmd_output = duthosts.command(cmd_to_run)[dut_hostname]["stdout"]
             except RunAnsibleModuleFail as cmd_err:
-                output = cmd_err.results["stdout"]
-                err = cmd_err.results["stderr"]
-                cmd_output = output if output else err
+                results = cmd_err.results
+                # Some failures (e.g. a missing binary) leave stdout/stderr empty and
+                # only populate the ansible "msg" field. Fall back to it so the real
+                # error is surfaced rather than being reported as an empty string.
+                cmd_output = results.get("stdout") or results.get("stderr") or results.get("msg") or str(cmd_err)
                 logging.info(f'Command Error!\nError message: "{cmd_output}"')
-                if raise_err:
-                    raise Exception(cmd_output)
 
             cmd_output = str(cmd_output)
             logging.info(f'Output: {cmd_output}')

--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -199,3 +199,13 @@ def run_ntp(duthost, ntp_daemon_in_use):
         duthost.service(name='chrony', state='restarted')
     pytest_assert(wait_until(720, 10, 0, check_ntp_status, duthost, ntp_daemon_in_use),
                   "NTP not in sync")
+
+
+def stop_ntp(duthost, ntp_daemon_in_use):
+    """Stop the NTP daemon on the DUT so it does not adjust the system clock.
+
+    Intended for tests that deliberately change the clock. The daemon is expected
+    to be restarted afterwards (e.g. via run_ntp) to restore the correct time.
+    """
+    service_name = 'chrony' if ntp_daemon_in_use == NtpDaemon.CHRONY else 'ntp'
+    duthost.service(name=service_name, state='stopped')


### PR DESCRIPTION

### Description of PR


Summary:
`tests/clock/test_clock.py::test_config_clock_date` was silently **skipped** on
ntpsec/chrony based images (e.g. 202605) with a misleading, empty-detail reason
`Skipped: Unreachable NTP server <ip>:`, even though the DUT was reachable.

Root cause: the `restore_time` fixture relied on the legacy `ntpdate` / `service ntp`
commands, which no longer exist on ntpsec/chrony images. The ansible call failed with
`[Errno 2] No such file or directory: b'ntpdate'`, but `ClockUtils.run_cmd` only read
stdout/stderr (both empty), so the skip reason came out blank and wrongly blamed the
network. Once the skip is removed, a second latent bug surfaces: the invalid-input
assertions expect the old Click double-quote format (`"<YYYY-MM-DD>"`), while current
Click emits single quotes (`'<YYYY-MM-DD>'`).

This PR reworks the clock time-restore flow to be NTP-daemon aware and to stop
skipping/masking failures. Reviewers can start at `tests/clock/conftest.py`
(`restore_time`) and the new `stop_ntp` helper in `tests/common/helpers/ntp_helper.py`.
No new dependencies.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
 clock/test_clock.py::test_show_clock ✓                                                                                                       
 clock/test_clock.py::test_config_clock_timezone ✓                                                                                           
 clock/test_clock.py::test_config_clock_date ✓ 
202605: <SONiC.202605.4_0_0_52-fd751d667> - `test_config_clock_date` PASSED on a t0 testbed with a chrony-based DUT (previously SKIPPED).

### Approach
#### What is the motivation for this PR?
`config clock date` had effectively zero coverage on current images: the test silently
skipped instead of running. The fix restores real coverage and makes genuine NTP or CLI
failures surface as actual test failures rather than skips.

#### How did you do it?
- Added a reusable `stop_ntp(duthost, ntp_daemon_in_use)` helper in
  `tests/common/helpers/ntp_helper.py` (companion to the existing `run_ntp`), keeping
  all NTP daemon control in one place.
- Rewrote `restore_time` in `tests/clock/conftest.py` to detect the daemon via
  `get_ntp_daemon_in_use` (ntpsec / chrony / ntp), stop it during the test, and
  re-synchronise afterwards via `run_ntp`, which restarts the daemon and asserts sync.
- Removed the obsolete, skip-prone `ntp_server` autouse fixture and the legacy NTP
  constants (`ntpdate`, `service ntp`, `show ntp`, `config ntp add|del`).
- Made `ClockUtils.run_cmd` fall back to the ansible `msg` field so a missing-binary
  error is surfaced instead of an empty string; removed the now-unused `raise_err` arg.
- Updated `ERR_MISSING_DATE` / `ERR_MISSING_TIME` to the exact current Click output
  (single quotes) — strict, verbatim assertions (no normalization/masking).

#### How did you verify/test it?
- Ran `test_config_clock_date` on a t0 testbed whose DUT uses chrony: it now executes
  end-to-end and passes (previously skipped).
- `flake8 --max-line-length=120` clean on all changed files.
- Verified daemon handling for ntpsec, chrony and classic ntp; unsupported daemons fail
  loudly via the existing `pytest.fail` in `get_ntp_daemon_in_use` (no silent skip).

#### Any platform specific information?
Not platform specific. Works across ntpsec, chrony and classic ntp based images; no
`ntpdate`/`service ntp` assumptions remain.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
