### PR TITLE
Decrease packet delay time in ARP stress tests

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -119,7 +119,8 @@ def add_arp(ptf_intf_ipv4_addr, intf1_index, ptfadapter):
                                           hw_tgt='ff:ff:ff:ff:ff:ff'
                                           )
         # Add a short delay to avoid packet loss
-        time.sleep(0.01)
+        if ip_num % 100 == 0:
+            time.sleep(0.01)
         testutils.send_packet(ptfadapter, intf1_index, pkt)
     logger.info("Sending {} arp entries".format(ip_num))
 
@@ -223,7 +224,8 @@ def add_nd(ptfadapter, ip_and_intf_info, ptf_intf_index, nd_available):
         fake_src_addr = generate_global_addr(nd_entry_mac)
         ns_pkt = ipv6_packets_for_test(ip_and_intf_info, nd_entry_mac, fake_src_addr)
         # Add a short delay to avoid packet loss
-        time.sleep(0.01)
+        if entry % 100 == 0:
+            time.sleep(0.01)
         testutils.send_packet(ptfadapter, ptf_intf_index, ns_pkt)
     logger.info("Sending {} ipv6 neighbor entries".format(nd_available))
 


### PR DESCRIPTION
### Description of PR
Decrease the sleep time in ARP stress tests from 0.01 every packet to 0.01 every 100 packets

Summary:

### Type of change


- [] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: -
### Tested branch

- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

### Approach
#### What is the motivation for this PR?
On slow test servers, test_stress_arp.py would fail due to long sleep times during sending packets.

#### How did you do it?
Noticed that a lot of time is spent sleeping while sending packets, so decreasing this time was a reasonable fix.

#### How did you verify/test it?
Run the test on a slow server. Overall, the running time decreases while older test servers can still run the test.

#### Any platform specific information?
-

#### Supported testbed topology if it's a new test case?
-

### Documentation
-
