### PR TITLE
[BMC] Exclude redfish from random container check in test_syslog_rate_limit

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -36,6 +36,10 @@ LOG_EXPECT_LAST_MESSAGE = '.*{}rate-limit-test: This is a test log:.*'
 # rsyslogd-version-dependent, so only a presence check is performed (not an exact count).
 LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = r'.*(?:begin to drop messages|messages lost) due to rate-limiting.*'
 
+# BMC syslog rate limit ignore container list
+# Bridge-network redfish on BMC does not forward container# logs to host /var/log/syslog
+BMC_SYSLOG_RATE_LIMIT_IGNORE_CONTAINERS = ['redfish']
+
 pytestmark = [
     pytest.mark.topology("any")
 ]
@@ -94,7 +98,8 @@ def test_syslog_rate_limit(rand_selected_dut):
     # Copy tests/syslog/log_generator.py to DUT
     rand_selected_dut.copy(src=LOCAL_LOG_GENERATOR_FILE, dest=REMOTE_LOG_GENERATOR_FILE)
 
-    verify_container_rate_limit(rand_selected_dut)
+    verify_container_rate_limit(
+        rand_selected_dut, ignore_containers=get_rate_limit_ignore_containers(rand_selected_dut))
     verify_host_rate_limit(rand_selected_dut)
 
     # Save configuration and reload, verify the configuration can be loaded
@@ -103,8 +108,20 @@ def test_syslog_rate_limit(rand_selected_dut):
     config_reload(rand_selected_dut, safe_reload=True)
 
     # database does not support syslog rate limit configuration persist
-    verify_container_rate_limit(rand_selected_dut, ignore_containers=['database'])
+    verify_container_rate_limit(
+        rand_selected_dut,
+        ignore_containers=get_rate_limit_ignore_containers(rand_selected_dut, extra_ignore=['database']))
     verify_host_rate_limit(rand_selected_dut)
+
+
+def get_rate_limit_ignore_containers(duthost, extra_ignore=None):
+    """Containers excluded from random rate-limit verification."""
+    ignore = list(extra_ignore or [])
+    if duthost.is_bmc():
+        for name in BMC_SYSLOG_RATE_LIMIT_IGNORE_CONTAINERS:
+            if name not in ignore:
+                ignore.append(name)
+    return ignore
 
 
 def verify_container_rate_limit(rand_selected_dut, ignore_containers=[]):
@@ -129,6 +146,7 @@ def verify_container_rate_limit(rand_selected_dut, ignore_containers=[]):
     for item in feature_data:
         service_name = item['feature']
         if service_name in ignore_containers:
+            logger.info('Skipping syslog rate limit test for container {} (in ignore list)'.format(service_name))
             continue
         container_name = service_name
         if rand_selected_dut.is_multi_asic:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/27880
<!--
If you request a backport/cherry-pick below, link the GitHub issue or ADO work
item here (for example, "Fixes #<issue>" or "ADO: <work item URL>").
-->
This PR fixes issue #27880 

On BMC, skip redfish in the random container syslog rate-limit test because host LogAnalyzer cannot see redfish# logs. Bridge-network redfish on BMC does not forward container logs to the host syslog path the test uses, while feature redfish still has _support_syslog_rate_limit_ set to true. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result
<!--
Provide the tested image version and test evidence for each selected branch.
For example:
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
<img width="1574" height="565" alt="image" src="https://github.com/user-attachments/assets/7f08d6cf-74bf-4658-b304-14f3051c105f" />

### Approach
#### What is the motivation for this PR?

- On H6-128 BMC (_NetworkBmc_), _test_syslog_rate_limit_ can randomly select the redfish container after config reload. In-container steps succeed (_config syslog rate-limit-container, rsyslogd RUNNING, log generator runs_), but verification fails because the test expects _redfish#rate-limit-test_ lines on host /var/log/syslog via LogAnalyzer.

#### How did you do it?

- When duthost.is_bmc(), add redfish into the ignore list (_and any extra_ignore, e.g. database after reload_).

#### How did you verify/test it?
<!--
Summarize the overall validation here. For a backport/cherry-pick request,
provide branch-specific image versions and evidence in the Test result section.
-->
Ran _test_syslog_rate_limit_ test on BMC topo and made sure all tests are passing without any issues.

#### Any platform specific information?
'bmc-shared-mgmt' topo with H6-128-BMC HWsKU

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
