### PR TITLE
[test][ntp_helper] Force clock resync in teardown to avoid stale drifted clock affecting later tests

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -1,9 +1,12 @@
+import logging
 from enum import Enum
 import pytest
 import time
 from contextlib import contextmanager
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
 
 
 class NtpDaemon(Enum):
@@ -126,6 +129,19 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
     duthost.command("config ntp del %s" % (ptfhost.mgmt_ipv6 if ptf_use_ipv6 else ptfhost.mgmt_ip))
     for ntp_server in ntp_servers:
         duthost.command("config ntp add %s %s" % ("--iburst" if ntp_add_iburst_present else "", ntp_server))
+
+    # Earlier in this fixture, run_ntp() force-stepped the DUT's clock to match the PTF
+    # container's local, undisciplined reference clock (server 127.127.1.0 prefer), which
+    # can leave the DUT's clock off from real time by a large margin (seconds to minutes).
+    # Restoring the real NTP server config above is not enough to fix this: the ordinary
+    # NTP/chrony daemon only slews the clock during normal operation, which can take a very
+    # long time to correct a large offset -- or may never happen in a reasonable time frame
+    # on platforms where clock stepping (e.g. chrony's "makestep") is disabled. That stale,
+    # drifted clock can then linger and cause unrelated failures in later test cases (e.g.
+    # reboot tests that compare timestamps across the reboot boundary). So force a corrective
+    # step sync back to the real NTP servers now, instead of relying on slow slewing.
+    force_ntp_resync(duthost, ntp_daemon_type)
+
     # The time jump leads to exception in lldp_syncd. The exception has been handled by lldp_syncd,
     # but it will leave error messages in syslog, which will cause subsequent test cases to fail.
     # So we need to wait for a while to make sure the error messages are flushed.
@@ -181,9 +197,11 @@ def check_max_root_dispersion(host, max_dispersion, ntp_daemon_in_use):
         return False
 
 
-def run_ntp(duthost, ntp_daemon_in_use):
-    """ Verify that DUT is synchronized with configured NTP server """
-
+def _force_clock_step(duthost, ntp_daemon_in_use):
+    """One-shot, forced step sync of the DUT's clock against its currently configured
+    NTP server(s). Unlike normal daemon operation (which typically only slews the
+    clock), this can jump the clock by an arbitrary amount in a single step.
+    """
     if ntp_daemon_in_use == NtpDaemon.NTPSEC:
         duthost.service(name='ntp', state='stopped')
         duthost.command("timeout 20 ntpd -gq -u ntpsec:ntpsec")
@@ -197,5 +215,33 @@ def run_ntp(duthost, ntp_daemon_in_use):
         duthost.service(name='chrony', state='stopped')
         duthost.command("timeout 20 chronyd -q -F 1")
         duthost.service(name='chrony', state='restarted')
+
+
+def run_ntp(duthost, ntp_daemon_in_use):
+    """ Verify that DUT is synchronized with configured NTP server """
+
+    _force_clock_step(duthost, ntp_daemon_in_use)
     pytest_assert(wait_until(720, 10, 0, check_ntp_status, duthost, ntp_daemon_in_use),
                   "NTP not in sync")
+
+
+def force_ntp_resync(duthost, ntp_daemon_in_use):
+    """Force the DUT's clock to immediately step back in sync with its currently
+    configured NTP server(s), instead of waiting for the NTP daemon to slowly slew
+    it (which can take a very long time for large offsets, or may never converge
+    in a reasonable time frame on platforms where clock stepping, e.g. chrony's
+    "makestep", is disabled).
+
+    This is intended as a best-effort corrective action (e.g. in test teardown,
+    after the DUT's clock was intentionally forced to an arbitrary value earlier
+    in the test via run_ntp()/setup_ntp_context()), so failures here are logged
+    but not treated as fatal.
+    """
+    try:
+        _force_clock_step(duthost, ntp_daemon_in_use)
+        if not wait_until(60, 5, 0, check_ntp_status, duthost, ntp_daemon_in_use):
+            logger.warning(
+                "DUT %s did not report NTP sync within 60s after forced clock resync; "
+                "its clock may still be drifted for subsequent test cases", duthost.hostname)
+    except Exception as e:
+        logger.warning("Failed to force NTP resync on DUT %s: %s", duthost.hostname, e)


### PR DESCRIPTION
### Description of PR
Summary:
`setup_ntp_context()` (used by NTP tests such as `ip/test_mgmt_ipv6_only.py::test_ntp_ipv6_only`) intentionally force-steps the DUT's clock to match the PTF container's local, undisciplined reference clock (`server 127.127.1.0 prefer`) via `run_ntp()`. This can leave the DUT's clock off from real time by a large margin (observed: ~318 seconds).

Teardown restores the real NTP server configuration, but relies on the ordinary NTP/chrony daemon to slowly *slew* the clock back to correct time. On platforms where clock stepping is disabled (e.g. chrony's `makestep` directive commented out), this slew can take a very long time, leaving the DUT's clock stale/drifted long after the NTP test itself has completed.

This has been observed to deterministically cause nightly failures in a later, unrelated test that compares timestamps across a reboot boundary: `lldp/test_lldp_syncd.py::test_lldp_entry_table_after_reboot` fails with `Device did not reboot`, because the pre-reboot timestamp it captures is corrupted by drift left over from `ip/test_mgmt_ipv6_only.py::test_ntp_ipv6_only`, which runs earlier in the nightly test order on this testbed.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`test_ntp_ipv6_only` (and any other test using `setup_ntp_context`/`run_ntp`) leaves the DUT's clock significantly drifted after teardown, because it only restores the NTP server configuration and does not force a corrective re-sync. Combined with platforms that have `makestep` disabled (so chrony can only slew, never step), this drift can persist for tens of minutes, silently corrupting the clock baseline used by later, unrelated tests.

Root-caused via live DUT syslog forensics: `chronyd -q -F 1` logged `"System clock wrong by 318.102738 seconds (step)"` during `test_ntp_ipv6_only`, and the subsequent `lldp_syncd` reboot test (running ~30 minutes later in the nightly suite) failed its `assert dut_uptime > dut_datetime` check because the pre-reboot timestamp was still corrupted by this un-corrected drift.

#### How did you do it?

In `setup_ntp_context()`'s teardown, immediately after restoring the real NTP server configuration on the DUT, force a corrective one-shot step sync back to the real NTP servers (reusing the same step mechanism already used by `run_ntp()` for setup), instead of relying on the daemon's normal slow slewing behavior. This is implemented as a new `force_ntp_resync()` helper (with the shared step logic factored out into `_force_clock_step()`), and is best-effort: any failure is logged as a warning rather than failing the test, since this runs during teardown.

#### How did you verify/test it?

- `python3 -m py_compile` and `flake8` pass on the modified file.
- Pre-commit hooks (trim trailing whitespace, flake8, check python ast, etc.) pass.
- Verified logic against the exact syslog/log evidence collected from a real nightly failure (DUT `str4-Nokia-7220-Th6p-1`): confirmed the ~318s forced clock step during `test_ntp_ipv6_only`, and traced how the resulting drift (not corrected until much later via slow chrony slewing, since `makestep` is disabled on this platform) caused the subsequent `lldp_syncd` reboot test to fail.
- **Live functional verification on the affected physical testbed** (`str4-Nokia-7220-Th6p-1`, Nokia-IXR7220-H6-O256, chrony 4.6.1, `makestep` disabled):
  1. Baseline: DUT clock correct and in sync (`18:30:15 UTC`, matching real time).
  2. Reproduced the exact corruption at the same magnitude as the real failure: force-stepped the DUT's clock back 300s, then restarted chrony pointed at the real NTP servers only (the **old**, pre-fix teardown behavior — restore config, no forced resync). Result: after 15s the clock was still **~280s behind** real time, confirming chrony only slews and does not self-correct in a reasonable time window on this platform.
  3. Applied the fix's actual mechanism (`force_ntp_resync`: stop chrony → `timeout 20 chronyd -q -F 1` → restart chrony). Chrony logged `"System clock wrong by 298.6 seconds (step)"` and corrected the clock within ~5 seconds. Final state: DUT clock accurate (`18:33:46 UTC`, matching real time) and `System clock synchronized: yes` / `NTPSynchronized: yes`.
  - This directly demonstrates the fix resolves the drift left over from the forced clock step, instead of leaving it to slow (and on this platform, effectively non-functional) slewing.
- Attempted a full end-to-end pytest run of `ip/test_mgmt_ipv6_only.py::test_ntp_ipv6_only` against this same testbed, but hit an unrelated, pre-existing environment issue in the `duthosts` fixture (`KeyError: 'num_asic'` during facts-gathering) unconnected to this change. Recommend CI/nightly validation of the full `test_mgmt_ipv6_only.py` + `lldp/test_lldp_syncd.py` sequence before merge.

#### Any platform specific information?

The underlying drift-recovery issue is most visible on platforms where chrony's `makestep` directive is disabled (observed on Nokia-IXR7220-H6-O256), since without it the daemon can only slew at a limited rate (~86.4s/day), making a few-hundred-second offset take many hours to self-correct. The fix is platform-agnostic and applies to all three supported NTP daemons (chrony, ntp, ntpsec).

#### Supported testbed topology if it's a new test case?

N/A (not a new test case; fixes shared `ntp_helper.py` used across the `t0`/`t1`/topology-agnostic NTP test helpers).

### Documentation
N/A

