### PR TITLE
snappi: check fabric counters across DNX chassis

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -14,6 +14,7 @@ import os
 from copy import copy
 from tests.common.utilities import wait_until
 from tests.common.errors import RunAnsibleModuleFail
+from tests.common.devices.multi_asic import MultiAsicSonicHost
 from ipaddress import ip_address, IPv4Address, IPv6Address
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
 from tests.common.snappi_tests.common_helpers import get_addrs_in_subnet, get_peer_snappi_chassis, \
@@ -2093,43 +2094,307 @@ def get_snappi_ports_for_rdma(snappi_port_list, rdma_ports, tx_port_count, rx_po
     return multidut_snappi_ports
 
 
-def clear_fabric_counters(duthost):
-    """
-    Clears the fabric counters for the duthost based on broadcom-DNX platform.
-    Args:
-        duthost(obj): dut host object
-    Returns:
-        None
-    """
-    if "platform_asic" in duthost.facts and duthost.facts["platform_asic"] == "broadcom-dnx":
-        logger.info('Clearing fabric counters for DUT:{}'.format(duthost.hostname))
-        duthost.shell('sonic-clear fabriccountersport \n')
-        time.sleep(1)
+##############################################################################
+# Fabric counter checking (issue #27863)
+#
+# This clears and checks fabric counters on every reachable Broadcom-DNX
+# fabric-capable node in the testbed -- including a chassis supervisor or
+# sibling linecard that --host-pattern left out of `duthosts` -- not just the
+# DUT(s) selected for this test run.
+#
+# SCOPE NOTE: none of the snappi PFC/PFCWD test modules are enabled in
+# tests/test_parallel_modes/*.json, so this assumes the existing serial
+# (single pytest process) execution model and makes no claim of being safe
+# against a *different* concurrent pytest process. In particular,
+# "sonic-clear fabriccountersport" is "fabricstat -C": it saves the current
+# hardware counters as fabricstat's own on-switch baseline, and subsequent
+# "show fabric counters port" calls (from ANY caller) report deltas against
+# that single shared baseline. A second, independent clear moves the
+# baseline and can hide an error that occurred earlier in another caller's
+# observation window -- no amount of bookkeeping on our side can detect or
+# work around that, so we don't attempt to. Making this safe under
+# concurrent pytest processes is out of scope for #27863.
+##############################################################################
+
+_FABRIC_REQUIRED_COLUMNS = ("PORT", "STATE", "CRC", "FEC_UNCORRECTABLE")
+_FABRIC_NA_VALUE = "N/A"
 
 
-def check_fabric_counters(duthost):
+class FabricCounterParseError(Exception):
+    """Raised when 'show fabric counters port' output cannot be parsed safely."""
+
+
+def fabric_capable(facts):
+    """Return True if this node has a real internal Broadcom-DNX fabric to check.
+
+    Includes: every modular-chassis linecard or supervisor, regardless of that
+    particular node's own ASIC count -- a linecard inside a chassis can itself
+    be single-ASIC and still have fabric-facing ports. Also includes a fixed,
+    non-modular Broadcom-DNX box that is genuinely multi-ASIC internally.
+
+    Excludes: standalone single-ASIC Broadcom-DNX pizza boxes (no fabric
+    links), and any non-Broadcom-DNX platform. ASIC count alone is never used
+    to decide the modular-chassis case.
     """
-    Check for the fabric counters for the duthost based on broadcom-DNX platform.
-    Test assert if the value of CRC, and FEC_UNCORRECTABLE.
-    Args:
-        duthost(obj): dut host object
-    Returns:
-        None
+    if facts.get("platform_asic") != "broadcom-dnx":
+        return False
+    if facts.get("modular_chassis"):
+        return True
+    return facts.get("num_asic", 1) > 1
+
+
+def parse_fabric_counter_rows(raw_output):
+    """Parse the *unfiltered* output of 'show fabric counters port' into a list
+    of dicts keyed by the column names taken from the header actually printed,
+    never by fixed numeric position. This keeps working whether or not the
+    CLI happens to emit an ASIC column, regardless of column order, and
+    whether the header/table repeats once per ASIC namespace.
     """
-    if "platform_asic" in duthost.facts and duthost.facts["platform_asic"] == "broadcom-dnx":
-        raw_out = duthost.shell("show fabric counters port | grep -Ev 'ASIC|---|down'")['stdout']
-        logger.info('Verifying fabric counters for DUT:{}'.format(duthost.hostname))
-        for line in raw_out.split('\n'):
-            # Checking if the port is UP.
-            if 'up' in line:
-                val_list = line.split()
-                crc_errors = int(val_list[7].replace(',', ''))
-                fec_uncor_err = int(val_list[9].replace(',', ''))
-                # Assert if CRC or FEC uncorrected errors are non-zero.
-                pytest_assert(crc_errors == 0, 'CRC errors:{} for DUT:{}, ASIC:{}, Port:{}'.
-                              format(crc_errors, duthost.hostname, val_list[0], val_list[1]))
-                pytest_assert(fec_uncor_err == 0, 'Forward Uncorrectable errors:{} for DUT:{}, ASIC:{}, Port:{}'.
-                              format(fec_uncor_err, duthost.hostname, val_list[0], val_list[1]))
+    header = None
+    rows = []
+    for line in raw_output.splitlines():
+        tokens = line.split()
+        if not tokens:
+            continue
+        if tokens[0].isdigit():
+            if header is None:
+                raise FabricCounterParseError(
+                    "fabric counters: data row seen before any header row: {!r}".format(line))
+            if len(tokens) != len(header):
+                raise FabricCounterParseError(
+                    "fabric counters: row has {} column(s), header has {}: {!r}".format(
+                        len(tokens), len(header), line))
+            rows.append(dict(zip(header, tokens)))
+        else:
+            upper_tokens = [t.upper() for t in tokens]
+            if "PORT" in upper_tokens and "STATE" in upper_tokens:
+                # (Re)arms on every header-looking line; harmless when the CLI
+                # prints one table per ASIC namespace and repeats the header.
+                header = upper_tokens
+
+    if header is None:
+        raise FabricCounterParseError(
+            "fabric counters: no header row found in 'show fabric counters port' output")
+    missing = [c for c in _FABRIC_REQUIRED_COLUMNS if c not in header]
+    if missing:
+        raise FabricCounterParseError(
+            "fabric counters: missing required column(s) {} in header {}".format(missing, header))
+    return rows
+
+
+def parse_fabric_counter_value(row, column, port_label):
+    """Read one numeric counter column, handling comma-formatted integers and
+    the CLI's 'N/A' sentinel explicitly.
+
+    Returns None for 'N/A' (unreadable right now) -- callers must treat that
+    as unknown, never as zero. Raises FabricCounterParseError for anything
+    else that doesn't parse as an int, since that means our column-name
+    assumptions are wrong and silently ignoring it could hide a real error.
+    """
+    raw = row.get(column)
+    if raw is None:
+        raise FabricCounterParseError(
+            "fabric counters: row for port {} has no '{}' column".format(port_label, column))
+    if raw == _FABRIC_NA_VALUE:
+        return None
+    try:
+        return int(raw.replace(",", ""))
+    except ValueError:
+        raise FabricCounterParseError(
+            "fabric counters: unparseable {} value {!r} for port {}".format(column, raw, port_label))
+
+
+def evaluate_fabric_counter_row(row):
+    """Return (crc, fec) for a row whose STATE is up -- either value may be
+    None if that counter reads as 'N/A' -- or None if STATE is not up (a
+    down/unknown port is never evaluated). Raises FabricCounterParseError for
+    a malformed (non-integer, non-'N/A') counter value.
+    """
+    if row.get("STATE", "").lower() != "up":
+        return None
+    port_label = row.get("PORT", "?")
+    return (parse_fabric_counter_value(row, "CRC", port_label),
+            parse_fabric_counter_value(row, "FEC_UNCORRECTABLE", port_label))
+
+
+def is_fabric_error_fail(hostname, selected_hostnames, remote_switch_id, selected_switch_ids):
+    """Fail-vs-warning policy for one erroring fabric port:
+
+    - error on a selected DUT -> FAIL, no peer lookup needed.
+    - error on a non-selected DUT whose remote endpoint's switch_id belongs
+      to a selected DUT -> FAIL.
+    - anything else (remote endpoint is a non-selected DUT, or can't be
+      attributed at all) -> WARNING.
+    """
+    if hostname in selected_hostnames:
+        return True
+    return bool(remote_switch_id) and remote_switch_id in selected_switch_ids
+
+
+# ---------------------------------------------------------------------------
+# Single-node I/O
+# ---------------------------------------------------------------------------
+
+def read_fabric_counters(duthost):
+    raw_out = duthost.shell("show fabric counters port")['stdout']
+    return parse_fabric_counter_rows(raw_out)
+
+
+def clear_fabric_counters_on(duthost):
+    logger.info('Clearing fabric counters for DUT:{}'.format(duthost.hostname))
+    duthost.shell('sonic-clear fabriccountersport \n')
+    time.sleep(1)
+
+
+def resolve_remote_switch_id(duthost, row):
+    """Resolve the STATE_DB FABRIC_PORT_TABLE REMOTE_MOD for one counters row.
+
+    Returns None (unavailable) rather than guessing when a multi-ASIC node's
+    row has no ASIC column -- attribution would be ambiguous, and silently
+    defaulting to ASIC 0 could misattribute a real error.
+    """
+    if "ASIC" in row:
+        asic = duthost.asic_instance(int(row["ASIC"]))
+    elif len(duthost.asics) == 1:
+        asic = duthost.asic_instance()
+    else:
+        return None
+    if asic is None:
+        return None
+    cmd = "STATE_DB hget 'FABRIC_PORT_TABLE|PORT{}' REMOTE_MOD".format(row.get("PORT"))
+    try:
+        out = asic.run_sonic_db_cli_cmd(cmd)['stdout'].strip()
+    except RunAnsibleModuleFail:
+        return None
+    return out or None
+
+
+def get_switch_ids(duthost):
+    """Return the DEVICE_METADATA switch_id (as a string) for every ASIC on
+    this node."""
+    switch_ids = []
+    for asic in duthost.asics:
+        try:
+            cfacts = asic.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+            switch_id = cfacts.get('DEVICE_METADATA', {}).get('localhost', {}).get('switch_id')
+        except RunAnsibleModuleFail:
+            switch_id = None
+        if switch_id:
+            switch_ids.append(str(switch_id))
+    return switch_ids
+
+
+def _construct_extra_duthost(duthosts, hostname):
+    """Construct a MultiAsicSonicHost for a testbed node outside `duthosts`
+    (e.g. a chassis supervisor or sibling linecard --host-pattern left out).
+    Returns None only when the node is genuinely unreachable; any other
+    failure propagates so a real bug is never masked as 'the DUT is absent'.
+    """
+    try:
+        return MultiAsicSonicHost(duthosts.ansible_adhoc, hostname, duthosts, duthosts.tbinfo["topo"]["type"])
+    except RunAnsibleModuleFail as exc:
+        if getattr(exc.results, "is_unreachable", False):
+            logger.warning(
+                "fabric counters: %s is unreachable, excluding it from the fabric check scope: %s", hostname, exc)
+            return None
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Testbed-wide scope: discovery + clear + check
+# ---------------------------------------------------------------------------
+
+class FabricCounterScope(object):
+    """Discovers every reachable Broadcom-DNX fabric-capable node in the
+    testbed -- including a chassis SUP/LC --host-pattern left out of
+    `duthosts` -- and clears/checks fabric counters on all of them.
+    """
+
+    def __init__(self, fabric_nodes, selected_hostnames, selected_switch_ids):
+        self.fabric_nodes = fabric_nodes
+        self.selected_hostnames = selected_hostnames
+        self.selected_switch_ids = selected_switch_ids
+
+    @classmethod
+    def discover(cls, duthosts):
+        selected_hostnames = set(duthosts.duts)
+        known_hostnames = {node.hostname for node in duthosts.nodes}
+
+        extra_nodes = []
+        for hostname in duthosts.tbinfo["duts"]:
+            if hostname in known_hostnames:
+                continue
+            node = _construct_extra_duthost(duthosts, hostname)
+            if node is not None:
+                extra_nodes.append(node)
+
+        all_nodes = list(duthosts.nodes) + extra_nodes
+        fabric_nodes = [node for node in all_nodes if fabric_capable(node.facts)]
+
+        # Only the selected DUT(s)' own switch_ids are needed: a fabric error
+        # on a non-selected DUT is a WARNING whether its peer is a *known*
+        # non-selected DUT or can't be attributed at all, so there is no need
+        # to map every node's switch_id to its owner.
+        selected_switch_ids = set()
+        for node in fabric_nodes:
+            if node.hostname in selected_hostnames:
+                selected_switch_ids.update(get_switch_ids(node))
+
+        return cls(fabric_nodes, selected_hostnames, selected_switch_ids)
+
+    def clear(self):
+        """Clear fabric counters on every reachable fabric-capable node."""
+        for node in self.fabric_nodes:
+            clear_fabric_counters_on(node)
+
+    def check(self):
+        """Check fabric counters on every reachable fabric-capable node."""
+        for node in self.fabric_nodes:
+            for row in read_fabric_counters(node):
+                counters = evaluate_fabric_counter_row(row)
+                if counters is None:
+                    continue
+                crc, fec = counters
+                port_label = row.get("PORT", "?")
+                if crc is None or fec is None:
+                    logger.warning(
+                        "fabric counters: unreadable (N/A) CRC/FEC_UNCORRECTABLE for %s port %s",
+                        node.hostname, port_label)
+                    continue
+                if crc == 0 and fec == 0:
+                    continue
+                self._report_error(node, row, crc, fec)
+
+    def _report_error(self, node, row, crc, fec):
+        message = 'Fabric errors on DUT:{} ASIC:{} Port:{} CRC:{} FEC_UNCORRECTABLE:{}'.format(
+            node.hostname, row.get("ASIC", "0"), row.get("PORT", "?"), crc, fec)
+
+        remote_switch_id = None
+        if node.hostname not in self.selected_hostnames:
+            remote_switch_id = resolve_remote_switch_id(node, row)
+
+        if is_fabric_error_fail(node.hostname, self.selected_hostnames, remote_switch_id, self.selected_switch_ids):
+            pytest_assert(False, message)
+        else:
+            logger.warning(message)
+
+
+_fabric_counter_scope_cache = {}
+
+
+def get_fabric_counter_scope(duthosts):
+    """Return the FabricCounterScope for this duthosts collection, discovering
+    it once per pytest process. Safe to cache: discovery only reflects
+    static topology/config (which nodes exist, which are fabric-capable,
+    which switch_ids the selected DUT(s) own) -- it never caches live counter
+    values, and clear()/check() always talk to the live DUTs.
+    """
+    key = id(duthosts)
+    scope = _fabric_counter_scope_cache.get(key)
+    if scope is None:
+        scope = FabricCounterScope.discover(duthosts)
+        _fabric_counter_scope_cache[key] = scope
+    return scope
 
 
 def setup_config_uhd_connect(request, tbinfo, ha_test_case=None):

--- a/tests/common/unit_tests/snappi_tests/unit_test_fabric_counters.py
+++ b/tests/common/unit_tests/snappi_tests/unit_test_fabric_counters.py
@@ -1,0 +1,353 @@
+"""Unit tests for the fabric counter clear/check helpers in
+``tests/common/snappi_tests/snappi_fixtures.py`` (issue #27863).
+
+The target module imports heavy sonic-mgmt/ansible/snappi deps at import
+time, so -- following the convention in unit_test_common_helpers.py -- we
+extract just the definitions under test via ``ast`` and exec them in an
+isolated namespace instead of importing the module directly.
+
+Run with::
+
+    python3 -m pytest --noconftest \\
+        tests/common/unit_tests/snappi_tests/unit_test_fabric_counters.py -v
+"""
+
+import ast
+from pathlib import Path
+from enum import Enum
+from unittest.mock import MagicMock
+
+import pytest
+
+MODULE_PATH = (Path(__file__).resolve().parents[3] /
+               "common/snappi_tests/snappi_fixtures.py")
+
+
+class _FakeRunAnsibleModuleFail(Exception):
+    """Stand-in for tests.common.errors.RunAnsibleModuleFail, which itself
+    requires the (unavailable in this unit-test environment) ansible
+    package to import. Only its name needs to exist for the extracted
+    functions' `except RunAnsibleModuleFail:` clauses to resolve."""
+
+    def __init__(self, msg, results=None):
+        super().__init__(msg)
+        self.results = results
+
+
+def _load(*names):
+    """Extract one or more top-level definitions (functions, classes, or
+    simple module-level assignments) from snappi_fixtures.py by name, and
+    exec them together in one isolated namespace so interdependent pieces
+    (e.g. a function and the Enum/exception it references) resolve
+    correctly without importing the whole module.
+    """
+    tree = ast.parse(MODULE_PATH.read_text())
+    wanted = set(names)
+    nodes = []
+    found = set()
+    for node in tree.body:
+        node_name = getattr(node, "name", None)
+        if node_name in wanted:
+            nodes.append(node)
+            found.add(node_name)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id in wanted:
+                    nodes.append(node)
+                    found.add(target.id)
+    missing = wanted - found
+    if missing:
+        raise LookupError(sorted(missing))
+
+    ns = {
+        "Enum": Enum,
+        "logger": MagicMock(),
+        "RunAnsibleModuleFail": _FakeRunAnsibleModuleFail,
+    }
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(MODULE_PATH), "exec"), ns)
+    if len(names) == 1:
+        return ns[names[0]]
+    return tuple(ns[name] for name in names)
+
+
+# ---------------------------------------------------------------------------
+# fabric_capable
+# ---------------------------------------------------------------------------
+
+def test_fabric_capable_non_dnx_excluded():
+    fabric_capable = _load("fabric_capable")
+    facts = {"platform_asic": "cisco-8000", "modular_chassis": True, "num_asic": 8}
+    assert fabric_capable(facts) is False
+
+
+def test_fabric_capable_standalone_single_asic_dnx_excluded():
+    fabric_capable = _load("fabric_capable")
+    facts = {"platform_asic": "broadcom-dnx", "modular_chassis": False, "num_asic": 1}
+    assert fabric_capable(facts) is False
+
+
+def test_fabric_capable_fixed_multi_asic_dnx_included():
+    fabric_capable = _load("fabric_capable")
+    facts = {"platform_asic": "broadcom-dnx", "modular_chassis": False, "num_asic": 4}
+    assert fabric_capable(facts) is True
+
+
+def test_fabric_capable_single_asic_modular_chassis_lc_included():
+    fabric_capable = _load("fabric_capable")
+    facts = {"platform_asic": "broadcom-dnx", "modular_chassis": True, "num_asic": 1}
+    assert fabric_capable(facts) is True
+
+
+def test_fabric_capable_modular_chassis_supervisor_included():
+    fabric_capable = _load("fabric_capable")
+    facts = {"platform_asic": "broadcom-dnx", "modular_chassis": True, "num_asic": 12}
+    assert fabric_capable(facts) is True
+
+
+# ---------------------------------------------------------------------------
+# parse_fabric_counter_rows
+# ---------------------------------------------------------------------------
+
+_ASIC_PRESENT_OUTPUT = """\
+    ASIC    PORT    STATE    IN_CELL    OUT_CELL    CRC    FEC_CORRECTABLE    FEC_UNCORRECTABLE
+    ----    ----    -----    -------    --------    ---    ---------------    ------------------
+       0       0       up          0       1,234      0                  0                     0
+       0       1     down          0           0      0                  0                     0
+       0       2       up          0           5     12                  3                     4
+"""
+
+_ASIC_ABSENT_OUTPUT = """\
+    PORT    STATE    IN_CELL    OUT_CELL    CRC    FEC_CORRECTABLE    FEC_UNCORRECTABLE
+    ----    -----    -------    --------    ---    ---------------    ------------------
+       0       up          0       1,234      0                  0                     0
+"""
+
+_REORDERED_EXTRA_OUTPUT = """\
+    PORT    EXTRA_COL    STATE    FEC_UNCORRECTABLE    CRC
+    ----    ---------    -----    ------------------    ---
+       3           99       up                     0      5
+"""
+
+_REPEATED_HEADER_OUTPUT = """\
+ASIC    PORT    STATE    CRC    FEC_UNCORRECTABLE
+----    ----    -----    ---    ------------------
+   0       0       up      0                     0
+   0       1       up     12                     4
+
+ASIC    PORT    STATE    CRC    FEC_UNCORRECTABLE
+----    ----    -----    ---    ------------------
+   1       0       up      0                     0
+"""
+
+
+def _load_parse_fabric_counter_rows():
+    # _FABRIC_REQUIRED_COLUMNS is referenced unconditionally (not just on the
+    # error path), so it must always be loaded alongside the parser.
+    parse_fabric_counter_rows, _ = _load("parse_fabric_counter_rows", "_FABRIC_REQUIRED_COLUMNS")
+    return parse_fabric_counter_rows
+
+
+def test_parse_fabric_counter_rows_with_asic_column():
+    parse_fabric_counter_rows = _load_parse_fabric_counter_rows()
+    rows = parse_fabric_counter_rows(_ASIC_PRESENT_OUTPUT)
+    assert len(rows) == 3
+    assert rows[0]["ASIC"] == "0" and rows[0]["PORT"] == "0" and rows[0]["STATE"] == "up"
+    assert rows[2]["CRC"] == "12" and rows[2]["FEC_UNCORRECTABLE"] == "4"
+
+
+def test_parse_fabric_counter_rows_without_asic_column():
+    parse_fabric_counter_rows = _load_parse_fabric_counter_rows()
+    rows = parse_fabric_counter_rows(_ASIC_ABSENT_OUTPUT)
+    assert len(rows) == 1
+    assert "ASIC" not in rows[0]
+    assert rows[0]["PORT"] == "0"
+    assert rows[0]["CRC"] == "0"
+
+
+def test_parse_fabric_counter_rows_reordered_and_extra_columns():
+    parse_fabric_counter_rows = _load_parse_fabric_counter_rows()
+    rows = parse_fabric_counter_rows(_REORDERED_EXTRA_OUTPUT)
+    assert len(rows) == 1
+    row = rows[0]
+    # Values must be read by column NAME, independent of position/extra columns.
+    assert row["PORT"] == "3"
+    assert row["EXTRA_COL"] == "99"
+    assert row["FEC_UNCORRECTABLE"] == "0"
+    assert row["CRC"] == "5"
+
+
+def test_parse_fabric_counter_rows_repeated_header_blocks():
+    parse_fabric_counter_rows = _load_parse_fabric_counter_rows()
+    rows = parse_fabric_counter_rows(_REPEATED_HEADER_OUTPUT)
+    assert len(rows) == 3
+    assert [r["ASIC"] for r in rows] == ["0", "0", "1"]
+
+
+def test_parse_fabric_counter_rows_missing_required_column_raises():
+    parse_fabric_counter_rows, FabricCounterParseError, _ = _load(
+        "parse_fabric_counter_rows", "FabricCounterParseError", "_FABRIC_REQUIRED_COLUMNS")
+    raw = "ASIC    PORT    STATE    CRC\n----    ----    -----    ---\n"
+    with pytest.raises(FabricCounterParseError):
+        parse_fabric_counter_rows(raw)
+
+
+def test_parse_fabric_counter_rows_no_header_raises():
+    parse_fabric_counter_rows, FabricCounterParseError = _load(
+        "parse_fabric_counter_rows", "FabricCounterParseError")
+    with pytest.raises(FabricCounterParseError):
+        parse_fabric_counter_rows("   \n   \n")
+
+
+def test_parse_fabric_counter_rows_data_row_before_header_raises():
+    parse_fabric_counter_rows, FabricCounterParseError = _load(
+        "parse_fabric_counter_rows", "FabricCounterParseError")
+    with pytest.raises(FabricCounterParseError):
+        parse_fabric_counter_rows("0    0    up    0    0\n")
+
+
+# ---------------------------------------------------------------------------
+# parse_fabric_counter_value
+# ---------------------------------------------------------------------------
+
+def _load_parse_fabric_counter_value():
+    # _FABRIC_NA_VALUE is referenced unconditionally, so it must always be
+    # loaded alongside the function.
+    parse_fabric_counter_value, _, _fcpe = _load(
+        "parse_fabric_counter_value", "_FABRIC_NA_VALUE", "FabricCounterParseError")
+    return parse_fabric_counter_value, _fcpe
+
+
+def test_parse_fabric_counter_value_plain_integer():
+    parse_fabric_counter_value, _ = _load_parse_fabric_counter_value()
+    assert parse_fabric_counter_value({"CRC": "7"}, "CRC", "3") == 7
+
+
+def test_parse_fabric_counter_value_comma_formatted():
+    parse_fabric_counter_value, _ = _load_parse_fabric_counter_value()
+    assert parse_fabric_counter_value({"CRC": "1,234"}, "CRC", "3") == 1234
+
+
+def test_parse_fabric_counter_value_na_is_unreadable():
+    parse_fabric_counter_value, _ = _load_parse_fabric_counter_value()
+    assert parse_fabric_counter_value({"CRC": "N/A"}, "CRC", "3") is None
+
+
+def test_parse_fabric_counter_value_malformed_raises():
+    parse_fabric_counter_value, FabricCounterParseError = _load_parse_fabric_counter_value()
+    with pytest.raises(FabricCounterParseError):
+        parse_fabric_counter_value({"CRC": "not-a-number"}, "CRC", "3")
+
+
+# ---------------------------------------------------------------------------
+# evaluate_fabric_counter_row
+# ---------------------------------------------------------------------------
+
+def _load_evaluate_row():
+    # References parse_fabric_counter_value (-> _FABRIC_NA_VALUE, FabricCounterParseError).
+    evaluate_fabric_counter_row, _, _, _ = _load(
+        "evaluate_fabric_counter_row", "parse_fabric_counter_value",
+        "_FABRIC_NA_VALUE", "FabricCounterParseError")
+    return evaluate_fabric_counter_row
+
+
+def test_evaluate_row_state_down_is_ignored():
+    evaluate_fabric_counter_row = _load_evaluate_row()
+    # STATE != up must short-circuit before the (garbage) counter is ever parsed.
+    row = {"PORT": "1", "STATE": "down", "CRC": "not-a-number", "FEC_UNCORRECTABLE": "0"}
+    assert evaluate_fabric_counter_row(row) is None
+
+
+def test_evaluate_row_zero_counters():
+    evaluate_fabric_counter_row = _load_evaluate_row()
+    row = {"PORT": "1", "STATE": "up", "CRC": "0", "FEC_UNCORRECTABLE": "0"}
+    assert evaluate_fabric_counter_row(row) == (0, 0)
+
+
+def test_evaluate_row_crc_error():
+    evaluate_fabric_counter_row = _load_evaluate_row()
+    row = {"PORT": "1", "STATE": "up", "CRC": "12", "FEC_UNCORRECTABLE": "0"}
+    assert evaluate_fabric_counter_row(row) == (12, 0)
+
+
+def test_evaluate_row_fec_uncorrectable_error():
+    evaluate_fabric_counter_row = _load_evaluate_row()
+    row = {"PORT": "1", "STATE": "up", "CRC": "0", "FEC_UNCORRECTABLE": "4"}
+    assert evaluate_fabric_counter_row(row) == (0, 4)
+
+
+def test_evaluate_row_na_counter_is_none_not_zero():
+    evaluate_fabric_counter_row = _load_evaluate_row()
+    row = {"PORT": "1", "STATE": "up", "CRC": "N/A", "FEC_UNCORRECTABLE": "0"}
+    crc, fec = evaluate_fabric_counter_row(row)
+    assert crc is None      # unreadable -- never coerced to 0
+    assert fec == 0
+
+
+# ---------------------------------------------------------------------------
+# is_fabric_error_fail
+# ---------------------------------------------------------------------------
+
+def test_is_fabric_error_fail_local_selected_dut():
+    is_fabric_error_fail = _load("is_fabric_error_fail")
+    # selected_switch_ids deliberately wrong/empty: must not even be consulted.
+    assert is_fabric_error_fail("lc1", {"lc1"}, "999", set()) is True
+
+
+def test_is_fabric_error_fail_remote_switch_id_selected():
+    is_fabric_error_fail = _load("is_fabric_error_fail")
+    assert is_fabric_error_fail("sup1", {"lc1"}, "100", {"100"}) is True
+
+
+def test_is_fabric_error_fail_remote_switch_id_not_selected_is_warning():
+    is_fabric_error_fail = _load("is_fabric_error_fail")
+    assert is_fabric_error_fail("sup1", {"lc1"}, "999", {"100"}) is False
+
+
+def test_is_fabric_error_fail_unavailable_remote_mod_is_warning():
+    is_fabric_error_fail = _load("is_fabric_error_fail")
+    assert is_fabric_error_fail("sup1", {"lc1"}, None, {"100"}) is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_remote_switch_id: ASIC attribution
+# ---------------------------------------------------------------------------
+
+def test_resolve_remote_switch_id_multi_asic_row_without_asic_column_unresolved():
+    resolve_remote_switch_id = _load("resolve_remote_switch_id")
+    duthost = MagicMock()
+    duthost.hostname = "lc1"
+    duthost.asics = [MagicMock(), MagicMock()]   # multi-ASIC node
+    row = {"PORT": "5", "STATE": "up", "CRC": "1", "FEC_UNCORRECTABLE": "0"}  # no "ASIC" key
+
+    result = resolve_remote_switch_id(duthost, row)
+
+    assert result is None
+    duthost.asic_instance.assert_not_called()
+
+
+def test_resolve_remote_switch_id_single_asic_row_without_asic_column_defaults():
+    resolve_remote_switch_id = _load("resolve_remote_switch_id")
+    duthost = MagicMock()
+    duthost.hostname = "pizza1"
+    duthost.asics = [MagicMock()]   # single-ASIC node
+    duthost.asic_instance.return_value.run_sonic_db_cli_cmd.return_value = {"stdout": "42\n"}
+    row = {"PORT": "5", "STATE": "up", "CRC": "1", "FEC_UNCORRECTABLE": "0"}  # no "ASIC" key
+
+    result = resolve_remote_switch_id(duthost, row)
+
+    assert result == "42"
+    duthost.asic_instance.assert_called_once_with()
+
+
+def test_resolve_remote_switch_id_uses_asic_column_when_present():
+    resolve_remote_switch_id = _load("resolve_remote_switch_id")
+    duthost = MagicMock()
+    duthost.hostname = "lc1"
+    duthost.asics = [MagicMock(), MagicMock()]
+    duthost.asic_instance.return_value.run_sonic_db_cli_cmd.return_value = {"stdout": "7"}
+    row = {"ASIC": "1", "PORT": "5", "STATE": "up", "CRC": "1", "FEC_UNCORRECTABLE": "0"}
+
+    result = resolve_remote_switch_id(duthost, row)
+
+    assert result == "7"
+    duthost.asic_instance.assert_called_once_with(1)

--- a/tests/snappi_tests/pfc/test_pfc_mixed_speed.py
+++ b/tests/snappi_tests/pfc/test_pfc_mixed_speed.py
@@ -5,7 +5,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_grap
     fanout_graph_facts          # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, cleanup_config, get_snappi_ports_for_rdma, snappi_multi_base_config, \
-    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters, \
+    get_snappi_ports, get_snappi_ports_multi_dut, get_fabric_counter_scope, \
     get_snappi_ports_single_dut      # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list, \
     lossy_prio_list, all_prio_list, disable_pfcwd                                                   # noqa: F401
@@ -135,8 +135,7 @@ def test_mixed_speed_diff_dist_over(snappi_api,                   # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     try:
         run_pfc_test(api=snappi_api,
@@ -154,8 +153,7 @@ def test_mixed_speed_diff_dist_over(snappi_api,                   # noqa: F811
                      snappi_extra_params=snappi_extra_params)
 
         # Check the fabric counter for the line-cards.
-        for dut in duthosts:
-            check_fabric_counters(dut)
+        get_fabric_counter_scope(duthosts).check()
 
     finally:
         cleanup_config(dut_list, snappi_ports)
@@ -271,8 +269,7 @@ def test_mixed_speed_uni_dist_over(snappi_api,                   # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     try:
         run_pfc_test(api=snappi_api,
@@ -289,8 +286,7 @@ def test_mixed_speed_uni_dist_over(snappi_api,                   # noqa: F811
                      test_def=test_def,
                      snappi_extra_params=snappi_extra_params)
 
-        for dut in duthosts:
-            check_fabric_counters(dut)
+        get_fabric_counter_scope(duthosts).check()
 
     finally:
         cleanup_config(dut_list, snappi_ports)
@@ -405,8 +401,7 @@ def test_mixed_speed_no_congestion(snappi_api,                   # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     try:
         run_pfc_test(api=snappi_api,
@@ -423,8 +418,7 @@ def test_mixed_speed_no_congestion(snappi_api,                   # noqa: F811
                      test_def=test_def,
                      snappi_extra_params=snappi_extra_params)
 
-        for dut in duthosts:
-            check_fabric_counters(dut)
+        get_fabric_counter_scope(duthosts).check()
 
     finally:
         cleanup_config(dut_list, snappi_ports)

--- a/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
+++ b/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
@@ -6,7 +6,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, \
     snappi_testbed_config, get_snappi_ports_single_dut, snappi_port_selection, \
     get_snappi_ports, tgen_port_info, is_snappi_multidut, \
-    get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters, \
+    get_snappi_ports_multi_dut, get_fabric_counter_scope, \
     snappi_multi_base_config                                                                        # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list, \
     lossy_prio_list, all_prio_list, disable_pfcwd                                                   # noqa: F401
@@ -124,8 +124,7 @@ def test_multiple_prio_diff_dist(snappi_api,                    # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     try:
         run_pfc_test(api=snappi_api,
@@ -142,8 +141,7 @@ def test_multiple_prio_diff_dist(snappi_api,                    # noqa: F811
                      test_def=test_def,
                      snappi_extra_params=snappi_extra_params)
 
-        for dut in duthosts:
-            check_fabric_counters(dut)
+        get_fabric_counter_scope(duthosts).check()
     finally:
         cleanup_config(dut_list, snappi_ports)
 
@@ -239,8 +237,7 @@ def test_multiple_prio_uni_dist(snappi_api,                     # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     try:
         run_pfc_test(api=snappi_api,
@@ -257,8 +254,7 @@ def test_multiple_prio_uni_dist(snappi_api,                     # noqa: F811
                      test_def=test_def,
                      snappi_extra_params=snappi_extra_params)
 
-        for dut in duthosts:
-            check_fabric_counters(dut)
+        get_fabric_counter_scope(duthosts).check()
     finally:
         cleanup_config(dut_list, snappi_ports)
 
@@ -355,8 +351,7 @@ def test_single_lossless_prio(snappi_api,                   # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     try:
         run_pfc_test(api=snappi_api,
@@ -373,7 +368,6 @@ def test_single_lossless_prio(snappi_api,                   # noqa: F811
                      test_def=test_def,
                      snappi_extra_params=snappi_extra_params)
 
-        for dut in duthosts:
-            check_fabric_counters(dut)
+        get_fabric_counter_scope(duthosts).check()
     finally:
         cleanup_config(dut_list, snappi_ports)

--- a/tests/snappi_tests/pfc/test_pfc_port_congestion.py
+++ b/tests/snappi_tests/pfc/test_pfc_port_congestion.py
@@ -6,7 +6,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, \
     snappi_testbed_config, get_snappi_ports_single_dut, snappi_port_selection, \
     get_snappi_ports, tgen_port_info, is_snappi_multidut, get_snappi_ports_multi_dut, \
-    clear_fabric_counters, check_fabric_counters, snappi_multi_base_config                          # noqa: F401
+    get_fabric_counter_scope, snappi_multi_base_config                          # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list, \
     lossy_prio_list, all_prio_list, disable_pfcwd                                                   # noqa: F401
 from tests.snappi_tests.pfc.files.pfc_congestion_helper import run_pfc_test, get_test_subtype_from_ports
@@ -125,8 +125,7 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     try:
         run_pfc_test(api=snappi_api,
@@ -143,8 +142,7 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
                      test_def=test_def,
                      snappi_extra_params=snappi_extra_params)
 
-        for dut in duthosts:
-            check_fabric_counters(dut)
+        get_fabric_counter_scope(duthosts).check()
     finally:
         cleanup_config(dut_list, snappi_ports)
 
@@ -237,8 +235,7 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     try:
         run_pfc_test(api=snappi_api,
@@ -255,8 +252,7 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
                      test_def=test_def,
                      snappi_extra_params=snappi_extra_params)
 
-        for dut in duthosts:
-            check_fabric_counters(dut)
+        get_fabric_counter_scope(duthosts).check()
     finally:
         cleanup_config(dut_list, snappi_ports)
 
@@ -351,8 +347,7 @@ def test_multiple_prio_equal_dist(snappi_api,                   # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     try:
         run_pfc_test(api=snappi_api,
@@ -369,8 +364,7 @@ def test_multiple_prio_equal_dist(snappi_api,                   # noqa: F811
                      test_def=test_def,
                      snappi_extra_params=snappi_extra_params)
 
-        for dut in duthosts:
-            check_fabric_counters(dut)
+        get_fabric_counter_scope(duthosts).check()
     finally:
         cleanup_config(dut_list, snappi_ports)
 
@@ -467,8 +461,7 @@ def test_multiple_prio_non_cngtn(snappi_api,                   # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     try:
         run_pfc_test(api=snappi_api,
@@ -485,7 +478,6 @@ def test_multiple_prio_non_cngtn(snappi_api,                   # noqa: F811
                      test_def=test_def,
                      snappi_extra_params=snappi_extra_params)
 
-        for dut in duthosts:
-            check_fabric_counters(dut)
+        get_fabric_counter_scope(duthosts).check()
     finally:
         cleanup_config(dut_list, snappi_ports)

--- a/tests/snappi_tests/pfcwd/test_pfcwd_actions.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_actions.py
@@ -6,7 +6,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_grap
     fanout_graph_facts   # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_multi_base_config, cleanup_config, get_snappi_ports_for_rdma, \
-    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters, \
+    get_snappi_ports, get_snappi_ports_multi_dut, get_fabric_counter_scope, \
     get_snappi_ports_single_dut      # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list, \
     lossy_prio_list, all_prio_list                                                                  # noqa: F401
@@ -165,8 +165,7 @@ def test_pfcwd_drop_90_10(snappi_api,                  # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     logger.info('PFC-WD stats at the start of the test:')
     for prio in test_prio_list:
@@ -214,8 +213,7 @@ def test_pfcwd_drop_90_10(snappi_api,                  # noqa: F811
                         logger.info('PFCWD Stats:for dut:{}, port:{},prio:{}, stats::{}'.
                                     format(dut.hostname, port['peer_port'], prio, pfcwd_stats))
 
-    for dut in duthosts:
-        check_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).check()
 
 
 # This is a single-tx-single-rx test.
@@ -294,8 +292,7 @@ def test_pfcwd_drop_uni(snappi_api,                  # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     logger.info('PFC-WD stats at the start of the test:')
     for prio in test_prio_list:
@@ -343,8 +340,7 @@ def test_pfcwd_drop_uni(snappi_api,                  # noqa: F811
                         logger.info('PFCWD Stats:for dut:{}, port:{},prio:{}, stats::{}'.
                                     format(dut.hostname, port['peer_port'], prio, pfcwd_stats))
 
-    for dut in duthosts:
-        check_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).check()
 
 
 @pytest.mark.parametrize('port_map', port_map)
@@ -467,8 +463,7 @@ def test_pfcwd_frwd_90_10(snappi_api,                  # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     logger.info('PFC-WD stats at the start of the test:')
     for prio in test_prio_list:
@@ -516,8 +511,7 @@ def test_pfcwd_frwd_90_10(snappi_api,                  # noqa: F811
                         logger.info('PFCWD Stats:for dut:{}, port:{},prio:{}, stats::{}'.
                                     format(dut.hostname, port['peer_port'], prio, pfcwd_stats))
 
-    for dut in duthosts:
-        check_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).check()
 
 
 # This is an oversubscribe-testcase.
@@ -606,8 +600,7 @@ def test_pfcwd_drop_over_subs_40_09(snappi_api,                  # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     logger.info('PFC-WD stats at the start of the test:')
     for prio in test_prio_list:
@@ -655,8 +648,7 @@ def test_pfcwd_drop_over_subs_40_09(snappi_api,                  # noqa: F811
                         logger.info('PFCWD Stats:for dut:{}, port:{},prio:{}, stats::{}'.
                                     format(dut.hostname, port['peer_port'], prio, pfcwd_stats))
 
-    for dut in duthosts:
-        check_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).check()
 
 
 @pytest.mark.parametrize('port_map', over_subs_port_map)
@@ -777,8 +769,7 @@ def test_pfcwd_frwd_over_subs_40_09(snappi_api,                  # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     logger.info('PFC-WD stats at the start of the test:')
     for prio in test_prio_list:
@@ -825,8 +816,7 @@ def test_pfcwd_frwd_over_subs_40_09(snappi_api,                  # noqa: F811
                         pfcwd_stats = get_pfcwd_stats(dut, port['peer_port'], prio)
                         logger.info('PFCWD Stats:for dut:{}, port:{},prio:{}, stats::{}'.
                                     format(dut.hostname, port['peer_port'], prio, pfcwd_stats))
-    for dut in duthosts:
-        check_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).check()
 
 
 # This is an non-oversubscribe-testcase.
@@ -907,8 +897,8 @@ def test_pfcwd_disable_pause_cngtn(snappi_api,                  # noqa: F811
 
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
+    get_fabric_counter_scope(duthosts).clear()
     for dut in duthosts:
-        clear_fabric_counters(dut)
         if dut.facts.get('asic_type') == "cisco-8000":
             modify_voq_watchdog_cisco_8000(dut, False)
 
@@ -926,5 +916,4 @@ def test_pfcwd_disable_pause_cngtn(snappi_api,                  # noqa: F811
                  test_def=test_def,
                  snappi_extra_params=snappi_extra_params)
 
-    for dut in duthosts:
-        check_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).check()

--- a/tests/snappi_tests/pfcwd/test_pfcwd_mixed_speed.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_mixed_speed.py
@@ -5,7 +5,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_grap
     fanout_graph_facts     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, cleanup_config, get_snappi_ports_for_rdma, snappi_multi_base_config, \
-    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters, \
+    get_snappi_ports, get_snappi_ports_multi_dut, get_fabric_counter_scope, \
     get_snappi_ports_single_dut     # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list, \
     lossy_prio_list, all_prio_list                                                                  # noqa: F401
@@ -135,8 +135,7 @@ def test_mixed_speed_pfcwd_enable(snappi_api,                   # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
-    for dut in duthosts:
-        clear_fabric_counters(dut)
+    get_fabric_counter_scope(duthosts).clear()
 
     try:
         run_pfc_test(api=snappi_api,
@@ -153,8 +152,7 @@ def test_mixed_speed_pfcwd_enable(snappi_api,                   # noqa: F811
                      test_def=test_def,
                      snappi_extra_params=snappi_extra_params)
 
-        for dut in duthosts:
-            check_fabric_counters(dut)
+        get_fabric_counter_scope(duthosts).check()
 
     finally:
         cleanup_config(dut_list, snappi_ports)
@@ -271,8 +269,8 @@ def test_mixed_speed_pfcwd_disable(snappi_api,                   # noqa: F811
     else:
         dut_list = [snappi_ports[0]['duthost'], snappi_ports[-1]['duthost']]
 
+    get_fabric_counter_scope(duthosts).clear()
     for dut in duthosts:
-        clear_fabric_counters(dut)
         if dut.facts['asic_type'] == "cisco-8000":
             modify_voq_watchdog_cisco_8000(dut, False)
 
@@ -291,8 +289,7 @@ def test_mixed_speed_pfcwd_disable(snappi_api,                   # noqa: F811
                      test_def=test_def,
                      snappi_extra_params=snappi_extra_params)
 
-        for dut in duthosts:
-            check_fabric_counters(dut)
+        get_fabric_counter_scope(duthosts).check()
 
     finally:
         cleanup_config(dut_list, snappi_ports)


### PR DESCRIPTION
### Description of PR

Improve Snappi fabric-counter validation for Broadcom-DNX systems.

Fixes #27863

### Type of change

* [ ] Bug fix
* [x] Testbed and Framework(new/improvement)
* [ ] New Test case
* [x] Test case improvement

### Back port request

No backport requested.

### Tested branch

* [x] master

### Test result

```text
python3 -m pytest --noconftest tests/common/unit_tests/snappi_tests/ -v

30 passed
```

Additional validation:

```text
python3 -m compileall -q <changed Python files>
git diff --check
```

Both completed successfully.

Hardware/Snappi integration testing was not available locally.

### Approach

#### What is the motivation for this PR?

Fabric counters were checked only on DUTs included by `--host-pattern`. On modular DNX systems this could omit a supervisor or sibling linecard, losing fabric-error visibility from the other endpoint.

Standalone single-ASIC DNX pizza boxes could also enter the existing check despite not having internal fabric links.

#### How did you do it?

* Discover reachable DUTs from the complete testbed topology, including SUPs/LCs omitted by `--host-pattern`.
* Check Broadcom-DNX nodes that have fabric links:

  * modular chassis nodes
  * fixed multi-ASIC DNX systems
* Exclude standalone single-ASIC DNX systems.
* Parse `show fabric counters port` using runtime column names instead of fixed column indexes.
* Support output both with and without an ASIC column.
* Use `REMOTE_MOD` and selected DUT switch IDs to apply the requested error policy.
* Fail for errors affecting a selected DUT or its fabric peer.
* Warn for unrelated or unattributable errors on out-of-pattern DUTs.
* Add focused unit coverage for fabric eligibility, CLI parsing, counter evaluation, and peer attribution.

#### How did you verify/test it?

Added focused unit tests under:

`tests/common/unit_tests/snappi_tests/unit_test_fabric_counters.py`

All lightweight Snappi unit tests pass: 30/30.

#### Any platform specific information?

Fabric validation applies to Broadcom-DNX systems with actual fabric links.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
