### PR TITLE
skip test_pfcwd_interval on SN6600_LD lossy-only hwsku

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2834,8 +2834,8 @@ generic_config_updater/test_pfcwd_interval.py:
     conditions_logical_operator: or
     conditions:
       - "asic_type not in ['mellanox', 'cisco-8000']"
-      - hwsku in ['Mellanox-SN5600-C224O8', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C512S2', 'Mellanox-SN5640-C508O1X2',
-                   'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']
+      - hwsku in ['Mellanox-SN5600-C224O8', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C512S2', 'Mellanox-SN5640-C508O1X2','Mellanox-SN6600_LD-P128C2',
+                   'Mellanox-SN6600_LD-P64O128C2', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']
       - "'bmc' in topo_type"
 
 generic_config_updater/test_pfcwd_status.py:


### PR DESCRIPTION
Change-Id: I4acd3973c51e2a52c7c5a6c639df98de08e1ead5

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Skip `generic_config_updater/test_pfcwd_interval.py` on the SN6600_LD lossy-only hwskus (`Mellanox-SN6600_LD-P128C2` and `Mellanox-SN6600_LD-P64O128C2`).


Summary:
Fixes # (issue)
`test_pfcwd_interval` requires a lossless configuration, which is not available on these lossy-only SN6600_LD hwskus, so the test is not applicable there. This adds those two hwskus to the existing `hwsku in [...]` skip condition for the test in `tests_mark_conditions.yaml`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
test skipped on skus like expected

### Approach
#### What is the motivation for this PR?
`test_pfcwd_interval` needs a lossless configuration that does not exist on the SN6600_LD lossy-only hwskus, so it is not applicable and should be skipped there.

#### How did you do it?
Added `Mellanox-SN6600_LD-P128C2` and `Mellanox-SN6600_LD-P64O128C2` to the `hwsku in [...]` skip condition of `generic_config_updater/test_pfcwd_interval.py` in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`.

#### How did you verify/test it?
Verified the conditional-mark entry parses and that the test is skipped on the listed SN6600_LD hwskus.

#### Any platform specific information?
Applies to Mellanox SN6600_LD lossy-only hwskus (`Mellanox-SN6600_LD-P128C2`, `Mellanox-SN6600_LD-P64O128C2`).

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
