### PR TITLE
Disable memory utilization checks on CACL scale tests

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -24,7 +24,8 @@ from tests.common.fixtures.duthost_utils import dut_qos_maps_module  # noqa F401
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1')
+    pytest.mark.topology('t0', 't1'),
+    pytest.mark.disable_memory_utilization
 ]
 
 DEFAULT_MAPPING_TYPE = "AZURE"
@@ -520,7 +521,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         ):
             with allure.step("Do warm-reboot"):
                 reboot(duthost, localhost, reboot_type="warm", safe_reboot=True, check_intf_up_ports=True,
-                       wait_warmboot_finalizer=True)
+                       wait_warmboot_finalizer=True, ignore_loganalyzer=loganalyzer)
 
             with allure.step("Run test after warm-reboot"):
                 self._run_test(ptfadapter, duthost, tbinfo, test_params, inner_dst_ip_list, dut_qos_maps_module,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary:
- Add `pytest.mark.disable_memory_utilization` to `test_cacl_scale_rules_ipv4` and `test_cacl_scale_rules_ipv6`.
- These scale cases load 150 CACL rules (50 each in SNMP-ACL, SSH_ONLY, NTP_ACL). The autouse memory plugin samples in teardown before fixture `config_reload`, so monit `memory_usage` can rise ~11% to ~23% and fail even though CACL assertions pass.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A
