### PR TITLE
kubesonic: poll for daemonset pod readiness instead of fixed 15s sleep

### DIFF
--- a/tests/kubesonic/test_k8s_join_disjoin.py
+++ b/tests/kubesonic/test_k8s_join_disjoin.py
@@ -5,6 +5,7 @@ import time
 from datetime import datetime
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import get_image_type
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,8 @@ KUBELET_DEFAULT_CONFIG_BAK = f"{KUBELET_DEFAULT_CONFIG}.bak"
 DAEMONSET_NODE_LABEL = "deployDaemonset"
 DAEMONSET_POD_LABEL = "test-ds-pod"
 DAEMONSET_CONTAINER_NAME = "mock-ds-container"
+DAEMONSET_POD_TIMEOUT_SECOND = 120
+DAEMONSET_POD_CHECK_INTERVAL = 5
 VMHOST_PARAM_DEFAULT = None
 DUT_CERT_DIR = "/etc/sonic/credentials"
 DUT_CERT_BAK = f"{DUT_CERT_DIR}.bak"
@@ -440,28 +443,58 @@ def trigger_disjoin_and_check(duthost, vmhost):
     logger.info(f"Successfully disjoined duthost {duthost.hostname} from k8s cluster")
 
 
+def _get_daemonset_pod_status(duthost, vmhost):
+    return vmhost.shell(
+        f"{NO_PROXY} minikube kubectl -- get pods -l group={DAEMONSET_POD_LABEL} "
+        f"--field-selector spec.nodeName={duthost.hostname}",
+        module_ignore_errors=True)
+
+
+def _is_daemonset_pod_running(duthost, vmhost):
+    status = _get_daemonset_pod_status(duthost, vmhost)
+    return "1/1" in status["stdout"] and "Running" in status["stdout"]
+
+
+def _is_daemonset_container_present(duthost):
+    result = duthost.shell(f"docker ps | grep {DAEMONSET_CONTAINER_NAME}", module_ignore_errors=True)
+    return result["stdout"].strip() != ""
+
+
+def _is_daemonset_pod_deleted(duthost, vmhost):
+    status = _get_daemonset_pod_status(duthost, vmhost)
+    return "No resources found" in status["stderr"]
+
+
+def _is_daemonset_container_absent(duthost):
+    result = duthost.shell(f"docker ps | grep {DAEMONSET_CONTAINER_NAME}", module_ignore_errors=True)
+    return result["stdout"].strip() == ""
+
+
 def deploy_daemonset_pod_and_check(duthost, vmhost):
     logger.info("Start to label node and check if the daemonset pod is deployed")
     vmhost.shell(f"{NO_PROXY} minikube kubectl -- label node {duthost.hostname} {DAEMONSET_NODE_LABEL}=true")
-    time.sleep(15)
-    ds_pod_status = vmhost.shell(f"{NO_PROXY} minikube kubectl -- get pods -l group={DAEMONSET_POD_LABEL} \
-                                    --field-selector spec.nodeName={duthost.hostname}")
-    pytest_assert("1/1" in ds_pod_status["stdout"], "Failed to find daemonset pod from k8s")
-    pytest_assert("Running" in ds_pod_status["stdout"], "Failed to find daemonset pod from k8s")
-    container_status = duthost.shell(f"docker ps |grep {DAEMONSET_CONTAINER_NAME}", module_ignore_errors=True)
-    pytest_assert(container_status["stdout"] != "", "Failed to find daemonset pod from duthost")
+    pytest_assert(
+        wait_until(DAEMONSET_POD_TIMEOUT_SECOND, DAEMONSET_POD_CHECK_INTERVAL, 0,
+                   _is_daemonset_pod_running, duthost, vmhost),
+        "Failed to find daemonset pod from k8s")
+    pytest_assert(
+        wait_until(DAEMONSET_POD_TIMEOUT_SECOND, DAEMONSET_POD_CHECK_INTERVAL, 0,
+                   _is_daemonset_container_present, duthost),
+        "Failed to find daemonset pod from duthost")
     logger.info("Successfully deployed daemonset pod")
 
 
 def delete_daemonset_pod_and_check(duthost, vmhost):
     logger.info("Start to unlabel node and check if the daemonset pod is deleted")
     vmhost.shell(f"{NO_PROXY} minikube kubectl -- label node {duthost.hostname} {DAEMONSET_NODE_LABEL}-")
-    time.sleep(15)
-    ds_pod_status = vmhost.shell(f"{NO_PROXY} minikube kubectl -- get pods -l group={DAEMONSET_POD_LABEL} \
-                                    --field-selector spec.nodeName={duthost.hostname}")
-    pytest_assert("No resources found" in ds_pod_status["stderr"], "Failed to delete daemonset")
-    container_status = duthost.shell("docker ps |grep {DAEMONSET_CONTAINER_NAME}", module_ignore_errors=True)
-    pytest_assert(container_status["stdout"] == "", "Failed to delete daemonset pod")
+    pytest_assert(
+        wait_until(DAEMONSET_POD_TIMEOUT_SECOND, DAEMONSET_POD_CHECK_INTERVAL, 0,
+                   _is_daemonset_pod_deleted, duthost, vmhost),
+        "Failed to delete daemonset")
+    pytest_assert(
+        wait_until(DAEMONSET_POD_TIMEOUT_SECOND, DAEMONSET_POD_CHECK_INTERVAL, 0,
+                   _is_daemonset_container_absent, duthost),
+        "Failed to delete daemonset pod")
     logger.info("Successfully deleted daemonset pod")
 
 


### PR DESCRIPTION
### Description of PR

`kubesonic/test_k8s_join_disjoin.py::test_kubesonic_join_and_disjoin` intermittently fails with `Failed to find daemonset pod from k8s` (tracked by PBI 38770822, `AI_flaky_category: k8s_daemonset_pod_not_found`).

`deploy_daemonset_pod_and_check` labeled the node then did a single fixed `time.sleep(15)` before hard-asserting the pod was `1/1`/`Running`. When pod scheduling / sandbox setup / container start takes longer than 15s (load- and topology-dependent, worst on T0), the pod is still `0/1 ContainerCreating` and the assert fails with no retry. Telemetry confirms a timing flake: the join step always succeeds first, and the same physical testbeds pass and fail intermittently (25-80%), typically passing on retry with no other change.

#### Fix
- Replace the fixed `sleep(15)` + immediate assert with bounded polling via `wait_until` (120s timeout, 5s interval) for both the deploy and delete paths. The check now returns as soon as the pod reaches `1/1`/`Running`, and tolerates slow boxes up to 120s.
- Fix a latent bug in the delete path: the DUT container check used a plain string `docker ps |grep {DAEMONSET_CONTAINER_NAME}` (no f-string), so it grepped a literal brace token, always returned empty, and the assertion passed vacuously. It now uses a correct f-string.

#### How to verify it
Run `test_kubesonic_join_and_disjoin` on a T0 testbed; the daemonset deploy/delete checks now poll instead of asserting once after a fixed wait.

Validated using elastictest on test device

### Approach
#### What is the motivation for this PR?
Reduce nightly flakiness of the kubesonic join/disjoin test caused by an insufficient fixed wait for daemonset pod readiness.

#### How did you do it?
Bounded polling with `wait_until` in place of `time.sleep` + single assert.

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A
Status: FINISHED , Result: PASSED 3 / SKIPPED 1 / FAILED 0 (4) , Progress: 100%




#### Which release branch to backport?
- [x] 202605