### PR TITLE
Fix bgp suppress fib Ansible extra vars

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -486,9 +486,9 @@ def setup_vrf_cfg(duthost, cfg_facts, nbrhosts, tbinfo, loganalyzer):
         cfg_t1['BGP_NEIGHBOR'][bgp_neighbor].pop('nhopself', None)
         cfg_t1['BGP_NEIGHBOR'][bgp_neighbor].pop('rrclient', None)
     port_list = get_port_connected_with_vm(duthost, tbinfo, nbrhosts)
-    vm_list = nbrhosts.keys()
+    vm_list = list(nbrhosts.keys())
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    port_channel_list = mg_facts['minigraph_portchannels'].keys()
+    port_channel_list = list(mg_facts['minigraph_portchannels'].keys())
     if len(port_channel_list) == 0:
         upstream_port_list = get_port_connected_with_vm(duthost, tbinfo, nbrhosts, vm_type="T2")
         port_list.extend(upstream_port_list)


### PR DESCRIPTION
### Description of PR

Summary:
Fixes Ansible datatag failures in gp/test_bgp_suppress_fib.py when the VRF template path passes Python dict_keys views through xtra_vars.

Related ADO PBI: https://msazure.visualstudio.com/One/_workitems/edit/39641560

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): ADO 39641560
Failure type: regression / other

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Pre-commit on changed file passed locally:
python -m pre_commit run --files tests/bgp/test_bgp_suppress_fib.py

### Approach
#### What is the motivation for this PR?

Nightly 	est_bgp_route_without_suppress / suppress-FIB setup fails before test validation with nsible.module_utils._internal._datatag.NotTaggableError: <class 'dict_keys'> is not taggable. The failure is triggered while Ansible processes xtra_vars for gp/vrf_config_db.j2.

#### How did you do it?

Converted 
brhosts.keys() and mg_facts['minigraph_portchannels'].keys() to concrete lists before storing them in xtra_vars.

#### How did you verify/test it?

Ran pre-commit for the changed file successfully.

#### Any platform specific information?

Observed on Arista-7060CX-32S-C32 T1/T1-LAG internal nightly, but the fix is test-code-only and applies to all platforms.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.