### PR TITLE
fix(ci): halve dualtor VPP worker count

### DIFF
--- a/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
+++ b/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
@@ -2,7 +2,12 @@ import os
 import argparse
 import math
 import logging
-from constant import PR_CHECKER_TOPOLOGY_NAME, MAX_INSTANCE_NUMBER, MAX_GET_TOKEN_RETRY_TIMES
+from constant import (
+    MAX_GET_TOKEN_RETRY_TIMES,
+    MAX_INSTANCE_NUMBER,
+    PR_CHECKER_TOPOLOGY_NAME,
+    WORKER_COUNT_DIVISOR_BY_TOPOLOGY,
+)
 from azure.kusto.data import KustoConnectionStringBuilder, KustoClient
 
 logging.basicConfig(level=logging.INFO)
@@ -125,7 +130,12 @@ def main(scripts, topology, branch, prepare_time, target_pr_test_time):
     # As we need some time to prepare testbeds, the prepare time should be subtracted.
     # Obtain the number of instances by rounding up the calculation.
     # To prevent unexpected situations, we set the maximum number of instance
-    print(min(math.ceil(total_running_time / 60 / (target_pr_test_time - prepare_time)), MAX_INSTANCE_NUMBER))
+    worker_count = min(
+        math.ceil(total_running_time / 60 / (target_pr_test_time - prepare_time)),
+        MAX_INSTANCE_NUMBER
+    )
+    worker_count_divisor = WORKER_COUNT_DIVISOR_BY_TOPOLOGY.get(topology, 1)
+    print(math.ceil(worker_count / worker_count_divisor))
 
 
 if __name__ == '__main__':

--- a/.azure-pipelines/impacted_area_testing/constant.py
+++ b/.azure-pipelines/impacted_area_testing/constant.py
@@ -45,4 +45,8 @@ CONTROL_PLANE_DEDUP_RULES = [
 ]
 
 MAX_INSTANCE_NUMBER = 40
+WORKER_COUNT_DIVISOR_BY_TOPOLOGY = {
+    "dualtor-vpp": 2,
+    "dualtor-aa-vpp": 2,
+}
 MAX_GET_TOKEN_RETRY_TIMES = 3


### PR DESCRIPTION
### Description of PR

Summary:
Reduce the dynamically calculated worker count by half for `dualtor-vpp` and `dualtor-aa-vpp` PR test plans.

Fixes # (issue) N/A

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

- Python compilation passed for the changed modules.
- Flake8 passed for the changed modules.
- Verified worker reductions of 1 to 1, 2 to 1, 3 to 2, and 40 to 20.

### Approach
#### What is the motivation for this PR?

Dual-ToR VPP testbeds consume more resources per worker than single-DUT topologies. Their impacted-area PR checks should therefore request half the normal calculated worker count. The pending `dualtor-aa-vpp` checker is introduced by #27739.

#### How did you do it?

Added a topology-to-divisor mapping for `dualtor-vpp` and `dualtor-aa-vpp`. After applying the existing global worker cap, the instance calculator divides the worker count by two and rounds up. Other topologies retain the existing calculation.

#### How did you verify/test it?

Compiled and linted the changed Python files, then checked representative worker counts around odd values and the global maximum.

#### Any platform specific information?

This applies only to SONiC-VPP dual-ToR topologies.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
