### PR TITLE
fix power_off_reboot test for platform with high psu budget

### DIFF
--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -21,6 +21,11 @@ INTERFACE_WAIT_TIME = 300
 DPU_STATUS_TIMEOUT = 360
 DPU_STATUS_INTERVAL = 30
 
+# min PSUs to power on together. Unlisted platforms default to 1.
+MIN_PSU_ON = {
+    "x86_64-nvidia_sn5640-r0": 2
+}
+
 
 @pytest.fixture(scope="module", autouse=True)
 def set_max_time_for_interfaces(duthost):
@@ -208,13 +213,19 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
     # 2. Turn off all PSUs, turn on PSU2, then check.
     # 3. Turn off all PSUs, turn on one of the PSU, then turn on the other PSU, then check.
     power_on_seq_list = []
+    psu_pdus_list = []
     for psu, pdus in psu_to_pdus.items():
         pytest_assert(any(int(pdu.get('output_watts', '1')) !=
                       0 for pdu in pdus), "PSU {} is not getting power".format(psu))
         if not is_chassis:
-            power_on_seq_list.append(pdus)
-    # Append all_outlets unless it would duplicate the single existing entry
-    # For chassis the list is empty here, so all_outlets becomes the only entry
+            psu_pdus_list.append(pdus)
+    # Special case: platforms in MIN_PSU_ON power on PSUs in groups (e.g. 4 PSUs -> 1+2, 3+4, then all).
+    min_psu_count = 1
+    if duthost.facts["platform"] in MIN_PSU_ON:
+        min_psu_count = MIN_PSU_ON[duthost.facts["platform"]]
+    for i in range(0, len(psu_pdus_list), min_psu_count):
+        group = psu_pdus_list[i:i + min_psu_count]
+        power_on_seq_list.append([outlet for pdus in group for outlet in pdus])
     if len(power_on_seq_list) != 1:
         power_on_seq_list.append(all_outlets)
     logging.info("Got all power on sequences {}".format(power_on_seq_list))


### PR DESCRIPTION

### Description of PR

Summary:
Fixes #27799 
Previous change https://github.com/sonic-net/sonic-mgmt/pull/27449 fix the duplicate entries in power_on_seq_list when there is only one PSU in test_power_off.py. But on some platforms, such as Mellanox-SN5640, single PSU is not able to start the dut. We think it is necessary to set minimum number of PSUs to meet the platform power budget.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/sonic-net/sonic-mgmt/issues/27799
Failure type: regression

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
tested on 202605: 

<img width="196" height="182" alt="image" src="https://github.com/user-attachments/assets/50f23b9c-e05e-4c4a-abf2-6e054a6bb929" />


### Approach
#### What is the motivation for this PR?
to set a minimum number of PSUs to turn on to start the switch based on platform
#### How did you do it?
for platform in list, set a specific number, otherwise set to 1
#### How did you verify/test it?
fix the test and it passed on Mellanox-SN5640

#### Any platform specific information?
Yes, this fix is specific for those platforms which have high PSU requirement, and cannot be started up using single PSU
#### Supported testbed topology if it's a new test case?
not a new case
### Documentation
N/A
