### PR TITLE
Add ansible/vars/topo_t2_single_node_max_32p.yml

### DIFF
--- a/ansible/vars/topo_t2_single_node_max_32p.yml
+++ b/ansible/vars/topo_t2_single_node_max_32p.yml
@@ -1,0 +1,908 @@
+topology:
+  VMs:
+    VM01T3:
+      vlans:
+        - 0
+      vm_offset: 0
+    VM02T3:
+      vlans:
+        - 1
+      vm_offset: 1
+    VM03T3:
+      vlans:
+        - 2
+      vm_offset: 2
+    VM04T3:
+      vlans:
+        - 3
+      vm_offset: 3
+    VM05T3:
+      vlans:
+        - 4
+      vm_offset: 4
+    VM06T3:
+      vlans:
+        - 5
+      vm_offset: 5
+    VM07T3:
+      vlans:
+        - 6
+      vm_offset: 6
+    VM08T3:
+      vlans:
+        - 7
+      vm_offset: 7
+    VM09T3:
+      vlans:
+        - 8
+      vm_offset: 8
+    VM10T3:
+      vlans:
+        - 9
+      vm_offset: 9
+    VM11T3:
+      vlans:
+        - 10
+      vm_offset: 10
+    VM12T3:
+      vlans:
+        - 11
+      vm_offset: 11
+    VM13T3:
+      vlans:
+        - 12
+      vm_offset: 12
+    VM14T3:
+      vlans:
+        - 13
+      vm_offset: 13
+    VM15T3:
+      vlans:
+        - 14
+      vm_offset: 14
+    VM16T3:
+      vlans:
+        - 15
+      vm_offset: 15
+    VM01LT2:
+      vlans:
+        - 16
+      vm_offset: 16
+    VM02LT2:
+      vlans:
+        - 17
+      vm_offset: 17
+    VM03LT2:
+      vlans:
+        - 18
+      vm_offset: 18
+    VM04LT2:
+      vlans:
+        - 19
+      vm_offset: 19
+    VM05LT2:
+      vlans:
+        - 20
+      vm_offset: 20
+    VM06LT2:
+      vlans:
+        - 21
+      vm_offset: 21
+    VM07LT2:
+      vlans:
+        - 22
+      vm_offset: 22
+    VM08LT2:
+      vlans:
+        - 23
+      vm_offset: 23
+    VM09LT2:
+      vlans:
+        - 24
+      vm_offset: 24
+    VM10LT2:
+      vlans:
+        - 25
+      vm_offset: 25
+    VM11LT2:
+      vlans:
+        - 26
+      vm_offset: 26
+    VM12LT2:
+      vlans:
+        - 27
+      vm_offset: 27
+    VM13LT2:
+      vlans:
+        - 28
+      vm_offset: 28
+    VM14LT2:
+      vlans:
+        - 29
+      vm_offset: 29
+    VM15LT2:
+      vlans:
+        - 30
+      vm_offset: 30
+    VM16LT2:
+      vlans:
+        - 31
+      vm_offset: 31
+
+  DUT:
+    loopback:
+      ipv4:
+        - 10.1.0.1/32
+      ipv6:
+        - fc00:10::1/128
+
+configuration_properties:
+  common:
+    dut_asn: 66000
+    dut_confed_asn: 65100
+    dut_confed_peers: 65300
+    dut_type: UpperSpineRouter
+    podset_number: 400
+    tor_number: 16
+    tor_subnet_number: 8
+    max_tor_subnet_number: 32
+    tor_subnet_size: 128
+    nhipv4: 10.10.0.254
+    nhipv6: fc00::ff
+  core:
+    swrole: core
+  leaf:
+    swrole: leaf
+
+configuration:
+  VM01T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.0
+          - fc00::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Port-Channel1:
+        ipv4: 10.0.0.1/31
+        ipv6: fc00::2/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.1/24
+      ipv6: fc00::2/64
+
+  VM02T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.2
+          - fc00::5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.2/32
+        ipv6: 2064:100::2/128
+      Port-Channel1:
+        ipv4: 10.0.0.3/31
+        ipv6: fc00::6/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.2/24
+      ipv6: fc00::3/64
+
+  VM03T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.4
+          - fc00::9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.3/32
+        ipv6: 2064:100::3/128
+      Port-Channel1:
+        ipv4: 10.0.0.5/31
+        ipv6: fc00::a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.3/24
+      ipv6: fc00::4/64
+
+  VM04T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.6
+          - fc00::d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.4/32
+        ipv6: 2064:100::4/128
+      Port-Channel1:
+        ipv4: 10.0.0.7/31
+        ipv6: fc00::e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.4/24
+      ipv6: fc00::5/64
+
+  VM05T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.8
+          - fc00::11
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.5/32
+        ipv6: 2064:100::5/128
+      Port-Channel1:
+        ipv4: 10.0.0.9/31
+        ipv6: fc00::12/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.5/24
+      ipv6: fc00::6/64
+
+  VM06T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.10
+          - fc00::15
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.6/32
+        ipv6: 2064:100::6/128
+      Port-Channel1:
+        ipv4: 10.0.0.11/31
+        ipv6: fc00::16/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.6/24
+      ipv6: fc00::7/64
+
+  VM07T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.12
+          - fc00::19
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.7/32
+        ipv6: 2064:100::7/128
+      Port-Channel1:
+        ipv4: 10.0.0.13/31
+        ipv6: fc00::1a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.7/24
+      ipv6: fc00::8/64
+
+  VM08T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.14
+          - fc00::1d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.8/32
+        ipv6: 2064:100::8/128
+      Port-Channel1:
+        ipv4: 10.0.0.15/31
+        ipv6: fc00::1e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.8/24
+      ipv6: fc00::9/64
+
+  VM09T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.16
+          - fc00::21
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.9/32
+        ipv6: 2064:100::9/128
+      Port-Channel1:
+        ipv4: 10.0.0.17/31
+        ipv6: fc00::22/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.9/24
+      ipv6: fc00::a/64
+
+  VM10T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.18
+          - fc00::25
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.10/32
+        ipv6: 2064:100::a/128
+      Port-Channel1:
+        ipv4: 10.0.0.19/31
+        ipv6: fc00::26/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.10/24
+      ipv6: fc00::b/64
+
+  VM11T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.20
+          - fc00::29
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.11/32
+        ipv6: 2064:100::b/128
+      Port-Channel1:
+        ipv4: 10.0.0.21/31
+        ipv6: fc00::2a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.11/24
+      ipv6: fc00::c/64
+
+  VM12T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.22
+          - fc00::2d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.12/32
+        ipv6: 2064:100::c/128
+      Port-Channel1:
+        ipv4: 10.0.0.23/31
+        ipv6: fc00::2e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.12/24
+      ipv6: fc00::d/64
+
+  VM13T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.24
+          - fc00::31
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.13/32
+        ipv6: 2064:100::d/128
+      Port-Channel1:
+        ipv4: 10.0.0.25/31
+        ipv6: fc00::32/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.13/24
+      ipv6: fc00::e/64
+
+  VM14T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.26
+          - fc00::35
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.14/32
+        ipv6: 2064:100::e/128
+      Port-Channel1:
+        ipv4: 10.0.0.27/31
+        ipv6: fc00::36/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.14/24
+      ipv6: fc00::f/64
+
+  VM15T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.28
+          - fc00::39
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.15/32
+        ipv6: 2064:100::f/128
+      Port-Channel1:
+        ipv4: 10.0.0.29/31
+        ipv6: fc00::3a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.15/24
+      ipv6: fc00::10/64
+
+  VM16T3:
+    properties:
+      - common
+      - core
+    bgp:
+      peer_in_bgp_confed: true
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.30
+          - fc00::3d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.16/32
+        ipv6: 2064:100::10/128
+      Port-Channel1:
+        ipv4: 10.0.0.31/31
+        ipv6: fc00::3e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.0.16/24
+      ipv6: fc00::11/64
+
+  VM01LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.128
+          - fc00::101
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.65/32
+        ipv6: 2064:100::41/128
+      Ethernet1:
+        ipv4: 10.0.0.129/31
+        ipv6: fc00::102/126
+    bp_interface:
+      ipv4: 10.10.246.65/24
+      ipv6: fc0a::42/64
+
+  VM02LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.130
+          - fc00::105
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.66/32
+        ipv6: 2064:100::42/128
+      Ethernet1:
+        ipv4: 10.0.0.131/31
+        ipv6: fc00::106/126
+    bp_interface:
+      ipv4: 10.10.246.66/24
+      ipv6: fc0a::43/64
+
+  VM03LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.132
+          - fc00::109
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.67/32
+        ipv6: 2064:100::43/128
+      Ethernet1:
+        ipv4: 10.0.0.133/31
+        ipv6: fc00::10a/126
+    bp_interface:
+      ipv4: 10.10.246.67/24
+      ipv6: fc0a::44/64
+
+  VM04LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.134
+          - fc00::10d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.68/32
+        ipv6: 2064:100::44/128
+      Ethernet1:
+        ipv4: 10.0.0.135/31
+        ipv6: fc00::10e/126
+    bp_interface:
+      ipv4: 10.10.246.68/24
+      ipv6: fc0a::45/64
+
+  VM05LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.136
+          - fc00::111
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.69/32
+        ipv6: 2064:100::45/128
+      Ethernet1:
+        ipv4: 10.0.0.137/31
+        ipv6: fc00::112/126
+    bp_interface:
+      ipv4: 10.10.246.69/24
+      ipv6: fc0a::46/64
+
+  VM06LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.138
+          - fc00::115
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.70/32
+        ipv6: 2064:100::46/128
+      Ethernet1:
+        ipv4: 10.0.0.139/31
+        ipv6: fc00::116/126
+    bp_interface:
+      ipv4: 10.10.246.70/24
+      ipv6: fc0a::47/64
+
+  VM07LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.140
+          - fc00::119
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.71/32
+        ipv6: 2064:100::47/128
+      Ethernet1:
+        ipv4: 10.0.0.141/31
+        ipv6: fc00::11a/126
+    bp_interface:
+      ipv4: 10.10.246.71/24
+      ipv6: fc0a::48/64
+
+  VM08LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.142
+          - fc00::11d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.72/32
+        ipv6: 2064:100::48/128
+      Ethernet1:
+        ipv4: 10.0.0.143/31
+        ipv6: fc00::11e/126
+    bp_interface:
+      ipv4: 10.10.246.72/24
+      ipv6: fc0a::49/64
+
+  VM09LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.144
+          - fc00::121
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.73/32
+        ipv6: 2064:100::49/128
+      Ethernet1:
+        ipv4: 10.0.0.145/31
+        ipv6: fc00::122/126
+    bp_interface:
+      ipv4: 10.10.246.73/24
+      ipv6: fc0a::4a/64
+
+  VM10LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.146
+          - fc00::125
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.74/32
+        ipv6: 2064:100::4a/128
+      Ethernet1:
+        ipv4: 10.0.0.147/31
+        ipv6: fc00::126/126
+    bp_interface:
+      ipv4: 10.10.246.74/24
+      ipv6: fc0a::4b/64
+
+  VM11LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.148
+          - fc00::129
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.75/32
+        ipv6: 2064:100::4b/128
+      Ethernet1:
+        ipv4: 10.0.0.149/31
+        ipv6: fc00::12a/126
+    bp_interface:
+      ipv4: 10.10.246.75/24
+      ipv6: fc0a::4c/64
+
+  VM12LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.150
+          - fc00::12d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.76/32
+        ipv6: 2064:100::4c/128
+      Ethernet1:
+        ipv4: 10.0.0.151/31
+        ipv6: fc00::12e/126
+    bp_interface:
+      ipv4: 10.10.246.76/24
+      ipv6: fc0a::4d/64
+
+  VM13LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.152
+          - fc00::131
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.77/32
+        ipv6: 2064:100::4d/128
+      Ethernet1:
+        ipv4: 10.0.0.153/31
+        ipv6: fc00::132/126
+    bp_interface:
+      ipv4: 10.10.246.77/24
+      ipv6: fc0a::4e/64
+
+  VM14LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.154
+          - fc00::135
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.78/32
+        ipv6: 2064:100::4e/128
+      Ethernet1:
+        ipv4: 10.0.0.155/31
+        ipv6: fc00::136/126
+    bp_interface:
+      ipv4: 10.10.246.78/24
+      ipv6: fc0a::4f/64
+
+  VM15LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.156
+          - fc00::139
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.79/32
+        ipv6: 2064:100::4f/128
+      Ethernet1:
+        ipv4: 10.0.0.157/31
+        ipv6: fc00::13a/126
+    bp_interface:
+      ipv4: 10.10.246.79/24
+      ipv6: fc0a::50/64
+
+  VM16LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
+      peers:
+        66000:
+          - 10.0.0.158
+          - fc00::13d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.80/32
+        ipv6: 2064:100::50/128
+      Ethernet1:
+        ipv4: 10.0.0.159/31
+        ipv6: fc00::13e/126
+    bp_interface:
+      ipv4: 10.10.246.80/24
+      ipv6: fc0a::51/64


### PR DESCRIPTION
### Description of PR

Summary:
- Add `ansible/vars/topo_t2_single_node_max_32p.yml`, a 32-VM T2 single-node max topology definition.
- Complements the existing upstream topologies `topo_t2_single_node_max.yml`, `topo_t2_single_node_max_64p.yml`, and `topo_t2_single_node_max_64p_v2.yml`.
- Includes BGP confederation configuration consistent with the existing T2 single-node max topologies.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
- master: topology file added; YAML structure matches existing `topo_t2_single_node_max_64p.yml` (topology / configuration_properties / configuration) with 32 VMs instead of 64.

### Approach

#### What is the motivation for this PR?
Upstream already ships 64-port T2 single-node max topology vars files but not the 32-port variant. Adding `topo_t2_single_node_max_32p.yml` enables testbeds that use the upstream underscored topology name with 32 peer VMs.

#### How did you do it?
Added `ansible/vars/topo_t2_single_node_max_32p.yml` with the same overall schema as `topo_t2_single_node_max_64p.yml`, sized for 32 VMs, including confederation configuration.

#### How did you verify/test it?
Validated YAML parses and top-level structure matches the existing max_64p topology file (32 VMs vs 64).

#### Any platform specific information?
N/A — topology definition only.

#### Supported testbed topology if it's a new test case?
Not a new test case. Adds topology vars for `t2_single_node_max_32p`.

### Documentation 
<!--
(Put an X below to select as applicable)
-->

- [ ] Change log provided
- [x] Documentation (N/A)
- [ ] Community blog post

Made with [Cursor](https://cursor.com)