### PR TITLE
[transceiver] Add reset module as part of restoration

### DIFF
--- a/tests/transceiver/cdb_firmware_upgrade/firmware_operations.py
+++ b/tests/transceiver/cdb_firmware_upgrade/firmware_operations.py
@@ -519,8 +519,11 @@ def restore_module_to_original(duthost, port, port_context, metadata_map):
                 target_version=orig_inactive, expect_link_up=False,
             )
 
-    failures += scenario_ops.perform_ports_startup(
-        duthost, port_context["subports"], system_attrs["port_startup_wait_sec"],
+    failures += scenario_ops.perform_sfputil_reset(
+        duthost, [port], port_context["subports"],
+        system_attrs["port_shutdown_wait_sec"],
+        system_attrs["port_startup_wait_sec"],
+        recover_wait_sec=system_attrs["transceiver_reset_i2c_recover_sec"],
     )
     return failures
 


### PR DESCRIPTION
### Description of PR

Summary:
Ensures CDB firmware baseline restoration ends with a module reset and subport recovery.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request:
Failure type:

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

### Approach
#### What is the motivation for this PR?

Ensure modules finish package-level firmware restoration in a reset and recovered state.

#### How did you do it?

Replaced the final port startup with the existing `perform_sfputil_reset` helper, using the configured shutdown, startup, and I2C recovery intervals.

#### How did you verify/test it?
- ran cdb_firmware_upgrade tests with new restoration policy and verified they pass.

#### Any platform specific information?


#### Supported testbed topology if it's a new test case?


#### Documentation

MSFT ADO - 39535718