### PR TITLE
Rate-limit MAC-move storm to avoid neighsyncd netlink overflow

### DIFF
--- a/tests/fdb/files/fdb_mac_move_storm.py
+++ b/tests/fdb/files/fdb_mac_move_storm.py
@@ -74,6 +74,13 @@ def main():
                         help="seconds between progress reports on stdout")
     parser.add_argument("--vlan-tag", type=int, default=None,
                         help="if set, insert an 802.1Q tag with this VID on every frame")
+    parser.add_argument("--pps", type=float, default=0.0,
+                        help="aggregate send rate limit in packets/second across both "
+                             "interfaces; 0 means unlimited. MAC_MOVE_GUARD only needs "
+                             "threshold/detect_interval moves per second per MAC, and "
+                             "pacing keeps the CPU-punted copies of the storm under the "
+                             "CoPP ARP policer so the kernel netlink consumers in the "
+                             "swss container are not overrun.")
     args = parser.parse_args()
 
     signal.signal(signal.SIGTERM, _stop)
@@ -91,15 +98,25 @@ def main():
     n = len(pkts)
 
     sys.stdout.write(
-        "storm started: iface_a={} iface_b={} num_macs={} router_mac={} vlan_tag={}\n".format(
-            args.iface_a, args.iface_b, n, args.router_mac, args.vlan_tag))
+        "storm started: iface_a={} iface_b={} num_macs={} router_mac={} vlan_tag={} "
+        "pps={}\n".format(
+            args.iface_a, args.iface_b, n, args.router_mac, args.vlan_tag,
+            args.pps if args.pps > 0 else "unlimited"))
     sys.stdout.flush()
+
+    # One round sends every MAC on both interfaces (2 * n frames) and produces
+    # exactly one MAC move per MAC on the DUT, so the round period that yields
+    # the requested rate is (2 * n) / pps. Pacing per round rather than per
+    # packet keeps the per-frame cost negligible.
+    round_period = (2.0 * n / args.pps) if args.pps > 0 else 0.0
 
     sent = 0
     last_report = time.time()
+    next_round = time.time()
     while _running:
         # One round: each MAC is sent on iface_a immediately followed by iface_b,
         # producing one FDB MAC-move event per MAC per round on the DUT.
+        next_round += round_period
         for i in range(n):
             if not _running:
                 break
@@ -110,6 +127,14 @@ def main():
             except OSError as e:
                 sys.stderr.write("send error on mac index {}: {}\n".format(i, e))
                 time.sleep(0.01)
+        if round_period:
+            delay = next_round - time.time()
+            if delay > 0:
+                time.sleep(delay)
+            elif delay < -round_period:
+                # Fell behind by more than one full round; re-anchor instead of
+                # bursting to catch up.
+                next_round = time.time()
         now = time.time()
         elapsed = now - last_report
         if elapsed >= args.report_interval:

--- a/tests/fdb/test_fdb_mac_move.py
+++ b/tests/fdb/test_fdb_mac_move.py
@@ -46,6 +46,20 @@ STORM_VLAN_TAG = 100
 MAC_MOVE_GUARD_THRESHOLD = 100
 MAC_MOVE_GUARD_DETECT_INTERVAL = 10
 MAC_MOVE_GUARD_ACTION_INTERVAL = 60
+# Rate limit applied to the storm sender. The guard trips when a single MAC
+# moves MAC_MOVE_GUARD_THRESHOLD times inside MAC_MOVE_GUARD_DETECT_INTERVAL,
+# i.e. THRESHOLD / DETECT_INTERVAL moves per second per MAC. Sending faster
+# adds nothing to what these tests assert, but every storm frame is also
+# copied to the CPU by the arp_req trap and shows up as a kernel-bridge FDB
+# move on RTNLGRP_NEIGH, which overruns the netlink receive queue of the swss
+# syncd daemons. Pace the sender at a fixed multiple of the required rate: the
+# guard still trips within a couple of seconds while the punted copies stay
+# below the CoPP arp_req policer.
+STORM_MOVE_RATE_MARGIN = 5
+STORM_MOVES_PER_SEC_PER_MAC = STORM_MOVE_RATE_MARGIN * int(math.ceil(
+    float(MAC_MOVE_GUARD_THRESHOLD) / MAC_MOVE_GUARD_DETECT_INTERVAL))
+# Each move costs two frames: one on each of the two storm interfaces.
+STORM_PPS = STORM_MOVES_PER_SEC_PER_MAC * STORM_NUM_MACS * 2
 # Action interval used by the DISABLE_LEARN_ON_MAC_WITH_ACL test. Kept high so
 # the bad MAC is not auto-released while we drive the storm and observe
 # orchagent quiescence. The test reconfigures this to a small value after the
@@ -265,22 +279,26 @@ def _select_two_vlan_member_ptf_ports(conf_facts, ptfhost, mg_facts):
     return ptf_a, ptf_b, vlan_id, iface_a, iface_b, dut_a, dut_b
 
 
-def _start_storm_sender(ptfhost, iface_a, iface_b, router_mac, vlan_tag=None):
+def _start_storm_sender(ptfhost, iface_a, iface_b, router_mac, vlan_tag=None,
+                        pps=STORM_PPS):
     """Copy the storm script to ptfhost and launch it in background. Returns the pid.
 
     If ``vlan_tag`` is provided, frames are 802.1Q-tagged with that VID.
+
+    ``pps`` caps the aggregate send rate across both interfaces so the storm
+    stays just above the rate MAC_MOVE_GUARD needs in order to trip.
     """
     ptfhost.copy(src=STORM_SENDER_LOCAL_PATH, dest=STORM_SENDER_REMOTE_PATH, mode="0755")
     ptfhost.shell("rm -f {}".format(STORM_SENDER_LOG), module_ignore_errors=True)
     vlan_arg = "--vlan-tag {} ".format(vlan_tag) if vlan_tag is not None else ""
     cmd = (
         "nohup python3 {script} --iface-a {ia} --iface-b {ib} --router-mac {rmac} "
-        "--num-macs {n} --mac-base {base} --report-interval {ri} {vlan}"
+        "--num-macs {n} --mac-base {base} --report-interval {ri} --pps {pps} {vlan}"
         "> {log} 2>&1 & echo $!"
     ).format(
         script=STORM_SENDER_REMOTE_PATH, ia=iface_a, ib=iface_b, rmac=router_mac,
         n=STORM_NUM_MACS, base=STORM_MAC_BASE, ri=STORM_REPORT_INTERVAL,
-        vlan=vlan_arg,
+        vlan=vlan_arg, pps=pps,
         log=STORM_SENDER_LOG,
     )
     res = ptfhost.shell(cmd)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Problem
`test_fdb_mac_move_guard_disable_port` can pass functionally (port disable and recovery) but fail at teardown when loganalyzer finds:

ERR swss#neighsyncd: :- readData: netlink reports out of memory on reading a netlink socket. High possibility of a lost message
### Description of PR
Rate-limit the PTF MAC-move storm used by `test_fdb_mac_move.py` to prevent `neighsyncd` netlink receive-buffer overflow during MAC_MOVE_GUARD tests.

Summary:
Fixes # (issue)
1. **`fdb_mac_move_storm.py`**
   - Add `--pps` CLI argument (aggregate packets/sec across both interfaces;
     `0` = unlimited for manual/debug use).
   - Pace by round: `round_period = (2 * num_macs) / pps`.
   - Re-anchor schedule if the sender falls behind (avoid catch-up bursts).
2. **`test_fdb_mac_move.py`**
   - Derive `STORM_PPS` from MMG config with a 5× margin:
     - `STORM_MOVES_PER_SEC_PER_MAC = 5 * ceil(100/10) = 50`
     - `STORM_PPS = 50 * 4 MACs * 2 frames/move = 400`
   - Pass `--pps 400` from `_start_storm_sender()` (default for all callers).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
[test_fdb_mac_move_2026-09-08-07-38-34.log](https://github.com/user-attachments/files/32099986/test_fdb_mac_move_2026-09-08-07-38-34.log)
