### PR TITLE
[BMC] Console test suite fixes for BMC dut

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -850,7 +850,7 @@ configlet/test_add_rack.py:
 #######################################
 #####            console          #####
 #######################################
-console/(?!test_console_(?:driver|reversessh)\.py):
+^console/(?!test_console_(?:driver|reversessh)\.py):
   regex: true
   skip:
     reason: 'Only console driver and reverse SSH tests are compatible with BMC'

--- a/tests/console/test_console_driver.py
+++ b/tests/console/test_console_driver.py
@@ -29,6 +29,14 @@ def test_console_driver(duthost, conn_graph_facts):  # noqa: F811
     device_prefix = duthost.get_serial_device_prefix()
     ls_out = duthost.shell('ls {}*'.format(device_prefix), module_ignore_errors=True)['stdout']
     existing_ttys = set(ls_out.split())
+    if duthost.is_bmc():
+        # H6 BMC exposes a PTY pair alongside the console line node
+        # (/dev/ttySwitchCpu0-PTM, /dev/ttySwitchCpu0-PTS). They match the prefix but
+        # are not separate CONSOLE_PORT lines.
+        existing_ttys = {
+            name for name in existing_ttys
+            if not (name.endswith('-PTM') or name.endswith('-PTS'))
+        }
     pytest_assert(
         existing_ttys,
         "No tty devices matching prefix '{}' were created by the console driver on DUT '{}'".format(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
This PR fixes the following,

- _test_console_driver_ on BMC: H6 BMC creates PTY helper nodes (/dev/ttySwitchCpu0-PTM, -PTS) alongside the real console TTY. The test took them as extra console lines. Ignore -PTM/-PTS only when duthost is BMC.

- Change the console-suite skip regex with **^console/** so it no longer matches the substring console/ inside **dut_console/**, which incorrectly skipped telnet console tests (e.g. _escape character_) with the “_Only console driver and reverse SSH…_” reason. This was introduced as part of #https://github.com/sonic-net/sonic-mgmt/pull/26843

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
<img width="1543" height="577" alt="image" src="https://github.com/user-attachments/assets/ab24c1fe-97fb-44e4-815c-0a3ef1672a60" />

<img width="1702" height="814" alt="image" src="https://github.com/user-attachments/assets/1077ca0e-4277-408a-ad6d-6df405b7ce8e" />

### Approach
#### What is the motivation for this PR?

- _test_console_driver_ : On BMC, ls on the console device prefix also lists PTY helpers (…-PTM, …-PTS) next to the real line node (e.g. /dev/ttySwitchCpu0). The test treated them as extra CONSOLE lines and failed the inventory match.

- _Conditional marks_ — The BMC rule that skips most of tests/console/ used a regex console/(?!…), which matched the substring console/ in dut_console/. Telnet console tests were skipped with “_Only console driver and reverse SSH tests are compatible with BMC_” instead of running.

#### How did you do it?

- tests/console/test_console_driver.py — When duthost.is_bmc(), filter -PTM and -PTS out of existing_ttys before comparing to device_serial_link.

- _tests/common/plugins/conditional_mark/tests_mark_conditions.yaml_ — Modify the BMC console skip pattern: console/(?!test_console_(?:driver|reversessh)\.py) → ^console/(?!…) so only the console/ test package is affected, not dut_console/.

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->

- Ran console tests on BMC topo and made sure all tests are passing without any issues.

#### Any platform specific information?
'bmc-shared-mgmt' topo with H6-128-BMC HWsKU

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
