### PR TITLE
[sfp][mellanox] Check SFP Software Control Setting for test_power_override

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -19,7 +19,7 @@ from tests.common.platform.transceiver_utils import is_sw_control_enabled, \
     get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled
 from tests.common.mellanox_data import is_mellanox_device
 from collections import defaultdict
-from tests.platform_tests.mellanox.conftest import is_sw_control_feature_enabled  # noqa: F401
+from tests.platform_tests.mellanox.conftest import is_sw_control_feature_enabled
 
 from .platform_api_test_base import PlatformApiTestBase
 
@@ -826,13 +826,13 @@ class TestSfpApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_tx_disable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                        platform_api_conn, is_sw_control_feature_enabled):    # noqa: F811
+                        platform_api_conn):    # noqa: F811
         """This function tests both the get_tx_disable() and tx_disable() APIs"""
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
         if is_mellanox_device(duthost):
             port_indices_to_tested = self.get_port_indices_to_tested_for_mellanox_device(
-                duthost, is_sw_control_feature_enabled)
+                duthost, is_sw_control_feature_enabled(duthost))
         else:
             port_indices_to_tested = self.sfp_setup["sfp_test_port_indices"]
 
@@ -859,13 +859,13 @@ class TestSfpApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_tx_disable_channel(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                                platform_api_conn, is_sw_control_feature_enabled):     # noqa: F811
+                                platform_api_conn):     # noqa: F811
         """This function tests both the get_tx_disable_channel() and tx_disable_channel() APIs"""
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx", "nokia"])
         if is_mellanox_device(duthost):
             port_indices_to_tested = self.get_port_indices_to_tested_for_mellanox_device(
-                duthost, is_sw_control_feature_enabled)
+                duthost, is_sw_control_feature_enabled(duthost))
         else:
             port_indices_to_tested = self.sfp_setup["sfp_test_port_indices"]
 
@@ -960,13 +960,13 @@ class TestSfpApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_power_override(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                            platform_api_conn, is_sw_control_feature_enabled):    # noqa: F811
+                            platform_api_conn):    # noqa: F811
         """This function tests both the get_power_override() and set_power_override() APIs"""
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx", "nokia"])
         if is_mellanox_device(duthost):
             port_indices_to_tested = self.get_port_indices_to_tested_for_mellanox_device(
-                duthost, is_sw_control_feature_enabled)
+                duthost, is_sw_control_feature_enabled(duthost))
         else:
             port_indices_to_tested = self.sfp_setup["sfp_test_port_indices"]
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -960,12 +960,17 @@ class TestSfpApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_power_override(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                            platform_api_conn):    # noqa: F811
+                            platform_api_conn, is_sw_control_feature_enabled):    # noqa: F811
         """This function tests both the get_power_override() and set_power_override() APIs"""
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx", "nokia"])
+        if is_mellanox_device(duthost):
+            port_indices_to_tested = self.get_port_indices_to_tested_for_mellanox_device(
+                duthost, is_sw_control_feature_enabled)
+        else:
+            port_indices_to_tested = self.sfp_setup["sfp_test_port_indices"]
 
-        for i in self.sfp_setup["sfp_test_port_indices"]:
+        for i in port_indices_to_tested:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
                 continue

--- a/tests/platform_tests/mellanox/conftest.py
+++ b/tests/platform_tests/mellanox/conftest.py
@@ -37,6 +37,7 @@ def get_sw_control_ports(duthosts, rand_one_dut_hostname, conn_graph_facts):
     if is_sw_control_feature_enabled(duthost):
         sw_ports = get_ports_supporting_sc(duthost)
         return sw_ports
+    return []
 
 
 @pytest.fixture(scope="module")

--- a/tests/platform_tests/mellanox/conftest.py
+++ b/tests/platform_tests/mellanox/conftest.py
@@ -27,14 +27,14 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture(scope="module")
 def is_sw_control_feature_enabled(duthost):
     return sc_supported(duthost) and sc_ms_sku(duthost) and check_sc_sai_attribute_value(duthost)
 
 
 @pytest.fixture(scope="module")
-def get_sw_control_ports(duthost, is_sw_control_feature_enabled, conn_graph_facts):
-    if is_sw_control_feature_enabled:
+def get_sw_control_ports(duthosts, rand_one_dut_hostname, conn_graph_facts):
+    duthost = duthosts[rand_one_dut_hostname]
+    if is_sw_control_feature_enabled(duthost):
         sw_ports = get_ports_supporting_sc(duthost)
         return sw_ports
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary:

Apply the existing Mellanox software-control eligibility check to `test_power_override`. This prevents the test from calling mutating transceiver APIs on firmware-controlled modules, consistent with `test_tx_disable` and `test_tx_disable_channel`.

Each call site also now checks software control on its selected DUT, preventing mismatched decisions in multi-DUT runs.

No additional dependencies are required.

ADO: https://msazure.visualstudio.com/One/_workitems/edit/39520944

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
 - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: https://msazure.visualstudio.com/One/_workitems/edit/39520944
Failure type: Test applicability regression

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

- SN4600C regression on `vms28-t0-4600c-03`, SONiC.20260510.17, without reimaging:
  https://elastictest.org/scheduler/testplan/6ab1f0c4942eb0c0d456847d
  - `test_power_override`: passed. Getter succeeded on ports 61-64; unsupported setters were skipped.
  - `test_tx_disable` and `test_tx_disable_channel`: skipped because no ports were eligible for software control.
  - `test_check_sfp_eeprom_with_option_dom`: both parameter variants passed.
  - Pretests and posttests passed. Overall: 19 passed, 6 skipped, no failures or errors.

- Pre-fix failure, Mellanox SONiC.20260510.12:
  https://elastictest.org/scheduler/testplan/6a95348069f529d156cccbc8
  - `test_power_override` attempted to modify firmware-controlled SN4600C transceivers and failed.
  - In the same run, `test_tx_disable` and `test_tx_disable_channel` skipped through the existing software-control check.

### Approach
#### What is the motivation for this PR?

`test_power_override` currently runs on firmware-controlled Mellanox transceivers, where EEPROM writes are unsupported and cause false failures. SN4600C is excluded from the existing `PLATFORM_GENERATION` allow-list for transceiver software control. The TX-disable tests therefore already skip these software-control mutations; this change applies the same established behavior to `test_power_override`.

#### How did you do it?

Converted `is_sw_control_feature_enabled` to a DUT-taking function so each test evaluates the DUT selected by `enum_rand_one_per_hwsku_hostname`.

`test_power_override` continues to check every configured transceiver and run the initial `get_power_override`. Immediately before `set_power_override`, Mellanox ports are skipped when software control is disabled for the device or port. Behavior for non-Mellanox platforms is unchanged.

#### How did you verify/test it?

Ran the three affected SFP API tests and both EEPROM DOM variants on SN4600C without reimaging: 3 passed and 2 expected skips. See the regression run above.

#### Any platform specific information?

The change affects Mellanox DUTs only. SN4600C is outside the existing platform allow-list for transceiver software control, so mutating transceiver APIs are not applicable.

Other vendors continue testing all configured transceiver indices.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A