### PR TITLE
Restore mux state

### DIFF
--- a/tests/dualtor/test_standalone_tunnel_route.py
+++ b/tests/dualtor/test_standalone_tunnel_route.py
@@ -30,10 +30,17 @@ pytestmark = [
 
 @pytest.fixture(autouse=True)
 def cleanup_neighbors(duthosts):
-    """Cleanup neighbors."""
-    duthosts.shell("sonic-clear arp")
-    duthosts.shell("sonic-clear ndp")
-    return
+    """Cleanup neighbors while preventing background neighbor updates."""
+    arp_update_stop_cmd = "docker exec swss supervisorctl stop arp_update"
+    arp_update_start_cmd = "docker exec swss supervisorctl start arp_update"
+
+    try:
+        duthosts.shell(arp_update_stop_cmd)
+        duthosts.shell("sonic-clear arp")
+        duthosts.shell("sonic-clear ndp")
+        yield
+    finally:
+        duthosts.shell(arp_update_start_cmd)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Description of PR
Summary:
Improve dual-ToR QoS test cleanup by isolating mux handling in a yield fixture. The fixture:

- Disables mux safely during QoS tests.
- Backs up and replaces `write_standby.py` with a valid no-op script.
- Restores and verifies the original script during teardown.
- Re-enables mux on both ToRs.
- Warns and continues when a stale backup from an interrupted run already exists.

Fixes # https://github.com/sonic-net/sonic-mgmt/issues/26834

### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605
- [ ] N/A

### Test result
- 202605: 20260917.42 

### Approach
#### What is the motivation for this PR?
QoS tests on dual-ToR systems temporarily modify mux handling. If a test is interrupted, a stale backup file may remain and cause the next run to fail unnecessarily.

#### How did you do it?
Moved mux handling into a class-scoped yield fixture. The fixture preserves the original `write_standby.py`, installs a no-op script while mux is disabled, and restores and verifies the original script during teardown.

Existing stale backups are detected and logged as warnings before being overwritten.


#### How did you verify/test it?
Manually verified on a dual-ToR testbed by running the QoS test suite with mux handling enabled and disabled.
The validation covered:
- Normal QoS test execution.
- Restoration of `write_standby.py` after test completion even with interruption.
- Re-enabling mux on both ToRs during fixture teardown.
- Re-running the tests with a pre-existing `.bkup` file to confirm that a warning is logged and the test proceeds successfully.
- Confirming that the stale backup is overwritten and removed during cleanup.


#### Any platform specific information?
Applies to dual-ToR QoS testbeds, including active-standby mux configurations.

#### Supported testbed topology if it's a new test case?
Dual-ToR topology. No new test case was added.

### Documentation
N/A
