### PR TITLE
Skip fan and PSU platform tests on SN6600_LD

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -134,9 +134,11 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_status_led:
 #######################################
 platform_tests/api/test_chassis_fans.py:
   skip:
-    reason: "Skip on BMC as no fan"
+    reason: "Skip on BMC as no fan, or on Mellanox LD platform which has no chassis fans"
+    conditions_logical_operator: or
     conditions:
       - "'bmc' in topo_type"
+      - "asic_type in ['mellanox'] and 'sn6600_ld' in platform"
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_direction:
   xfail:
@@ -320,9 +322,11 @@ platform_tests/api/test_component.py::TestComponentApi::test_update_firmware:
 #######################################
 platform_tests/api/test_fan_drawer.py:
   skip:
-    reason: "Skip on BMC as no fan"
+    reason: "Skip on BMC as no fan, or on Mellanox LD platform which has no fan drawer"
+    conditions_logical_operator: or
     conditions:
       - "'bmc' in topo_type"
+      - "asic_type in ['mellanox'] and 'sn6600_ld' in platform"
 
 platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_maximum_consumed_power:
   skip:
@@ -376,9 +380,11 @@ platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_le
 #######################################
 platform_tests/api/test_fan_drawer_fans.py:
   skip:
-    reason: "Skip on BMC as no fan"
+    reason: "Skip on BMC as no fan, or on Mellanox LD platform which has no fan drawer fans"
+    conditions_logical_operator: or
     conditions:
       - "'bmc' in topo_type"
+      - "asic_type in ['mellanox'] and 'sn6600_ld' in platform"
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_model:
   skip:
@@ -479,9 +485,11 @@ platform_tests/api/test_pdb.py:
 #######################################
 platform_tests/api/test_psu.py:
   skip:
-    reason: "Skip on BMC as no psu"
+    reason: "Skip on BMC as no psu, or on Mellanox LD platform which has no PSUs"
+    conditions_logical_operator: or
     conditions:
       - "'bmc' in topo_type"
+      - "asic_type in ['mellanox'] and 'sn6600_ld' in platform"
 
 platform_tests/api/test_psu.py::TestPsuApi::test_fans:
   skip:
@@ -568,9 +576,11 @@ platform_tests/api/test_psu.py::test_temperature:
 
 platform_tests/api/test_psu_fans.py:
   skip:
-    reason: "Skip on BMC as no psu fan"
+    reason: "Skip on BMC as no psu fan, or on Mellanox LD platform which has no PSU fans"
+    conditions_logical_operator: or
     conditions:
       - "'bmc' in topo_type"
+      - "asic_type in ['mellanox'] and 'sn6600_ld' in platform"
 
 platform_tests/api/test_psu_fans.py::TestPsuFans::test_get_error_description:
   xfail:
@@ -1084,10 +1094,12 @@ platform_tests/cli/test_show_platform.py::test_show_platform_current:
 
 platform_tests/cli/test_show_platform.py::test_show_platform_fan:
   skip:
-    reason: "Unsupported platform API"
+    reason: "Unsupported platform API, BMC, or Mellanox LD platform which has no fans"
+    conditions_logical_operator: or
     conditions:
       - "is_multi_asic==True and release in ['201911']"
       - "'bmc' in topo_type"
+      - "asic_type in ['mellanox'] and 'sn6600_ld' in platform"
 
 platform_tests/cli/test_show_platform.py::test_show_platform_firmware_status:
   skip:
@@ -1108,12 +1120,13 @@ platform_tests/cli/test_show_platform.py::test_show_platform_psustatus:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6518
   skip:
-    reason: "Test should be skipped on DPU for it doesn't have PSUs."
+    reason: "Test should be skipped on DPU, BMC, or Mellanox LD for it doesn't have PSUs."
     conditions_logical_operator: or
     conditions:
       - "'nvda_bf' in platform"
       - "platform in ['arm64-elba-asic-flash128-r0']"
       - "'bmc' in topo_type"
+      - "asic_type in ['mellanox'] and 'sn6600_ld' in platform"
 
 platform_tests/cli/test_show_platform.py::test_show_platform_psustatus_json:
   xfail:
@@ -1122,12 +1135,13 @@ platform_tests/cli/test_show_platform.py::test_show_platform_psustatus_json:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6518
   skip:
-    reason: "Test should be skipped on DPU for it doesn't have PSUs."
+    reason: "Test should be skipped on DPU, BMC, or Mellanox LD for it doesn't have PSUs."
     conditions_logical_operator: or
     conditions:
       - "'nvda_bf' in platform"
       - "platform in ['arm64-elba-asic-flash128-r0']"
       - "'bmc' in topo_type"
+      - "asic_type in ['mellanox'] and 'sn6600_ld' in platform"
 
 platform_tests/cli/test_show_platform.py::test_show_platform_ssdhealth:
   skip:


### PR DESCRIPTION
### Description of PR
Skip fan and PSU platform APIs on liquid-cooled SN6600_LD, which has no chassis fans, fan drawers, or PSUs.
Summary:
Fixes # (issue)
- Skip `platform_tests/api/test_chassis_fans.py`
- Skip `platform_tests/api/test_fan_drawer.py` and `test_fan_drawer_fans.py`
- Skip `platform_tests/api/test_psu.py` and `test_psu_fans.py`
- Skip `test_show_platform_fan`, `test_show_platform_psustatus`, and `test_show_platform_psustatus_json`
### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement
### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A
### Test result
### Approach
#### What is the motivation for this PR?
SN6600_LD is liquid-cooled and has no chassis fans, fan drawers, or PSUs. Those platform APIs were already skipped on BMC, but still ran on `sn6600_ld` and are not applicable.
#### How did you do it?
Updated `tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml` to OR `asic_type in ['mellanox'] and 'sn6600_ld' in platform` into the existing skip conditions for the fan/PSU API and CLI tests.
#### How did you verify/test it?
Verified the YAML parses and that the skip condition matches Mellanox SN6600_LD platforms.
#### Any platform specific information?
Mellanox SN6600_LD (`'sn6600_ld' in platform`). BMC skips are unchanged.
#### Supported testbed topology if it's a new test case?
### Documentation