### PR TITLE
[Arista] Add VRM sensor checks for Arista 7280dr3a SKUs

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -8083,6 +8083,42 @@ sensors_checks:
       - tmp464-i2c-28-48/JE0_C Diode/temp5_crit_alarm
       - tmp464-i2c-28-48/JE0_C Diode/temp5_fault
       - tmp464-i2c-28-48/JE0_C Diode/temp5_max_alarm
+      - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_crit_alarm
+      - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_lcrit_alarm
+      - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_max_alarm
+      - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_crit_alarm
+      - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_lcrit_alarm
+      - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_max_alarm
+      - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_crit_alarm
+      - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_lcrit_alarm
+      - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_max_alarm
+      - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_crit_alarm
+      - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_lcrit_alarm
+      - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_max_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_crit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_lcrit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_max_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_crit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_lcrit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_max_alarm
+      - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_crit_alarm
+      - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_lcrit_alarm
+      - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_max_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_crit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_lcrit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_max_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_crit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_lcrit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_max_alarm
+      - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_crit_alarm
+      - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_lcrit_alarm
+      - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_max_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_crit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_lcrit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_max_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_crit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_lcrit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_max_alarm
 
     compares:
       fan: [ ]
@@ -8116,6 +8152,30 @@ sensors_checks:
         - tmp464-i2c-28-48/JE1_C Diode/temp4_crit
       - - tmp464-i2c-28-48/JE0_C Diode/temp5_input
         - tmp464-i2c-28-48/JE0_C Diode/temp5_crit
+      - - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_input
+        - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_crit
+      - - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_input
+        - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_crit
+      - - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_input
+        - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_crit
+      - - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_input
+        - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_crit
+      - - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_input
+        - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_crit
+      - - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_input
+        - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_crit
+      - - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_input
+        - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_crit
+      - - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_input
+        - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_crit
+      - - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_input
+        - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_crit
+      - - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_input
+        - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_crit
+      - - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_input
+        - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_crit
+      - - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_input
+        - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_crit
 
     non_zero:
       fan:
@@ -8241,6 +8301,42 @@ sensors_checks:
       - tmp464-i2c-28-48/JE0_C Diode/temp5_crit_alarm
       - tmp464-i2c-28-48/JE0_C Diode/temp5_fault
       - tmp464-i2c-28-48/JE0_C Diode/temp5_max_alarm
+      - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_crit_alarm
+      - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_lcrit_alarm
+      - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_max_alarm
+      - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_crit_alarm
+      - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_lcrit_alarm
+      - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_max_alarm
+      - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_crit_alarm
+      - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_lcrit_alarm
+      - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_max_alarm
+      - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_crit_alarm
+      - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_lcrit_alarm
+      - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_max_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_crit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_lcrit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_max_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_crit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_lcrit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_max_alarm
+      - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_crit_alarm
+      - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_lcrit_alarm
+      - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_max_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_crit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_lcrit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_max_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_crit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_lcrit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_max_alarm
+      - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_crit_alarm
+      - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_lcrit_alarm
+      - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_max_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_crit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_lcrit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_max_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_crit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_lcrit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_max_alarm
 
     compares:
       fan: [ ]
@@ -8274,6 +8370,30 @@ sensors_checks:
         - tmp464-i2c-28-48/JE1_C Diode/temp4_crit
       - - tmp464-i2c-28-48/JE0_C Diode/temp5_input
         - tmp464-i2c-28-48/JE0_C Diode/temp5_crit
+      - - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_input
+        - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_crit
+      - - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_input
+        - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_crit
+      - - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_input
+        - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_crit
+      - - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_input
+        - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_crit
+      - - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_input
+        - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_crit
+      - - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_input
+        - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_crit
+      - - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_input
+        - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_crit
+      - - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_input
+        - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_crit
+      - - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_input
+        - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_crit
+      - - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_input
+        - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_crit
+      - - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_input
+        - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_crit
+      - - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_input
+        - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_crit
 
     non_zero:
       fan:
@@ -8399,6 +8519,42 @@ sensors_checks:
       - tmp464-i2c-28-48/JE0_C Diode/temp5_crit_alarm
       - tmp464-i2c-28-48/JE0_C Diode/temp5_fault
       - tmp464-i2c-28-48/JE0_C Diode/temp5_max_alarm
+      - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_crit_alarm
+      - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_lcrit_alarm
+      - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_max_alarm
+      - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_crit_alarm
+      - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_lcrit_alarm
+      - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_max_alarm
+      - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_crit_alarm
+      - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_lcrit_alarm
+      - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_max_alarm
+      - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_crit_alarm
+      - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_lcrit_alarm
+      - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_max_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_crit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_lcrit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_max_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_crit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_lcrit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_max_alarm
+      - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_crit_alarm
+      - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_lcrit_alarm
+      - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_max_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_crit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_lcrit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_max_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_crit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_lcrit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_max_alarm
+      - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_crit_alarm
+      - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_lcrit_alarm
+      - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_max_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_crit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_lcrit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_max_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_crit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_lcrit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_max_alarm
 
     compares:
       fan: [ ]
@@ -8432,6 +8588,30 @@ sensors_checks:
         - tmp464-i2c-28-48/JE1_C Diode/temp4_crit
       - - tmp464-i2c-28-48/JE0_C Diode/temp5_input
         - tmp464-i2c-28-48/JE0_C Diode/temp5_crit
+      - - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_input
+        - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_crit
+      - - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_input
+        - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_crit
+      - - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_input
+        - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_crit
+      - - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_input
+        - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_crit
+      - - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_input
+        - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_crit
+      - - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_input
+        - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_crit
+      - - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_input
+        - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_crit
+      - - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_input
+        - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_crit
+      - - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_input
+        - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_crit
+      - - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_input
+        - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_crit
+      - - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_input
+        - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_crit
+      - - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_input
+        - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_crit
 
     non_zero:
       fan:
@@ -8557,6 +8737,42 @@ sensors_checks:
       - tmp464-i2c-28-48/JE0_C Diode/temp5_crit_alarm
       - tmp464-i2c-28-48/JE0_C Diode/temp5_fault
       - tmp464-i2c-28-48/JE0_C Diode/temp5_max_alarm
+      - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_crit_alarm
+      - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_lcrit_alarm
+      - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_max_alarm
+      - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_crit_alarm
+      - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_lcrit_alarm
+      - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_max_alarm
+      - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_crit_alarm
+      - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_lcrit_alarm
+      - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_max_alarm
+      - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_crit_alarm
+      - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_lcrit_alarm
+      - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_max_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_crit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_lcrit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_max_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_crit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_lcrit_alarm
+      - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_max_alarm
+      - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_crit_alarm
+      - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_lcrit_alarm
+      - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_max_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_crit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_lcrit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_max_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_crit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_lcrit_alarm
+      - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_max_alarm
+      - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_crit_alarm
+      - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_lcrit_alarm
+      - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_max_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_crit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_lcrit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_max_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_crit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_lcrit_alarm
+      - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_max_alarm
 
     compares:
       fan: [ ]
@@ -8590,6 +8806,30 @@ sensors_checks:
         - tmp464-i2c-28-48/JE1_C Diode/temp4_crit
       - - tmp464-i2c-28-48/JE0_C Diode/temp5_input
         - tmp464-i2c-28-48/JE0_C Diode/temp5_crit
+      - - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_input
+        - raa228228-i2c-25-4c/POS0V75_VDDC_JE0/temp1_crit
+      - - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_input
+        - raa228228-i2c-25-4c/POS0V75_RTVDD_JE0/temp2_crit
+      - - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_input
+        - raa228228-i2c-25-4d/POS0V75_VDDC_JE1/temp1_crit
+      - - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_input
+        - raa228228-i2c-25-4d/POS0V75_RTVDD_JE1/temp2_crit
+      - - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_input
+        - isl68221-i2c-25-54/POS1V2_HBM0_VDD_JE0/temp1_crit
+      - - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_input
+        - isl68221-i2c-25-54/POS1V2_HBM1_VDD_JE0/temp2_crit
+      - - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_input
+        - isl68221-i2c-25-54/POS1V2_TVDD_JE0/temp3_crit
+      - - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_input
+        - isl68221-i2c-25-55/POS1V2_HBM0_VDD_JE1/temp1_crit
+      - - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_input
+        - isl68221-i2c-25-55/POS1V2_HBM1_VDD_JE1/temp2_crit
+      - - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_input
+        - isl68221-i2c-25-55/POS1V2_TVDD_JE1/temp3_crit
+      - - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_input
+        - isl68225-i2c-25-61/QSFP_3V3_LEFT/temp1_crit
+      - - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_input
+        - isl68225-i2c-25-61/QSFP_3V3_RIGHT/temp2_crit
 
     non_zero:
       fan:


### PR DESCRIPTION


### Description of PR

Arista 7280DR3A SKUs now exposes RAA228228 and ISL68221 temperature sensors through hwmon. 

Hereby, extending the platform sensor validation data in ansible/group_vars/sonic/sku-sensors-data.yml  for Arista specific SKUs to cover the VRM temperature sensors introduced by the corresponding sonic-buildimage change.

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result

With the updates in platform.json and sensors.conf in the platfrom files proposed in https://github.com/sonic-net/sonic-buildimage/pull/29476, 

202605:

Sonic-mgmt test `platform_tests/test_sensors.py` passed on 7280DR3AK SKU with added sensors
```
platform_tests/test_sensors.py::test_sensors PASSED                             [100%]
```

202511:

Sonic-mgmt test `platform_tests/test_sensors.py` passed on 7280DR3AK SKU with added sensors
```
platform_tests/test_sensors.py::test_sensors PASSED                             [100%]
```



### Approach
#### What is the motivation for this PR?

Arista 7280DR3A SKUs now supports RAA228228 and ISL68221 temperature sensors through hwmon. 

#### How did you do it?

Update ansible/group_vars/sonic/sku-sensors-data.yml with relevant paths for testing the relevant sensors

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

Ran `tests/platform_tests/test_sensors.py`. Test passed. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
